### PR TITLE
issue template: add notes about creating tickets for next release

### DIFF
--- a/ISSUE_TEMPLATE/next.md
+++ b/ISSUE_TEMPLATE/next.md
@@ -87,3 +87,8 @@ curl -H 'Accept: application/json' 'https://updates.coreos.fedoraproject.org/v1/
 ```
 
 NOTE: In the future, most of these steps will be automated and a syncer will push the updated metadata to S3.
+
+## Open an issue for the next release
+
+- [ ] Open an issue in this repo with the approximate date in the title of the next release in this stream.
+  - Add the `jira` label to the ticket

--- a/ISSUE_TEMPLATE/stable.md
+++ b/ISSUE_TEMPLATE/stable.md
@@ -87,3 +87,8 @@ curl -H 'Accept: application/json' 'https://updates.coreos.fedoraproject.org/v1/
 ```
 
 NOTE: In the future, most of these steps will be automated and a syncer will push the updated metadata to S3.
+
+## Open an issue for the next release
+
+- [ ] Open an issue in this repo with the approximate date in the title of the next release in this stream.
+  - Add the `jira` label to the ticket

--- a/ISSUE_TEMPLATE/testing.md
+++ b/ISSUE_TEMPLATE/testing.md
@@ -87,3 +87,8 @@ curl -H 'Accept: application/json' 'https://updates.coreos.fedoraproject.org/v1/
 ```
 
 NOTE: In the future, most of these steps will be automated and a syncer will push the updated metadata to S3.
+
+## Open an issue for the next release
+
+- [ ] Open an issue in this repo with the approximate date in the title of the next release in this stream.
+  - Add the `jira` label to the ticket


### PR DESCRIPTION
Each time we finish up a release let's create the tickets for the next
one. This will allow for us to plan appropriately for them and also make
sure any scheduling conflicts are addressed early.