### PR TITLE
Revert "testing: pause rollout of 33.20201201.2.1"

### DIFF
--- a/updates/testing.json
+++ b/updates/testing.json
@@ -51,6 +51,16 @@
           "start_percentage": 1.0
         }
       }
+    },
+    {
+      "version": "33.20201201.2.1",
+      "metadata": {
+        "rollout": {
+          "duration_minutes": 1440,
+          "start_epoch": 1608127200,
+          "start_percentage": 0.0
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
This reverts commit 9fa9a0655b542de942fd154419c41ab0f7c010b6.

The issue is a problem, but a known issue and not one introduced
by this update.