### PR TITLE
stable: fix 32.20200907.3.0 rollout start year

### DIFF
--- a/updates/stable.json
+++ b/updates/stable.json
@@ -25,7 +25,7 @@
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1569249000,
+          "start_epoch": 1600871400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
This fixes a mistake in the rollout start year (2019 vs 2020).