### PR TITLE
stable: rollout 32.20200615.3.0 (barrier release)

### DIFF
--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,165 +1,165 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2020-06-16T14:55:01Z"
+        "last-modified": "2020-06-30T16:03:25Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "32.20200601.3.0",
+                    "release": "32.20200615.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "4b21be940efe60957adb1440712b702d1ad0f09ec598455555ced27bac6195e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "5f328edc9d8f91ed93f7780b0f32630d8d5498da6327a857f14a854aa7b76c56"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "32.20200601.3.0",
+                    "release": "32.20200615.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "5683bad6307ea1626725c79fc88f38ba0ac32c847755b3b2f3e126ed47a66cd5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "03015bbaecadf504c400450a545850b0148e98dec2851459de7d35e9c7b95b30"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "32.20200601.3.0",
+                    "release": "32.20200615.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7d7abd74f32ee159e90bd23ebbbb882d9716cb176a0349af23876fc705820132"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e56dbfff4e3d97821995c43b9afc4f1dffbe1e8df5490e7288e5d9b2161f3020"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "32.20200601.3.0",
+                    "release": "32.20200615.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "87c5eadd5f862a924b9cc81b5dd6dfdda28e0392ef9e973b78d948b0168df738"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "79d8ed863f485637076e69cf50c487eeb19076b08aebf0253ff7fd36992cb856"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "32.20200601.3.0",
+                    "release": "32.20200615.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "33c30633d7fa4e8288401a04135eab7778df581139f601d900b63b4a574ed61c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e0144989e88c810d47142a49548f18e4a377cd283accaaf1aa5437ebd142ac3c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "32.20200601.3.0",
+                    "release": "32.20200615.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "17605fc24e9531e319ee310684beb48cd2687a681e1082d130049eb3b7372748"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "351d17e3c991b4c58743565ef0b25a5492de4461fe00125bcca82c45cc4f0f5b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "32.20200601.3.0",
+                    "release": "32.20200615.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "65c91dac67cc9fa454c548e7fc2b5ce601c055c76ad2357b008da42727e7563a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "21467797b6318cfcdcdf619d727edd1ae7ebfe95fdde997275824c809b329d57"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-live.x86_64.iso.sig",
-                                "sha256": "90b2b646ad2208f822a54a6a42f3e4399d2bb346edf56b25f047bdbb8a04ac67"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-live.x86_64.iso.sig",
+                                "sha256": "769b8d4a1ae1b159c91599d6566ddea551af3c121f843ec69211ff99d64b5ca3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-live-kernel-x86_64.sig",
-                                "sha256": "34869fe6d5ed7e83e0873f348450f65e8800005620f8b736dcc610b5bfbf61da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-live-kernel-x86_64.sig",
+                                "sha256": "ce2bb288a1ea4a34a4a6cf9fa221cde75855554af811d225639e2d8cffd8512a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "08621f5f8c07128ee9708055e765dd8cb9006538cc48bbb2f9410fcca7aba5d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "c0c09f6ba0a6050c4ab48c2dce15211257401e156597fc725863690c519573bf"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "6be1a68be00d889d91f1de10c98ff1af72acb4c97ec969ce38af4c477a0ef757"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "ba6777955d9ce8cb80e7beff0c2a5feb975871646cc9553bb5b26d710ac52630"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "32.20200601.3.0",
+                    "release": "32.20200615.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "fe78c348189d745eb5f6f80ff9eb2af67da8e84880d264f4301faaf7c2a72646"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "e5e54af7ca2090977c1000a1c83ee5a0bc49fb8ec7a1bbdf6ff9e102f0d4f5f7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "32.20200601.3.0",
+                    "release": "32.20200615.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "48a4240df3f38ff83bfc85a0f1f3c24f6beb4f03fa5453f5d5eda73f9ea14099"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "270f2f0ce0e405fa605aec52a09038e2b20a13b9b5d79bdd4878c4fe3f4fa7e6"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "32.20200601.3.0",
+                    "release": "32.20200615.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "1c33fc7f25ad4ae3a077c94d8169e48315985a554da6c9e4967137cdbd081054"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "b9a5fb9810d563ef8fb19f7e8c0bc4e31eaa77c6a7bbb0ba9bc3cec7d154ca72"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "32.20200601.3.0",
+                    "release": "32.20200615.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200601.3.0/x86_64/fedora-coreos-32.20200601.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "a3185469f93dfc91f1ab1ca51f00207efd6a449ea3a8510f2c24eeba51a3de84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200615.3.0/x86_64/fedora-coreos-32.20200615.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "1bbf989272d9ac2a3fedc186ac29665173320dad345f40eb8a7d4559885a1daf"
                             }
                         }
                     }
@@ -169,86 +169,91 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "32.20200601.3.0",
-                            "image": "ami-0f1be0d8cf6194d80"
+                            "release": "32.20200615.3.0",
+                            "image": "ami-05ee1a89925411b7e"
                         },
                         "ap-east-1": {
-                            "release": "32.20200601.3.0",
-                            "image": "ami-0a7059c5f3da46dbe"
+                            "release": "32.20200615.3.0",
+                            "image": "ami-07d618bbc3c0cdbec"
                         },
                         "ap-northeast-1": {
-                            "release": "32.20200601.3.0",
-                            "image": "ami-0a408bc2a85842cb1"
+                            "release": "32.20200615.3.0",
+                            "image": "ami-01223b200e5616b4c"
                         },
                         "ap-northeast-2": {
-                            "release": "32.20200601.3.0",
-                            "image": "ami-0abada7e9a1e28b2a"
+                            "release": "32.20200615.3.0",
+                            "image": "ami-0e15c19ec2fcd647e"
                         },
                         "ap-south-1": {
-                            "release": "32.20200601.3.0",
-                            "image": "ami-01a250a5c17f2eb8b"
+                            "release": "32.20200615.3.0",
+                            "image": "ami-04d6b14f9c333e2b3"
                         },
                         "ap-southeast-1": {
-                            "release": "32.20200601.3.0",
-                            "image": "ami-000a62bb821867691"
+                            "release": "32.20200615.3.0",
+                            "image": "ami-039821f40b123ca23"
                         },
                         "ap-southeast-2": {
-                            "release": "32.20200601.3.0",
-                            "image": "ami-07ca0cd3777f94bb7"
+                            "release": "32.20200615.3.0",
+                            "image": "ami-09e0ee45f6679d42d"
                         },
                         "ca-central-1": {
-                            "release": "32.20200601.3.0",
-                            "image": "ami-0c423f97d610ea6ca"
+                            "release": "32.20200615.3.0",
+                            "image": "ami-08b31128ca353ba44"
                         },
                         "eu-central-1": {
-                            "release": "32.20200601.3.0",
-                            "image": "ami-0e026067825c0da62"
+                            "release": "32.20200615.3.0",
+                            "image": "ami-091c453d5a53158ec"
                         },
                         "eu-north-1": {
-                            "release": "32.20200601.3.0",
-                            "image": "ami-061adc91ab14a4e96"
+                            "release": "32.20200615.3.0",
+                            "image": "ami-08ad8185aa2acd598"
                         },
                         "eu-south-1": {
-                            "release": "32.20200601.3.0",
-                            "image": "ami-02beb9764e1cd3bf2"
+                            "release": "32.20200615.3.0",
+                            "image": "ami-0ef0b930a31ca2968"
                         },
                         "eu-west-1": {
-                            "release": "32.20200601.3.0",
-                            "image": "ami-0355461c86dd161ac"
+                            "release": "32.20200615.3.0",
+                            "image": "ami-0ef36164cffe2a9df"
                         },
                         "eu-west-2": {
-                            "release": "32.20200601.3.0",
-                            "image": "ami-00ab765d00fdc3ab0"
+                            "release": "32.20200615.3.0",
+                            "image": "ami-04a0720b451508d71"
                         },
                         "eu-west-3": {
-                            "release": "32.20200601.3.0",
-                            "image": "ami-00c93a3a1fe4be0b0"
+                            "release": "32.20200615.3.0",
+                            "image": "ami-048d41c21125d2544"
                         },
                         "me-south-1": {
-                            "release": "32.20200601.3.0",
-                            "image": "ami-06bb5ad55e2245d69"
+                            "release": "32.20200615.3.0",
+                            "image": "ami-0a7c56159c3572f96"
                         },
                         "sa-east-1": {
-                            "release": "32.20200601.3.0",
-                            "image": "ami-074fb5ffebdba8582"
+                            "release": "32.20200615.3.0",
+                            "image": "ami-0b7b683f8f6dbec11"
                         },
                         "us-east-1": {
-                            "release": "32.20200601.3.0",
-                            "image": "ami-0ac9fa195c3a98c56"
+                            "release": "32.20200615.3.0",
+                            "image": "ami-02545325b519192df"
                         },
                         "us-east-2": {
-                            "release": "32.20200601.3.0",
-                            "image": "ami-0697c9290ad3a6dc1"
+                            "release": "32.20200615.3.0",
+                            "image": "ami-0a41a7c6b8cf1357d"
                         },
                         "us-west-1": {
-                            "release": "32.20200601.3.0",
-                            "image": "ami-084be7b827ddc2324"
+                            "release": "32.20200615.3.0",
+                            "image": "ami-041647c00abc7706a"
                         },
                         "us-west-2": {
-                            "release": "32.20200601.3.0",
-                            "image": "ami-0bbbb164e878f75ea"
+                            "release": "32.20200615.3.0",
+                            "image": "ami-0cb648f75c50223d0"
                         }
                     }
+                },
+                "gcp": {
+                    "project": "fedora-coreos-cloud",
+                    "family": "fedora-coreos-stable",
+                    "name": "fedora-coreos-32-20200615-3-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,14 +1,25 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2020-06-16T14:55:01Z"
+    "last-modified": "2020-06-30T16:26:58Z"
   },
   "releases": [
     {
       "version": "32.20200601.3.0",
       "metadata": {
         "rollout": {
-          "start_epoch": 1592325000,
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "32.20200615.3.0",
+      "metadata": {
+        "barrier": {
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/484"
+        },
+        "rollout": {
+          "start_epoch": 1593540000,
           "start_percentage": 0.0,
           "duration_minutes": 4320
         }


### PR DESCRIPTION
This a barrier release for https://github.com/coreos/fedora-coreos-tracker/issues/484
This also adds the GCP Cloud launchable stream.