### PR TITLE
testing: temporarily hide 31.20191127.1 rollout

### DIFF
--- a/updates/testing.json
+++ b/updates/testing.json
@@ -19,16 +19,6 @@
           "reason": "https://github.com/coreos/fedora-coreos-streams/issues/30"
         }
       }
-    },
-    {
-      "version": "31.20191127.1",
-      "metadata": {
-        "rollout": {
-          "start_epoch": 1575385200,
-          "start_percentage": 0.0,
-          "duration_minutes": 2880
-        }
-      }
     }
   ]
 }


### PR DESCRIPTION
We fully rolled out `31.20191127.1` on `testing`, but it looks like
auto-updating from some old releases might not be safe.
Temporarily hiding this rollout while we investigate
https://github.com/coreos/fedora-coreos-tracker/issues/322.