### PR TITLE
updates: dual rollout (testing/next) on 2020-09-09

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,170 +1,170 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2020-09-02T04:08:53Z"
+        "last-modified": "2020-09-09T09:10:55Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "32.20200901.1.0",
+                    "release": "32.20200907.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "232cb83055bca45d2484b1355d2ac1f7254e1bbb203d16be54c4130e7d1b03c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "c82c6b96d3e06d727a4c614b3a978075e5dc6a3ff37c3159cf86e6b7d1d4e38f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "32.20200901.1.0",
+                    "release": "32.20200907.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "21a9c5094083289fb25b5470ee18e0d72a187dd69075de8f49362db3967974f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "038f4bea9e27a929380b533258ea464f64de1a9f88a8eaa9724ebafe9db90f5d"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "32.20200901.1.0",
+                    "release": "32.20200907.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "79bacb1366fa0cc993edc9e3483a230e8e0902ec3b754099813ec5c061946889"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "c2f384b167891dd0541abd639552242b43c5f4ee53c1a3a4fe98dd483e002823"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "32.20200901.1.0",
+                    "release": "32.20200907.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "5612bf80d20e71cde4f68ef6aa913ffce12e79fdd9ee787c94ed81d6ed81a651"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "f84bdfb0c45e85819682391d074d110276f55da73708fc230641ed73f100a5f8"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "32.20200901.1.0",
+                    "release": "32.20200907.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "75dd88389db986f269e1ebd2ea9a62fdebcfc5d59ae435fc28ccd21ec830271c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "55d648b83cc756d3943b53b2223f4782615c54233f0c1f49e389cb1eb1aaa90a"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "32.20200901.1.0",
+                    "release": "32.20200907.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "298cfab2a25763c99cbf0a3dc2227a859fd8e9cdd40450f5e72e488d12e2d609"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "1bef9bb4ab72c447a01a9eb58989c52a8ec3206f52637964d66b1bf1e799028e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "32.20200901.1.0",
+                    "release": "32.20200907.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "3a747907ba73d03df19ee460734b17a016b175910f6f460eb20cc3d3d055822e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "de2735d48964d854107a5c3e22b2e69060382fcd6c13fc7b41c0749b25692b97"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-live.x86_64.iso.sig",
-                                "sha256": "ded5f167d54df3c843f448673bbb561fb81044e0352f370fe48aa3b2f8866cf0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-live.x86_64.iso.sig",
+                                "sha256": "e338ba38db771f553f3d87edd01ddcf12a1ecdc09978ad36bbc463301fa1a320"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-live-kernel-x86_64.sig",
-                                "sha256": "234f126d67e2876e7c0e2b59b8c4e2d64d4213a8527d2cc48959ddaff9d4cea8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-live-kernel-x86_64.sig",
+                                "sha256": "e87bad6e053b930bcc6db5f1d866905ddfd1d8333f52844f1eb6786de38a6ab3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "ad0ee6a707170d969b8c3c50467862c20c84457de9d1238553c93c633123b16a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "6507ac76042ff8cabf6e048a523cddd2a237a6ebf1e38226d086e479a70d9686"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "3c1e1d19278f962dad0d9f487eb24fc48dcc7fea817f2ac96bd006d4a8724035"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "8d7f347c69503bd1602ac2b98f19cd047194827d8055b7a1c4270d3c98dd6e26"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "66af08bf74d788d29646a050ec8141e0f250c634baada57746a1c2b9d52bbf48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "0b80b3aa9dd188ec366b260aa7f1b28251fb6cf1cbbedd667af9a562687e9648"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "32.20200901.1.0",
+                    "release": "32.20200907.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "b6225cdf85a31d5ed5e9d4e9ff3a40e503afb46b89e4a78bb051060fd87ed8f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "656d2446ad9a367d61d4cf3929b89b954c02e53f70dfb4cef98377baeed82deb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "32.20200901.1.0",
+                    "release": "32.20200907.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "c403c29015dc14a493d0a1f428419183111469b0ba2c45df59dce21d8c66eea6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "9e34d8cf2ca35aeb9a469f216634883fb4d0c7f67b32cc6277799c55d85378bc"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "32.20200901.1.0",
+                    "release": "32.20200907.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "a527f786a90ec7eda16dfc38457c36660826ade14bba38475cd91d64e3bbb3ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "caf86f2ceaaecc00545040ab7503298dfb91d29679d8c44d222da98e645427dc"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "32.20200901.1.0",
+                    "release": "32.20200907.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200901.1.0/x86_64/fedora-coreos-32.20200901.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "2e9b17808300026182901fa47a1e69d54a4742879e9ef4de34e47ddfd64948bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/32.20200907.1.0/x86_64/fedora-coreos-32.20200907.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "44f829678fe0b8193611acd24e3889d07285d730df616cf9f4391a293b9ec25d"
                             }
                         }
                     }
@@ -174,91 +174,91 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "32.20200901.1.0",
-                            "image": "ami-045309129dc9141ab"
+                            "release": "32.20200907.1.0",
+                            "image": "ami-087697d5e6d9b1568"
                         },
                         "ap-east-1": {
-                            "release": "32.20200901.1.0",
-                            "image": "ami-04879b4d022b590ca"
+                            "release": "32.20200907.1.0",
+                            "image": "ami-069443d1539ed6444"
                         },
                         "ap-northeast-1": {
-                            "release": "32.20200901.1.0",
-                            "image": "ami-0dca1ce6d027789c4"
+                            "release": "32.20200907.1.0",
+                            "image": "ami-034d78bd97425f9a4"
                         },
                         "ap-northeast-2": {
-                            "release": "32.20200901.1.0",
-                            "image": "ami-0d57b161b1153ec61"
+                            "release": "32.20200907.1.0",
+                            "image": "ami-099338a5a2b423fe5"
                         },
                         "ap-south-1": {
-                            "release": "32.20200901.1.0",
-                            "image": "ami-046dac94eac0cfd0a"
+                            "release": "32.20200907.1.0",
+                            "image": "ami-07ae3e340708ed916"
                         },
                         "ap-southeast-1": {
-                            "release": "32.20200901.1.0",
-                            "image": "ami-057e6259b3864ac65"
+                            "release": "32.20200907.1.0",
+                            "image": "ami-0ab1d2417db40b4ec"
                         },
                         "ap-southeast-2": {
-                            "release": "32.20200901.1.0",
-                            "image": "ami-0f5eb7f68d4b09aed"
+                            "release": "32.20200907.1.0",
+                            "image": "ami-05624bdd1679c172c"
                         },
                         "ca-central-1": {
-                            "release": "32.20200901.1.0",
-                            "image": "ami-0a856a387413fea6d"
+                            "release": "32.20200907.1.0",
+                            "image": "ami-06bbcc11801284227"
                         },
                         "eu-central-1": {
-                            "release": "32.20200901.1.0",
-                            "image": "ami-0a39f5915457423fb"
+                            "release": "32.20200907.1.0",
+                            "image": "ami-0de464838de76af4e"
                         },
                         "eu-north-1": {
-                            "release": "32.20200901.1.0",
-                            "image": "ami-0227e74450ec433b7"
+                            "release": "32.20200907.1.0",
+                            "image": "ami-07abed9e368d67cca"
                         },
                         "eu-south-1": {
-                            "release": "32.20200901.1.0",
-                            "image": "ami-06a5b40e3ce772bc6"
+                            "release": "32.20200907.1.0",
+                            "image": "ami-056763c1dfc643077"
                         },
                         "eu-west-1": {
-                            "release": "32.20200901.1.0",
-                            "image": "ami-06cdee0c9a2ff223d"
+                            "release": "32.20200907.1.0",
+                            "image": "ami-0629c2ab057cc216c"
                         },
                         "eu-west-2": {
-                            "release": "32.20200901.1.0",
-                            "image": "ami-01fa3c17eb8f8ce5f"
+                            "release": "32.20200907.1.0",
+                            "image": "ami-0538a70b7e269a94a"
                         },
                         "eu-west-3": {
-                            "release": "32.20200901.1.0",
-                            "image": "ami-0670ce699a1f0f21f"
+                            "release": "32.20200907.1.0",
+                            "image": "ami-0212b5c446e195206"
                         },
                         "me-south-1": {
-                            "release": "32.20200901.1.0",
-                            "image": "ami-064204ba0320a3475"
+                            "release": "32.20200907.1.0",
+                            "image": "ami-0663e813c90f3d728"
                         },
                         "sa-east-1": {
-                            "release": "32.20200901.1.0",
-                            "image": "ami-0faddbefda4e7e2fc"
+                            "release": "32.20200907.1.0",
+                            "image": "ami-0bd7d47beb4d686c2"
                         },
                         "us-east-1": {
-                            "release": "32.20200901.1.0",
-                            "image": "ami-0f3a0b5afd68263ed"
+                            "release": "32.20200907.1.0",
+                            "image": "ami-0247c20d652d82e69"
                         },
                         "us-east-2": {
-                            "release": "32.20200901.1.0",
-                            "image": "ami-061ff27b46541f379"
+                            "release": "32.20200907.1.0",
+                            "image": "ami-0a387c4746fe3cd5e"
                         },
                         "us-west-1": {
-                            "release": "32.20200901.1.0",
-                            "image": "ami-068c80cb3cdc629ec"
+                            "release": "32.20200907.1.0",
+                            "image": "ami-03eb481b7b9cf816c"
                         },
                         "us-west-2": {
-                            "release": "32.20200901.1.0",
-                            "image": "ami-0243b04f8012d5ee5"
+                            "release": "32.20200907.1.0",
+                            "image": "ami-0ba567560d34006ab"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-32-20200901-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-32-20200907-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,170 +1,170 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2020-09-04T18:32:28Z"
+        "last-modified": "2020-09-09T09:10:17Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "32.20200824.2.1",
+                    "release": "32.20200907.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "6da5233cae194f03ccba9ccccb342f548d2a7658db041f0d6495f4cc68ffb948"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "088fe2c8403b3cd77efbd68c1e6f65e07c0b70b818492d16f8adab9aa54ff9cf"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "32.20200824.2.1",
+                    "release": "32.20200907.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "742a43bfc7b5fb630112b7f6d061789bdeca0b4382d5864e11aac748d299f18e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "2b1d82a5c72a1f99e0911f0311a4ce67925da5d81838c2547996eb68147892c2"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "32.20200824.2.1",
+                    "release": "32.20200907.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "f48715a465b493ea866f5653ebf595ab1499fd961c5aabe9e1a14e03b0872235"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "df647044930256e4ce6aa64d3b9e813e6abddd4cdf218ef7a3afbb4e5ffe6b45"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "32.20200824.2.1",
+                    "release": "32.20200907.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "bec7a6b5d33d3096541c9e3854c5eed60a92f9859c9c66b4ee7897bfd584e845"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "ac123a7aa91665eb89172fc329411c210f1e7ddb2c79c31f9d3455f5b3d30ce6"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "32.20200824.2.1",
+                    "release": "32.20200907.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "1b5bbcbc2dfede57a1da6d96002eaf23841d163690a9b5a88aa6f533f7373587"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "f6d67fd14f215d289df8dac8271119b882d5d2f3b3dd4df259677bf45a7cfdc3"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "32.20200824.2.1",
+                    "release": "32.20200907.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "57b568f6136b7ea1c738af9a6240be6b69650c68a4ef255bd58f6c3053c6a00e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "166854f86e48e40754c5d187543b7017a8512b61357bb23af912f92cd3e0dc59"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "32.20200824.2.1",
+                    "release": "32.20200907.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "f83379bc1c1897998fded9dc563623b807356d360a212f8c7bc62036e49717a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "f0528cf0c9054f21f16ceb6c3fec94e59bedd6d1603cc25431062a017d877162"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-live.x86_64.iso.sig",
-                                "sha256": "1ff5936889074e149b2e6555f7f60426ddea16faa44bf7b72e345d97fe73e9fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-live.x86_64.iso.sig",
+                                "sha256": "df6d796a7e78d30a683ac2729348508c99d9486852d0a9cc8acf84f3d21f5039"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-live-kernel-x86_64.sig",
-                                "sha256": "249d9f9b59bc96904de096a5b6a15a7892a596bdc109e6b7b123fe69f5969b9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-live-kernel-x86_64.sig",
+                                "sha256": "e87bad6e053b930bcc6db5f1d866905ddfd1d8333f52844f1eb6786de38a6ab3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "8db888023766f6bdb6a8a1786d6dac1140b7610f7a1fbb8b95aedead1c24976c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "a9db46aa6619ae66cb575f100a62de8ca7caee2bb4491a7098b3786ec9591949"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "916bb79cc4f6f4d2bac7f45535ce135bf5383308360719f6fe50e760c8eaad34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "d7e3f6dd0e092760942b1f7462cf143e0d26b5436c5a3981800898b1c1377f28"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "f26f0dc84837ee8c43761e28b5f35cbe635822e2c7982ed0e33a1db0afc3573a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "4ecb6a5d5c0d3bf087e9bd15061637faa9c860922fb1175cb6bb151a43b5e4dc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "32.20200824.2.1",
+                    "release": "32.20200907.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "1da55d24c7e60001b28ee1343c791646ae5b1540d4fa56e5683c39c7b6cd8f9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "c31fd1a5e3b9b5ad273c44a682f8ff04f64148ffe121b729143ee416de493e03"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "32.20200824.2.1",
+                    "release": "32.20200907.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "9313cd04f4f03514110d8c097b1bce7becd0113c8675f76935e9dcd56243d770"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e39707fd1c6d74dd0b9d70b9a76e367453865bef29dae0b36a82fc189e2b4af0"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "32.20200824.2.1",
+                    "release": "32.20200907.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "d893bdc67c45d4edf2c517f790c684a5d09c02a77d00eea2c0a1ffb99a063f92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "9f2eea39ebb35c00cfe199bcab0fd565ffb85a06e45cb42d6bed56b272147b2e"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "32.20200824.2.1",
+                    "release": "32.20200907.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200824.2.1/x86_64/fedora-coreos-32.20200824.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "1324c77db2c7543d8e5b6172c7c6120ad95b0f5965dd3a12112656213540a0fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200907.2.0/x86_64/fedora-coreos-32.20200907.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "21246333eb3c305c01bcb713e20a6e9518025b67f3bc778b29f1e30abdc688d6"
                             }
                         }
                     }
@@ -174,91 +174,91 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "32.20200824.2.1",
-                            "image": "ami-05e46f06243ba8c70"
+                            "release": "32.20200907.2.0",
+                            "image": "ami-0a85f2a63c003f718"
                         },
                         "ap-east-1": {
-                            "release": "32.20200824.2.1",
-                            "image": "ami-0feb4d303cb52e4ef"
+                            "release": "32.20200907.2.0",
+                            "image": "ami-051128497dffe68a7"
                         },
                         "ap-northeast-1": {
-                            "release": "32.20200824.2.1",
-                            "image": "ami-05f06b132db246a0b"
+                            "release": "32.20200907.2.0",
+                            "image": "ami-0a0c25ba2e1426916"
                         },
                         "ap-northeast-2": {
-                            "release": "32.20200824.2.1",
-                            "image": "ami-0fd9e405a45d05e8d"
+                            "release": "32.20200907.2.0",
+                            "image": "ami-0cd709eb38de8b302"
                         },
                         "ap-south-1": {
-                            "release": "32.20200824.2.1",
-                            "image": "ami-0183064998e68ea5b"
+                            "release": "32.20200907.2.0",
+                            "image": "ami-0aa4d7762a562c90c"
                         },
                         "ap-southeast-1": {
-                            "release": "32.20200824.2.1",
-                            "image": "ami-03e89c39f0088e40b"
+                            "release": "32.20200907.2.0",
+                            "image": "ami-07a48781613db6e5c"
                         },
                         "ap-southeast-2": {
-                            "release": "32.20200824.2.1",
-                            "image": "ami-0900a633ce3409895"
+                            "release": "32.20200907.2.0",
+                            "image": "ami-09b0f9e3133fc9f4c"
                         },
                         "ca-central-1": {
-                            "release": "32.20200824.2.1",
-                            "image": "ami-047a3992fd83ec5ef"
+                            "release": "32.20200907.2.0",
+                            "image": "ami-04b09d4b85b208bd3"
                         },
                         "eu-central-1": {
-                            "release": "32.20200824.2.1",
-                            "image": "ami-0d6daf073a0707da3"
+                            "release": "32.20200907.2.0",
+                            "image": "ami-0711fcfc796a0fd06"
                         },
                         "eu-north-1": {
-                            "release": "32.20200824.2.1",
-                            "image": "ami-08201782aca6e5ac1"
+                            "release": "32.20200907.2.0",
+                            "image": "ami-032e00cfbb8b8d3cb"
                         },
                         "eu-south-1": {
-                            "release": "32.20200824.2.1",
-                            "image": "ami-0ecd7f45c727d8ade"
+                            "release": "32.20200907.2.0",
+                            "image": "ami-052454c5321ed39f5"
                         },
                         "eu-west-1": {
-                            "release": "32.20200824.2.1",
-                            "image": "ami-045f3f1a5b027ab67"
+                            "release": "32.20200907.2.0",
+                            "image": "ami-07d625be7cba171e3"
                         },
                         "eu-west-2": {
-                            "release": "32.20200824.2.1",
-                            "image": "ami-03e39c6198381b15d"
+                            "release": "32.20200907.2.0",
+                            "image": "ami-0f0ac2baf493507c8"
                         },
                         "eu-west-3": {
-                            "release": "32.20200824.2.1",
-                            "image": "ami-08317fcaab05fa2c1"
+                            "release": "32.20200907.2.0",
+                            "image": "ami-08835be43a77fa881"
                         },
                         "me-south-1": {
-                            "release": "32.20200824.2.1",
-                            "image": "ami-018d418cf3d41a12b"
+                            "release": "32.20200907.2.0",
+                            "image": "ami-026ce401a639d6fde"
                         },
                         "sa-east-1": {
-                            "release": "32.20200824.2.1",
-                            "image": "ami-07c21e3954e07b15a"
+                            "release": "32.20200907.2.0",
+                            "image": "ami-0e0f0ed701a35367c"
                         },
                         "us-east-1": {
-                            "release": "32.20200824.2.1",
-                            "image": "ami-0d38e89f12ee7cc7f"
+                            "release": "32.20200907.2.0",
+                            "image": "ami-0ded0cd213b4cc308"
                         },
                         "us-east-2": {
-                            "release": "32.20200824.2.1",
-                            "image": "ami-0c8c7c4cf039b0c25"
+                            "release": "32.20200907.2.0",
+                            "image": "ami-0ef724996f0f11abe"
                         },
                         "us-west-1": {
-                            "release": "32.20200824.2.1",
-                            "image": "ami-081c8c0cfe9e95e97"
+                            "release": "32.20200907.2.0",
+                            "image": "ami-0ee4469f945620958"
                         },
                         "us-west-2": {
-                            "release": "32.20200824.2.1",
-                            "image": "ami-0219bac9db3652831"
+                            "release": "32.20200907.2.0",
+                            "image": "ami-00d97715fc9aed12b"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-32-20200824-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-32-20200907-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2020-09-02T04:08:53Z"
+    "last-modified": "2020-09-09T09:12:48Z"
   },
   "releases": [
     {
@@ -13,7 +13,7 @@
       }
     },
     {
-      "version": "32.20200824.1.0",
+      "version": "32.20200901.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -21,11 +21,11 @@
       }
     },
     {
-      "version": "32.20200901.1.0",
+      "version": "32.20200907.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1599055200,
+          "start_epoch": 1599645600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2020-09-04T18:32:28Z"
+    "last-modified": "2020-09-09T09:12:48Z"
   },
   "releases": [
     {
@@ -29,7 +29,7 @@
       }
     },
     {
-      "version": "32.20200824.2.0",
+      "version": "32.20200824.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -37,11 +37,11 @@
       }
     },
     {
-      "version": "32.20200824.2.1",
+      "version": "32.20200907.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1599247800,
+          "start_epoch": 1599645600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
* testing rollout of 32.20200907.2.0 scheduled for 2020/09/09 10:00 UTC for 2880m (48.0h)
* next rollout of 32.20200907.1.0 scheduled for 2020/09/09 10:00 UTC for 2880m (48.0h)