### PR TITLE
Rollout testing and stable on 2020-10-07

### DIFF
--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,170 +1,182 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2020-09-23T10:33:21Z"
+        "last-modified": "2020-10-07T09:27:40Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "32.20200907.3.0",
+                    "release": "32.20200923.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "032dec53c5f1e2d2d4e7fd58a010f4b44810b4e2a0705d33ae9ba5cfd6dbaa4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "c78b3c0c00d1be3cfef6eca7d53873094c2b44ef68e497cae8a1b5b0496ff988"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "32.20200907.3.0",
+                    "release": "32.20200923.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "6855d10edc644ae04990f0cbcd33445a54e663d2c94f17512c62b997e9dcfe6a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "0d546f9153d5337858e388e8e3f4381159983c561fba5d9d5949c6bfa0c863c9"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "32.20200907.3.0",
+                    "release": "32.20200923.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "27e2418d5c676ec997b0244ab76f4818bc0c276ea8837292d22b9f93b298246f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "a9218af7b5d4cece9b5430385831364123267d46741799965d4e29a5baa42c57"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "32.20200907.3.0",
+                    "release": "32.20200923.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "8b50bd94d6def939ccef3e5d01e500ef24fa2ce26eee2df1e631587d85325d77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "505b81f6d3953988fe92e2372637eab5d3889d812a30bee108aa4bed6bf518cb"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "32.20200907.3.0",
+                    "release": "32.20200923.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "c0998a4f4a5007e0ae25760292fcea1de11305b79bf73ba676afe0e04e4e7f8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "f7cc7ee406e46e3d226980350357a82002f1f23e1418b6fd46d81799ad1de124"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "32.20200907.3.0",
+                    "release": "32.20200923.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "9dbd2cfb30bd20531baae7071a9cbdc9c62c76254b74e1f4a0f9b9dfdba64e95"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "4c4cd5f79d9fbc98c1e5c30fde875ff11b96eb19bebe81476a0019d6771b133f"
+                            }
+                        }
+                    }
+                },
+                "ibmcloud": {
+                    "release": "32.20200923.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "e52b14ab7dad7b625f29f13d2efc2a252b3c86ce3bb1984d29c9b8ebc0c1acb4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "32.20200907.3.0",
+                    "release": "32.20200923.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "01da8cfcd586ae2e1e75c4b6ce620bda361bf2e773ef93ddfc9a70d26446cd6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "909654d6cb518b60c8c76b9f2c1ba8b644757ceb51e004d9f2a20a08ed914f7b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-live.x86_64.iso.sig",
-                                "sha256": "6417d5a65d1b3cce5276b52613ba3a81302de17d0155888fad0d7305c1678866"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-live.x86_64.iso.sig",
+                                "sha256": "ee48cbfef880dc626ddde1d7a684319979fbfec7236a2a68334efeb0a945b75c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-live-kernel-x86_64.sig",
                                 "sha256": "79715e767eecb01e4334525a7fdfa394256d91082cd008321c00cf5ae6b955e2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "d93cc80cbd9c0491c480eb57569f3151434ac9733d6664e19bad98571df91c8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "2bd098de312fba06a02109fdf14b6d201589b52910789f0f0c8714bfe36521c7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "f84bebd62080f336d308c01e369e2ba36613dbd07d31bafda9cb09168f80fb8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "93b098c8e6dc7cb14fab83a5ee92a0d571565214d5211156d4c8cc0320a96b5e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "949e5731d5e23b65af8d3dcacacdf55849d1be5444910278f286788570f7ce8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "ba73ccda373341972bd27c3b1c5a9f53f69b8f36a8b95bf6418c40a9d6103935"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "32.20200907.3.0",
+                    "release": "32.20200923.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "0c8eeae0e10978811c92db8c086fe5a9f968c05a0cd31d63c796bb044d4232d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "83038ad07db94ffc40e88ed52ff24bdbff3d1f3d91ec68afb8a192f07eb517a0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "32.20200907.3.0",
+                    "release": "32.20200923.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "bb029ac270f4554f2c2a7f8521951f2697ce0f326d666104437e3e87f72e0f89"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "b87d2296b5903bc1e665166724634f8052b3e3046dcfb9d52395ac87bc98e880"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "32.20200907.3.0",
+                    "release": "32.20200923.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "e7fc452fbbcc882e6230bd8583a645fc4d3ea268ce1908f35ccf35ba45736f2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "6c91d49e8ee5376150360510e821d56b3a817c44ab096d96bb16d4767212c05a"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "32.20200907.3.0",
+                    "release": "32.20200923.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "587221656ed51de858bbb9df200edae5c7dbdb5c8d150c59afe75b75d9f0139f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200923.3.0/x86_64/fedora-coreos-32.20200923.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "60ea677c3fa8e347792bf19864b508465999d34b541193f4a80fa66b78719b99"
                             }
                         }
                     }
@@ -174,91 +186,91 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "32.20200907.3.0",
-                            "image": "ami-0a5c53b93561af539"
+                            "release": "32.20200923.3.0",
+                            "image": "ami-0f7e62d40b1d8b802"
                         },
                         "ap-east-1": {
-                            "release": "32.20200907.3.0",
-                            "image": "ami-06f9d87e973e1bf6d"
+                            "release": "32.20200923.3.0",
+                            "image": "ami-00cef673e384ec770"
                         },
                         "ap-northeast-1": {
-                            "release": "32.20200907.3.0",
-                            "image": "ami-09a3af8c527647dfd"
+                            "release": "32.20200923.3.0",
+                            "image": "ami-0d2d6e14de030587c"
                         },
                         "ap-northeast-2": {
-                            "release": "32.20200907.3.0",
-                            "image": "ami-08d42f3688a686a1c"
+                            "release": "32.20200923.3.0",
+                            "image": "ami-00a0a10d9a1950ef8"
                         },
                         "ap-south-1": {
-                            "release": "32.20200907.3.0",
-                            "image": "ami-0c22bbddfbc054be2"
+                            "release": "32.20200923.3.0",
+                            "image": "ami-054de22be16222a42"
                         },
                         "ap-southeast-1": {
-                            "release": "32.20200907.3.0",
-                            "image": "ami-08cbaba611dbf201f"
+                            "release": "32.20200923.3.0",
+                            "image": "ami-052e26ccc372694ef"
                         },
                         "ap-southeast-2": {
-                            "release": "32.20200907.3.0",
-                            "image": "ami-0573150d02f5e153d"
+                            "release": "32.20200923.3.0",
+                            "image": "ami-08ffb6d4f3fefcb3c"
                         },
                         "ca-central-1": {
-                            "release": "32.20200907.3.0",
-                            "image": "ami-052c421799283c7db"
+                            "release": "32.20200923.3.0",
+                            "image": "ami-0cd0d0f0e5da6611f"
                         },
                         "eu-central-1": {
-                            "release": "32.20200907.3.0",
-                            "image": "ami-02e8fbe5b9d2d4835"
+                            "release": "32.20200923.3.0",
+                            "image": "ami-080562761586928c1"
                         },
                         "eu-north-1": {
-                            "release": "32.20200907.3.0",
-                            "image": "ami-0714d84aae3341de0"
+                            "release": "32.20200923.3.0",
+                            "image": "ami-0ee58594e32c1477b"
                         },
                         "eu-south-1": {
-                            "release": "32.20200907.3.0",
-                            "image": "ami-0897c52cc0c86c0fb"
+                            "release": "32.20200923.3.0",
+                            "image": "ami-08a6e75302f644b44"
                         },
                         "eu-west-1": {
-                            "release": "32.20200907.3.0",
-                            "image": "ami-05d45b625d57c78dc"
+                            "release": "32.20200923.3.0",
+                            "image": "ami-0854632b603f74262"
                         },
                         "eu-west-2": {
-                            "release": "32.20200907.3.0",
-                            "image": "ami-0b9fc89e38a02864d"
+                            "release": "32.20200923.3.0",
+                            "image": "ami-03f9186056ef07057"
                         },
                         "eu-west-3": {
-                            "release": "32.20200907.3.0",
-                            "image": "ami-053ac50e362437a7e"
+                            "release": "32.20200923.3.0",
+                            "image": "ami-074d94ba50600a869"
                         },
                         "me-south-1": {
-                            "release": "32.20200907.3.0",
-                            "image": "ami-0cbadd049ce5ac859"
+                            "release": "32.20200923.3.0",
+                            "image": "ami-06f62b3bb64c8ffbe"
                         },
                         "sa-east-1": {
-                            "release": "32.20200907.3.0",
-                            "image": "ami-099b348d7ef595629"
+                            "release": "32.20200923.3.0",
+                            "image": "ami-076a329ed8cf6df5a"
                         },
                         "us-east-1": {
-                            "release": "32.20200907.3.0",
-                            "image": "ami-0cb1aeddb441467e4"
+                            "release": "32.20200923.3.0",
+                            "image": "ami-0eeb1ef502d7b850d"
                         },
                         "us-east-2": {
-                            "release": "32.20200907.3.0",
-                            "image": "ami-0c8bb587b04f8046b"
+                            "release": "32.20200923.3.0",
+                            "image": "ami-0920314eaa28f4b86"
                         },
                         "us-west-1": {
-                            "release": "32.20200907.3.0",
-                            "image": "ami-0389ae32ada1d8f7e"
+                            "release": "32.20200923.3.0",
+                            "image": "ami-0840b41831dda8542"
                         },
                         "us-west-2": {
-                            "release": "32.20200907.3.0",
-                            "image": "ami-039d9ca2b93efcb4b"
+                            "release": "32.20200923.3.0",
+                            "image": "ami-0372b0fe5a117e5c2"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-32-20200907-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-32-20200923-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,170 +1,182 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2020-09-24T18:24:44Z"
+        "last-modified": "2020-10-07T09:28:48Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "32.20200923.2.0",
+                    "release": "32.20201004.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "b747d5be5df7f932d1ea29221d254d83c0241f7c1e63a395531f22cd5a8a2baa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "6d1e7685be3142d2761c102c4c26b4fd623d713dae0a480e8b3bf48952f077ec"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "32.20200923.2.0",
+                    "release": "32.20201004.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "cab81882ab29e476eea4f9379fc82f790b96d76ccc73dc9b19378dcc66a89559"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "9c4637b14a54b5a31f73ab0a2522213821bef97b3ccebabff1f8551c7458b3cf"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "32.20200923.2.0",
+                    "release": "32.20201004.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "efa6011e78f42c72769ae93593d7cdf5ddf492b86c9c3fd5bce2d4496d330826"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "0e96a9d87d3d5fc203b9f33ae37857e85fb4899a2cec2ed0337d74a497638073"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "32.20200923.2.0",
+                    "release": "32.20201004.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "3f699800df918efd61c02aa34711822e0922235f1edd1dbb718e2410d50c23a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "5632823fafd1324d5caa1b6969d5b40cc6177796495aef54d41eb1d86fae70c6"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "32.20200923.2.0",
+                    "release": "32.20201004.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "0bc548590df26f604ede7787247462128393ad4c920b4f63d5568539cd93bf36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "66504e2979fc6d4db70c8b3c4eaa28f843a5c25ba5a067645b5b935d36ed37d7"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "32.20200923.2.0",
+                    "release": "32.20201004.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "71b4f410e4670b32a71c4639ce126cb7982571ba4a97501eaf84d38f817e6548"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "4530ffe3c3d1833ba977312b927ed3fe76b9d4eb4ca53a90a9cb434348eb314f"
+                            }
+                        }
+                    }
+                },
+                "ibmcloud": {
+                    "release": "32.20201004.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "71c3d848056b673a58dbe7fb7fc8af1abf6ac894fd2dbf7a741f4dd542ebfa07"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "32.20200923.2.0",
+                    "release": "32.20201004.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "7778deed785dbeee2cb7b68e0cc84fdda39f09c61531ec4ff7515423b1c170a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "d16f33d7fb287a56b77054086658cf17cebd3d9764981e4aaf32d49c09c10269"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-live.x86_64.iso.sig",
-                                "sha256": "299693928b0742ad53f83a648f87dd14affd88c00f8528166cbe29e4f0d6e8b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-live.x86_64.iso.sig",
+                                "sha256": "b1216ccdf785953b58180eab8320fea28bbe00a92987f21463092b2e672ade7e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-live-kernel-x86_64.sig",
-                                "sha256": "79715e767eecb01e4334525a7fdfa394256d91082cd008321c00cf5ae6b955e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-live-kernel-x86_64.sig",
+                                "sha256": "4eea90c4066ce1e880bcf9b2b40f46fc7f8e6238522d79ea7124efc0039015c1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "261371f6197013619ea8b02bed88765bc893846536cc0e330839ef731ecf4bfd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "452d3189c1bb37ff742238beaa2549308c80f5ef2b8eed15f7064aeb0431f171"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "187c11705bc2f5e06cf8b1e0b4cc4c8627a387104532600d93f49bbe38a0231e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "9a102c49862ed79a5e4a4611a70bba82f0b35afff194fcd5cfda6a4fb05cb47f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "1f125c965d220fd7df08e596b16d4e4dcd83f1d3b087c69618732069e2a046d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "dea29a42a435172d70eed697dda6f0bd91ba227f0588b7656a492cca872f636a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "32.20200923.2.0",
+                    "release": "32.20201004.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "739f352868daeb509a12187443f8f7814b2b6fa897cfee136c4f7ecebae58fb9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "699e990b5689c61d268307dddab0d95d581566a6785aea3c0c1712940141b074"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "32.20200923.2.0",
+                    "release": "32.20201004.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "8e9e4b60f6451f015db58b3a7214a7e251e67dd21cacf38375f624720d23852c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "35e8bc3198d6284b7254bf1b2b3194b1126f1bea28937e1e141b5b3ec1479276"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "32.20200923.2.0",
+                    "release": "32.20201004.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "79c79e2773c93a5762a4f69d44067afcd5678cfa4591d888eb9d0852b99dbaae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "8a341e40734b2d1a584661ba7b0d93ce18759af4baebda0c9056173cdcdb710f"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "32.20200923.2.0",
+                    "release": "32.20201004.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20200923.2.0/x86_64/fedora-coreos-32.20200923.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "14c5e6c4bce3b3463d12a85b4c238082a37ce90ef03f3be542fa93f4f72a58df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201004.2.0/x86_64/fedora-coreos-32.20201004.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "33f12365e0253a26bd672e142d556f70deffd96e8c509097c4392f6a8d633f38"
                             }
                         }
                     }
@@ -174,91 +186,91 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "32.20200923.2.0",
-                            "image": "ami-0f6cb47fd6912a152"
+                            "release": "32.20201004.2.0",
+                            "image": "ami-073ea61fdc82c24c1"
                         },
                         "ap-east-1": {
-                            "release": "32.20200923.2.0",
-                            "image": "ami-0a93948e1af4e4c14"
+                            "release": "32.20201004.2.0",
+                            "image": "ami-04d1628dd9c21ed1d"
                         },
                         "ap-northeast-1": {
-                            "release": "32.20200923.2.0",
-                            "image": "ami-0d68a243047049501"
+                            "release": "32.20201004.2.0",
+                            "image": "ami-09e7d07118a61e04f"
                         },
                         "ap-northeast-2": {
-                            "release": "32.20200923.2.0",
-                            "image": "ami-052b169917df2949e"
+                            "release": "32.20201004.2.0",
+                            "image": "ami-0bb89117119becc0c"
                         },
                         "ap-south-1": {
-                            "release": "32.20200923.2.0",
-                            "image": "ami-00c394cff96fce798"
+                            "release": "32.20201004.2.0",
+                            "image": "ami-01a2e539ab9d8efd7"
                         },
                         "ap-southeast-1": {
-                            "release": "32.20200923.2.0",
-                            "image": "ami-0418a8387eb72b596"
+                            "release": "32.20201004.2.0",
+                            "image": "ami-0d1440f015bfd17d7"
                         },
                         "ap-southeast-2": {
-                            "release": "32.20200923.2.0",
-                            "image": "ami-0650530598e7ca70d"
+                            "release": "32.20201004.2.0",
+                            "image": "ami-0b5a773b223d71272"
                         },
                         "ca-central-1": {
-                            "release": "32.20200923.2.0",
-                            "image": "ami-0db826dade05c9ae8"
+                            "release": "32.20201004.2.0",
+                            "image": "ami-0f683763c349fce75"
                         },
                         "eu-central-1": {
-                            "release": "32.20200923.2.0",
-                            "image": "ami-088fa5cbcf10d6920"
+                            "release": "32.20201004.2.0",
+                            "image": "ami-03f7533d375f67538"
                         },
                         "eu-north-1": {
-                            "release": "32.20200923.2.0",
-                            "image": "ami-0dbd7a6e2554e2f57"
+                            "release": "32.20201004.2.0",
+                            "image": "ami-0e95082ef683d5396"
                         },
                         "eu-south-1": {
-                            "release": "32.20200923.2.0",
-                            "image": "ami-0e7dcf4f30919c84b"
+                            "release": "32.20201004.2.0",
+                            "image": "ami-050439eee260e9b50"
                         },
                         "eu-west-1": {
-                            "release": "32.20200923.2.0",
-                            "image": "ami-03fe33cf3763fc790"
+                            "release": "32.20201004.2.0",
+                            "image": "ami-035069d609585d956"
                         },
                         "eu-west-2": {
-                            "release": "32.20200923.2.0",
-                            "image": "ami-0681094b5182cc841"
+                            "release": "32.20201004.2.0",
+                            "image": "ami-0424517523e752204"
                         },
                         "eu-west-3": {
-                            "release": "32.20200923.2.0",
-                            "image": "ami-05e5f85c62dae9984"
+                            "release": "32.20201004.2.0",
+                            "image": "ami-02d02bfda2fbc53e1"
                         },
                         "me-south-1": {
-                            "release": "32.20200923.2.0",
-                            "image": "ami-0006d4240412aecf5"
+                            "release": "32.20201004.2.0",
+                            "image": "ami-027979974d9f5d0c8"
                         },
                         "sa-east-1": {
-                            "release": "32.20200923.2.0",
-                            "image": "ami-016e34abf62f081d5"
+                            "release": "32.20201004.2.0",
+                            "image": "ami-06dd69af3983e6fad"
                         },
                         "us-east-1": {
-                            "release": "32.20200923.2.0",
-                            "image": "ami-030d1f9af05fe2283"
+                            "release": "32.20201004.2.0",
+                            "image": "ami-0a1626f51b48b3347"
                         },
                         "us-east-2": {
-                            "release": "32.20200923.2.0",
-                            "image": "ami-0b86c1a7107070cf0"
+                            "release": "32.20201004.2.0",
+                            "image": "ami-08003446fb79156d5"
                         },
                         "us-west-1": {
-                            "release": "32.20200923.2.0",
-                            "image": "ami-0d8dac18e4a92fd47"
+                            "release": "32.20201004.2.0",
+                            "image": "ami-07ad89ed84bc4092d"
                         },
                         "us-west-2": {
-                            "release": "32.20200923.2.0",
-                            "image": "ami-081f474c0951cace8"
+                            "release": "32.20201004.2.0",
+                            "image": "ami-05e55626ce97e8b6c"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-32-20200923-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-32-20201004-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2020-09-23T10:35:19Z"
+    "last-modified": "2020-10-07T09:29:39Z"
   },
   "releases": [
     {
@@ -21,7 +21,7 @@
       }
     },
     {
-      "version": "32.20200824.3.0",
+      "version": "32.20200907.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -29,11 +29,11 @@
       }
     },
     {
-      "version": "32.20200907.3.0",
+      "version": "32.20200923.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1600871400,
+          "start_epoch": 1602077400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2020-09-24T18:27:11Z"
+    "last-modified": "2020-10-07T09:29:39Z"
   },
   "releases": [
     {
@@ -37,7 +37,7 @@
       }
     },
     {
-      "version": "32.20200907.2.2",
+      "version": "32.20200923.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -45,11 +45,11 @@
       }
     },
     {
-      "version": "32.20200923.2.0",
+      "version": "32.20201004.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1600974000,
+          "start_epoch": 1602077400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Double rollouts:
 * 32.20201004.2.0 on `testing`
 * 32.20200923.3.0 on `stable`