### PR TITLE
updates: stop next/testing rollouts

### DIFF
--- a/updates/next.json
+++ b/updates/next.json
@@ -19,16 +19,6 @@
           "start_percentage": 1.0
         }
       }
-    },
-    {
-      "version": "32.20200809.1.0",
-      "metadata": {
-        "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1597159800,
-          "start_percentage": 0.0
-        }
-      }
     }
   ]
 }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -35,16 +35,6 @@
           "start_percentage": 1.0
         }
       }
-    },
-    {
-      "version": "32.20200809.2.0",
-      "metadata": {
-        "rollout": {
-          "start_epoch": 1597159800,
-          "start_percentage": 0.0,
-          "duration_minutes": 2880
-        }
-      }
     }
   ]
 }


### PR DESCRIPTION
We found an issue with the PXE rootfs artifact where coreos-installer
can't verify it [1]. We're going to do a new set of builds so let's stop
the next/testing rollouts of 32.20200809.1.0 and 32.20200809.2.0 so we
don't update users two times in as many days.

[1] https://github.com/coreos/fedora-coreos-streams/issues/158#issuecomment-672013148