### PR TITLE
streams/next: rollback stream metadata to 32.20200517.1.0 briefly

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,153 +1,153 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2020-06-03T15:08:25Z"
+        "last-modified": "2020-06-03T17:54:11Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "32.20200601.1.0",
+                    "release": "32.20200517.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "8fff1967cd2b5d336a18c2f1fb1bd566590a1e6226603d4b100765f3bedd3e62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "00d463bb75ae98d723ae03ba50dc38a4790fd88dcf5767a2753b7758a70a9662"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "32.20200601.1.0",
+                    "release": "32.20200517.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "475027a12808c7b2298dfcb32028605147aa14a25fc9067b728ba0d0257347dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "ace6a2226cb9142cdcc41f00849bcbe45e761f9c9b339e7fa4a9ed79fadf363b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "32.20200601.1.0",
+                    "release": "32.20200517.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7aea719e29139a98ddcf2c41f526eb8082edf6a459619ec51a18a0cd578cbd90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "fad529db18348874827d4ef8522ff36748dedca723355e4d60069045e39be3ab"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "32.20200601.1.0",
+                    "release": "32.20200517.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "030c9cd76c706193d58576152c66455e885b2e1d5273194d005001a109b4ca06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "4c10662859cc7cc6a43977fcc252afb164a2c1b5011f88052290dcebbee7686c"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "32.20200601.1.0",
+                    "release": "32.20200517.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "122e3e5a59d8f001ba4a18ac19c939532779440bde7eac0e553da30484244627"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e848f301b01270df0f188fe8d07907897b1cf03fc4f899275489f7b20a651a22"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "32.20200601.1.0",
+                    "release": "32.20200517.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "620222c7c97d5efa4f495c3fc6cd5e5fdf9ccca41dc42919f2adfcf44a09b4ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "b64998376b63a9408ffcc3d91eee8e077628008de70e47160603818806521db1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "32.20200601.1.0",
+                    "release": "32.20200517.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "9fac81d714cc6ed76ef37eb077881bac07ab33675b448dfd673e79387de42f28"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "34d617f81146d9dfa2e836356a20496e1b89a55d9160cb154f7253258e9f3899"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-live.x86_64.iso.sig",
-                                "sha256": "240aa5be802a21f3ff9e39d3101159a69b235c29df7301e029ddac263edbc713"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-live.x86_64.iso.sig",
+                                "sha256": "785488d8fab61653fd1b140a91ce20a5661c6e0bc2483ce3d73a2c47b1ef736f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-live-kernel-x86_64.sig",
-                                "sha256": "34869fe6d5ed7e83e0873f348450f65e8800005620f8b736dcc610b5bfbf61da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-live-kernel-x86_64.sig",
+                                "sha256": "d7c5d2f02679d777374cf377ed6ebaa3e0dae35c02200a6f6bcb1c9a1af280dd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "c1e2a951a93079b49c48e93e7ef1d30489f153f6d89b8c4be1871a5061d326c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "15f619bd80a7a1e788127b2052a848a432ffb181d562a1afa662259c75e85203"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "7c34315e25537ce0c92001f0c6bac641126e097c7b8ab5123ba5eb9f42acf048"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "077de411d530ea98833e4cdc227611804dd2bf46933ae1087eee98be061b368e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "32.20200601.1.0",
+                    "release": "32.20200517.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "16731de146050436fc1448489642255eef6b0bd2c169384cc4a81d6c4a3d7b18"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "19d880d6a0dcc92bc2082640a2020916c6d3c24d2adefe101d56b673a4569d1a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "32.20200601.1.0",
+                    "release": "32.20200517.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "657068bab61b58e18608889d07c1a81c52635a6c0c54c05de610218efc176454"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "80ab634f89a3d808725266734e7f9f1cbb2b7c941f064d9beac2f747cf3a36c1"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "32.20200601.1.0",
+                    "release": "32.20200517.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.0/x86_64/fedora-coreos-32.20200601.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "2bda3dafb197fb43eb06be7c2eccf060223aa3f4926623f0651baba931737937"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200517.1.0/x86_64/fedora-coreos-32.20200517.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "6ce75595c52df824765c41e870d5e76001b9994e0c3a9c286b4b87e7c16e8712"
                             }
                         }
                     }
@@ -157,80 +157,80 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "32.20200601.1.0",
-                            "image": "ami-031a226ead52c6a0b"
+                            "release": "32.20200517.1.0",
+                            "image": "ami-05f3ff9faa0f90664"
                         },
                         "ap-east-1": {
-                            "release": "32.20200601.1.0",
-                            "image": "ami-0e5d0ae8b34aec2ea"
+                            "release": "32.20200517.1.0",
+                            "image": "ami-04ca68d955fa2d222"
                         },
                         "ap-northeast-1": {
-                            "release": "32.20200601.1.0",
-                            "image": "ami-0b2137b9f3521b964"
+                            "release": "32.20200517.1.0",
+                            "image": "ami-085b8396cbf82a95c"
                         },
                         "ap-northeast-2": {
-                            "release": "32.20200601.1.0",
-                            "image": "ami-016b54ea53ee8769a"
+                            "release": "32.20200517.1.0",
+                            "image": "ami-0d5f9c627fc71f4a8"
                         },
                         "ap-south-1": {
-                            "release": "32.20200601.1.0",
-                            "image": "ami-0d298f93d930877d2"
+                            "release": "32.20200517.1.0",
+                            "image": "ami-038871f707029b3b1"
                         },
                         "ap-southeast-1": {
-                            "release": "32.20200601.1.0",
-                            "image": "ami-0e533ac6f97783a51"
+                            "release": "32.20200517.1.0",
+                            "image": "ami-054195b32b288b68f"
                         },
                         "ap-southeast-2": {
-                            "release": "32.20200601.1.0",
-                            "image": "ami-0d275d07ac06238f7"
+                            "release": "32.20200517.1.0",
+                            "image": "ami-066bb2a3b78994a2f"
                         },
                         "ca-central-1": {
-                            "release": "32.20200601.1.0",
-                            "image": "ami-02da5cac4928be9b5"
+                            "release": "32.20200517.1.0",
+                            "image": "ami-01fc7f476bda136d5"
                         },
                         "eu-central-1": {
-                            "release": "32.20200601.1.0",
-                            "image": "ami-0fe2120bdc07724f1"
+                            "release": "32.20200517.1.0",
+                            "image": "ami-0cf481c5aef9037c8"
                         },
                         "eu-north-1": {
-                            "release": "32.20200601.1.0",
-                            "image": "ami-0da15c103a586b233"
+                            "release": "32.20200517.1.0",
+                            "image": "ami-0cd42e41bb157bb00"
                         },
                         "eu-west-1": {
-                            "release": "32.20200601.1.0",
-                            "image": "ami-08e89319497046ca6"
+                            "release": "32.20200517.1.0",
+                            "image": "ami-0d876d99e62536481"
                         },
                         "eu-west-2": {
-                            "release": "32.20200601.1.0",
-                            "image": "ami-08a293a50d5f4ddf8"
+                            "release": "32.20200517.1.0",
+                            "image": "ami-00553cd4e9b6e1a9d"
                         },
                         "eu-west-3": {
-                            "release": "32.20200601.1.0",
-                            "image": "ami-0b710583e1f7e21b6"
+                            "release": "32.20200517.1.0",
+                            "image": "ami-0dc432956fb5c3939"
                         },
                         "me-south-1": {
-                            "release": "32.20200601.1.0",
-                            "image": "ami-0bdcadaef7543f4be"
+                            "release": "32.20200517.1.0",
+                            "image": "ami-0bfc9c2cf6afdcd24"
                         },
                         "sa-east-1": {
-                            "release": "32.20200601.1.0",
-                            "image": "ami-05ed8f35d677fe268"
+                            "release": "32.20200517.1.0",
+                            "image": "ami-0935bb3853ee0f209"
                         },
                         "us-east-1": {
-                            "release": "32.20200601.1.0",
-                            "image": "ami-0204bc26cf653fabf"
+                            "release": "32.20200517.1.0",
+                            "image": "ami-090641efb77c55d6f"
                         },
                         "us-east-2": {
-                            "release": "32.20200601.1.0",
-                            "image": "ami-0ebb81d9f24b8ddfa"
+                            "release": "32.20200517.1.0",
+                            "image": "ami-09ab09cdd1c2f82d2"
                         },
                         "us-west-1": {
-                            "release": "32.20200601.1.0",
-                            "image": "ami-0ffb253fdd8107b4f"
+                            "release": "32.20200517.1.0",
+                            "image": "ami-04e352e77ea99e353"
                         },
                         "us-west-2": {
-                            "release": "32.20200601.1.0",
-                            "image": "ami-0dc22ab962bfdf162"
+                            "release": "32.20200517.1.0",
+                            "image": "ami-01ab4e24c74d7448a"
                         }
                     }
                 }


### PR DESCRIPTION
We accidentally ran the release job against the wrong release for
next so let's roll this back briefly while we fix things up.
https://github.com/coreos/fedora-coreos-streams/issues/109#issuecomment-638361523