### PR TITLE
rollouts: stable and testing, 2020-04-08

### DIFF
--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,141 +1,153 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2020-03-25T23:08:32Z"
+        "last-modified": "2020-04-09T14:12:12Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "31.20200310.3.0",
+                    "release": "31.20200323.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "cc714038ade3e70228c26540e5d412397048cffb877fd827f90614a393fd053a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d53f0f854b294a337ae470621f00e5982ab3efc6476c71e8d5ed9c1321278c20"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "31.20200310.3.0",
+                    "release": "31.20200323.3.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "98dc73458e321048826de51a776ef325fcbf0646b40ba7b5cd51fcdfc1c30607"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "2ec4a5843f4ec76cd548b250d49ea46f2a1c5a9d08102189d79e3ff44e206210"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "31.20200310.3.0",
+                    "release": "31.20200323.3.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "68703320962b52e164c48a562d6c9c6d95c45e2564d27a9c48dc83722da1b87d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "c986ece89a6cdbd19b1ea00aa6bbe9d4a178cacdf2fdefa427aeb91fb19b4122"
+                            }
+                        }
+                    }
+                },
+                "digitalocean": {
+                    "release": "31.20200323.3.2",
+                    "formats": {
+                        "qcow2.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "eec7b7c1561b202accac28589dd46121b5cb3cf56888302c037d2e741462bba6"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "31.20200310.3.0",
+                    "release": "31.20200323.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a3c62e95f288ca4865bab24658172ff7218b87a58caaf8d9a15efcaa096a15bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "6c2cafb47c94ec0a09b31f14de51e3a1eeeca0b7785f036463f86cbf9b6f424e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "31.20200310.3.0",
+                    "release": "31.20200323.3.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "653e29fe22bca2da80e3c1bb95847d761f7d6fef9883c37ae3c37b14a961a1c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "8eca7c44340096b549c7db23c8e3f365272cd9f2ae36e4a4dea17df1899ed6d1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "31.20200310.3.0",
+                    "release": "31.20200323.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "90ffe428ba802792f8815b34a2314b90800fcf5d2ca7630b8d7631b28b940aa0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "62adea4a065c7840ff03e222bf5545dc2b690a6ab45e3356febe6d46df2f81d2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-live.x86_64.iso.sig",
-                                "sha256": "41b1abe28250b8b5622da397e43caa2192dcc146e23de1b2d901c8d134150679"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-live.x86_64.iso.sig",
+                                "sha256": "97e92519d4512bfe17d55ded19d97ebaa1a2a09cc04d5c6cff98efead6e0bcf0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-live-kernel-x86_64.sig",
-                                "sha256": "1d75758325541eff3f7c221120c013c94940cc3ba36b23542ded2c636330a06f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-live-kernel-x86_64.sig",
+                                "sha256": "6d6d41536292bfd5f33bcca2d1b880fe3441ec70ee7ea94dedf53fc5749a8b1e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "511d4040dd11ba482b27b6fd386e9f3bbb58d784baefabe2424bc88fdb33f33e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "91c86a46669af44e696d8bd0302c96e5395e1232b5aae489a03dc1dee0964aad"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "48690ee5aec9816457ea8aaee305f3ed3e51017cefb118681d19f3f669c845bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "b349a2714cd7fd6ae39b3b881d6c377d0096367d728e67acd6c21a944d237ab4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "31.20200310.3.0",
+                    "release": "31.20200323.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "3bb87873f0dbf41a530354cb077fb339f54a0ed6ddede6f45f3ea8de22e0f96e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "398723072106fc31ece950f593a5c865aaec4486ce86589a1b17f0877f222bb7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "31.20200310.3.0",
+                    "release": "31.20200323.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "f312eae7c5e16ac4c03ebb167129c258b85ddeac355e1fccbe70833156a23e32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "f3445ae8c1fd0e28999bf47e50a3d8ac65914e93af680ea0ef09e14ffe4f7061"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "31.20200310.3.0",
+                    "release": "31.20200323.3.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200310.3.0/x86_64/fedora-coreos-31.20200310.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "15eb3999e6d583cabf4d196596c3f89a365a9d24866f8672e277df05ee624575"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200323.3.2-vmware.x86_64.ova.sig",
+                                "sha256": "7fa37e8b3d48eb981ae4249fe8da5c3252e4fd666daa26b66770a59a7d67a41f"
                             }
                         }
                     }
@@ -145,76 +157,76 @@
                 "aws": {
                     "regions": {
                         "ap-east-1": {
-                            "release": "31.20200310.3.0",
-                            "image": "ami-0297249db53e2036d"
+                            "release": "31.20200323.3.2",
+                            "image": "ami-08d6921fd91921e9c"
                         },
                         "ap-northeast-1": {
-                            "release": "31.20200310.3.0",
-                            "image": "ami-0d14b2307acf12fa6"
+                            "release": "31.20200323.3.2",
+                            "image": "ami-09a37c9e350bbe0c9"
                         },
                         "ap-northeast-2": {
-                            "release": "31.20200310.3.0",
-                            "image": "ami-0f622a7b0e52c7295"
+                            "release": "31.20200323.3.2",
+                            "image": "ami-072ec527252742403"
                         },
                         "ap-south-1": {
-                            "release": "31.20200310.3.0",
-                            "image": "ami-02f54eeb2546e0581"
+                            "release": "31.20200323.3.2",
+                            "image": "ami-0a809178d1cef40f8"
                         },
                         "ap-southeast-1": {
-                            "release": "31.20200310.3.0",
-                            "image": "ami-0c2b3075153e5b407"
+                            "release": "31.20200323.3.2",
+                            "image": "ami-0fdf46939724e6e93"
                         },
                         "ap-southeast-2": {
-                            "release": "31.20200310.3.0",
-                            "image": "ami-0a53fd8bd20a2e815"
+                            "release": "31.20200323.3.2",
+                            "image": "ami-04113787d19bd6cc3"
                         },
                         "ca-central-1": {
-                            "release": "31.20200310.3.0",
-                            "image": "ami-00049388b11911ff0"
+                            "release": "31.20200323.3.2",
+                            "image": "ami-0340007112067b242"
                         },
                         "eu-central-1": {
-                            "release": "31.20200310.3.0",
-                            "image": "ami-08358bec521facba9"
+                            "release": "31.20200323.3.2",
+                            "image": "ami-097cf68f602744516"
                         },
                         "eu-north-1": {
-                            "release": "31.20200310.3.0",
-                            "image": "ami-0f521688f205f4112"
+                            "release": "31.20200323.3.2",
+                            "image": "ami-03afc4dae5ad24454"
                         },
                         "eu-west-1": {
-                            "release": "31.20200310.3.0",
-                            "image": "ami-09b324a3eff1abae9"
+                            "release": "31.20200323.3.2",
+                            "image": "ami-0e233151e0b55f120"
                         },
                         "eu-west-2": {
-                            "release": "31.20200310.3.0",
-                            "image": "ami-0c42b5f0e450b0d5c"
+                            "release": "31.20200323.3.2",
+                            "image": "ami-0a3def5dd914b1a3a"
                         },
                         "eu-west-3": {
-                            "release": "31.20200310.3.0",
-                            "image": "ami-0d012791aca16a81d"
+                            "release": "31.20200323.3.2",
+                            "image": "ami-0f468e7bb78ad6cf5"
                         },
                         "me-south-1": {
-                            "release": "31.20200310.3.0",
-                            "image": "ami-009914839c7b6f49e"
+                            "release": "31.20200323.3.2",
+                            "image": "ami-0dfc2d24b3417c879"
                         },
                         "sa-east-1": {
-                            "release": "31.20200310.3.0",
-                            "image": "ami-0fb193f9f5aaf77fc"
+                            "release": "31.20200323.3.2",
+                            "image": "ami-0837173dc833ba5cd"
                         },
                         "us-east-1": {
-                            "release": "31.20200310.3.0",
-                            "image": "ami-0c0261fbc08b1b65a"
+                            "release": "31.20200323.3.2",
+                            "image": "ami-0e9e09e1c9076ed97"
                         },
                         "us-east-2": {
-                            "release": "31.20200310.3.0",
-                            "image": "ami-087891c79012c7f54"
+                            "release": "31.20200323.3.2",
+                            "image": "ami-092807bdf2e6f44a4"
                         },
                         "us-west-1": {
-                            "release": "31.20200310.3.0",
-                            "image": "ami-042e4e676b10ccfbf"
+                            "release": "31.20200323.3.2",
+                            "image": "ami-00b19ec3ac76c420a"
                         },
                         "us-west-2": {
-                            "release": "31.20200310.3.0",
-                            "image": "ami-023f4e516b35c5f9c"
+                            "release": "31.20200323.3.2",
+                            "image": "ami-09f69131016f74c53"
                         }
                     }
                 }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,153 +1,153 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2020-03-31T20:29:32Z"
+        "last-modified": "2020-04-09T14:10:37Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "31.20200323.2.1",
+                    "release": "31.20200407.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "a6c6d0040baf7501dee535e75f7441db9e5988dca9cd2907385b8d840fd44d8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "83013c86447e871e057e3cc9b49fb22338406c79aa0778b7e12636ae8d8b9f49"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "31.20200323.2.1",
+                    "release": "31.20200407.2.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "529bc19b8200ab1b495da85cdfe2f605cfb6ac4d882525d02673738c902616ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "d3ca781c8db6ac7e7664b6ee92c1696e5628aa70f2c1d3726df7d3c46328ecfb"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "31.20200323.2.1",
+                    "release": "31.20200407.2.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "fe800932b21dce38f63bff6a597912d36982617199021b9a873d2cc85bc8da9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "7f229bb420dda3fb73468773ef3253247e766b0edc64dc8614bf0a33ac7a8503"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "31.20200323.2.1",
+                    "release": "31.20200407.2.2",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "44047e3378fb83ddb73ff64d5e4e573026079e7eb424da5ae9a2bf2724b4b38e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "b79fa703b7a560480585a0a24a9a03ef67105db6e0b245c54315ba158d85c238"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "31.20200323.2.1",
+                    "release": "31.20200407.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "42a6c5bbaa4a6459683119ce85b54932d7f1b432e275f75150ec1f0409185e9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "99f2e48ea1a078118dfc26df4038c03c63f0f4b86d98e2fc146fe73148bcc48d"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "31.20200323.2.1",
+                    "release": "31.20200407.2.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "e801c9dac1e17ec295b97bc9ed0096b4a1fa613c2f3ea58928ccafe4b2796da0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "7a0199363ffaa519bacf21a138f3f9b457d1608bb37a5fce0d58ecae8faaf5fd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "31.20200323.2.1",
+                    "release": "31.20200407.2.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "22d8b27eadbcdb0973611bb595cee92aa848ed85d23c2167f4171baca426e55b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "69c2cc4597ca541c6aea3b88d7cbbcd5166ec730116591ff613233a6edf8c3b5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-live.x86_64.iso.sig",
-                                "sha256": "cf637475e1481cb317972afb212982d3b0d71ccefaac2812e00f0d1943d890b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-live.x86_64.iso.sig",
+                                "sha256": "e785c1242a81f32355ac40877c20a7a77c84e34776a2fb132d9067f8e11a44d3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-live-kernel-x86_64.sig",
-                                "sha256": "6d6d41536292bfd5f33bcca2d1b880fe3441ec70ee7ea94dedf53fc5749a8b1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-live-kernel-x86_64.sig",
+                                "sha256": "620334cafef8b212966bb1e6cbc9f6065a2cbb792d461f4a4ba96bc901690680"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "3b346e895bcc8fe5476890e23f8d84a22b6984b3489acd367fe99bda99c7fc51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "75342fa99bbf2e902d4165190dc8c07b7c903ffa39b65deb1b886b7b1871837f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "0dad0021d854de3256f56ac4e5fb67cf1f2001131b19487696258971e54225c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "e2fab0c626151bec2e49d36a77be7cfcc214b0900cefbb0f455744b3927f812a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "31.20200323.2.1",
+                    "release": "31.20200407.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "861aff7878be588408af912161e6b205d330595c371039fbbb84371a28e68f1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "537358430d55b38ab1d607fb32c25e1668c792fc90abf9c191bf984e2f45e446"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "31.20200323.2.1",
+                    "release": "31.20200407.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "fd5686ed99e50192d6b27f841512e8f051e8a311f5c1249f1beee7dd548b8c3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "d4c5382b18b6d4ce24b5e11cb0d853bff31ca2e8d6a575bb57fffdc0948cc28e"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "31.20200323.2.1",
+                    "release": "31.20200407.2.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200323.2.1/x86_64/fedora-coreos-31.20200323.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "25c7530a88a5da78f2ba19d373bd66f7a31e89bedf9be5427b30f945ab098426"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200407.2.2/x86_64/fedora-coreos-31.20200407.2.2-vmware.x86_64.ova.sig",
+                                "sha256": "c221641afc0d507cfea62d6698a762bb74748ce222c2c9e278bac9790cabc273"
                             }
                         }
                     }
@@ -157,76 +157,76 @@
                 "aws": {
                     "regions": {
                         "ap-east-1": {
-                            "release": "31.20200323.2.1",
-                            "image": "ami-0f13bd5bac5839e15"
+                            "release": "31.20200407.2.2",
+                            "image": "ami-0c3a05f4310fdbbfc"
                         },
                         "ap-northeast-1": {
-                            "release": "31.20200323.2.1",
-                            "image": "ami-031b4b0d88371b125"
+                            "release": "31.20200407.2.2",
+                            "image": "ami-0354700f73f332dcf"
                         },
                         "ap-northeast-2": {
-                            "release": "31.20200323.2.1",
-                            "image": "ami-05f64fc0c9aaf1533"
+                            "release": "31.20200407.2.2",
+                            "image": "ami-0b40166136ec36a99"
                         },
                         "ap-south-1": {
-                            "release": "31.20200323.2.1",
-                            "image": "ami-0ceb615c7862dccde"
+                            "release": "31.20200407.2.2",
+                            "image": "ami-067e5ee4d108273c9"
                         },
                         "ap-southeast-1": {
-                            "release": "31.20200323.2.1",
-                            "image": "ami-0354aa44fb15a7fd0"
+                            "release": "31.20200407.2.2",
+                            "image": "ami-02a7675c4c1f6f89e"
                         },
                         "ap-southeast-2": {
-                            "release": "31.20200323.2.1",
-                            "image": "ami-073efd569230f7c50"
+                            "release": "31.20200407.2.2",
+                            "image": "ami-0e2cdb686a7858de8"
                         },
                         "ca-central-1": {
-                            "release": "31.20200323.2.1",
-                            "image": "ami-0afc8050e2aa9ce88"
+                            "release": "31.20200407.2.2",
+                            "image": "ami-07a373fbeffca5743"
                         },
                         "eu-central-1": {
-                            "release": "31.20200323.2.1",
-                            "image": "ami-0fa41bdfea0794863"
+                            "release": "31.20200407.2.2",
+                            "image": "ami-06411563f4df4abdc"
                         },
                         "eu-north-1": {
-                            "release": "31.20200323.2.1",
-                            "image": "ami-01dacef6ebde8d587"
+                            "release": "31.20200407.2.2",
+                            "image": "ami-08b340d116dbf7f1b"
                         },
                         "eu-west-1": {
-                            "release": "31.20200323.2.1",
-                            "image": "ami-0937155c37c4f80ee"
+                            "release": "31.20200407.2.2",
+                            "image": "ami-01d18cdab50669e5c"
                         },
                         "eu-west-2": {
-                            "release": "31.20200323.2.1",
-                            "image": "ami-02362031b075668b1"
+                            "release": "31.20200407.2.2",
+                            "image": "ami-0134fe6726d831b8c"
                         },
                         "eu-west-3": {
-                            "release": "31.20200323.2.1",
-                            "image": "ami-0f60161f9b92d1058"
+                            "release": "31.20200407.2.2",
+                            "image": "ami-0461f78fb65301095"
                         },
                         "me-south-1": {
-                            "release": "31.20200323.2.1",
-                            "image": "ami-0f3a3d886e86594af"
+                            "release": "31.20200407.2.2",
+                            "image": "ami-0306638a7f7246104"
                         },
                         "sa-east-1": {
-                            "release": "31.20200323.2.1",
-                            "image": "ami-0fb66e45777e98c49"
+                            "release": "31.20200407.2.2",
+                            "image": "ami-0742e146563fd0125"
                         },
                         "us-east-1": {
-                            "release": "31.20200323.2.1",
-                            "image": "ami-04f3f431993686d5e"
+                            "release": "31.20200407.2.2",
+                            "image": "ami-004418e3c139e4d53"
                         },
                         "us-east-2": {
-                            "release": "31.20200323.2.1",
-                            "image": "ami-04dcc591b7dcc494d"
+                            "release": "31.20200407.2.2",
+                            "image": "ami-0dcdb8b6c1c48d586"
                         },
                         "us-west-1": {
-                            "release": "31.20200323.2.1",
-                            "image": "ami-046469cb880d74c48"
+                            "release": "31.20200407.2.2",
+                            "image": "ami-046a5b1957a20cbe9"
                         },
                         "us-west-2": {
-                            "release": "31.20200323.2.1",
-                            "image": "ami-0fd2ed6d4ef7ef9ed"
+                            "release": "31.20200407.2.2",
+                            "image": "ami-0dbecfc6d99686fb4"
                         }
                     }
                 }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,11 +1,11 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2020-03-25T23:08:32Z"
+    "last-modified": "2020-04-09T14:14:07Z"
   },
   "releases": [
     {
-      "version": "31.20200223.3.0",
+      "version": "31.20200310.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -13,10 +13,10 @@
       }
     },
     {
-      "version": "31.20200310.3.0",
+      "version": "31.20200323.3.2",
       "metadata": {
         "rollout": {
-          "start_epoch": 1585231200,
+          "start_epoch": 1586442600,
           "start_percentage": 0.0,
           "duration_minutes": 2880
         }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2020-03-31T20:29:32Z"
+    "last-modified": "2020-04-09T14:14:07Z"
   },
   "releases": [
     {
@@ -21,7 +21,7 @@
       }
     },
     {
-      "version": "31.20200323.2.0",
+      "version": "31.20200323.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -29,10 +29,10 @@
       }
     },
     {
-      "version": "31.20200323.2.1",
+      "version": "31.20200407.2.2",
       "metadata": {
         "rollout": {
-          "start_epoch": 1585749600,
+          "start_epoch": 1586442600,
           "start_percentage": 0.0,
           "duration_minutes": 2880
         }


### PR DESCRIPTION
This contains two rollouts:
 * stable, 31.20200323.3.2
 * testing, 31.20200407.2.2