### PR TITLE
testing: rollout 33.20201116.2.0

### DIFF
--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,182 +1,182 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2020-11-05T21:20:52Z"
+        "last-modified": "2020-11-18T11:16:57Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "32.20201104.2.0",
+                    "release": "33.20201116.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "94c481c3403a62c5401eb3a4fabf489427eb8020d70d1d8c6c2180be1353e698"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "cd2ba61c596d389c87fd97d6bb081439ae67769fe1e5cd524553dcd8e0766bfb"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "32.20201104.2.0",
+                    "release": "33.20201116.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "c91a3959b1ee00477b95ffa9f5e1a91b29478404e91edaefb64c06024bbfafdb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "0dca17c0f808a382046253554f49f9afaeccd533fc9a90d8beec52599d0ffe80"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "32.20201104.2.0",
+                    "release": "33.20201116.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "1e1e2feab837ef89bc24b4b3bc603ca4902f872b77f0145f6c5aa614e6765a77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "76f6103a1c3a646f22c8a49b484c2639c3f5aeaac83eb5673f02e70e8704d212"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "32.20201104.2.0",
+                    "release": "33.20201116.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "7fc80394470b9aaff4a452bb0b7cf9ba04a51f5901669512030d207c9d8c7bd1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "bcc9c3e6e62c3ef4e4de7fb8cf07cf5e34ef08c6d0e4d6d0d86fea6b020d82a2"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "32.20201104.2.0",
+                    "release": "33.20201116.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a35be0bc5842564d65cd3de1d9db8b0c390298dc6a17c26cadd527d51396a040"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "a1824bad16fcbdffb390b52ca0ffd6042fa55d3b906cea0c07d856e3d39f92c1"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "32.20201104.2.0",
+                    "release": "33.20201116.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "1e20b6b56c8278645391e5c4da40bbfa7ac364fd68b7d70efe7c51742892cdd7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f40147cec2c0c9e1b50170b3fdbd57cab11fdca193098052b4018b25458f36a1"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "32.20201104.2.0",
+                    "release": "33.20201116.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "31de08f3b4f3fb9ea0213b83ac99176ddf0deff06ae07206ccf43c57254b3fcc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "e476132d7c85d2dbce8522e674521aeb406a8b82bf41b6914927ac76d526c61e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "32.20201104.2.0",
+                    "release": "33.20201116.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "a0ae640b84efa68d08e1acddf5b2bf7e9a1e02d79683a16cd616bd59639aece5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "a31f9e3e922a9400225509a98aa81098f7d7367040cd0858e5321af044764c49"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-live.x86_64.iso.sig",
-                                "sha256": "bac0e648bed0df3335414b61271463d0c49a06089e025b70f65e4b733458778a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-live.x86_64.iso.sig",
+                                "sha256": "cee44ac18e8dc49a5f078fa882164f3994e96c90078b301313095a2b9db68a81"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-live-kernel-x86_64.sig",
-                                "sha256": "cbbb327196f67e4e48ae401357b159e0418317d97d243a4da4b6d01a4f02e0b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-live-kernel-x86_64.sig",
+                                "sha256": "d24f9e246558e4c04771da9569677947ab33f41455df9fa36e7c742f2dc25a2e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "a2e2e57191a48fcf846a2d3e3c1dae524bb60f00e53dfbb3b03be99ea481d790"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "5ecfba751807d8208fb99aa868dabf2c3f9095855f130b57108f23ba7f0f14ca"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "2d6b3e94c09159a8cd20fee6ac04decb5b899724cdd13b2bbdcb62f0e57e8efe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "8b824022ef9c88dd8912d8e8bce45cffa4236efeb2769d37e054ec05f3cd3beb"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "73a15e989070dd2b63d4092c76ce1095ffeaeb5a1021cd0da42dba1d28e599a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "e43bf6f0105f6fe39480694c52f87fe54340d46c708f0f4503ac0771f2fc681e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "32.20201104.2.0",
+                    "release": "33.20201116.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "cb41731b50d1e7ecde87772229cbd3feb2111729602067847f67f55d3c1c01bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "11d07838607ca67d234a6b27c7fba740625fbf0f61102a91c8d46186b2154142"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "32.20201104.2.0",
+                    "release": "33.20201116.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "25da2d2e358ac8a9399014a835c60a0e714c7d2b907a011b6711fb69f3999c51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "dffba49ccf7391ffa62d019b9a3f26144ee8fa4b010f151cfc879d853ff648ec"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "32.20201104.2.0",
+                    "release": "33.20201116.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "281675d6f2ac7224a1bb24999a7618db11af8444ebd7f1f6f54449924602288c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "f67dd60255e7ed6aa90a7a56db4436e6bded0a7287def27ad9e21ddd8f0f249f"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "32.20201104.2.0",
+                    "release": "33.20201116.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/32.20201104.2.0/x86_64/fedora-coreos-32.20201104.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "d21777a75c1d303841f243fb31999dcec4b67e8194d16772308a2d9eeb57ede1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20201116.2.0/x86_64/fedora-coreos-33.20201116.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "751b1dc7c0600d676e995fecfc35eef0d5b91cae930f0cd885157dba631b2021"
                             }
                         }
                     }
@@ -186,91 +186,91 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "32.20201104.2.0",
-                            "image": "ami-0dbc60783ff17dd94"
+                            "release": "33.20201116.2.0",
+                            "image": "ami-0e6dd93976a949f5f"
                         },
                         "ap-east-1": {
-                            "release": "32.20201104.2.0",
-                            "image": "ami-060e6a5b7c326ad19"
+                            "release": "33.20201116.2.0",
+                            "image": "ami-025addc026119cb41"
                         },
                         "ap-northeast-1": {
-                            "release": "32.20201104.2.0",
-                            "image": "ami-017d30a4ca9abfdec"
+                            "release": "33.20201116.2.0",
+                            "image": "ami-02a196d8958c55779"
                         },
                         "ap-northeast-2": {
-                            "release": "32.20201104.2.0",
-                            "image": "ami-0b5add2250ece117a"
+                            "release": "33.20201116.2.0",
+                            "image": "ami-08655070695ed2608"
                         },
                         "ap-south-1": {
-                            "release": "32.20201104.2.0",
-                            "image": "ami-059b26846f235ab7b"
+                            "release": "33.20201116.2.0",
+                            "image": "ami-00e05c1965b743782"
                         },
                         "ap-southeast-1": {
-                            "release": "32.20201104.2.0",
-                            "image": "ami-062e9e3d87e258f8a"
+                            "release": "33.20201116.2.0",
+                            "image": "ami-035b3d4d8740eefa0"
                         },
                         "ap-southeast-2": {
-                            "release": "32.20201104.2.0",
-                            "image": "ami-0fa0383c9fe7ab725"
+                            "release": "33.20201116.2.0",
+                            "image": "ami-07976f76eb04da821"
                         },
                         "ca-central-1": {
-                            "release": "32.20201104.2.0",
-                            "image": "ami-014fda33e758164ca"
+                            "release": "33.20201116.2.0",
+                            "image": "ami-0361ffb76ae77a623"
                         },
                         "eu-central-1": {
-                            "release": "32.20201104.2.0",
-                            "image": "ami-0764a590f84382da8"
+                            "release": "33.20201116.2.0",
+                            "image": "ami-0aa85ff1310ba1f76"
                         },
                         "eu-north-1": {
-                            "release": "32.20201104.2.0",
-                            "image": "ami-04beca6141e25fe6e"
+                            "release": "33.20201116.2.0",
+                            "image": "ami-0a83ed78a1b2505c6"
                         },
                         "eu-south-1": {
-                            "release": "32.20201104.2.0",
-                            "image": "ami-056db908dc14062d4"
+                            "release": "33.20201116.2.0",
+                            "image": "ami-03830d8db33dad2b1"
                         },
                         "eu-west-1": {
-                            "release": "32.20201104.2.0",
-                            "image": "ami-08eb77b9954e45903"
+                            "release": "33.20201116.2.0",
+                            "image": "ami-04d3968cae6349946"
                         },
                         "eu-west-2": {
-                            "release": "32.20201104.2.0",
-                            "image": "ami-09ad1fe81aa7a76cf"
+                            "release": "33.20201116.2.0",
+                            "image": "ami-0ee909cebfb7965d8"
                         },
                         "eu-west-3": {
-                            "release": "32.20201104.2.0",
-                            "image": "ami-00e71fd2196ec40b1"
+                            "release": "33.20201116.2.0",
+                            "image": "ami-0a4b9204d56f209ec"
                         },
                         "me-south-1": {
-                            "release": "32.20201104.2.0",
-                            "image": "ami-011d3b1a564d08f0f"
+                            "release": "33.20201116.2.0",
+                            "image": "ami-0bda07901efc661f9"
                         },
                         "sa-east-1": {
-                            "release": "32.20201104.2.0",
-                            "image": "ami-0244a73440ea60f22"
+                            "release": "33.20201116.2.0",
+                            "image": "ami-01c5732f3da320ad6"
                         },
                         "us-east-1": {
-                            "release": "32.20201104.2.0",
-                            "image": "ami-0e307ecf30a086201"
+                            "release": "33.20201116.2.0",
+                            "image": "ami-0498bc91e9c7c93cb"
                         },
                         "us-east-2": {
-                            "release": "32.20201104.2.0",
-                            "image": "ami-0d80d8f94551d9266"
+                            "release": "33.20201116.2.0",
+                            "image": "ami-0026c11e54e8b9b0f"
                         },
                         "us-west-1": {
-                            "release": "32.20201104.2.0",
-                            "image": "ami-0bfe4fff48dee888a"
+                            "release": "33.20201116.2.0",
+                            "image": "ami-02235417c84390eef"
                         },
                         "us-west-2": {
-                            "release": "32.20201104.2.0",
-                            "image": "ami-007a0541119f3905e"
+                            "release": "33.20201116.2.0",
+                            "image": "ami-0974326585f66d28f"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-32-20201104-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-33-20201116-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2020-11-05T21:20:52Z"
+    "last-modified": "2020-11-18T11:16:57Z"
   },
   "releases": [
     {
@@ -37,7 +37,7 @@
       }
     },
     {
-      "version": "32.20201018.2.0",
+      "version": "32.20201104.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -45,11 +45,11 @@
       }
     },
     {
-      "version": "32.20201104.2.0",
+      "version": "33.20201116.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1604615400,
+          "start_epoch": 1605708000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
```
testing
    version: 33.20201116.2.0
    start: 2020-11-18 14:00:00+00:00 UTC (in 2:40:30)
           2020-11-18 09:00:00-05:00 Raleigh/New York/Toronto
           2020-11-18 15:00:00+01:00 Berlin/France/Poland
    duration: 2880m (48.0h)
```