### PR TITLE
{next,testing}: revert metal artifacts

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,7 +1,7 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2020-08-11T09:22:34Z"
+        "last-modified": "2020-08-11T15:23:21Z"
     },
     "architectures": {
         "x86_64": {
@@ -79,44 +79,39 @@
                     }
                 },
                 "metal": {
-                    "release": "32.20200809.1.0",
+                    "release": "32.20200726.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200809.1.0/x86_64/fedora-coreos-32.20200809.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200809.1.0/x86_64/fedora-coreos-32.20200809.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "680585fa964feb3a932b924551185a6aef928dea7c30003115beea3e0b36fa68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200726.1.0/x86_64/fedora-coreos-32.20200726.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200726.1.0/x86_64/fedora-coreos-32.20200726.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "db2469380a052c53482fb0baf7cfd5dceabb02d55cbfd8ec142e6ca63237bd57"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200809.1.0/x86_64/fedora-coreos-32.20200809.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200809.1.0/x86_64/fedora-coreos-32.20200809.1.0-live.x86_64.iso.sig",
-                                "sha256": "32e97cfb4ddd92a98ddf2b6973b9982cfc0995276b673381c18b1695ad0f4b72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200726.1.0/x86_64/fedora-coreos-32.20200726.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200726.1.0/x86_64/fedora-coreos-32.20200726.1.0-live.x86_64.iso.sig",
+                                "sha256": "ab01f80b53b2bfb46a5d83ca16b651495f03bb1816c88c74c7aab090e80ec5de"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200809.1.0/x86_64/fedora-coreos-32.20200809.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200809.1.0/x86_64/fedora-coreos-32.20200809.1.0-live-kernel-x86_64.sig",
-                                "sha256": "bb46e75620a7f2fe6330d45db6abf4ac101b51556250c929e2d8e50db92378cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200726.1.0/x86_64/fedora-coreos-32.20200726.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200726.1.0/x86_64/fedora-coreos-32.20200726.1.0-live-kernel-x86_64.sig",
+                                "sha256": "dd36f5b3c57e917d2108eebb10022462616f949b3aaaadccae107fe4216e76b5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200809.1.0/x86_64/fedora-coreos-32.20200809.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200809.1.0/x86_64/fedora-coreos-32.20200809.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "d1277ef5d797020740c0cd7e96a77e2debf3425aaa83dbd77ea2da06a2bb9584"
-                            },
-                            "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200809.1.0/x86_64/fedora-coreos-32.20200809.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200809.1.0/x86_64/fedora-coreos-32.20200809.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "76efc598865ac14f396ba26af14b286c6fbc2ec7ff1ec6a13d1d1094159e14ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200726.1.0/x86_64/fedora-coreos-32.20200726.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200726.1.0/x86_64/fedora-coreos-32.20200726.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "040707794dd4c1a5f01131cb8088fd112fe246fc830e287580b64d0c665f7bb6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200809.1.0/x86_64/fedora-coreos-32.20200809.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200809.1.0/x86_64/fedora-coreos-32.20200809.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "3ce1f9cf666330ef9b6424c16d19626c2d9ec3b2a95c8edc9388964c0845f202"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200726.1.0/x86_64/fedora-coreos-32.20200726.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200726.1.0/x86_64/fedora-coreos-32.20200726.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "dbb6eae20b270bee0f3f289d0f3298924017236f5c11f1afb88a5f7562176db3"
                             }
                         }
                     }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,7 +1,7 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2020-08-11T09:12:04Z"
+        "last-modified": "2020-08-11T15:22:24Z"
     },
     "architectures": {
         "x86_64": {
@@ -79,44 +79,39 @@
                     }
                 },
                 "metal": {
-                    "release": "32.20200809.2.0",
+                    "release": "32.20200726.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200809.2.0/x86_64/fedora-coreos-32.20200809.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200809.2.0/x86_64/fedora-coreos-32.20200809.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "7bd8ec612b6a993d5750703710cd7990a93673e8f27121d04474369d8920ff0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200726.2.0/x86_64/fedora-coreos-32.20200726.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200726.2.0/x86_64/fedora-coreos-32.20200726.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "189e8f8c2ab92cd3056b93b119a3ce7d01c3e1741f7004fffdacb01a33312985"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200809.2.0/x86_64/fedora-coreos-32.20200809.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200809.2.0/x86_64/fedora-coreos-32.20200809.2.0-live.x86_64.iso.sig",
-                                "sha256": "d33a306fe6980aea34c030b3f09b270a6e2984998c338a5916386a505a0c9cb9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200726.2.0/x86_64/fedora-coreos-32.20200726.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200726.2.0/x86_64/fedora-coreos-32.20200726.2.0-live.x86_64.iso.sig",
+                                "sha256": "88dcd3a2e3ccdab642263646891b57c9c88dbf7cd66f581a4710c9a8aafbfefa"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200809.2.0/x86_64/fedora-coreos-32.20200809.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200809.2.0/x86_64/fedora-coreos-32.20200809.2.0-live-kernel-x86_64.sig",
-                                "sha256": "bb46e75620a7f2fe6330d45db6abf4ac101b51556250c929e2d8e50db92378cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200726.2.0/x86_64/fedora-coreos-32.20200726.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200726.2.0/x86_64/fedora-coreos-32.20200726.2.0-live-kernel-x86_64.sig",
+                                "sha256": "dd36f5b3c57e917d2108eebb10022462616f949b3aaaadccae107fe4216e76b5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200809.2.0/x86_64/fedora-coreos-32.20200809.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200809.2.0/x86_64/fedora-coreos-32.20200809.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "9041f64349602cce228e803cfa249c184a4f65948d503381ed1281f8dbfb24bc"
-                            },
-                            "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200809.2.0/x86_64/fedora-coreos-32.20200809.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200809.2.0/x86_64/fedora-coreos-32.20200809.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "764b1b169108bb35d28d2a025c699a9cd640693c6facb09a37a496e5cc75a831"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200726.2.0/x86_64/fedora-coreos-32.20200726.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200726.2.0/x86_64/fedora-coreos-32.20200726.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "13b9544a89ab741f2e64197f1ba5e898c921535dbdd5cbf61f9b4c9a1408f952"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200809.2.0/x86_64/fedora-coreos-32.20200809.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200809.2.0/x86_64/fedora-coreos-32.20200809.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "d2e72d1538548eba91dae0190a2cb17dfb30b336705bd32e7b804cf289b904d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200726.2.0/x86_64/fedora-coreos-32.20200726.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200726.2.0/x86_64/fedora-coreos-32.20200726.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "9588a1db7e23d04c12e9412746383d612888aefc54567c48fd63bba06ecab3c4"
                             }
                         }
                     }


### PR DESCRIPTION
`coreos-installer download` won't download the PXE rootfs artifact, since it's smaller than 1 MiB.