### PR TITLE
updates: stop all rollouts

### DIFF
--- a/updates/next.json
+++ b/updates/next.json
@@ -1,18 +1,8 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2020-05-19T19:38:23Z"
+    "last-modified": "2020-06-02T20:25:43Z"
   },
   "releases": [
-    {
-      "version": "32.20200517.1.0",
-      "metadata": {
-        "rollout": {
-          "start_epoch": 1589920200,
-          "start_percentage": 0.0,
-          "duration_minutes": 2880
-        }
-      }
-    }
   ]
 }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,18 +1,8 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2020-05-19T19:38:23Z"
+    "last-modified": "2020-06-02T20:25:43Z"
   },
   "releases": [
-    {
-      "version": "31.20200505.3.0",
-      "metadata": {
-        "rollout": {
-          "start_epoch": 1589920200,
-          "start_percentage": 0.0,
-          "duration_minutes": 2880
-        }
-      }
-    }
   ]
 }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2020-05-19T19:38:23Z"
+    "last-modified": "2020-06-02T20:25:43Z"
   },
   "releases": [
     {
@@ -17,16 +17,6 @@
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-streams/issues/30"
-        }
-      }
-    },
-    {
-      "version": "31.20200517.2.0",
-      "metadata": {
-        "rollout": {
-          "start_epoch": 1589920200,
-          "start_percentage": 0.0,
-          "duration_minutes": 2880
         }
       }
     }


### PR DESCRIPTION
This drops all completed rollouts, mitigating rpm-ostree bug
while preparing for the next triple round of releases.