### PR TITLE
ci: migrate to new coreos-ci project

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,19 +1,20 @@
-@Library('github.com/coreos/coreos-ci-lib@master') _
+// Documentation: https://github.com/coreos/coreos-ci/blob/master/README-upstream-ci.md
 
-coreos.pod([image: 'quay.io/coreos-assembler/coreos-assembler:master']) {
+// we just use cosaPod for `make` here
+cosaPod {
     checkout scm
 
     stage("Syntax Check") {
-        coreos.shwrap("make syntax-check")
+        shwrap("make syntax-check")
     }
 
     /* TODO
     stage("Schema Validation") {
-        coreos.shwrap("make schema-check")
+        shwrap("make schema-check")
     }
     */
 
     stage("Print Rollouts") {
-        coreos.shwrap("make print-rollouts")
+        shwrap("make print-rollouts")
     }
 }


### PR DESCRIPTION
Nothing fancy, just a few substitutions.

Requires: https://github.com/coreos/coreos-ci/pull/6