### PR TITLE
templates: don't manually sync to S3 anymore 

### DIFF
--- a/ISSUE_TEMPLATE/next.md
+++ b/ISSUE_TEMPLATE/next.md
@@ -73,12 +73,7 @@ A reviewer can validate the `start_epoch` time by running `date -u -d @<EPOCH>`.
 - [ ] Commit the changes and open a PR against the repo.
 - [ ] Post a link to the PR as a comment to this issue
 - [ ] Wait for the PR to be approved.
-- [ ] Once approved, merge it and push the content to S3:
-
-```
-aws s3 sync --acl public-read --cache-control 'max-age=60' --exclude '*' --include 'streams/*' --include 'updates/*' . s3://fcos-builds
-```
-
+- [ ] Once approved, merge it and verify that the `sync-stream-metadata` job syncs the contents to S3
 - [ ] Verify the new version shows up on [the download page](https://getfedora.org/en/coreos/download/)
 - [ ] Verify the incoming edges are showing up in the update graph:
 
@@ -86,7 +81,7 @@ aws s3 sync --acl public-read --cache-control 'max-age=60' --exclude '*' --inclu
 curl -H 'Accept: application/json' 'https://updates.coreos.fedoraproject.org/v1/graph?basearch=x86_64&stream=next&rollout_wariness=0'
 ```
 
-NOTE: In the future, most of these steps will be automated and a syncer will push the updated metadata to S3.
+NOTE: In the future, most of these steps will be automated.
 
 ## Open an issue for the next release
 

--- a/ISSUE_TEMPLATE/stable.md
+++ b/ISSUE_TEMPLATE/stable.md
@@ -73,12 +73,7 @@ A reviewer can validate the `start_epoch` time by running `date -u -d @<EPOCH>`.
 - [ ] Commit the changes and open a PR against the repo.
 - [ ] Post a link to the PR as a comment to this issue
 - [ ] Wait for the PR to be approved.
-- [ ] Once approved, merge it and push the content to S3:
-
-```
-aws s3 sync --acl public-read --cache-control 'max-age=60' --exclude '*' --include 'streams/*' --include 'updates/*' . s3://fcos-builds
-```
-
+- [ ] Once approved, merge it and verify that the `sync-stream-metadata` job syncs the contents to S3
 - [ ] Verify the new version shows up on [the download page](https://getfedora.org/en/coreos/download/)
 - [ ] Verify the incoming edges are showing up in the update graph:
 
@@ -86,7 +81,7 @@ aws s3 sync --acl public-read --cache-control 'max-age=60' --exclude '*' --inclu
 curl -H 'Accept: application/json' 'https://updates.coreos.fedoraproject.org/v1/graph?basearch=x86_64&stream=stable&rollout_wariness=0'
 ```
 
-NOTE: In the future, most of these steps will be automated and a syncer will push the updated metadata to S3.
+NOTE: In the future, most of these steps will be automated.
 
 ## Open an issue for the next release
 

--- a/ISSUE_TEMPLATE/testing.md
+++ b/ISSUE_TEMPLATE/testing.md
@@ -73,12 +73,7 @@ A reviewer can validate the `start_epoch` time by running `date -u -d @<EPOCH>`.
 - [ ] Commit the changes and open a PR against the repo.
 - [ ] Post a link to the PR as a comment to this issue
 - [ ] Wait for the PR to be approved.
-- [ ] Once approved, merge it and push the content to S3:
-
-```
-aws s3 sync --acl public-read --cache-control 'max-age=60' --exclude '*' --include 'streams/*' --include 'updates/*' . s3://fcos-builds
-```
-
+- [ ] Once approved, merge it and verify that the `sync-stream-metadata` job syncs the contents to S3
 - [ ] Verify the new version shows up on [the download page](https://getfedora.org/en/coreos/download/)
 - [ ] Verify the incoming edges are showing up in the update graph:
 
@@ -86,7 +81,7 @@ aws s3 sync --acl public-read --cache-control 'max-age=60' --exclude '*' --inclu
 curl -H 'Accept: application/json' 'https://updates.coreos.fedoraproject.org/v1/graph?basearch=x86_64&stream=testing&rollout_wariness=0'
 ```
 
-NOTE: In the future, most of these steps will be automated and a syncer will push the updated metadata to S3.
+NOTE: In the future, most of these steps will be automated.
 
 ## Open an issue for the next release
 

--- a/release-prereqs.md
+++ b/release-prereqs.md
@@ -2,9 +2,8 @@
 
 - access to the official CentOS CI fedora-coreos namespace
 - access to the AWS S3 fcos-builds bucket
-- the following packages installed: `awscli gnupg2 git`
+- the following packages installed: `awscli git`
 - [`fedora-coreos-stream-generator`](https://github.com/coreos/fedora-coreos-stream-generator/)
-- your GPG key linked to your FAS account
 - a checkout and GitHub fork of [`this repo`](https://github.com/coreos/fedora-coreos-streams)
 - a checkout and GitHub fork of [`fedora-coreos-config`](https://github.com/coreos/fedora-coreos-config)
 - a checkout of [`fedora-coreos-releng-automation`](https://github.com/coreos/fedora-coreos-releng-automation)

--- a/release-prereqs.md
+++ b/release-prereqs.md
@@ -1,8 +1,6 @@
 # Prerequisites for performing a release
 
 - access to the official CentOS CI fedora-coreos namespace
-- access to the AWS S3 fcos-builds bucket
-- the following packages installed: `awscli git`
 - [`fedora-coreos-stream-generator`](https://github.com/coreos/fedora-coreos-stream-generator/)
 - a checkout and GitHub fork of [`this repo`](https://github.com/coreos/fedora-coreos-streams)
 - a checkout and GitHub fork of [`fedora-coreos-config`](https://github.com/coreos/fedora-coreos-config)


### PR DESCRIPTION
We have a job that does that now:

coreos/fedora-coreos-pipeline#236

This allows us to drop the requirement on releasers having direct access
to the S3 bucket.