### PR TITLE
updates: add barrier releases as part of f33 bump SOP

### DIFF
--- a/updates/stable.json
+++ b/updates/stable.json
@@ -5,6 +5,14 @@
   },
   "releases": [
     {
+      "version": "31.20200517.3.0",
+      "metadata": {
+        "barrier": {
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/480#issuecomment-631724629"
+        }
+      }
+    },
+    {
       "version": "32.20200615.3.0",
       "metadata": {
         "barrier": {

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -21,6 +21,14 @@
       }
     },
     {
+      "version": "31.20200517.2.0",
+      "metadata": {
+        "barrier": {
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/480#issuecomment-631724629"
+        }
+      }
+    },
+    {
       "version": "32.20200615.2.2",
       "metadata": {
         "barrier": {


### PR DESCRIPTION
As part of the procedure to move to the next major Fedora release
we are adding a barrier for the last release of Fedora CoreOS based
on Fedora 31 content. This is a guarantee that systems have the
appropriate keys to validate the commits signed by the latest builds.

Note: there were no F31 releases on the `next` stream so skip adding
      the barrier release there.

See:

- https://github.com/coreos/fedora-coreos-tracker/issues/480#issuecomment-631724629
- https://github.com/coreos/fedora-coreos-config#moving-to-a-new-major-version-n-of-fedora