### PR TITLE
updates: stop all rollouts for next/testing

### DIFF
--- a/updates/next.json
+++ b/updates/next.json
@@ -1,18 +1,8 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2020-06-03T21:45:10Z"
+    "last-modified": "2020-06-11T18:33:59Z"
   },
   "releases": [
-    {
-      "version": "32.20200601.1.1",
-      "metadata": {
-        "rollout": {
-          "start_epoch": 1591279200,
-          "start_percentage": 0.0,
-          "duration_minutes": 2880
-        }
-      }
-    }
   ]
 }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2020-06-03T15:08:25Z"
+    "last-modified": "2020-06-11T18:33:59Z"
   },
   "releases": [
     {
@@ -17,16 +17,6 @@
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-streams/issues/30"
-        }
-      }
-    },
-    {
-      "version": "32.20200601.2.1",
-      "metadata": {
-        "rollout": {
-          "start_epoch": 1591200000,
-          "start_percentage": 0.0,
-          "duration_minutes": 4320
         }
       }
     }


### PR DESCRIPTION
This drops all completed rollouts, mitigating rpm-ostree bug
while preparing for an intermediate release of testing/next.