### PR TITLE
next: rollout 32.20200625.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,165 +1,165 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2020-06-25T15:18:18Z"
+        "last-modified": "2020-06-26T13:54:07Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "32.20200615.1.3",
+                    "release": "32.20200625.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "44cbcc6325bb1915b2bf53eb6e27b63acd8340eeaba0f30653022c58b8985613"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "b2b791b2a4b736512c631ba83745a5bf83bbb1cd39106456503eeb5303f493ac"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "32.20200615.1.3",
+                    "release": "32.20200625.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "11d54a5daf9f853a15a1fff48cb604759962399ea5036814667292571a93e834"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "8cb734838bfbbc4d5c3696a13e8530eb565acf7a65af092287c7f6f987c3b588"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "32.20200615.1.3",
+                    "release": "32.20200625.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-azure.x86_64.vhd.xz.sig",
-                                "sha256": "129660c84bff271662010d7a66b73d794d46f2e1a3f431aa30d93edd7a95c1cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "baf5dd13cd22cb6f7ac6cb25264840c23c1867bbe23ffff893d8d401e874afba"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "32.20200615.1.3",
+                    "release": "32.20200625.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "2ff1bb48c57cfb47139f3d89a6bcc24d2966fb489858d5355d93c1ffb7948c65"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "f4c1d9f269726b1b9d796602c887d8a53828c0fb51ee02e6d0161dd60e08f0c8"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "32.20200615.1.3",
+                    "release": "32.20200625.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "b10a82cc43d6180d2e1836df76bae4f1fb5aae8ef3605b3b69c2bc8dd8a9ea48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "a1159b500fc3e53375b347859cffb33618d8462e100041384a0b9b3f29a9ee9c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "32.20200615.1.3",
+                    "release": "32.20200625.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-gcp.x86_64.tar.gz.sig",
-                                "sha256": "1f588a413b510cb23632b0e5c665143a7a9a54958ffc7b6af95814eae91c2083"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "e140716d3fe4c31dfe2dbf4dd76ea0bd0bbc67c23721285b29dd4fe06e6388ec"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "32.20200615.1.3",
+                    "release": "32.20200625.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "7c979adca06d8b51e9c7ef2eb8b6cf7d92094bc65bb977c4671a9dfd42bce7ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "3f67c27703982c4a1b8212795d615b6f3e0faf6ba329b12b2be2ec4a7d7a2601"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-live.x86_64.iso.sig",
-                                "sha256": "c9ca1ff72d2577f69516824d3ac9a4214f0db19d8f08e8cd1e0ff9c04f51b46f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-live.x86_64.iso.sig",
+                                "sha256": "cb8ec7c390946de0657d1974fab8893689c8fca80e7e8a4ab350b4216c0b0635"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-live-kernel-x86_64.sig",
-                                "sha256": "ce2bb288a1ea4a34a4a6cf9fa221cde75855554af811d225639e2d8cffd8512a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-live-kernel-x86_64.sig",
+                                "sha256": "e58b29e5394b4167f0573c89c23b3b9bfe577c527ef160898cd6e0882a3ed8e8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-live-initramfs.x86_64.img.sig",
-                                "sha256": "5832c0a4054e638f9457a66606d0748ca6fff01002866816c57dda6651bac8a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "0bd933edea4586ab4212972b705e78bdb97b65e60bd3509315aceec161305f91"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-metal.x86_64.raw.xz.sig",
-                                "sha256": "440258627e438d3f1e9931661004b0d073ebb701ba1d948f8261797743d79aa8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "a73183412cd0d9d76b510b648cc9e5198c5a59c3c3971bd059144d1367bab2be"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "32.20200615.1.3",
+                    "release": "32.20200625.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e16a4a5aab47ebf483591e1715fd1604efb6c478362cf1a5136e8bba487ec368"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "6bc99d77bcec933aae90aedfbe8191ea6e22694b3fc9480a6740a5f4fe6214ef"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "32.20200615.1.3",
+                    "release": "32.20200625.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "0ed4ab3af0d2873d53dc419012f185cb1ca9576fcffd995c5cc7fc86bcf6a684"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "7b72d521e0b21c1d3a70c011cb53aba54e4ff90de74d5db49477c22f511039b8"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "32.20200615.1.3",
+                    "release": "32.20200625.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-vmware.x86_64.ova.sig",
-                                "sha256": "75f8efc10e6f913451c2034158e13271047f2ea36f3d12bbadbd3f113c58be87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "30fc24b180012f7c97c9ff81e2cb21be2a7207e4297ed18b9c221e69477c179d"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "32.20200615.1.3",
+                    "release": "32.20200625.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200615.1.3/x86_64/fedora-coreos-32.20200615.1.3-vultr.x86_64.raw.xz.sig",
-                                "sha256": "24c9d33da149550b17ccd225ed648ab6c32b6508942e2f5ca2fb435857f6d298"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200625.1.0/x86_64/fedora-coreos-32.20200625.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "3c06b143650f1200223a294c6eacd1f2b317493dc873b2fc1c107f488b944259"
                             }
                         }
                     }
@@ -169,91 +169,91 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "32.20200615.1.3",
-                            "image": "ami-0a990da769cd41d64"
+                            "release": "32.20200625.1.0",
+                            "image": "ami-0919a227edca9536a"
                         },
                         "ap-east-1": {
-                            "release": "32.20200615.1.3",
-                            "image": "ami-00cd3894aac58727e"
+                            "release": "32.20200625.1.0",
+                            "image": "ami-06d2f6826ee33db5b"
                         },
                         "ap-northeast-1": {
-                            "release": "32.20200615.1.3",
-                            "image": "ami-0e6eb2dc5dcdc9ac2"
+                            "release": "32.20200625.1.0",
+                            "image": "ami-02aaebda100fcfc85"
                         },
                         "ap-northeast-2": {
-                            "release": "32.20200615.1.3",
-                            "image": "ami-0b94c0038fb91c466"
+                            "release": "32.20200625.1.0",
+                            "image": "ami-0117cd63909204915"
                         },
                         "ap-south-1": {
-                            "release": "32.20200615.1.3",
-                            "image": "ami-05b3e8600ff5b51da"
+                            "release": "32.20200625.1.0",
+                            "image": "ami-0c103e5248d0c7dcb"
                         },
                         "ap-southeast-1": {
-                            "release": "32.20200615.1.3",
-                            "image": "ami-099ebb837b3075ac2"
+                            "release": "32.20200625.1.0",
+                            "image": "ami-07f66d82c3ed1c675"
                         },
                         "ap-southeast-2": {
-                            "release": "32.20200615.1.3",
-                            "image": "ami-058fffb04e97fa942"
+                            "release": "32.20200625.1.0",
+                            "image": "ami-0abf161aa4de40174"
                         },
                         "ca-central-1": {
-                            "release": "32.20200615.1.3",
-                            "image": "ami-0fb86376fe9e5c0d6"
+                            "release": "32.20200625.1.0",
+                            "image": "ami-0b2869218081e725c"
                         },
                         "eu-central-1": {
-                            "release": "32.20200615.1.3",
-                            "image": "ami-0a719fab8303f91db"
+                            "release": "32.20200625.1.0",
+                            "image": "ami-0ce3a383e20f6021b"
                         },
                         "eu-north-1": {
-                            "release": "32.20200615.1.3",
-                            "image": "ami-0654067704925d691"
+                            "release": "32.20200625.1.0",
+                            "image": "ami-0624dc52ac9fc4cce"
                         },
                         "eu-south-1": {
-                            "release": "32.20200615.1.3",
-                            "image": "ami-088deae1d86f0211c"
+                            "release": "32.20200625.1.0",
+                            "image": "ami-0b68faf031926510a"
                         },
                         "eu-west-1": {
-                            "release": "32.20200615.1.3",
-                            "image": "ami-07f0b9b01a3d289f6"
+                            "release": "32.20200625.1.0",
+                            "image": "ami-0394e53ca5ebed946"
                         },
                         "eu-west-2": {
-                            "release": "32.20200615.1.3",
-                            "image": "ami-0f2191bd82b580a9f"
+                            "release": "32.20200625.1.0",
+                            "image": "ami-0eb8fb820a87e8274"
                         },
                         "eu-west-3": {
-                            "release": "32.20200615.1.3",
-                            "image": "ami-02af95046eb208309"
+                            "release": "32.20200625.1.0",
+                            "image": "ami-0d79d159a5c606b24"
                         },
                         "me-south-1": {
-                            "release": "32.20200615.1.3",
-                            "image": "ami-0e0bf257f6b826dcc"
+                            "release": "32.20200625.1.0",
+                            "image": "ami-0c0ede9582650d553"
                         },
                         "sa-east-1": {
-                            "release": "32.20200615.1.3",
-                            "image": "ami-092fa16d70b72478e"
+                            "release": "32.20200625.1.0",
+                            "image": "ami-05d7ed85dbbc7cfac"
                         },
                         "us-east-1": {
-                            "release": "32.20200615.1.3",
-                            "image": "ami-07a5d5117612cee28"
+                            "release": "32.20200625.1.0",
+                            "image": "ami-00964bba0f1b08322"
                         },
                         "us-east-2": {
-                            "release": "32.20200615.1.3",
-                            "image": "ami-04f6180b11dca78da"
+                            "release": "32.20200625.1.0",
+                            "image": "ami-00baaa93cb74c3587"
                         },
                         "us-west-1": {
-                            "release": "32.20200615.1.3",
-                            "image": "ami-069ae89468aacd452"
+                            "release": "32.20200625.1.0",
+                            "image": "ami-025d1a1f5d65ad003"
                         },
                         "us-west-2": {
-                            "release": "32.20200615.1.3",
-                            "image": "ami-063a9a812a8970d35"
+                            "release": "32.20200625.1.0",
+                            "image": "ami-00e5b5bc447511e79"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-32-20200615-1-3-gcp-x86-64"
+                    "name": "fedora-coreos-32-20200625-1-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2020-06-25T15:18:18Z"
+    "last-modified": "2020-06-26T13:54:07Z"
   },
   "releases": [
     {
@@ -9,11 +9,16 @@
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/484"
-        },
+        }
+      }
+    },
+    {
+      "version": "32.20200625.1.0",
+      "metadata": {
         "rollout": {
-          "start_epoch": 1593102600,
+          "start_epoch": 1593181800,
           "start_percentage": 0.0,
-          "duration_minutes": 720
+          "duration_minutes": 1440
         }
       }
     }


### PR DESCRIPTION
This release bumps the package set and also restores persistent NIC
naming. See the following issue for context:

https://github.com/coreos/fedora-coreos-tracker/issues/484