### PR TITLE
next: rollout 33.20201117.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,182 +1,182 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2020-11-05T21:28:52Z"
+        "last-modified": "2020-11-19T14:12:05Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "33.20201104.1.0",
+                    "release": "33.20201117.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "933125b10e3a0a861e3b8da49f87c0a6ff7b9880e1d4d33641b3d1ef56baaf80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "a633aaa05ac184d47861fdb80059d658987cb8037901c918f9385c8813c302db"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "33.20201104.1.0",
+                    "release": "33.20201117.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "2380b6e1e47c906ffc6d6a2d22d10f1a4ac80286b85b0a1042e42cbf6ad92e3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "f2f9b7ebb02566293132b46081e7428a0ea6eb34ea8a2b25fb0c6611e13ca00e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "33.20201104.1.0",
+                    "release": "33.20201117.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "b3583e952028683f12e5992f03a3c9496e704771c8092296b54968c281f539b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "f2a1f4c0c986a32545adda7dbdb3bbdce8174bbbf65ffd78707b598ef23036e1"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "33.20201104.1.0",
+                    "release": "33.20201117.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "01ccbef4a373bdbde5335ef4e96f2a676fb24942016e3cde8182625b625db2ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "d03569d4690e4435f5d13e7d59bc923f6ab88f624b00211957af27e85b7f7a4b"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "33.20201104.1.0",
+                    "release": "33.20201117.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "3723342c40cb439dd6d2eaa636d549952b2ebf89717117752e7dae9ee9310f47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "f23fc612d08d118d6c6c1d6f6ce9bb32f73112392ce3bfd25316a9ecd44f60e2"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "33.20201104.1.0",
+                    "release": "33.20201117.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "9cac3fb1ee7dd27a2cf624bd9e0ca46dd12b785b663223e8c7e89062bd09ec5f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "e464d49958339c4b441e0b59e9c27a60b4412a66d8958aba263444e19f4dd43a"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "33.20201104.1.0",
+                    "release": "33.20201117.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "5599833b9a3ca2a21b08abfb852115d8a7c0521ed3a54b847c1ba9a92566bfae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "0c23c74b309f29cfffeccc3863c43d1db5bf7042bbd5ba5eb7663fec129be4b2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "33.20201104.1.0",
+                    "release": "33.20201117.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "b313e55c1c4e682276b4515923fff0b6f5cf81f2831b014773c846580b7ab794"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "5ecf3d3728d6541dfb7ab33a438d97c73e319fd089dcc15bf2a4fad749988084"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-live.x86_64.iso.sig",
-                                "sha256": "ae197902f69fdb96a802eab2704b1bf20a0e1764e173a81d1b59722654b8fc2b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-live.x86_64.iso.sig",
+                                "sha256": "3188e75823ccc753e2eef77bc4907978d30cc47c49ff58b4b3197218246d7485"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-live-kernel-x86_64.sig",
-                                "sha256": "b90575679d81947165fdbe37d786621660a2baa1c1af16d3543ca1d9cb0eecc0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-live-kernel-x86_64.sig",
+                                "sha256": "d24f9e246558e4c04771da9569677947ab33f41455df9fa36e7c742f2dc25a2e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "fbb5e6f0a3201737f2cd48363ddb5c83ff4ec19fbcf35de669334d3db794dcb6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "7dae3684c4812ca94c1bd29959eb9719ce79d8f5d71eebc734857764444edd28"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "ba3872a35b3d15e59523ee0484140ff8fdb88510446ee7cf2ae6e7269a00e12f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "912c6bbd1c1734c2100027e4a73ee5853e9d2781b0a5bece5fdf4980cc493f17"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "ac50a1d87ac0adedaef624e3c2c036001acf188dde714d49ed72ed1dd35ad6ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "7868c408096718107d83aed97a7ccc9a7e662f8700f6988c36b42db654028cdd"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "33.20201104.1.0",
+                    "release": "33.20201117.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "2acd01c37eb8e46de71f6435b1a6c7e5afa5635c0404f667144dc632370705b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "36e7ebc0e1558f1f1fb4bcb38524952b9fa074b097437ef671a8ed0c1e1d6a88"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "33.20201104.1.0",
+                    "release": "33.20201117.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "1fdeae3fdd4e2ff49e59d478cf4e5fc76b01b5c4e9ab0ad6da973b563aa5f151"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "04ddcae77f403bea486f98bf6f9bc41125345a2750e85e77f967d3b549c29405"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "33.20201104.1.0",
+                    "release": "33.20201117.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "521120ce9220bb3a0380fecd3ae83b18aa8550e9a24a2389afb2d5557df16112"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "7e14b8ce641f96a9eb2c69c811c8ab51f9cbf48280c6f589c65181245a1f884d"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "33.20201104.1.0",
+                    "release": "33.20201117.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201104.1.0/x86_64/fedora-coreos-33.20201104.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "c61d67d2685f2bfb5d500ff00a4b10cd2aaeb3ad5fc90d6490c38455f7037a7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20201117.1.0/x86_64/fedora-coreos-33.20201117.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "1b185e5d2621e16032d847c6636492b2b0f3a07b88df6f6e6bb47c9065148bf8"
                             }
                         }
                     }
@@ -186,91 +186,91 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "33.20201104.1.0",
-                            "image": "ami-0b68808bf0a1bab2e"
+                            "release": "33.20201117.1.0",
+                            "image": "ami-09a2d36b025d65985"
                         },
                         "ap-east-1": {
-                            "release": "33.20201104.1.0",
-                            "image": "ami-0ad2f48a014fa5977"
+                            "release": "33.20201117.1.0",
+                            "image": "ami-0ae6100198ad65389"
                         },
                         "ap-northeast-1": {
-                            "release": "33.20201104.1.0",
-                            "image": "ami-0afb74aa815cf2167"
+                            "release": "33.20201117.1.0",
+                            "image": "ami-0078dadfd38744978"
                         },
                         "ap-northeast-2": {
-                            "release": "33.20201104.1.0",
-                            "image": "ami-099338519eb8f1c7d"
+                            "release": "33.20201117.1.0",
+                            "image": "ami-01fbd8fb973dbe1a3"
                         },
                         "ap-south-1": {
-                            "release": "33.20201104.1.0",
-                            "image": "ami-003a2348488950506"
+                            "release": "33.20201117.1.0",
+                            "image": "ami-0e70f1c79cb9194b1"
                         },
                         "ap-southeast-1": {
-                            "release": "33.20201104.1.0",
-                            "image": "ami-024b21021113a6073"
+                            "release": "33.20201117.1.0",
+                            "image": "ami-0b00249811dfd0a11"
                         },
                         "ap-southeast-2": {
-                            "release": "33.20201104.1.0",
-                            "image": "ami-081d556a667200e8f"
+                            "release": "33.20201117.1.0",
+                            "image": "ami-0179463986cdd29b2"
                         },
                         "ca-central-1": {
-                            "release": "33.20201104.1.0",
-                            "image": "ami-0453811d88ba9b73b"
+                            "release": "33.20201117.1.0",
+                            "image": "ami-0adcf6fb5653867a7"
                         },
                         "eu-central-1": {
-                            "release": "33.20201104.1.0",
-                            "image": "ami-0500b67a0c6dea20d"
+                            "release": "33.20201117.1.0",
+                            "image": "ami-042b0a051c40952c6"
                         },
                         "eu-north-1": {
-                            "release": "33.20201104.1.0",
-                            "image": "ami-007b10e36327cb7a0"
+                            "release": "33.20201117.1.0",
+                            "image": "ami-0c5588ac3bd8941e7"
                         },
                         "eu-south-1": {
-                            "release": "33.20201104.1.0",
-                            "image": "ami-0647d6566fa30bffc"
+                            "release": "33.20201117.1.0",
+                            "image": "ami-051cb8c6bbe82e6f1"
                         },
                         "eu-west-1": {
-                            "release": "33.20201104.1.0",
-                            "image": "ami-0a80a1baae1ad09e3"
+                            "release": "33.20201117.1.0",
+                            "image": "ami-0dae05aa63eb95460"
                         },
                         "eu-west-2": {
-                            "release": "33.20201104.1.0",
-                            "image": "ami-0d0a685dd9dda72cb"
+                            "release": "33.20201117.1.0",
+                            "image": "ami-057511b950ae8028a"
                         },
                         "eu-west-3": {
-                            "release": "33.20201104.1.0",
-                            "image": "ami-074fa423d57f60641"
+                            "release": "33.20201117.1.0",
+                            "image": "ami-06b1b93d1a6622e64"
                         },
                         "me-south-1": {
-                            "release": "33.20201104.1.0",
-                            "image": "ami-0b1ec8ccf4c0d7d35"
+                            "release": "33.20201117.1.0",
+                            "image": "ami-048fb5f4257465cdd"
                         },
                         "sa-east-1": {
-                            "release": "33.20201104.1.0",
-                            "image": "ami-0f460653074781616"
+                            "release": "33.20201117.1.0",
+                            "image": "ami-071f217ba8f9c5739"
                         },
                         "us-east-1": {
-                            "release": "33.20201104.1.0",
-                            "image": "ami-08ae7387308b22a6a"
+                            "release": "33.20201117.1.0",
+                            "image": "ami-0ad84afeefc6400ad"
                         },
                         "us-east-2": {
-                            "release": "33.20201104.1.0",
-                            "image": "ami-02393c79e04bd6b6e"
+                            "release": "33.20201117.1.0",
+                            "image": "ami-054e2ecd7bc6802f7"
                         },
                         "us-west-1": {
-                            "release": "33.20201104.1.0",
-                            "image": "ami-05e4ca3af2a8410c6"
+                            "release": "33.20201117.1.0",
+                            "image": "ami-0b5399ba733f89f39"
                         },
                         "us-west-2": {
-                            "release": "33.20201104.1.0",
-                            "image": "ami-03ae6b606ad9c0880"
+                            "release": "33.20201117.1.0",
+                            "image": "ami-0e5c1bc916773e36e"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-33-20201104-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-33-20201117-1-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2020-11-05T21:28:52Z"
+    "last-modified": "2020-11-19T14:12:05Z"
   },
   "releases": [
     {
@@ -17,9 +17,6 @@
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/646"
-        },
-        "rollout": {
-          "start_percentage": 1.0
         }
       }
     },
@@ -27,8 +24,16 @@
       "version": "33.20201104.1.0",
       "metadata": {
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "33.20201117.1.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1604615400,
+          "start_epoch": 1605801600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
```
next
    version: 33.20201117.1.0
    start: 2020-11-19 16:00:00+00:00 UTC (in 1:44:46)
           2020-11-19 11:00:00-05:00 Raleigh/New York/Toronto
           2020-11-19 17:00:00+01:00 Berlin/France/Poland
    duration: 2880m (48.0h)
```