### PR TITLE
updates: stop all rollouts

### DIFF
--- a/updates/next.json
+++ b/updates/next.json
@@ -1,18 +1,8 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2020-06-11T21:41:39Z"
+    "last-modified": "2020-06-16T11:51:41Z"
   },
   "releases": [
-    {
-      "version": "32.20200601.1.2",
-      "metadata": {
-        "rollout": {
-          "start_epoch": 1591959600,
-          "start_percentage": 0.0,
-          "duration_minutes": 1440
-        }
-      }
-    }
   ]
 }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,18 +1,8 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2020-06-03T15:08:25Z"
+    "last-modified": "2020-06-16T11:51:41Z"
   },
   "releases": [
-    {
-      "version": "31.20200517.3.0",
-      "metadata": {
-        "rollout": {
-          "start_epoch": 1591200000,
-          "start_percentage": 0.0,
-          "duration_minutes": 2880
-        }
-      }
-    }
   ]
 }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2020-06-11T21:41:39Z"
+    "last-modified": "2020-06-16T11:51:41Z"
   },
   "releases": [
     {
@@ -17,16 +17,6 @@
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-streams/issues/30"
-        }
-      }
-    },
-    {
-      "version": "32.20200601.2.2",
-      "metadata": {
-        "rollout": {
-          "start_epoch": 1592218800,
-          "start_percentage": 0.0,
-          "duration_minutes": 1440
         }
       }
     }


### PR DESCRIPTION
This drops all completed rollouts, mitigating rpm-ostree bug
while preparing for next release targeted on 2020-06-16