### PR TITLE
ci: hook up to CoreOS CI

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,0 +1,19 @@
+@Library('github.com/coreos/coreos-ci-lib@master') _
+
+coreos.pod([image: 'quay.io/coreos-assembler/coreos-assembler:master']) {
+    checkout scm
+
+    stage("Syntax Check") {
+        coreos.shwrap("make syntax-check")
+    }
+
+    /* TODO
+    stage("Schema Validation") {
+        coreos.shwrap("make schema-check")
+    }
+    */
+
+    stage("Print Rollouts") {
+        coreos.shwrap("make print-rollouts")
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: syntax-check
+syntax-check:
+	@find streams updates -iname '*.json' | xargs -n 1 python3 -c 'import json, sys; json.load(open(sys.argv[1]))'
+
+.PHONY: print-rollouts
+print-rollouts:
+	@find updates -iname '*.json' | xargs -n 1 python3 -c '\
+	import json, sys, datetime; \
+	update = json.load(open(sys.argv[1])); \
+	stream = update["stream"]; \
+	release = update["releases"][-1]; \
+	version = release["version"]; \
+	rollout = release["metadata"]["rollout"]; \
+	ts = datetime.datetime.fromtimestamp(rollout["start_epoch"]); \
+	mins = rollout["duration_minutes"]; \
+	hrs = mins / 60.0; \
+	print(f"{stream} rollout of {version} scheduled for {ts} UTC for {mins}m ({hrs}h)");'


### PR DESCRIPTION
Do some basic syntax validation, as well as printing rollout details to
make it easier for reviewers. E.g.:

```
$ make print-rollouts
testing rollout of 31.20200127.2.0 scheduled for 2020-02-03 09:00:00 UTC for 1440m (24.0h)
stable rollout of 31.20200118.3.0 scheduled for 2020-02-03 09:00:00 UTC for 4320m (72.0h)
```