### PR TITLE
print-rollout.py: print time in familiar timezones

### DIFF
--- a/print-rollout.py
+++ b/print-rollout.py
@@ -1,4 +1,4 @@
-import json, sys, datetime
+import json, sys, datetime, dateutil.tz
 
 update = json.load(open(sys.argv[1]))
 stream = update["stream"]
@@ -21,6 +21,8 @@ if int(start_percentage * 100) == 100:
 else:
     ts = datetime.datetime.fromtimestamp(rollout["start_epoch"],
                                          datetime.timezone.utc)
+    raleigh_ts = ts.astimezone(dateutil.tz.gettz("America/Toronto"))
+    berlin_ts = ts.astimezone(dateutil.tz.gettz("Europe/Berlin"))
     mins = rollout["duration_minutes"]
     hrs = mins / 60.0
     ts_now = datetime.datetime.now(datetime.timezone.utc)
@@ -33,4 +35,6 @@ else:
     print(f"{stream}")
     print(f"    version: {version}")
     print(f"    start: {ts} UTC ({delta_str})")
+    print(f"           {raleigh_ts} Raleigh/New York/Toronto")
+    print(f"           {berlin_ts} Berlin/France/Poland")
     print(f"    duration: {mins}m ({hrs}h)")

--- a/print-rollout.py
+++ b/print-rollout.py
@@ -23,11 +23,12 @@ else:
                                          datetime.timezone.utc)
     mins = rollout["duration_minutes"]
     hrs = mins / 60.0
-    delta = ts - datetime.datetime.now(datetime.timezone.utc)
-    delta_str = str(delta).split(".")[0]
-    if delta_str.startswith("-"):
-        delta_str = f"{delta_str[1:]} ago"
+    ts_now = datetime.datetime.now(datetime.timezone.utc)
+    if ts_now > ts:
+        delta_str = str(ts_now - ts).split(".")[0]
+        delta_str = f"{delta_str} ago"
     else:
+        delta_str = str(ts - ts_now).split(".")[0]
         delta_str = f"in {delta_str}"
     print(f"{stream}")
     print(f"    version: {version}")


### PR DESCRIPTION
That should make it even easier to tell when the rollout is for
reviewers.

Having the delta is nice, but it becomes stale if the CI run happened
hours ago.