### PR TITLE
Revert "stable: rollout 33.20210117.3.1"

### DIFF
--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,182 +1,182 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2021-02-03T04:57:54Z"
+        "last-modified": "2021-01-28T18:58:26Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "33.20210117.3.1",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "297bd45b18b5bea69ac7de811642f8f331b5c02b4af81d061eb81502b92cf112"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "0375205f6f5c802406b0fec601c0184d8fe1c9b53ff2c30c41b48f2ff4179229"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "33.20210117.3.1",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "62d97646d576c8f4fb6d0850752abead77a2658bfb018becab8ea567eca079fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "eb40f71483a56520200c0811d55c16cba65276ca4ec9a8f96711a7a9ca8b9ced"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "33.20210117.3.1",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "a926c1f8e16bea58e3bdf9e2ce57ef4e26f1de791a3238750725ec1b347aacec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "8bec600157f4c8126ff47a00b97bb4dc23376eb6073802d02b43f63667b347b7"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "33.20210117.3.1",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "41a808a373fc36191c4fd5327a390066c21cceba8e0104a371f17557f1047621"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "f9c12028b982a43baa0cb0af6378400a249d9c4506711a2d247975fda5978327"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "33.20210117.3.1",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "f37045753f410ba962b38c38374abdf65c317a5356484b73c62d4d160637e8f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "052f8ffb165fd7058a1291b6e43d0147c9bc755105835fec7ab2302c5f72f406"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "33.20210117.3.1",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "6790f8b17398ac5e4b254135ef322b1a61a7ce23fffbb291cfe8e1a48246ddbb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "b0e63fe9d16962cb4d32b9b9d01671ea2971ffe66ff49e197bebdea23b34a3dd"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "33.20210117.3.1",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "4a8e19f9bd17ca3e0f2fbe844306b69c32f9d4ba1a5221d5e7ebda250b7c0096"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "aea849f4d4d6f1253407366387b873cbf54f29b7500b2f2433297bea9ec35cdc"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "33.20210117.3.1",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "94ac58f4515aff4687699a031c719b24f86aa4c1ce5d974d4e67c06c33037e55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "f55094bfa6a9fde8664089ebd5f3881203a4b362204596b54bb1415f4e8a86a7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-live.x86_64.iso.sig",
-                                "sha256": "5d806d7445aac42e6468111c23d0ad82f952a7ca37c2c26fe8b4ab2e3fc2cd35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live.x86_64.iso.sig",
+                                "sha256": "d064026d50386c8598269b7db6f9cb0408636b72e78bac56d80730e8d193b981"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-live-kernel-x86_64.sig",
-                                "sha256": "ef7c2c6d17c5434957586dc50cb24a11a70c91069ea99fbf7ee1f596817d4efd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live-kernel-x86_64.sig",
+                                "sha256": "199ec5a6c3084d2478fb5e6b958d3c3e18a6b777abd168082a8cf26ec5954c50"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "04c8c3ffaa81bc9754f588527ad5b6c35a2c645868feca57fd078352850b25a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "a80305c0554def0cc30127b9bcbc7d0bbd6e4d83a98ba63688ff781b6eee645f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "1a12d9ed6878b6985565c553964fc34d56377358c0cb3b3b1c64d08ca8594146"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "83f943f2b035bbef9c7bee4e5e76294e72eb4b7bbbb316aaec38319cf3ad6084"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "0f3a2e6c94be7238a5b337d37368c6f7c0c6dd2c3d0db6e7774b6f2dcf1fb511"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "dd960a9dc7f77567441c1d9c42ef2bc9da44f33e5e9d35e2eb8f4d889a9f52f5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "33.20210117.3.1",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "7b00bf212f7d49d8778f9e0828d73964e03d121d2020bf8db6d7520022efbf11"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "bc34bac9f30fa1bd9244d759cd1a809f294f143adfce16fa9a2272cffbf9db4a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "33.20210117.3.1",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e02774add0a74a75aa44b0d6b4660101e6e6ff683b36a3c1af489c9d80b2f378"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "fc4b97cbf10126a4a15824dbc300896ebebac07f86351c6c18ade0daa96a03e7"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "33.20210117.3.1",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "18a5eaf97957dd274ce827ae23d827aaa46db64f5bcc97f42536a0c21d230adc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "f77733c3ce0be892e7647bdca3e55681ccfb2da77cef87fbf1446f8f14af6be3"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "33.20210117.3.1",
+                    "release": "33.20210104.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.1/x86_64/fedora-coreos-33.20210117.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "5a36430a5c87028e1cb1c8b358f7896ceb228c5032f3dced702a281ee3ec86f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "b882700523d785e4c20c9ff6c76c3aa78bd4c67ae22401304799125399f87bc3"
                             }
                         }
                     }
@@ -186,91 +186,91 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "33.20210117.3.1",
-                            "image": "ami-026e30f046b53b56d"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0b638ea80adbc40b3"
                         },
                         "ap-east-1": {
-                            "release": "33.20210117.3.1",
-                            "image": "ami-025c256ce3c0d18ee"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0237d99b243b579c3"
                         },
                         "ap-northeast-1": {
-                            "release": "33.20210117.3.1",
-                            "image": "ami-0db99a35564abddd9"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0a90166e0b164edee"
                         },
                         "ap-northeast-2": {
-                            "release": "33.20210117.3.1",
-                            "image": "ami-081744fb5f807908e"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0e319b8d0d4fb0dd7"
                         },
                         "ap-south-1": {
-                            "release": "33.20210117.3.1",
-                            "image": "ami-0ba6e616df0f7ecb2"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0c1378ae03a9bded4"
                         },
                         "ap-southeast-1": {
-                            "release": "33.20210117.3.1",
-                            "image": "ami-0174fb3eaed94f349"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0fea43bb278f1b25d"
                         },
                         "ap-southeast-2": {
-                            "release": "33.20210117.3.1",
-                            "image": "ami-09919c20c9528ea61"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0dd80c2c2ca0baf26"
                         },
                         "ca-central-1": {
-                            "release": "33.20210117.3.1",
-                            "image": "ami-03afaba53441cff24"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-003b6d75d4286bca7"
                         },
                         "eu-central-1": {
-                            "release": "33.20210117.3.1",
-                            "image": "ami-0d99d896b79c677fc"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0cc2d935f680d7da0"
                         },
                         "eu-north-1": {
-                            "release": "33.20210117.3.1",
-                            "image": "ami-08c64433259cf9cb9"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-01ed1fbddb8990f74"
                         },
                         "eu-south-1": {
-                            "release": "33.20210117.3.1",
-                            "image": "ami-074b91e3396ccbad9"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-095b0097697993701"
                         },
                         "eu-west-1": {
-                            "release": "33.20210117.3.1",
-                            "image": "ami-0067a26deaf66bcfb"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-011fe8f9a8dac58e3"
                         },
                         "eu-west-2": {
-                            "release": "33.20210117.3.1",
-                            "image": "ami-016b2bb09d25ab6af"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0035c836f819b3988"
                         },
                         "eu-west-3": {
-                            "release": "33.20210117.3.1",
-                            "image": "ami-07ec73d9a99741731"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0a046a4426cbd432a"
                         },
                         "me-south-1": {
-                            "release": "33.20210117.3.1",
-                            "image": "ami-02a9b447b680cea0b"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-07164702e176a0686"
                         },
                         "sa-east-1": {
-                            "release": "33.20210117.3.1",
-                            "image": "ami-01aff1abb313633b4"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0e483e9925d9db132"
                         },
                         "us-east-1": {
-                            "release": "33.20210117.3.1",
-                            "image": "ami-026f5d11c38c86785"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-0248eec44bc6adf64"
                         },
                         "us-east-2": {
-                            "release": "33.20210117.3.1",
-                            "image": "ami-0b03391ecac3aea2e"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-064b5435774585892"
                         },
                         "us-west-1": {
-                            "release": "33.20210117.3.1",
-                            "image": "ami-0d35ce84344b565a5"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-00fc9b4f84130e876"
                         },
                         "us-west-2": {
-                            "release": "33.20210117.3.1",
-                            "image": "ami-0cdfe4881abcdbe10"
+                            "release": "33.20210104.3.1",
+                            "image": "ami-068d3c25e2755f36a"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-33-20210117-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-33-20210104-3-1-gcp-x86-64"
                 }
             }
         }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2021-02-03T04:57:54Z"
+    "last-modified": "2021-01-28T18:41:56Z"
   },
   "releases": [
     {
@@ -29,7 +29,7 @@
       }
     },
     {
-      "version": "33.20210104.3.1",
+      "version": "33.20210104.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -37,11 +37,11 @@
       }
     },
     {
-      "version": "33.20210117.3.1",
+      "version": "33.20210104.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1612368000,
+          "start_epoch": 1611862200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
This reverts commit 48260bc75e8edc41a00d6fff2dc498ee31210523.

This stable release is downgrading sudo back to the previous version
with CVE-2021-3156:

https://github.com/coreos/fedora-coreos-config/pull/834/commits/cb53902e1fe2a5f75dab3c3d946d763267ee8d18#r569584509