### PR TITLE
updates: triple rollout on 2020-06-03

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,153 +1,153 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2020-05-19T19:36:30Z"
+        "last-modified": "2020-06-03T15:08:25Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "32.20200517.1.0",
+                    "release": "32.20200601.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "00d463bb75ae98d723ae03ba50dc38a4790fd88dcf5767a2753b7758a70a9662"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8fff1967cd2b5d336a18c2f1fb1bd566590a1e6226603d4b100765f3bedd3e62"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "32.20200517.1.0",
+                    "release": "32.20200601.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "ace6a2226cb9142cdcc41f00849bcbe45e761f9c9b339e7fa4a9ed79fadf363b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "475027a12808c7b2298dfcb32028605147aa14a25fc9067b728ba0d0257347dd"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "32.20200517.1.0",
+                    "release": "32.20200601.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "fad529db18348874827d4ef8522ff36748dedca723355e4d60069045e39be3ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "7aea719e29139a98ddcf2c41f526eb8082edf6a459619ec51a18a0cd578cbd90"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "32.20200517.1.0",
+                    "release": "32.20200601.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "4c10662859cc7cc6a43977fcc252afb164a2c1b5011f88052290dcebbee7686c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "030c9cd76c706193d58576152c66455e885b2e1d5273194d005001a109b4ca06"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "32.20200517.1.0",
+                    "release": "32.20200601.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "e848f301b01270df0f188fe8d07907897b1cf03fc4f899275489f7b20a651a22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "122e3e5a59d8f001ba4a18ac19c939532779440bde7eac0e553da30484244627"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "32.20200517.1.0",
+                    "release": "32.20200601.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "b64998376b63a9408ffcc3d91eee8e077628008de70e47160603818806521db1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "620222c7c97d5efa4f495c3fc6cd5e5fdf9ccca41dc42919f2adfcf44a09b4ed"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "32.20200517.1.0",
+                    "release": "32.20200601.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "34d617f81146d9dfa2e836356a20496e1b89a55d9160cb154f7253258e9f3899"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "9fac81d714cc6ed76ef37eb077881bac07ab33675b448dfd673e79387de42f28"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-live.x86_64.iso.sig",
-                                "sha256": "785488d8fab61653fd1b140a91ce20a5661c6e0bc2483ce3d73a2c47b1ef736f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-live.x86_64.iso.sig",
+                                "sha256": "240aa5be802a21f3ff9e39d3101159a69b235c29df7301e029ddac263edbc713"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-live-kernel-x86_64.sig",
-                                "sha256": "d7c5d2f02679d777374cf377ed6ebaa3e0dae35c02200a6f6bcb1c9a1af280dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-live-kernel-x86_64.sig",
+                                "sha256": "34869fe6d5ed7e83e0873f348450f65e8800005620f8b736dcc610b5bfbf61da"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "15f619bd80a7a1e788127b2052a848a432ffb181d562a1afa662259c75e85203"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "c1e2a951a93079b49c48e93e7ef1d30489f153f6d89b8c4be1871a5061d326c7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "077de411d530ea98833e4cdc227611804dd2bf46933ae1087eee98be061b368e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "7c34315e25537ce0c92001f0c6bac641126e097c7b8ab5123ba5eb9f42acf048"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "32.20200517.1.0",
+                    "release": "32.20200601.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "19d880d6a0dcc92bc2082640a2020916c6d3c24d2adefe101d56b673a4569d1a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "16731de146050436fc1448489642255eef6b0bd2c169384cc4a81d6c4a3d7b18"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "32.20200517.1.0",
+                    "release": "32.20200601.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "80ab634f89a3d808725266734e7f9f1cbb2b7c941f064d9beac2f747cf3a36c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "657068bab61b58e18608889d07c1a81c52635a6c0c54c05de610218efc176454"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "32.20200517.1.0",
+                    "release": "32.20200601.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "6ce75595c52df824765c41e870d5e76001b9994e0c3a9c286b4b87e7c16e8712"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "2bda3dafb197fb43eb06be7c2eccf060223aa3f4926623f0651baba931737937"
                             }
                         }
                     }
@@ -157,80 +157,80 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "32.20200517.1.0",
-                            "image": "ami-05f3ff9faa0f90664"
+                            "release": "32.20200601.1.0",
+                            "image": "ami-031a226ead52c6a0b"
                         },
                         "ap-east-1": {
-                            "release": "32.20200517.1.0",
-                            "image": "ami-04ca68d955fa2d222"
+                            "release": "32.20200601.1.0",
+                            "image": "ami-0e5d0ae8b34aec2ea"
                         },
                         "ap-northeast-1": {
-                            "release": "32.20200517.1.0",
-                            "image": "ami-085b8396cbf82a95c"
+                            "release": "32.20200601.1.0",
+                            "image": "ami-0b2137b9f3521b964"
                         },
                         "ap-northeast-2": {
-                            "release": "32.20200517.1.0",
-                            "image": "ami-0d5f9c627fc71f4a8"
+                            "release": "32.20200601.1.0",
+                            "image": "ami-016b54ea53ee8769a"
                         },
                         "ap-south-1": {
-                            "release": "32.20200517.1.0",
-                            "image": "ami-038871f707029b3b1"
+                            "release": "32.20200601.1.0",
+                            "image": "ami-0d298f93d930877d2"
                         },
                         "ap-southeast-1": {
-                            "release": "32.20200517.1.0",
-                            "image": "ami-054195b32b288b68f"
+                            "release": "32.20200601.1.0",
+                            "image": "ami-0e533ac6f97783a51"
                         },
                         "ap-southeast-2": {
-                            "release": "32.20200517.1.0",
-                            "image": "ami-066bb2a3b78994a2f"
+                            "release": "32.20200601.1.0",
+                            "image": "ami-0d275d07ac06238f7"
                         },
                         "ca-central-1": {
-                            "release": "32.20200517.1.0",
-                            "image": "ami-01fc7f476bda136d5"
+                            "release": "32.20200601.1.0",
+                            "image": "ami-02da5cac4928be9b5"
                         },
                         "eu-central-1": {
-                            "release": "32.20200517.1.0",
-                            "image": "ami-0cf481c5aef9037c8"
+                            "release": "32.20200601.1.0",
+                            "image": "ami-0fe2120bdc07724f1"
                         },
                         "eu-north-1": {
-                            "release": "32.20200517.1.0",
-                            "image": "ami-0cd42e41bb157bb00"
+                            "release": "32.20200601.1.0",
+                            "image": "ami-0da15c103a586b233"
                         },
                         "eu-west-1": {
-                            "release": "32.20200517.1.0",
-                            "image": "ami-0d876d99e62536481"
+                            "release": "32.20200601.1.0",
+                            "image": "ami-08e89319497046ca6"
                         },
                         "eu-west-2": {
-                            "release": "32.20200517.1.0",
-                            "image": "ami-00553cd4e9b6e1a9d"
+                            "release": "32.20200601.1.0",
+                            "image": "ami-08a293a50d5f4ddf8"
                         },
                         "eu-west-3": {
-                            "release": "32.20200517.1.0",
-                            "image": "ami-0dc432956fb5c3939"
+                            "release": "32.20200601.1.0",
+                            "image": "ami-0b710583e1f7e21b6"
                         },
                         "me-south-1": {
-                            "release": "32.20200517.1.0",
-                            "image": "ami-0bfc9c2cf6afdcd24"
+                            "release": "32.20200601.1.0",
+                            "image": "ami-0bdcadaef7543f4be"
                         },
                         "sa-east-1": {
-                            "release": "32.20200517.1.0",
-                            "image": "ami-0935bb3853ee0f209"
+                            "release": "32.20200601.1.0",
+                            "image": "ami-05ed8f35d677fe268"
                         },
                         "us-east-1": {
-                            "release": "32.20200517.1.0",
-                            "image": "ami-090641efb77c55d6f"
+                            "release": "32.20200601.1.0",
+                            "image": "ami-0204bc26cf653fabf"
                         },
                         "us-east-2": {
-                            "release": "32.20200517.1.0",
-                            "image": "ami-09ab09cdd1c2f82d2"
+                            "release": "32.20200601.1.0",
+                            "image": "ami-0ebb81d9f24b8ddfa"
                         },
                         "us-west-1": {
-                            "release": "32.20200517.1.0",
-                            "image": "ami-04e352e77ea99e353"
+                            "release": "32.20200601.1.0",
+                            "image": "ami-0ffb253fdd8107b4f"
                         },
                         "us-west-2": {
-                            "release": "32.20200517.1.0",
-                            "image": "ami-01ab4e24c74d7448a"
+                            "release": "32.20200601.1.0",
+                            "image": "ami-0dc22ab962bfdf162"
                         }
                     }
                 }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,153 +1,153 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2020-05-19T19:33:53Z"
+        "last-modified": "2020-06-03T15:08:25Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "31.20200505.3.0",
+                    "release": "31.20200517.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "aa50fe0fba38c0797604158655b9a14a2471b25cda1f0390ebef36c8c2ea4741"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "34d51f74e6fc0e06cb3da946eab0dddafa3ad0109a3f7af9026c95faeaa154d8"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "31.20200505.3.0",
+                    "release": "31.20200517.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "6f2d0da079acf3aac7ec7508f1971fbe9145f5b5f0379135af83ae5e0ff812cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "38f25ced594c00115f557b088461c742b02bc8d8110192904eb45a5f34dd857f"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "31.20200505.3.0",
+                    "release": "31.20200517.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "3f56be0f9c29a95afc857f70ecff865e20273132f54bc17a11b8b1f5c757a73f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "c2a7a1376563248a44dec39cb943394e58f8de7c355ea9fc52977ff625059068"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "31.20200505.3.0",
+                    "release": "31.20200517.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "2c7233849aebfdb3291c96cb4ea19e4c181a0b9b808ca5f65e31eb50d20db757"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "88936467b569df3ed3eee8c41d47a8883dcfe4144026dd165f76eab3f9363246"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "31.20200505.3.0",
+                    "release": "31.20200517.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "9ca6e4c8c7d482e90063b978946ddfe74f2d4c9081056a93b9f3ce35bbf5d2b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "acfb64870db2d5ec49dce06e3212b3b926dbc4d5f8b1048bef4da46e497a9358"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "31.20200505.3.0",
+                    "release": "31.20200517.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "a8a8f698657a4d14f73292bc8629017ddc1b96f84daaaca0a939b1358f989447"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "e7a766cbba51fc35cb55d471c42ecc824519c6a3bd8a95577749676aeebf9b9c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "31.20200505.3.0",
+                    "release": "31.20200517.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "2d92660889b4a1bc28ed7d8df976a68af6d1558bdbc4a63cf2882cefaaf7c2d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "248986204e24a2d11847620ec3d0a290ad12c339f0b8c8656a107512b95d0da8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-live.x86_64.iso.sig",
-                                "sha256": "71c8fcb35812233e827cbfdcf33b9f97685ff5e909f7506794101c5742d7bad6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-live.x86_64.iso.sig",
+                                "sha256": "9b2267b6d55f83b3345dbab8c6861c62b19d85101c3b95b2b1d43583c0951961"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-live-kernel-x86_64.sig",
-                                "sha256": "a4d0cd9c916d02e15fa681ad4a9fe67334d972fef842700466f85a15929c3dbb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-live-kernel-x86_64.sig",
+                                "sha256": "345fd70d5aa0be344592853410100439f8733895c3e1856fa496ed4a3d02db86"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "01a467d0af6b127e444b500865965ae953bedd8dcd83f63065c5f9f8a4fabd0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "77a77e8842b737c590a49d77e45e2a6176d3d7570911d93e2fa2f97b8f951269"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "61135394e56af8b3212c2206525b3a0ea2f0d1c2c06e300b7c6d599f29618bca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "ebc38a6274888c95f42c4eaf76bdac69dcc72bdf090d604c8f84f9a42600f85d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "31.20200505.3.0",
+                    "release": "31.20200517.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "16c0ba644c438d31522c8d34fd3e03b4bc2c03008ae07a3036190b0cb8f93b26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "472b8ff779a03cb80d11c2bd8dfd96ee113018651849d80ff7fbed8453a05267"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "31.20200505.3.0",
+                    "release": "31.20200517.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "0057f323f54b0cb71652235cd6221810fca33176ad62ef62763c38125c38f740"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "4d5fff3348d7eff3b08a38948c1349dfaeaefc9fcb89b8d7443e2f276bbb271b"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "31.20200505.3.0",
+                    "release": "31.20200517.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200505.3.0/x86_64/fedora-coreos-31.20200505.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "51e0698555ce4c00f1dbaaedbb7de3fb2b566fd92954f57e673c1652c6441c45"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200517.3.0/x86_64/fedora-coreos-31.20200517.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "d09acb71382425b907ef7a12a369c70f0fa92aa6fd3753ff3a84f5c05e5c2fee"
                             }
                         }
                     }
@@ -157,80 +157,80 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "31.20200505.3.0",
-                            "image": "ami-06f63418f0044ba2d"
+                            "release": "31.20200517.3.0",
+                            "image": "ami-0d47ed06c0da2a001"
                         },
                         "ap-east-1": {
-                            "release": "31.20200505.3.0",
-                            "image": "ami-01afcca45e4e97dbd"
+                            "release": "31.20200517.3.0",
+                            "image": "ami-0bc86929b5ba42c36"
                         },
                         "ap-northeast-1": {
-                            "release": "31.20200505.3.0",
-                            "image": "ami-086276499c8fec53f"
+                            "release": "31.20200517.3.0",
+                            "image": "ami-0db249851af0aa8da"
                         },
                         "ap-northeast-2": {
-                            "release": "31.20200505.3.0",
-                            "image": "ami-0e58b4605c482872c"
+                            "release": "31.20200517.3.0",
+                            "image": "ami-013e786934df5d8e4"
                         },
                         "ap-south-1": {
-                            "release": "31.20200505.3.0",
-                            "image": "ami-0295f8b20527c6b09"
+                            "release": "31.20200517.3.0",
+                            "image": "ami-0e2faeaf24b071233"
                         },
                         "ap-southeast-1": {
-                            "release": "31.20200505.3.0",
-                            "image": "ami-0bd765e5383598c97"
+                            "release": "31.20200517.3.0",
+                            "image": "ami-01ea8473a3af70e7b"
                         },
                         "ap-southeast-2": {
-                            "release": "31.20200505.3.0",
-                            "image": "ami-0c897a15b3719d75d"
+                            "release": "31.20200517.3.0",
+                            "image": "ami-03a8cccf58b5781f4"
                         },
                         "ca-central-1": {
-                            "release": "31.20200505.3.0",
-                            "image": "ami-03f274eee93d3b757"
+                            "release": "31.20200517.3.0",
+                            "image": "ami-067aee3ee45182ddb"
                         },
                         "eu-central-1": {
-                            "release": "31.20200505.3.0",
-                            "image": "ami-0e88f38a08edfc8f5"
+                            "release": "31.20200517.3.0",
+                            "image": "ami-0bc4a7615242d57b5"
                         },
                         "eu-north-1": {
-                            "release": "31.20200505.3.0",
-                            "image": "ami-0910c6b5061728e8a"
+                            "release": "31.20200517.3.0",
+                            "image": "ami-0eccef236785de193"
                         },
                         "eu-west-1": {
-                            "release": "31.20200505.3.0",
-                            "image": "ami-03d7df2bf5cc7884e"
+                            "release": "31.20200517.3.0",
+                            "image": "ami-0d24340436e66c88a"
                         },
                         "eu-west-2": {
-                            "release": "31.20200505.3.0",
-                            "image": "ami-004b82cce7be75891"
+                            "release": "31.20200517.3.0",
+                            "image": "ami-0ed6ed18b8b501ae6"
                         },
                         "eu-west-3": {
-                            "release": "31.20200505.3.0",
-                            "image": "ami-005107340338177f6"
+                            "release": "31.20200517.3.0",
+                            "image": "ami-002fd9ccc4faba904"
                         },
                         "me-south-1": {
-                            "release": "31.20200505.3.0",
-                            "image": "ami-0af64e4c5b551b9b9"
+                            "release": "31.20200517.3.0",
+                            "image": "ami-019de0627beb9a212"
                         },
                         "sa-east-1": {
-                            "release": "31.20200505.3.0",
-                            "image": "ami-0a1d12745ffcbe36c"
+                            "release": "31.20200517.3.0",
+                            "image": "ami-0d3c5331442039d80"
                         },
                         "us-east-1": {
-                            "release": "31.20200505.3.0",
-                            "image": "ami-0fa4db1b6ee11c123"
+                            "release": "31.20200517.3.0",
+                            "image": "ami-00848c06968a080dd"
                         },
                         "us-east-2": {
-                            "release": "31.20200505.3.0",
-                            "image": "ami-0f81439728ee6f5b9"
+                            "release": "31.20200517.3.0",
+                            "image": "ami-0624ff8715fd4f319"
                         },
                         "us-west-1": {
-                            "release": "31.20200505.3.0",
-                            "image": "ami-0e2daaae856f51630"
+                            "release": "31.20200517.3.0",
+                            "image": "ami-0c32def1fce30edad"
                         },
                         "us-west-2": {
-                            "release": "31.20200505.3.0",
-                            "image": "ami-0f763ba4c044d01f3"
+                            "release": "31.20200517.3.0",
+                            "image": "ami-00a55300b90d0292d"
                         }
                     }
                 }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,153 +1,153 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2020-05-19T19:34:09Z"
+        "last-modified": "2020-06-03T15:08:25Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "31.20200517.2.0",
+                    "release": "32.20200601.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "e581baac4e12e596ffb82c2786c75da9c3cea326f4a8a7d7a2d4f4ad6184c43f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "62aa76f297dd5447f098343da79d3a96f30a3ced815f214cdafc63bad39cac1d"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "31.20200517.2.0",
+                    "release": "32.20200601.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "bd9b72663c83b5ed7a6d29953a93e8c4168910ca05c80512680d7cf76a212d6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "4a6201dfcd4da08fa6ba7d4ef643c9673c61d0dd4d228b13da58a43637a2c20f"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "31.20200517.2.0",
+                    "release": "32.20200601.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "b07d975c0ee68ccd13edc233a87c060251daceb0333b9cbdbea9c21d2a09aeed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "2488a17dcb811433e3bfce1055717e29eabd80d1738f6fde856356ce3fa9629b"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "31.20200517.2.0",
+                    "release": "32.20200601.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "cd9df9d270c86f660625a2290248e98ba2bce162f35e4c27e15dfdbc85fc1164"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "b21c2221bb5afdd7b54fafe0006764ebbd9c7d4b2cd6cf67b03aa34684ce07b6"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "31.20200517.2.0",
+                    "release": "32.20200601.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "8bf0d705d06e24a044f4959177ad27c61a273325e14a8e66a32935c469a788d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "3f7f8675e7d000e9544351874b39f084880187aabaa4c1778adef1fc06fd4b85"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "31.20200517.2.0",
+                    "release": "32.20200601.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "1f5347a7733b0fdbb0bad031e3fc4b4c9d23b29144a750346f711696c81ebd8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "a20f8e192dbfce6ee8776235725b2ab284746ec6ba46a6fd0f62861ff9309b3c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "31.20200517.2.0",
+                    "release": "32.20200601.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "25467cdeed32ea6562cc49a9a786b783b9d69ac4d83ed69098c9e0a514d6b55e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "509dd8ef7ccae1ca7be927177308dc6eee49356f4527d545fb80cd3686b17bae"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-live.x86_64.iso.sig",
-                                "sha256": "3a703f32496ff39a08d103418ca1e47bcdac98226cc9e5185c28097c58097f9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-live.x86_64.iso.sig",
+                                "sha256": "b07edec60fe0c1055be7608ea7469590d02d5e457ac8227d7b56f6de904c9b64"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-live-kernel-x86_64.sig",
-                                "sha256": "345fd70d5aa0be344592853410100439f8733895c3e1856fa496ed4a3d02db86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-live-kernel-x86_64.sig",
+                                "sha256": "34869fe6d5ed7e83e0873f348450f65e8800005620f8b736dcc610b5bfbf61da"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "278d89edfc4bcc865de2d2bbb5f792a1e2491072876bbb514dc193a180e31124"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "8d8f478ada237b4dc1eeb6f9689616a575c2839518601bb4d911a488f40480a4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "7b9369d836fce1a594b36aa6ba82d04c27dd639bdd2fc6771732ccc7ccbf4fbd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "be83fafffe38098f19be7a334e23b9adfe246ac66439522585b43546defa60bd"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "31.20200517.2.0",
+                    "release": "32.20200601.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "2f90ddf9dd30227bfb8f90eff33efe5c7f07e042bd4f07035ba4dbab7d9ae543"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "dd4271c0dc5eb2e5fbfed1c2807aa47d6e64dda3ad8c9801759f5f262a116b5d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "31.20200517.2.0",
+                    "release": "32.20200601.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "7be8e87a528933e1f01307344330c43285d7de59e04807facde9430379b8a039"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "99387259cb8a029b3bf9e2e334d7a141e3dacdd0d591543129eb1270d6862b64"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "31.20200517.2.0",
+                    "release": "32.20200601.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/31.20200517.2.0/x86_64/fedora-coreos-31.20200517.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "6f22f5933ede46d0ce5fc3148100372ec437fbb03f7607cbcc3d63b96aaaba10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "61069177ef30c89d379d4bd8b1ac09f0792f9ba99b36b26328fc4bea452d3f11"
                             }
                         }
                     }
@@ -157,80 +157,80 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "31.20200517.2.0",
-                            "image": "ami-00b3b700a8454b98e"
+                            "release": "32.20200601.2.1",
+                            "image": "ami-09e3091987e5b48d8"
                         },
                         "ap-east-1": {
-                            "release": "31.20200517.2.0",
-                            "image": "ami-0cbdd4671bddd10fe"
+                            "release": "32.20200601.2.1",
+                            "image": "ami-0f22eb8f087a7f037"
                         },
                         "ap-northeast-1": {
-                            "release": "31.20200517.2.0",
-                            "image": "ami-05882238cd31b9a37"
+                            "release": "32.20200601.2.1",
+                            "image": "ami-0f483ad40cde2a592"
                         },
                         "ap-northeast-2": {
-                            "release": "31.20200517.2.0",
-                            "image": "ami-0377cce1d106f341e"
+                            "release": "32.20200601.2.1",
+                            "image": "ami-0523711c5b40a02a0"
                         },
                         "ap-south-1": {
-                            "release": "31.20200517.2.0",
-                            "image": "ami-0963511f4b7d1d156"
+                            "release": "32.20200601.2.1",
+                            "image": "ami-0952c14f41d175b12"
                         },
                         "ap-southeast-1": {
-                            "release": "31.20200517.2.0",
-                            "image": "ami-0adb69d447a0bc0bc"
+                            "release": "32.20200601.2.1",
+                            "image": "ami-0bb1705dabe1132cd"
                         },
                         "ap-southeast-2": {
-                            "release": "31.20200517.2.0",
-                            "image": "ami-02b4357568f47ef2e"
+                            "release": "32.20200601.2.1",
+                            "image": "ami-039ef64af8a67eac2"
                         },
                         "ca-central-1": {
-                            "release": "31.20200517.2.0",
-                            "image": "ami-003f580e0ea5ffc16"
+                            "release": "32.20200601.2.1",
+                            "image": "ami-0eecf3ba0622d427d"
                         },
                         "eu-central-1": {
-                            "release": "31.20200517.2.0",
-                            "image": "ami-02414088c099a2e54"
+                            "release": "32.20200601.2.1",
+                            "image": "ami-08b1f4bd9a24cb534"
                         },
                         "eu-north-1": {
-                            "release": "31.20200517.2.0",
-                            "image": "ami-022f18184f043d4e5"
+                            "release": "32.20200601.2.1",
+                            "image": "ami-0034c2c32740431b9"
                         },
                         "eu-west-1": {
-                            "release": "31.20200517.2.0",
-                            "image": "ami-025376296e360b9ab"
+                            "release": "32.20200601.2.1",
+                            "image": "ami-0d11a8b6ac83d064d"
                         },
                         "eu-west-2": {
-                            "release": "31.20200517.2.0",
-                            "image": "ami-08e82661f2d05a991"
+                            "release": "32.20200601.2.1",
+                            "image": "ami-0ff9eab2a602d7576"
                         },
                         "eu-west-3": {
-                            "release": "31.20200517.2.0",
-                            "image": "ami-068c6bed2baf2b2cf"
+                            "release": "32.20200601.2.1",
+                            "image": "ami-0d4c523be61f109dc"
                         },
                         "me-south-1": {
-                            "release": "31.20200517.2.0",
-                            "image": "ami-06b0dc253cce026a3"
+                            "release": "32.20200601.2.1",
+                            "image": "ami-07f4cb63be7d97ab0"
                         },
                         "sa-east-1": {
-                            "release": "31.20200517.2.0",
-                            "image": "ami-080643cec4add6bc4"
+                            "release": "32.20200601.2.1",
+                            "image": "ami-05b66f6f45a82f134"
                         },
                         "us-east-1": {
-                            "release": "31.20200517.2.0",
-                            "image": "ami-0a531c8abe2d4ca27"
+                            "release": "32.20200601.2.1",
+                            "image": "ami-0f50c97915e3258c4"
                         },
                         "us-east-2": {
-                            "release": "31.20200517.2.0",
-                            "image": "ami-0ff5189b55f739444"
+                            "release": "32.20200601.2.1",
+                            "image": "ami-0dc3cfef3ccb48fc7"
                         },
                         "us-west-1": {
-                            "release": "31.20200517.2.0",
-                            "image": "ami-0f2db68ba5fb6cf6b"
+                            "release": "32.20200601.2.1",
+                            "image": "ami-0e90fde1b7f82e0ec"
                         },
                         "us-west-2": {
-                            "release": "31.20200517.2.0",
-                            "image": "ami-0019e3052e61af164"
+                            "release": "32.20200601.2.1",
+                            "image": "ami-09b3b13b5f036406a"
                         }
                     }
                 }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,8 +1,18 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2020-06-02T20:25:43Z"
+    "last-modified": "2020-06-03T15:08:25Z"
   },
   "releases": [
+    {
+      "version": "32.20200601.1.1",
+      "metadata": {
+        "rollout": {
+          "start_epoch": 1591200000,
+          "start_percentage": 0.0,
+          "duration_minutes": 2880
+        }
+      }
+    }
   ]
 }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,8 +1,18 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2020-06-02T20:25:43Z"
+    "last-modified": "2020-06-03T15:08:25Z"
   },
   "releases": [
+    {
+      "version": "31.20200517.3.0",
+      "metadata": {
+        "rollout": {
+          "start_epoch": 1591200000,
+          "start_percentage": 0.0,
+          "duration_minutes": 2880
+        }
+      }
+    }
   ]
 }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2020-06-02T20:25:43Z"
+    "last-modified": "2020-06-03T15:08:25Z"
   },
   "releases": [
     {
@@ -17,6 +17,16 @@
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-streams/issues/30"
+        }
+      }
+    },
+    {
+      "version": "32.20200601.2.1",
+      "metadata": {
+        "rollout": {
+          "start_epoch": 1591200000,
+          "start_percentage": 0.0,
+          "duration_minutes": 4320
         }
       }
     }


### PR DESCRIPTION
This schedules rollouts for latest stable/testing/next release,
starting on 2020-06-03. The rollout for testing is extra long
since this is an update that involved a major Fedora version
rebase.