### PR TITLE
testing: setup linear rollout for 30.20190801.0

### DIFF
--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,0 +1,19 @@
+{
+  "updates": {
+    "barriers": [],
+    "deadends": [
+      {
+        "version": "30.20190716.1",
+        "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/215"
+      }
+    ],
+    "rollouts": [
+      {
+        "version": "30.20190801.0",
+        "start_epoch": "1565017200",
+        "start_value": "0.0",
+        "duration_minutes": "120"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This sets up a rollout for `30.20190801.0`, linearly increasing over
a 2 hours window (`120 minutes`), starting at epoch `1565017200`.

```
$ date -u -d @1565017200
Mon Aug  5 15:00:00 UTC 2019
```