### PR TITLE
updates/testing: remove previous rollout

### DIFF
--- a/updates/testing.json
+++ b/updates/testing.json
@@ -21,14 +21,6 @@
       }
     },
     {
-      "version": "31.20200505.2.0",
-      "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        }
-      }
-    },
-    {
       "version": "31.20200505.2.1",
       "metadata": {
         "rollout": {


### PR DESCRIPTION
As a mild mitigation for
https://github.com/coreos/fedora-coreos-tracker/issues/481, let's remove
the previous rollout from the graph so that no more nodes get into that
state.