### PR TITLE
updates: stop all rollouts

### DIFF
--- a/print-rollout.py
+++ b/print-rollout.py
@@ -2,9 +2,17 @@ import json, sys, datetime
 
 update = json.load(open(sys.argv[1]))
 stream = update["stream"]
+releases = update.get("releases", None)
+if not releases:
+    print(f"{stream} has no rollouts")
+    sys.exit(0)
 release = update["releases"][-1]
 version = release["version"]
-rollout = release["metadata"]["rollout"]
+rollout = release["metadata"].get("rollout", None)
+if not rollout:
+    print(f"latest entry {version} on {stream} is not a rollout")
+    sys.exit(0)
+
 
 start_percentage = rollout["start_percentage"]
 # totally just going to ignore floating-point concerns here

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,26 +1,8 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2020-05-07T00:18:08Z"
+    "last-modified": "2020-05-19T15:47:08Z"
   },
   "releases": [
-    {
-      "version": "32.20200416.1.0",
-      "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        }
-      }
-    },
-    {
-      "version": "32.20200505.1.0",
-      "metadata": {
-        "rollout": {
-          "start_epoch": 1588860000,
-          "start_percentage": 0.0,
-          "duration_minutes": 2880
-        }
-      }
-    }
   ]
 }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,26 +1,8 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2020-05-06T20:47:12Z"
+    "last-modified": "2020-05-19T15:47:12Z"
   },
   "releases": [
-    {
-      "version": "31.20200407.3.0",
-      "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        }
-      }
-    },
-    {
-      "version": "31.20200420.3.0",
-      "metadata": {
-        "rollout": {
-          "start_epoch": 1588860000,
-          "start_percentage": 0.0,
-          "duration_minutes": 2880
-        }
-      }
-    }
   ]
 }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2020-05-14T02:52:29Z"
+    "last-modified": "2020-05-19T15:46:29Z"
   },
   "releases": [
     {
@@ -17,16 +17,6 @@
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-streams/issues/30"
-        }
-      }
-    },
-    {
-      "version": "31.20200505.2.1",
-      "metadata": {
-        "rollout": {
-          "start_epoch": 1589464800,
-          "start_percentage": 0.0,
-          "duration_minutes": 2880
         }
       }
     }


### PR DESCRIPTION
This drops all completed rollouts, mitigating rpm-ostree bug
while preparing for the next triple round of releases.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/481