### PR TITLE
Triple rollout for sudo CVE-2021-3156

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,182 +1,182 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2021-01-18T18:35:09Z"
+        "last-modified": "2021-01-28T18:58:31Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "33.20210117.1.0",
+                    "release": "33.20210117.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "49c340e2e5774271e134f93fca9a901923453041f82b1442e4b24f3f84d26e71"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "3fb2f1e89e2792e6a2fc90e7a81cc4802a7a8366c555d09ba65f838ef03001fb"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "33.20210117.1.0",
+                    "release": "33.20210117.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "b9a23e1bad0c9bab510d44352091a245786bb3fe35ba16b1f42717e8fb564ede"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "8f8d4ee0074855cace4a9ad4d1ef3fd6e55b2a76b8dbc5f24040aa552c05242e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "33.20210117.1.0",
+                    "release": "33.20210117.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "901fa84c7c226adf98ed6e16392a4892324a7e93a610687061762dc77448f4c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "ea9dcb25427bce82cd371da9807b3e4eaa16be4e6d83262845586d6e216bae70"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "33.20210117.1.0",
+                    "release": "33.20210117.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "3c85e5bb6cf30885616116736d652f4f5bcb1bcba39ee90fc830e78998f7da27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "7db6ec4fdbd1c18908a129446307c4c231cd1766154297855e53720b2391b48f"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "33.20210117.1.0",
+                    "release": "33.20210117.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "1cb0ca62b6e400504776fa07ec8a21b2c9a60e319121495a4c753ec66455e15b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "d3f7970e6cb90d4543cb4575dde6dba82b7952289ee2a65de0fc1ffe7626fcb3"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "33.20210117.1.0",
+                    "release": "33.20210117.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "7ba1e4ff6fc9ae5309a1ff08f73fbfe5d82d5e5222cd02c59f93178d8794da12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "28ee3b76201edac0c0ed99f3c342d45075677f35d25a685a052ae5b1be160765"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "33.20210117.1.0",
+                    "release": "33.20210117.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "8646753931f2a690599fbef72490deff33774e559f4b440923f6241fe9c899eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "6000c919f3bc69850863319b4d2188018937e415535b1c43ebd6b542a001dd93"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "33.20210117.1.0",
+                    "release": "33.20210117.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "b7de37d40564e81e32f91be286701f22b46db7f37f833e3982be1afe529f140c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "4dd1912fde64cf6f446bf2f8ca025220778302200dacdd7413f39e356aa5ecb3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-live.x86_64.iso.sig",
-                                "sha256": "8675bfb8e4a14c85c6c1dad7bd28dc7b4375ff823f910a99efe88f3c19343d23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-live.x86_64.iso.sig",
+                                "sha256": "2296bf6a7d25bbd9387dbf0e0ba786d933726ea8032739e00a5360393c820877"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-live-kernel-x86_64.sig",
                                 "sha256": "f364c53bde39e26b5f7b2811878c407a9f0e151326f9bb877c12d46460453d01"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "e38dea43724dc7d36ec101e660f80e6751476dbf343b9f874bdaf7e4867ad4ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "40bbcfba5a71cdaed682e23de36a4b11a1c130787869d348ab202ac001e3200c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "b151112a080c3f5c47c63de859d413d42069860e287f645f9884edc14e51101b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "c475dfb5c65537b0345e97cc18563b714d8e6dfb7f002d8515def7581a4436f7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "917999d278335a43b0567743f541fff12562d443a5f31b62a3336189ac76f859"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "7a0f09c3dbe321ff97eee900df9412731267368df977a21257a144596b8e1f51"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "33.20210117.1.0",
+                    "release": "33.20210117.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "965f455afad41820501484ee1cfd7328ffb81f9b258a1f8609596a67a7730e1a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "19d7b900918a5f1f8c811fda522d069070c3cda86eca160713f8e7d805e13f17"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "33.20210117.1.0",
+                    "release": "33.20210117.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "cba57a5e4ec5fc4b02a568aa3c36515aba14fb94f2eee073e19bad2755a5fc3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "877ec7350ff4fc7ed65a145712179ebb389b4d51786c7c89fc95dbaa561d7780"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "33.20210117.1.0",
+                    "release": "33.20210117.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "5fa17a30ad18890ad0f43aebf864f85bd9bff075ec6a15f66d8f7d8beb064ce3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "1505e5880f3b92b4707d4988ac86f4adf9d1d07f6779628ad8c618a27f623422"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "33.20210117.1.0",
+                    "release": "33.20210117.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.0/x86_64/fedora-coreos-33.20210117.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "0c31b634df906129b91a4b6e81b2b18e1ba46ddb77e69f09ab0a979c2bb623e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/33.20210117.1.1/x86_64/fedora-coreos-33.20210117.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "fdbafa26f4714df096890af39df1a1e58100f08112592a2c8d56586de1858e29"
                             }
                         }
                     }
@@ -186,91 +186,91 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "33.20210117.1.0",
-                            "image": "ami-04ddd7930583cae66"
+                            "release": "33.20210117.1.1",
+                            "image": "ami-0edef79169626c8a1"
                         },
                         "ap-east-1": {
-                            "release": "33.20210117.1.0",
-                            "image": "ami-0a00c33bf8f992ca5"
+                            "release": "33.20210117.1.1",
+                            "image": "ami-0317559fe75cefe9f"
                         },
                         "ap-northeast-1": {
-                            "release": "33.20210117.1.0",
-                            "image": "ami-0e1c16d82ee3ac68d"
+                            "release": "33.20210117.1.1",
+                            "image": "ami-0bc1e7fa1244f0c18"
                         },
                         "ap-northeast-2": {
-                            "release": "33.20210117.1.0",
-                            "image": "ami-0b3e7a2c8986168e9"
+                            "release": "33.20210117.1.1",
+                            "image": "ami-09c3090578b66f1bf"
                         },
                         "ap-south-1": {
-                            "release": "33.20210117.1.0",
-                            "image": "ami-092f9f7e5987018dd"
+                            "release": "33.20210117.1.1",
+                            "image": "ami-084cbd74e80e2bde1"
                         },
                         "ap-southeast-1": {
-                            "release": "33.20210117.1.0",
-                            "image": "ami-059d044efa8de29b7"
+                            "release": "33.20210117.1.1",
+                            "image": "ami-09e231d5648a43bc5"
                         },
                         "ap-southeast-2": {
-                            "release": "33.20210117.1.0",
-                            "image": "ami-0ec6656364916e1c9"
+                            "release": "33.20210117.1.1",
+                            "image": "ami-00e7090c90bbcd6f7"
                         },
                         "ca-central-1": {
-                            "release": "33.20210117.1.0",
-                            "image": "ami-0a5dd74c72d0e0895"
+                            "release": "33.20210117.1.1",
+                            "image": "ami-0551660c6b187dfbb"
                         },
                         "eu-central-1": {
-                            "release": "33.20210117.1.0",
-                            "image": "ami-0d9dc1cbd2770605a"
+                            "release": "33.20210117.1.1",
+                            "image": "ami-08b7c6565fa4c1c68"
                         },
                         "eu-north-1": {
-                            "release": "33.20210117.1.0",
-                            "image": "ami-0b9cbe7416a61cd92"
+                            "release": "33.20210117.1.1",
+                            "image": "ami-083662d5c3b7cd243"
                         },
                         "eu-south-1": {
-                            "release": "33.20210117.1.0",
-                            "image": "ami-0a22601b16e1686b6"
+                            "release": "33.20210117.1.1",
+                            "image": "ami-029415b9c80f63f8c"
                         },
                         "eu-west-1": {
-                            "release": "33.20210117.1.0",
-                            "image": "ami-03c78c7e237ff0b10"
+                            "release": "33.20210117.1.1",
+                            "image": "ami-0884c0073dd7d4099"
                         },
                         "eu-west-2": {
-                            "release": "33.20210117.1.0",
-                            "image": "ami-0c08bda33c02b8b99"
+                            "release": "33.20210117.1.1",
+                            "image": "ami-0df0db98f588d5039"
                         },
                         "eu-west-3": {
-                            "release": "33.20210117.1.0",
-                            "image": "ami-0572a774b2bc775e6"
+                            "release": "33.20210117.1.1",
+                            "image": "ami-09a512263e4585fc1"
                         },
                         "me-south-1": {
-                            "release": "33.20210117.1.0",
-                            "image": "ami-076dbc95d6cb81029"
+                            "release": "33.20210117.1.1",
+                            "image": "ami-0dbf61ec904dbd4ed"
                         },
                         "sa-east-1": {
-                            "release": "33.20210117.1.0",
-                            "image": "ami-0b1047f5af7594a87"
+                            "release": "33.20210117.1.1",
+                            "image": "ami-0e64612ad0ae08119"
                         },
                         "us-east-1": {
-                            "release": "33.20210117.1.0",
-                            "image": "ami-060e2e6adccc1c720"
+                            "release": "33.20210117.1.1",
+                            "image": "ami-01eb5470d2e057dcc"
                         },
                         "us-east-2": {
-                            "release": "33.20210117.1.0",
-                            "image": "ami-000f295fe8c032706"
+                            "release": "33.20210117.1.1",
+                            "image": "ami-053e187d8c4a84946"
                         },
                         "us-west-1": {
-                            "release": "33.20210117.1.0",
-                            "image": "ami-0a2ff156dcebf9835"
+                            "release": "33.20210117.1.1",
+                            "image": "ami-0da89136cb992f9e4"
                         },
                         "us-west-2": {
-                            "release": "33.20210117.1.0",
-                            "image": "ami-0d4ae1560f52b51ee"
+                            "release": "33.20210117.1.1",
+                            "image": "ami-0ee4a49faad3bb7b4"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-33-20210117-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-33-20210117-1-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,182 +1,182 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2021-01-18T18:36:00Z"
+        "last-modified": "2021-01-28T18:58:26Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "33.20210104.3.0",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "b4e11a46805a3d892d7cb1a3cb6e489aebb2ef432830ef9c5c93e82e5dfea8e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "0375205f6f5c802406b0fec601c0184d8fe1c9b53ff2c30c41b48f2ff4179229"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "33.20210104.3.0",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "1ae7bfd4db25ef68993e0e0b8cbb851f1eda5c688bead93d2cd0845714adfcfa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "eb40f71483a56520200c0811d55c16cba65276ca4ec9a8f96711a7a9ca8b9ced"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "33.20210104.3.0",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "6758de018541bf9b60b0b13342c7ce3cebbe1569dd5ddd986388a6d11ae28621"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "8bec600157f4c8126ff47a00b97bb4dc23376eb6073802d02b43f63667b347b7"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "33.20210104.3.0",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "6de9ad399bd5379a13b595830bec5c1ccb180b298e37254d23b14d1d3084c245"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "f9c12028b982a43baa0cb0af6378400a249d9c4506711a2d247975fda5978327"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "33.20210104.3.0",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "4977fff241b1ac78b88957c39162fec75191a760117d0394817b95f23dbb9c77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "052f8ffb165fd7058a1291b6e43d0147c9bc755105835fec7ab2302c5f72f406"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "33.20210104.3.0",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "dbce58aa75cc17e56a9c9f54210fcaebf0831d8cd4a86c382ab014c5eecad8af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "b0e63fe9d16962cb4d32b9b9d01671ea2971ffe66ff49e197bebdea23b34a3dd"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "33.20210104.3.0",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "1cb57f7fcf1dcbb1d929d8db4adbbf412152fd0e3bd322eb1d5e2bf6be03b8d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "aea849f4d4d6f1253407366387b873cbf54f29b7500b2f2433297bea9ec35cdc"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "33.20210104.3.0",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "8e2399b0e996f3fd0500e539944f21ec4308f2f8bc23da14072260fe6822fd4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "f55094bfa6a9fde8664089ebd5f3881203a4b362204596b54bb1415f4e8a86a7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-live.x86_64.iso.sig",
-                                "sha256": "b0cb8160ce4f87c70e31327465bfcf910ebc2edc8be534fffeb06a77f4f877aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live.x86_64.iso.sig",
+                                "sha256": "d064026d50386c8598269b7db6f9cb0408636b72e78bac56d80730e8d193b981"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live-kernel-x86_64.sig",
                                 "sha256": "199ec5a6c3084d2478fb5e6b958d3c3e18a6b777abd168082a8cf26ec5954c50"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "02d32634c189d4fbfa1418a5b27e220eae9f052fc4b74793535ee1bdb39deb9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "a80305c0554def0cc30127b9bcbc7d0bbd6e4d83a98ba63688ff781b6eee645f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "456c358c6f69f20491390be9f32fcebc90cb304ec450e01f445e4e3e69bba990"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "83f943f2b035bbef9c7bee4e5e76294e72eb4b7bbbb316aaec38319cf3ad6084"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "7ca9f41c99a185440c4f772c96a8b49b84005b550b37235c16fcc7c679f54e30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "dd960a9dc7f77567441c1d9c42ef2bc9da44f33e5e9d35e2eb8f4d889a9f52f5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "33.20210104.3.0",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "18b070255399672739f99f7aaed0720d5b77457cbe06322720b24b57459456b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "bc34bac9f30fa1bd9244d759cd1a809f294f143adfce16fa9a2272cffbf9db4a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "33.20210104.3.0",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "ea1aaf31a3410c333154bc6357cf6b8fd99b9c357cc2ad4e91b5f5ed76803a1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "fc4b97cbf10126a4a15824dbc300896ebebac07f86351c6c18ade0daa96a03e7"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "33.20210104.3.0",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "4db145b0e7e474c769446801ffb7cc85e09d60aa630afa202bc2b04f930ff7f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "f77733c3ce0be892e7647bdca3e55681ccfb2da77cef87fbf1446f8f14af6be3"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "33.20210104.3.0",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.0/x86_64/fedora-coreos-33.20210104.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "dd2f884270f6f06e54fb51c1f86a2fe3b2fc5555c3f9ba02c68a33a66b45eadc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "b882700523d785e4c20c9ff6c76c3aa78bd4c67ae22401304799125399f87bc3"
                             }
                         }
                     }
@@ -186,91 +186,91 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "33.20210104.3.0",
-                            "image": "ami-09d8beda13666ea1d"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0b638ea80adbc40b3"
                         },
                         "ap-east-1": {
-                            "release": "33.20210104.3.0",
-                            "image": "ami-0b35b668543f22644"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0237d99b243b579c3"
                         },
                         "ap-northeast-1": {
-                            "release": "33.20210104.3.0",
-                            "image": "ami-09253e293963cf482"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0a90166e0b164edee"
                         },
                         "ap-northeast-2": {
-                            "release": "33.20210104.3.0",
-                            "image": "ami-09ac1597749bdd568"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0e319b8d0d4fb0dd7"
                         },
                         "ap-south-1": {
-                            "release": "33.20210104.3.0",
-                            "image": "ami-018e502d4cbd738e6"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0c1378ae03a9bded4"
                         },
                         "ap-southeast-1": {
-                            "release": "33.20210104.3.0",
-                            "image": "ami-094d1768ddbaca843"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0fea43bb278f1b25d"
                         },
                         "ap-southeast-2": {
-                            "release": "33.20210104.3.0",
-                            "image": "ami-055103292d4a0fd78"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0dd80c2c2ca0baf26"
                         },
                         "ca-central-1": {
-                            "release": "33.20210104.3.0",
-                            "image": "ami-0c2a5fc0a4f7ae060"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-003b6d75d4286bca7"
                         },
                         "eu-central-1": {
-                            "release": "33.20210104.3.0",
-                            "image": "ami-069e79a05239d18c4"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0cc2d935f680d7da0"
                         },
                         "eu-north-1": {
-                            "release": "33.20210104.3.0",
-                            "image": "ami-0e6d5b2bf75113867"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-01ed1fbddb8990f74"
                         },
                         "eu-south-1": {
-                            "release": "33.20210104.3.0",
-                            "image": "ami-00f0946bacf68a5e8"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-095b0097697993701"
                         },
                         "eu-west-1": {
-                            "release": "33.20210104.3.0",
-                            "image": "ami-003a86de7184d6ab1"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-011fe8f9a8dac58e3"
                         },
                         "eu-west-2": {
-                            "release": "33.20210104.3.0",
-                            "image": "ami-017f075f330618d7d"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0035c836f819b3988"
                         },
                         "eu-west-3": {
-                            "release": "33.20210104.3.0",
-                            "image": "ami-06ce71744f29370fc"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0a046a4426cbd432a"
                         },
                         "me-south-1": {
-                            "release": "33.20210104.3.0",
-                            "image": "ami-0b6b365b11a3925a3"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-07164702e176a0686"
                         },
                         "sa-east-1": {
-                            "release": "33.20210104.3.0",
-                            "image": "ami-085c6f3e0b810c45c"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0e483e9925d9db132"
                         },
                         "us-east-1": {
-                            "release": "33.20210104.3.0",
-                            "image": "ami-03078b694f274ea32"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0248eec44bc6adf64"
                         },
                         "us-east-2": {
-                            "release": "33.20210104.3.0",
-                            "image": "ami-00857a3a7c28e688e"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-064b5435774585892"
                         },
                         "us-west-1": {
-                            "release": "33.20210104.3.0",
-                            "image": "ami-0fdd62e607544e013"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-00fc9b4f84130e876"
                         },
                         "us-west-2": {
-                            "release": "33.20210104.3.0",
-                            "image": "ami-0bd66dd8c9358318d"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-068d3c25e2755f36a"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-33-20210104-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-33-20210104-3-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,182 +1,182 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2021-01-18T18:35:36Z"
+        "last-modified": "2021-01-28T18:58:29Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "33.20210117.2.0",
+                    "release": "33.20210117.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "c069c56b92913261827d4770af70c222018edb6ecc559ae9d1db8888f9228ed8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "e25d9ff7347e40cdb8afb74152fbac1a5b2338609144dbadaec76739d04df733"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "33.20210117.2.0",
+                    "release": "33.20210117.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "abda9993a6c5c3985dd417344a6a4f4e4d54754249a4068c8e6ad69b9f0cda6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "9769c055e7604d0485675539d8898dd09de4422f900d7c2f29c7fe34c62f589e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "33.20210117.2.0",
+                    "release": "33.20210117.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "d493b58969bfd60795a0bb7385ecf795bd4987941fa8e7c880443c853cd5fe00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "77b6c68c4d4fcd80cef760c7459abe9500fa98454a8f10c6bbd57e4dac337e4b"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "33.20210117.2.0",
+                    "release": "33.20210117.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "30eaf1de713acc199943324c95c11fe60f9edb2193d4c6b536e1bf9e94ca357e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "3c3d458417f74faa2e892c2246d1986299e6a9b7c154d0fe84be00556096aa1c"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "33.20210117.2.0",
+                    "release": "33.20210117.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "d251aa7312865c7cc39c78f935c0137f39104dad46927836b6cb4232c59bd1b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "1355a2b161a52b25762bffbe117e8a58dcb70f34538564911be036e3358734e9"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "33.20210117.2.0",
+                    "release": "33.20210117.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "e2f75dc187b1cb676059def14ffc210f96285351f9928308d82d62edd28489bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "97209a0390dadc789abf6e1e3c791918ef20560098778e93f353d7fa95d043f7"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "33.20210117.2.0",
+                    "release": "33.20210117.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "1dd6cf3542478bff3728432e455843a76466a479688bb15047ebba99f941adf8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "091aed7550425f0de867286561e609d5e5122616d7a2c010208e930073751c8a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "33.20210117.2.0",
+                    "release": "33.20210117.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "39461e42a8772c00ea3f26a8a81f1228243f6225f84c4c16529942aaf1899fd4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "b4ce13454df10da656082e0aa0fbb9bb6821865f388d71cfd04c6a1e8472835b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-live.x86_64.iso.sig",
-                                "sha256": "687a700246ca424b59a4419cba2d8e6f947d7f4be0562dd0cf2ba01a1b1ba149"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-live.x86_64.iso.sig",
+                                "sha256": "62a3f04a39c8eefcca8119f973feb940ebd1bd77ae64bde1c509ccd18d980d27"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-live-kernel-x86_64.sig",
                                 "sha256": "f364c53bde39e26b5f7b2811878c407a9f0e151326f9bb877c12d46460453d01"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "62f70188c5635dca6bbf3d19f6a5348ff5f6b1a8a324dd56911a85799e26b8e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "5ab9547e067289681567e23b151fcb06d40ab44acda978252cdc787124014940"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "a7946f0fb8ed4bcac4c427258860d3bc87601a96d3aec3371f0424e7c93e17b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "7d694e9acd97ba519140d988d337c173c6f285df27adfcb6f79d759c4a7fd6ed"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "866b88d912a6a4394cc905edecf479f842a3f3291a9c9b59111d31b80fdc4042"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "5768f8814267c2bc7c0f8e2d4b82a9e226214575e4015778c46492d384d7beff"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "33.20210117.2.0",
+                    "release": "33.20210117.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "bdcd4b88656489eb1679c189048cf80ffff027bd0d765135d0e122928f929d0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "706a158fe6030e58cb04d897224a1aabf5d5c1e00afe3030386883fae3e28a06"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "33.20210117.2.0",
+                    "release": "33.20210117.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "9d8ddd91a223fa05b433793f06922a59239874f843caec97e2f778880a2f2b86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "ccdb460281bdebf2eca3f59d233a9a63e550acafb70c9b04e2581fb7dfbafc29"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "33.20210117.2.0",
+                    "release": "33.20210117.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "f94639da12b7bdb5c107096ebf8846f872ba5c7c516934707277d60c97e1820d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "ab6013f318d77d38163fc3c1be1f565238581a20ec90cdbb6967b55237de3959"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "33.20210117.2.0",
+                    "release": "33.20210117.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.0/x86_64/fedora-coreos-33.20210117.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "cb7463c1a9ace555c795ee5cc8e32ee0f1203d674d7a40ff421c4cb119ba8e10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210117.2.1/x86_64/fedora-coreos-33.20210117.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "a763da70372c1a81796bc08e7d3f0e8f306d95b7161642d8de93a14f4c7a0965"
                             }
                         }
                     }
@@ -186,91 +186,91 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "33.20210117.2.0",
-                            "image": "ami-0b4665b0d69c8207a"
+                            "release": "33.20210117.2.1",
+                            "image": "ami-0c1586eaec996b2fc"
                         },
                         "ap-east-1": {
-                            "release": "33.20210117.2.0",
-                            "image": "ami-0ab878a6e51a53c2b"
+                            "release": "33.20210117.2.1",
+                            "image": "ami-07d6055a83390f77c"
                         },
                         "ap-northeast-1": {
-                            "release": "33.20210117.2.0",
-                            "image": "ami-0369e944a37260c44"
+                            "release": "33.20210117.2.1",
+                            "image": "ami-005994491b029db23"
                         },
                         "ap-northeast-2": {
-                            "release": "33.20210117.2.0",
-                            "image": "ami-0f85aceb3b859c435"
+                            "release": "33.20210117.2.1",
+                            "image": "ami-0b65d8e536cd4758d"
                         },
                         "ap-south-1": {
-                            "release": "33.20210117.2.0",
-                            "image": "ami-0c2bead7aa4a403da"
+                            "release": "33.20210117.2.1",
+                            "image": "ami-04e3f1eab771b7fec"
                         },
                         "ap-southeast-1": {
-                            "release": "33.20210117.2.0",
-                            "image": "ami-0ab033f5267615e0b"
+                            "release": "33.20210117.2.1",
+                            "image": "ami-072fa57ac95a408dd"
                         },
                         "ap-southeast-2": {
-                            "release": "33.20210117.2.0",
-                            "image": "ami-027e3b71990031052"
+                            "release": "33.20210117.2.1",
+                            "image": "ami-0eeae2177488c2400"
                         },
                         "ca-central-1": {
-                            "release": "33.20210117.2.0",
-                            "image": "ami-084dc4a242aade6fd"
+                            "release": "33.20210117.2.1",
+                            "image": "ami-06f6836a6c18bbdae"
                         },
                         "eu-central-1": {
-                            "release": "33.20210117.2.0",
-                            "image": "ami-0d21be8bc088fffdb"
+                            "release": "33.20210117.2.1",
+                            "image": "ami-0346b87a305986068"
                         },
                         "eu-north-1": {
-                            "release": "33.20210117.2.0",
-                            "image": "ami-0c9d61ea26840d10a"
+                            "release": "33.20210117.2.1",
+                            "image": "ami-044e26ebd06316d30"
                         },
                         "eu-south-1": {
-                            "release": "33.20210117.2.0",
-                            "image": "ami-011cc4cb5aa9b8c97"
+                            "release": "33.20210117.2.1",
+                            "image": "ami-09b3a92819cfee1ad"
                         },
                         "eu-west-1": {
-                            "release": "33.20210117.2.0",
-                            "image": "ami-00dcd6e38fb830d1e"
+                            "release": "33.20210117.2.1",
+                            "image": "ami-0310556fce527d9dd"
                         },
                         "eu-west-2": {
-                            "release": "33.20210117.2.0",
-                            "image": "ami-0b17317aaa8e9b81c"
+                            "release": "33.20210117.2.1",
+                            "image": "ami-01ba8ffb346016e4a"
                         },
                         "eu-west-3": {
-                            "release": "33.20210117.2.0",
-                            "image": "ami-0505e13d3b4ad1a9a"
+                            "release": "33.20210117.2.1",
+                            "image": "ami-0f1e0423e22c6e3c9"
                         },
                         "me-south-1": {
-                            "release": "33.20210117.2.0",
-                            "image": "ami-013331459bb53fc37"
+                            "release": "33.20210117.2.1",
+                            "image": "ami-0c922f6bf73a5a3a2"
                         },
                         "sa-east-1": {
-                            "release": "33.20210117.2.0",
-                            "image": "ami-05507af5fe719d356"
+                            "release": "33.20210117.2.1",
+                            "image": "ami-0f9b96875dc8c1015"
                         },
                         "us-east-1": {
-                            "release": "33.20210117.2.0",
-                            "image": "ami-068b46bc83b15e878"
+                            "release": "33.20210117.2.1",
+                            "image": "ami-0e05ea22a6b1efe2f"
                         },
                         "us-east-2": {
-                            "release": "33.20210117.2.0",
-                            "image": "ami-08ff086dbb7a71ffa"
+                            "release": "33.20210117.2.1",
+                            "image": "ami-0e49728a825f43b27"
                         },
                         "us-west-1": {
-                            "release": "33.20210117.2.0",
-                            "image": "ami-0046809ae4797abe7"
+                            "release": "33.20210117.2.1",
+                            "image": "ami-02825d264a2a9f5a0"
                         },
                         "us-west-2": {
-                            "release": "33.20210117.2.0",
-                            "image": "ami-001d0de8e6019b8cc"
+                            "release": "33.20210117.2.1",
+                            "image": "ami-01862006460d46436"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-33-20210117-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-33-20210117-2-1-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2021-01-18T18:35:09Z"
+    "last-modified": "2021-01-28T18:41:56Z"
   },
   "releases": [
     {
@@ -21,7 +21,7 @@
       }
     },
     {
-      "version": "33.20210104.1.0",
+      "version": "33.20210117.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -29,11 +29,11 @@
       }
     },
     {
-      "version": "33.20210117.1.0",
+      "version": "33.20210117.1.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 1440,
-          "start_epoch": 1611005400,
+          "start_epoch": 1611862200,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2021-01-18T18:36:00Z"
+    "last-modified": "2021-01-28T18:41:56Z"
   },
   "releases": [
     {
@@ -29,7 +29,7 @@
       }
     },
     {
-      "version": "33.20201214.3.1",
+      "version": "33.20210104.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -37,11 +37,11 @@
       }
     },
     {
-      "version": "33.20210104.3.0",
+      "version": "33.20210104.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1611005400,
+          "start_epoch": 1611862200,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2021-01-18T18:35:36Z"
+    "last-modified": "2021-01-28T18:41:56Z"
   },
   "releases": [
     {
@@ -45,7 +45,7 @@
       }
     },
     {
-      "version": "33.20210104.2.0",
+      "version": "33.20210117.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -53,11 +53,11 @@
       }
     },
     {
-      "version": "33.20210117.2.0",
+      "version": "33.20210117.2.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1611005400,
+          "start_epoch": 1611862200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Async release for sudo CVE-2021-3156:
https://bodhi.fedoraproject.org/updates/FEDORA-2021-2cb63d912a

- stable: 33.20210104.3.1
- testing: 33.20210117.2.1
- next: 33.20210117.1.1