### PR TITLE
updates: rollout next on 06/12 and testing on 06/15

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,153 +1,165 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2020-06-03T21:45:10Z"
+        "last-modified": "2020-06-11T21:41:39Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "32.20200601.1.1",
+                    "release": "32.20200601.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "0845d9f7a7fd584560e85d6fba77c0a27be0380d3f2fb299fe3f1f42c57a3284"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "3acf002f0829e8c2d1f9e063b76eb2b68085625c5c7168c2be15697c232d9db4"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "32.20200601.1.1",
+                    "release": "32.20200601.1.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "c4b761cc4ab8823ad6846090e4a246066bf662d43dd46a4d15fdf186135a2c80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "5a138f13defe7ffe5271523ea92dda7a83c83ac9dd4f11c79081f9b9df9c1cd4"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "32.20200601.1.1",
+                    "release": "32.20200601.1.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7e485a4732414d27fc98279e18ec5008ac52da8c1e29dcc7bf1ba986254cadc3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "101dc810a38a084d5be6c9069cac1f956c771dee68dc2cfcbbbb717a05313511"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "32.20200601.1.1",
+                    "release": "32.20200601.1.2",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "bd9a54dd119bcab8533649aae91e3691c6021ee2497a9e3661e07d2347bcd275"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "9693a97ae55366e8b31657244984891db491b0ed4e02f7937d8ff233be86ed8e"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "32.20200601.1.1",
+                    "release": "32.20200601.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "715a951d78d173d65ff250f2e7c99ddea0355fa61f2e922a7fae4bf7c5ffeadd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "0b13625d34f3dff42465b200ac44926b9389e874fcb057a0d23afe1fe6cc68c0"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "32.20200601.1.1",
+                    "release": "32.20200601.1.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "6a4fc4addcacb22a0dc80ce7dd7570a45eadf3c0d66b834a8c6a31135823f472"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "ceef9568af649763a5e1f828b71b1800f7f7cf52b187d93099d54502a7082065"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "32.20200601.1.1",
+                    "release": "32.20200601.1.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "0c5107d074ec441091d39fbf1c8e7ab0afedb57ec8d15be21fcdf3e690f087e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "b7d85cae2c8699d0beac7c1911f11cab429f33b936d5788993c03ef36fd740b7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-live.x86_64.iso.sig",
-                                "sha256": "781f926e0da7c0b091941030b298d63084fcd23d5962c9feadb229b2e49dc0db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-live.x86_64.iso.sig",
+                                "sha256": "963ea7fe259a0b893a537ee601456f811ada021f13c15c376573c047ec532276"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-live-kernel-x86_64.sig",
                                 "sha256": "34869fe6d5ed7e83e0873f348450f65e8800005620f8b736dcc610b5bfbf61da"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "ab9155dba9e905ecf9fc38a3556ed366344f4c08bcc0584b4c6b8351ff343788"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "569ba2779eede2fff26babd83b711892613d39f9210231580c76f38382afe5aa"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "d6a8cf9cf04aa32511b32dd3f269a45489c1e3ab2f418b1745f47ecc6ca9b46e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "ed8e95928f059b67e61059e9e7e945aafe77182210fb2bc9d27db7c4bb112d80"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "32.20200601.1.1",
+                    "release": "32.20200601.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "0e05a7d39570d8ee2ee67125ac7444ee9f6d4dc9c419f75e77fc16b682a81b8d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "c884e8ea1ce1d847d66cc31f7a38757d0d6f32b4334958824b2eb9b8008f7a0b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "32.20200601.1.1",
+                    "release": "32.20200601.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "18bb053c125d19907b089991e129a2685db0b30396a68c7cbbb650d430a427f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "6dfe2a11970276ee7190f7b68a99f9d7450df0182624b9eba6476577b0362229"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "32.20200601.1.1",
+                    "release": "32.20200601.1.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.1/x86_64/fedora-coreos-32.20200601.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "6c2837e2ef5c5922253abe1d3fd5dbd3a0d6c77431909ba9c29a5c4a317007ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-vmware.x86_64.ova.sig",
+                                "sha256": "666bccb6c633fe600a29c192e385e837b68dec22ca0d8080ffc189a57dec9e61"
+                            }
+                        }
+                    }
+                },
+                "vultr": {
+                    "release": "32.20200601.1.2",
+                    "formats": {
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200601.1.2/x86_64/fedora-coreos-32.20200601.1.2-vultr.x86_64.raw.xz.sig",
+                                "sha256": "c5d797a8d5ac0787fafa751a96a2479bf72fb65a32fafd7289df3363907d4e2e"
                             }
                         }
                     }
@@ -157,80 +169,80 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "32.20200601.1.1",
-                            "image": "ami-01416f6cf5df20d75"
+                            "release": "32.20200601.1.2",
+                            "image": "ami-0bc7460475892ea11"
                         },
                         "ap-east-1": {
-                            "release": "32.20200601.1.1",
-                            "image": "ami-0119a50cb33ef0f66"
+                            "release": "32.20200601.1.2",
+                            "image": "ami-0c5a053cebee10ff8"
                         },
                         "ap-northeast-1": {
-                            "release": "32.20200601.1.1",
-                            "image": "ami-02ad3fe9f15498d8b"
+                            "release": "32.20200601.1.2",
+                            "image": "ami-0a480fa667a631aaa"
                         },
                         "ap-northeast-2": {
-                            "release": "32.20200601.1.1",
-                            "image": "ami-0b9466116d236b5dd"
+                            "release": "32.20200601.1.2",
+                            "image": "ami-01fa7cc8de4b33e6a"
                         },
                         "ap-south-1": {
-                            "release": "32.20200601.1.1",
-                            "image": "ami-0ddfdca8ca28b02a1"
+                            "release": "32.20200601.1.2",
+                            "image": "ami-050ee56e233bce0d8"
                         },
                         "ap-southeast-1": {
-                            "release": "32.20200601.1.1",
-                            "image": "ami-09fca3ebda26bdc9e"
+                            "release": "32.20200601.1.2",
+                            "image": "ami-0599e3fac53eb80cf"
                         },
                         "ap-southeast-2": {
-                            "release": "32.20200601.1.1",
-                            "image": "ami-0fefc1d4c1fc60de5"
+                            "release": "32.20200601.1.2",
+                            "image": "ami-0a6ea16eaa363f682"
                         },
                         "ca-central-1": {
-                            "release": "32.20200601.1.1",
-                            "image": "ami-0cea150665e9d9b40"
+                            "release": "32.20200601.1.2",
+                            "image": "ami-0916d41c39dd74b64"
                         },
                         "eu-central-1": {
-                            "release": "32.20200601.1.1",
-                            "image": "ami-03efd09d677e98c53"
+                            "release": "32.20200601.1.2",
+                            "image": "ami-06f95a1102f035f37"
                         },
                         "eu-north-1": {
-                            "release": "32.20200601.1.1",
-                            "image": "ami-0a419a5ed22f656af"
+                            "release": "32.20200601.1.2",
+                            "image": "ami-045aeadb56fedcac5"
                         },
                         "eu-west-1": {
-                            "release": "32.20200601.1.1",
-                            "image": "ami-080f1384c72a384fa"
+                            "release": "32.20200601.1.2",
+                            "image": "ami-0df80de6e1b1da599"
                         },
                         "eu-west-2": {
-                            "release": "32.20200601.1.1",
-                            "image": "ami-0c69618a28641efe8"
+                            "release": "32.20200601.1.2",
+                            "image": "ami-057649ea98944bfc2"
                         },
                         "eu-west-3": {
-                            "release": "32.20200601.1.1",
-                            "image": "ami-0a63c0e01f50e452b"
+                            "release": "32.20200601.1.2",
+                            "image": "ami-0dcc6018051a82944"
                         },
                         "me-south-1": {
-                            "release": "32.20200601.1.1",
-                            "image": "ami-083d395a721add92c"
+                            "release": "32.20200601.1.2",
+                            "image": "ami-079b5b98b11629b0d"
                         },
                         "sa-east-1": {
-                            "release": "32.20200601.1.1",
-                            "image": "ami-0ec4045de290617c8"
+                            "release": "32.20200601.1.2",
+                            "image": "ami-08e85868096eb76f0"
                         },
                         "us-east-1": {
-                            "release": "32.20200601.1.1",
-                            "image": "ami-0d11cc5edda319d99"
+                            "release": "32.20200601.1.2",
+                            "image": "ami-00f99f3a4c98e4852"
                         },
                         "us-east-2": {
-                            "release": "32.20200601.1.1",
-                            "image": "ami-002332831e467adf6"
+                            "release": "32.20200601.1.2",
+                            "image": "ami-0da64424c45aa7e20"
                         },
                         "us-west-1": {
-                            "release": "32.20200601.1.1",
-                            "image": "ami-0a5c9730785ed35eb"
+                            "release": "32.20200601.1.2",
+                            "image": "ami-00918da74113dfaad"
                         },
                         "us-west-2": {
-                            "release": "32.20200601.1.1",
-                            "image": "ami-03f4b7a68d8dba40f"
+                            "release": "32.20200601.1.2",
+                            "image": "ami-09b0e45957b080d8a"
                         }
                     }
                 }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,153 +1,165 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2020-06-03T15:08:25Z"
+        "last-modified": "2020-06-11T21:41:39Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "32.20200601.2.1",
+                    "release": "32.20200601.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "62aa76f297dd5447f098343da79d3a96f30a3ced815f214cdafc63bad39cac1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "4fc62e3fd4bb752f950974c60d0cd969c71aea70b2ddfadc6669c472f1f2e538"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "32.20200601.2.1",
+                    "release": "32.20200601.2.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "4a6201dfcd4da08fa6ba7d4ef643c9673c61d0dd4d228b13da58a43637a2c20f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "0906b952c13179d272c8f0a039e53d113cf326285a1c274e5c70c23bb1c97f64"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "32.20200601.2.1",
+                    "release": "32.20200601.2.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "2488a17dcb811433e3bfce1055717e29eabd80d1738f6fde856356ce3fa9629b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "214e26a2819ff4194114390092679c1d13655744bb7110c423bd99a8422d5ff1"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "32.20200601.2.1",
+                    "release": "32.20200601.2.2",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "b21c2221bb5afdd7b54fafe0006764ebbd9c7d4b2cd6cf67b03aa34684ce07b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "7f90d19171ef3a82f27bce51f5966cfbd298a6d89c784b76b541b03675102349"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "32.20200601.2.1",
+                    "release": "32.20200601.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "3f7f8675e7d000e9544351874b39f084880187aabaa4c1778adef1fc06fd4b85"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "ce659c379181679e840f811e0649404e921f760bf79115539c5934c6b45ac2d5"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "32.20200601.2.1",
+                    "release": "32.20200601.2.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "a20f8e192dbfce6ee8776235725b2ab284746ec6ba46a6fd0f62861ff9309b3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "a2be001c152463ef60e47203d37cd5c3b7f3ccafc61683aa4cca72b1481a18ca"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "32.20200601.2.1",
+                    "release": "32.20200601.2.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "509dd8ef7ccae1ca7be927177308dc6eee49356f4527d545fb80cd3686b17bae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "6dc6429cd69da31c7c4e6e6eec4d4755d380c206786d63fd28240ac0ddf97dba"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-live.x86_64.iso.sig",
-                                "sha256": "b07edec60fe0c1055be7608ea7469590d02d5e457ac8227d7b56f6de904c9b64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-live.x86_64.iso.sig",
+                                "sha256": "5e6311f62e47d080fcd04ed736754d39841afc9441850e4e058d0492b672e91e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-live-kernel-x86_64.sig",
                                 "sha256": "34869fe6d5ed7e83e0873f348450f65e8800005620f8b736dcc610b5bfbf61da"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "8d8f478ada237b4dc1eeb6f9689616a575c2839518601bb4d911a488f40480a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "d5ed095c81792d917ec1f96726426eb0fd145a399a3e29579a9395d6bd9577be"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "be83fafffe38098f19be7a334e23b9adfe246ac66439522585b43546defa60bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "ee8811d9628e6979686d64de12e2b054dbe44db6029ae18fe5d27c4ce95ad282"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "32.20200601.2.1",
+                    "release": "32.20200601.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "dd4271c0dc5eb2e5fbfed1c2807aa47d6e64dda3ad8c9801759f5f262a116b5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "412bfbd2105ac11e4536d3863f79552cbbe934d70ab048264d950e8a3dd914b0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "32.20200601.2.1",
+                    "release": "32.20200601.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "99387259cb8a029b3bf9e2e334d7a141e3dacdd0d591543129eb1270d6862b64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "19782ec93ed8a1f10115421b099cf989e023aba7e16c21b551e6762a4950cca2"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "32.20200601.2.1",
+                    "release": "32.20200601.2.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.1/x86_64/fedora-coreos-32.20200601.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "61069177ef30c89d379d4bd8b1ac09f0792f9ba99b36b26328fc4bea452d3f11"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-vmware.x86_64.ova.sig",
+                                "sha256": "cbaefe641358337f3190328b0dabe59d819208e28e0deb29984416235f6e71a7"
+                            }
+                        }
+                    }
+                },
+                "vultr": {
+                    "release": "32.20200601.2.2",
+                    "formats": {
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200601.2.2/x86_64/fedora-coreos-32.20200601.2.2-vultr.x86_64.raw.xz.sig",
+                                "sha256": "6fe0ae1e0d116e3e471ced29596d77f0834570d9b372c63e2576dd16da59f0b6"
                             }
                         }
                     }
@@ -157,80 +169,80 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "32.20200601.2.1",
-                            "image": "ami-09e3091987e5b48d8"
+                            "release": "32.20200601.2.2",
+                            "image": "ami-0e1af04abce2c0518"
                         },
                         "ap-east-1": {
-                            "release": "32.20200601.2.1",
-                            "image": "ami-0f22eb8f087a7f037"
+                            "release": "32.20200601.2.2",
+                            "image": "ami-0dbe4e661b40abdd5"
                         },
                         "ap-northeast-1": {
-                            "release": "32.20200601.2.1",
-                            "image": "ami-0f483ad40cde2a592"
+                            "release": "32.20200601.2.2",
+                            "image": "ami-0605e22c1e48f37ea"
                         },
                         "ap-northeast-2": {
-                            "release": "32.20200601.2.1",
-                            "image": "ami-0523711c5b40a02a0"
+                            "release": "32.20200601.2.2",
+                            "image": "ami-0fd6e70de63d912d3"
                         },
                         "ap-south-1": {
-                            "release": "32.20200601.2.1",
-                            "image": "ami-0952c14f41d175b12"
+                            "release": "32.20200601.2.2",
+                            "image": "ami-0da540c6f0311eaa4"
                         },
                         "ap-southeast-1": {
-                            "release": "32.20200601.2.1",
-                            "image": "ami-0bb1705dabe1132cd"
+                            "release": "32.20200601.2.2",
+                            "image": "ami-08b25703198c71b1b"
                         },
                         "ap-southeast-2": {
-                            "release": "32.20200601.2.1",
-                            "image": "ami-039ef64af8a67eac2"
+                            "release": "32.20200601.2.2",
+                            "image": "ami-08941e261e009a549"
                         },
                         "ca-central-1": {
-                            "release": "32.20200601.2.1",
-                            "image": "ami-0eecf3ba0622d427d"
+                            "release": "32.20200601.2.2",
+                            "image": "ami-033f1d25b27782b42"
                         },
                         "eu-central-1": {
-                            "release": "32.20200601.2.1",
-                            "image": "ami-08b1f4bd9a24cb534"
+                            "release": "32.20200601.2.2",
+                            "image": "ami-06b2e14639cbda701"
                         },
                         "eu-north-1": {
-                            "release": "32.20200601.2.1",
-                            "image": "ami-0034c2c32740431b9"
+                            "release": "32.20200601.2.2",
+                            "image": "ami-0a1f3cf3dcc6e9ca3"
                         },
                         "eu-west-1": {
-                            "release": "32.20200601.2.1",
-                            "image": "ami-0d11a8b6ac83d064d"
+                            "release": "32.20200601.2.2",
+                            "image": "ami-0b0a47b56f26da50b"
                         },
                         "eu-west-2": {
-                            "release": "32.20200601.2.1",
-                            "image": "ami-0ff9eab2a602d7576"
+                            "release": "32.20200601.2.2",
+                            "image": "ami-0b41bb6955245e2fe"
                         },
                         "eu-west-3": {
-                            "release": "32.20200601.2.1",
-                            "image": "ami-0d4c523be61f109dc"
+                            "release": "32.20200601.2.2",
+                            "image": "ami-0a54435f9a1bc4f0e"
                         },
                         "me-south-1": {
-                            "release": "32.20200601.2.1",
-                            "image": "ami-07f4cb63be7d97ab0"
+                            "release": "32.20200601.2.2",
+                            "image": "ami-0af5fc5e48e911260"
                         },
                         "sa-east-1": {
-                            "release": "32.20200601.2.1",
-                            "image": "ami-05b66f6f45a82f134"
+                            "release": "32.20200601.2.2",
+                            "image": "ami-00af77d2cfff5c13c"
                         },
                         "us-east-1": {
-                            "release": "32.20200601.2.1",
-                            "image": "ami-0f50c97915e3258c4"
+                            "release": "32.20200601.2.2",
+                            "image": "ami-015a9f826a7f02705"
                         },
                         "us-east-2": {
-                            "release": "32.20200601.2.1",
-                            "image": "ami-0dc3cfef3ccb48fc7"
+                            "release": "32.20200601.2.2",
+                            "image": "ami-0c1d26ba6e8183e0f"
                         },
                         "us-west-1": {
-                            "release": "32.20200601.2.1",
-                            "image": "ami-0e90fde1b7f82e0ec"
+                            "release": "32.20200601.2.2",
+                            "image": "ami-08f8fca60e45fd367"
                         },
                         "us-west-2": {
-                            "release": "32.20200601.2.1",
-                            "image": "ami-09b3b13b5f036406a"
+                            "release": "32.20200601.2.2",
+                            "image": "ami-04f8214270a35cf0f"
                         }
                     }
                 }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,8 +1,18 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2020-06-11T18:33:59Z"
+    "last-modified": "2020-06-11T21:41:39Z"
   },
   "releases": [
+    {
+      "version": "32.20200601.1.2",
+      "metadata": {
+        "rollout": {
+          "start_epoch": 1591959600,
+          "start_percentage": 0.0,
+          "duration_minutes": 1440
+        }
+      }
+    }
   ]
 }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2020-06-11T18:33:59Z"
+    "last-modified": "2020-06-11T21:41:39Z"
   },
   "releases": [
     {
@@ -17,6 +17,16 @@
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-streams/issues/30"
+        }
+      }
+    },
+    {
+      "version": "32.20200601.2.2",
+      "metadata": {
+        "rollout": {
+          "start_epoch": 1592218800,
+          "start_percentage": 0.0,
+          "duration_minutes": 1440
         }
       }
     }


### PR DESCRIPTION
Since `next` is a little more risky of a stream we can go ahead and
roll it out on Friday. For `testing` we'll wait til Monday. Since
the content in both releases is identical rolling out `next` early
will give us an early indication of if there is a problem.