### PR TITLE
testing: add barrier to the 33.20201116.2.0 release.

### DIFF
--- a/updates/testing.json
+++ b/updates/testing.json
@@ -47,6 +47,9 @@
     {
       "version": "33.20201116.2.0",
       "metadata": {
+        "barrier": {
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/646"
+        },
         "rollout": {
           "duration_minutes": 2880,
           "start_epoch": 1605708000,


### PR DESCRIPTION
This is the first f33 release on the `testing` stream. Let's make
it a barrier as agreed upon in https://github.com/coreos/fedora-coreos-tracker/issues/646.