### PR TITLE
next: rollout 32.20200416.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,4 @@ syntax-check:
 
 .PHONY: print-rollouts
 print-rollouts:
-	@find updates -iname '*.json' | xargs -n 1 python3 -c '\
-	import json, sys, datetime; \
-	update = json.load(open(sys.argv[1])); \
-	stream = update["stream"]; \
-	release = update["releases"][-1]; \
-	version = release["version"]; \
-	rollout = release["metadata"]["rollout"]; \
-	ts = datetime.datetime.fromtimestamp(rollout["start_epoch"]); \
-	mins = rollout["duration_minutes"]; \
-	hrs = mins / 60.0; \
-	print(f"{stream} rollout of {version} scheduled for {ts} UTC for {mins}m ({hrs}h)");'
+	@find updates -iname '*.json' | xargs -n 1 python3 print-rollout.py

--- a/print-rollout.py
+++ b/print-rollout.py
@@ -1,0 +1,12 @@
+import json, sys, datetime
+
+update = json.load(open(sys.argv[1]))
+stream = update["stream"]
+release = update["releases"][-1]
+version = release["version"]
+rollout = release["metadata"]["rollout"]
+ts = datetime.datetime.fromtimestamp(rollout["start_epoch"])
+mins = rollout["duration_minutes"]
+hrs = mins / 60.0
+
+print(f"{stream} rollout of {version} scheduled for {ts} UTC for {mins}m ({hrs}h)")

--- a/print-rollout.py
+++ b/print-rollout.py
@@ -5,8 +5,13 @@ stream = update["stream"]
 release = update["releases"][-1]
 version = release["version"]
 rollout = release["metadata"]["rollout"]
-ts = datetime.datetime.fromtimestamp(rollout["start_epoch"])
-mins = rollout["duration_minutes"]
-hrs = mins / 60.0
 
-print(f"{stream} rollout of {version} scheduled for {ts} UTC for {mins}m ({hrs}h)")
+start_percentage = rollout["start_percentage"]
+# totally just going to ignore floating-point concerns here
+if int(start_percentage * 100) == 100:
+    print(f"{stream} rollout of {version} at 100%")
+else:
+    ts = datetime.datetime.fromtimestamp(rollout["start_epoch"])
+    mins = rollout["duration_minutes"]
+    hrs = mins / 60.0
+    print(f"{stream} rollout of {version} scheduled for {ts} UTC for {mins}m ({hrs}h)")

--- a/streams/next.json
+++ b/streams/next.json
@@ -1,0 +1,236 @@
+{
+    "stream": "next",
+    "metadata": {
+        "last-modified": "2020-04-17T18:58:39Z"
+    },
+    "architectures": {
+        "x86_64": {
+            "artifacts": {
+                "aliyun": {
+                    "release": "32.20200416.1.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d7e244120a28b3e9eb2eac057c5aa4f523e29e28863645d64e1b99f932ab0432"
+                            }
+                        }
+                    }
+                },
+                "aws": {
+                    "release": "32.20200416.1.0",
+                    "formats": {
+                        "vmdk.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "cdfa273b7a304cf8fa906427e8819f6f7aef860375bd7c9ea5d7becc90a8c5ee"
+                            }
+                        }
+                    }
+                },
+                "azure": {
+                    "release": "32.20200416.1.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "aca58b40218b5a2d39c8fdaad16cc7f7bac099cf43745a866ea556a474255c38"
+                            }
+                        }
+                    }
+                },
+                "digitalocean": {
+                    "release": "32.20200416.1.0",
+                    "formats": {
+                        "qcow2.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "3404613072ee33e4e7f60e4775a2f26df08719c856bed880eab462ee454eb943"
+                            }
+                        }
+                    }
+                },
+                "exoscale": {
+                    "release": "32.20200416.1.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "28897e7ffd4edbcf3203515f653c499fe9f652f17859040ef389cbb67d5df1a2"
+                            }
+                        }
+                    }
+                },
+                "gcp": {
+                    "release": "32.20200416.1.0",
+                    "formats": {
+                        "tar.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "3576b494de3742e4a378423676c88f1d115077038094cd350ccace6fd02999c5"
+                            }
+                        }
+                    }
+                },
+                "metal": {
+                    "release": "32.20200416.1.0",
+                    "formats": {
+                        "4k.raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "cb070b945b31a5f8fb33610994018a04a9c4730a763b6a208476b531144ae3bc"
+                            }
+                        },
+                        "iso": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-live.x86_64.iso.sig",
+                                "sha256": "93dc3c552dd3d54b9930cbdb7e9823d8d29403252e8edf813f84ae752cafce10"
+                            }
+                        },
+                        "pxe": {
+                            "kernel": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-live-kernel-x86_64.sig",
+                                "sha256": "a3517751688bc60e549dd83bc3d8527f7f0abe1dadf6a0b5d1e961132b3f64d4"
+                            },
+                            "initramfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "f3b73ccf950160c98e57e879b899cd7cc3dffaa0b029a2eff3f74f9e42cab6c1"
+                            }
+                        },
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "d1c3c47ded04ad716efda38165af6eda9b31213cff9442c839b8d9166380c5fa"
+                            }
+                        }
+                    }
+                },
+                "openstack": {
+                    "release": "32.20200416.1.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "364c1dd3bb802c8061d6e2ac0d63ff035c7fa5edd11f5616af65a21570b49982"
+                            }
+                        }
+                    }
+                },
+                "qemu": {
+                    "release": "32.20200416.1.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "f8053e10ee0dffd760ad5f4c29f9bf8874115b0d5cb36b11fd2b44368422af90"
+                            }
+                        }
+                    }
+                },
+                "vmware": {
+                    "release": "32.20200416.1.0",
+                    "formats": {
+                        "ova": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200416.1.0/x86_64/fedora-coreos-32.20200416.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "03719bcefd87b215fa6057aa32c089d8fbf4635f095ba0a72bb09181f80f7d83"
+                            }
+                        }
+                    }
+                }
+            },
+            "images": {
+                "aws": {
+                    "regions": {
+                        "ap-east-1": {
+                            "release": "32.20200416.1.0",
+                            "image": "ami-093e73aab799b2585"
+                        },
+                        "ap-northeast-1": {
+                            "release": "32.20200416.1.0",
+                            "image": "ami-0c42e1789ecccbf2a"
+                        },
+                        "ap-northeast-2": {
+                            "release": "32.20200416.1.0",
+                            "image": "ami-0dee65e8f8218a996"
+                        },
+                        "ap-south-1": {
+                            "release": "32.20200416.1.0",
+                            "image": "ami-0202f6af0f81b44db"
+                        },
+                        "ap-southeast-1": {
+                            "release": "32.20200416.1.0",
+                            "image": "ami-0fdf3ca75f4517b22"
+                        },
+                        "ap-southeast-2": {
+                            "release": "32.20200416.1.0",
+                            "image": "ami-0c39a30b8f138e140"
+                        },
+                        "ca-central-1": {
+                            "release": "32.20200416.1.0",
+                            "image": "ami-059b71d958725a5c4"
+                        },
+                        "eu-central-1": {
+                            "release": "32.20200416.1.0",
+                            "image": "ami-07b58d816b52d56da"
+                        },
+                        "eu-north-1": {
+                            "release": "32.20200416.1.0",
+                            "image": "ami-0b8838b608e337c17"
+                        },
+                        "eu-west-1": {
+                            "release": "32.20200416.1.0",
+                            "image": "ami-0aecb8331b30eff66"
+                        },
+                        "eu-west-2": {
+                            "release": "32.20200416.1.0",
+                            "image": "ami-01f59a5308f5434e9"
+                        },
+                        "eu-west-3": {
+                            "release": "32.20200416.1.0",
+                            "image": "ami-0194edad0ac5e1545"
+                        },
+                        "me-south-1": {
+                            "release": "32.20200416.1.0",
+                            "image": "ami-0dc08ca255e507c0d"
+                        },
+                        "sa-east-1": {
+                            "release": "32.20200416.1.0",
+                            "image": "ami-0664d4354fb3750cf"
+                        },
+                        "us-east-1": {
+                            "release": "32.20200416.1.0",
+                            "image": "ami-0ebb2a14a7ffedce8"
+                        },
+                        "us-east-2": {
+                            "release": "32.20200416.1.0",
+                            "image": "ami-02befa6747a085f46"
+                        },
+                        "us-west-1": {
+                            "release": "32.20200416.1.0",
+                            "image": "ami-0031f6f396cdeb05d"
+                        },
+                        "us-west-2": {
+                            "release": "32.20200416.1.0",
+                            "image": "ami-0a0b3e8cf399d2056"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,0 +1,16 @@
+{
+  "stream": "next",
+  "metadata": {
+    "last-modified": "2020-04-17T18:59:10Z"
+  },
+  "releases": [
+    {
+      "version": "32.20200416.1.0",
+      "metadata": {
+        "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This is the first release, so there's nothing actually to update *from*
within this stream. Hence why the update rollout is already at 1.0.