### PR TITLE
stable: rollout 33.20210117.3.2

### DIFF
--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,182 +1,182 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2021-01-28T18:58:26Z"
+        "last-modified": "2021-02-03T21:38:12Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "33.20210104.3.1",
+                    "release": "33.20210117.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "0375205f6f5c802406b0fec601c0184d8fe1c9b53ff2c30c41b48f2ff4179229"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "117f9c236ff3055b48517af87f1a3e1abbd9630a2957c16e90cdc46f3e4e7cb5"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "33.20210104.3.1",
+                    "release": "33.20210117.3.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "eb40f71483a56520200c0811d55c16cba65276ca4ec9a8f96711a7a9ca8b9ced"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "5e026b7587082eecb8dd36905d850d1cf16193014e31737234163f765e322ed2"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "33.20210104.3.1",
+                    "release": "33.20210117.3.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "8bec600157f4c8126ff47a00b97bb4dc23376eb6073802d02b43f63667b347b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "64b8d127b20a96e763142d7f680c576db911a41f2584366ccc08b8fc06f3bc8e"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "33.20210104.3.1",
+                    "release": "33.20210117.3.2",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "f9c12028b982a43baa0cb0af6378400a249d9c4506711a2d247975fda5978327"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "1e19dee1700025dde896bc569355d28ca163001c21ea54a66701ffdda85e3c10"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "33.20210104.3.1",
+                    "release": "33.20210117.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "052f8ffb165fd7058a1291b6e43d0147c9bc755105835fec7ab2302c5f72f406"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "d346bdf4743917eb6007695fe95413d248a154ed6af5acb857fcf51fa6c6ea56"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "33.20210104.3.1",
+                    "release": "33.20210117.3.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "b0e63fe9d16962cb4d32b9b9d01671ea2971ffe66ff49e197bebdea23b34a3dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "1bcebfedf83af97c8a4aff90903bfc7dce79caa0b2d74375e9bcd248e54f748f"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "33.20210104.3.1",
+                    "release": "33.20210117.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "aea849f4d4d6f1253407366387b873cbf54f29b7500b2f2433297bea9ec35cdc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "8bee9c56de0b1d157d6bc23bfebd347f2fffa0c9278c64c8817e57daf174fccb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "33.20210104.3.1",
+                    "release": "33.20210117.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "f55094bfa6a9fde8664089ebd5f3881203a4b362204596b54bb1415f4e8a86a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "daf8f93b7038ecf63dbd248ee1dd4c5fabddcb838a15a2a69203abcf96cac913"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live.x86_64.iso.sig",
-                                "sha256": "d064026d50386c8598269b7db6f9cb0408636b72e78bac56d80730e8d193b981"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-live.x86_64.iso.sig",
+                                "sha256": "6f17299dec21670b2ec040964bd6e5e32e2668873c5f8bf1e0c809c2d9d5332d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live-kernel-x86_64.sig",
-                                "sha256": "199ec5a6c3084d2478fb5e6b958d3c3e18a6b777abd168082a8cf26ec5954c50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-live-kernel-x86_64.sig",
+                                "sha256": "ef7c2c6d17c5434957586dc50cb24a11a70c91069ea99fbf7ee1f596817d4efd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "a80305c0554def0cc30127b9bcbc7d0bbd6e4d83a98ba63688ff781b6eee645f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "0cf0898a8a2b673f7e892aa54444b9ea4651ac954153b6d0c232512d66f1066a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "83f943f2b035bbef9c7bee4e5e76294e72eb4b7bbbb316aaec38319cf3ad6084"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-live-rootfs.x86_64.img.sig",
+                                "sha256": "ebe66990a587bc00be3b2b20de69fa6f2d22d5127acd807032ec874d89315ecd"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "dd960a9dc7f77567441c1d9c42ef2bc9da44f33e5e9d35e2eb8f4d889a9f52f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "a4c7a180fc4af3d45249cde0378d0d0ceea3f15bafe49be0fca781deef797b18"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "33.20210104.3.1",
+                    "release": "33.20210117.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "bc34bac9f30fa1bd9244d759cd1a809f294f143adfce16fa9a2272cffbf9db4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "e7604b7ca881b01befa3a3759b40b17836cafc1cb521c00f3cddef4dc1229595"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "33.20210104.3.1",
+                    "release": "33.20210117.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "fc4b97cbf10126a4a15824dbc300896ebebac07f86351c6c18ade0daa96a03e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "0d0500a689cfc6fd5863ee8cc5b65e174664fb210a2779a450c5ffebde23c263"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "33.20210104.3.1",
+                    "release": "33.20210117.3.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "f77733c3ce0be892e7647bdca3e55681ccfb2da77cef87fbf1446f8f14af6be3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-vmware.x86_64.ova.sig",
+                                "sha256": "c592a9bff3e615e6cefc0a1d97f0f42b1811eda26d6aaf2483b704f53d2ca7d4"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "33.20210104.3.1",
+                    "release": "33.20210117.3.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210104.3.1/x86_64/fedora-coreos-33.20210104.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "b882700523d785e4c20c9ff6c76c3aa78bd4c67ae22401304799125399f87bc3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210117.3.2/x86_64/fedora-coreos-33.20210117.3.2-vultr.x86_64.raw.xz.sig",
+                                "sha256": "5977ce1f8c0c2a13c3ac3f5b1266b0d6533b153ca298776afadcba60a325a2b6"
                             }
                         }
                     }
@@ -186,91 +186,91 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "33.20210104.3.1",
-                            "image": "ami-0b638ea80adbc40b3"
+                            "release": "33.20210117.3.2",
+                            "image": "ami-0d0b365a7cfca9b97"
                         },
                         "ap-east-1": {
-                            "release": "33.20210104.3.1",
-                            "image": "ami-0237d99b243b579c3"
+                            "release": "33.20210117.3.2",
+                            "image": "ami-09fb3f3681418a19d"
                         },
                         "ap-northeast-1": {
-                            "release": "33.20210104.3.1",
-                            "image": "ami-0a90166e0b164edee"
+                            "release": "33.20210117.3.2",
+                            "image": "ami-075a5115a979f56dc"
                         },
                         "ap-northeast-2": {
-                            "release": "33.20210104.3.1",
-                            "image": "ami-0e319b8d0d4fb0dd7"
+                            "release": "33.20210117.3.2",
+                            "image": "ami-0c216f0c3f996a04f"
                         },
                         "ap-south-1": {
-                            "release": "33.20210104.3.1",
-                            "image": "ami-0c1378ae03a9bded4"
+                            "release": "33.20210117.3.2",
+                            "image": "ami-064a9d1ee731c325d"
                         },
                         "ap-southeast-1": {
-                            "release": "33.20210104.3.1",
-                            "image": "ami-0fea43bb278f1b25d"
+                            "release": "33.20210117.3.2",
+                            "image": "ami-0835c75eb7d90c1dc"
                         },
                         "ap-southeast-2": {
-                            "release": "33.20210104.3.1",
-                            "image": "ami-0dd80c2c2ca0baf26"
+                            "release": "33.20210117.3.2",
+                            "image": "ami-03179526f07174977"
                         },
                         "ca-central-1": {
-                            "release": "33.20210104.3.1",
-                            "image": "ami-003b6d75d4286bca7"
+                            "release": "33.20210117.3.2",
+                            "image": "ami-0280a5cbb6561a709"
                         },
                         "eu-central-1": {
-                            "release": "33.20210104.3.1",
-                            "image": "ami-0cc2d935f680d7da0"
+                            "release": "33.20210117.3.2",
+                            "image": "ami-063731a40aebbdc74"
                         },
                         "eu-north-1": {
-                            "release": "33.20210104.3.1",
-                            "image": "ami-01ed1fbddb8990f74"
+                            "release": "33.20210117.3.2",
+                            "image": "ami-0d26029761788d026"
                         },
                         "eu-south-1": {
-                            "release": "33.20210104.3.1",
-                            "image": "ami-095b0097697993701"
+                            "release": "33.20210117.3.2",
+                            "image": "ami-0cf93a234df7441e9"
                         },
                         "eu-west-1": {
-                            "release": "33.20210104.3.1",
-                            "image": "ami-011fe8f9a8dac58e3"
+                            "release": "33.20210117.3.2",
+                            "image": "ami-0417c6996955403ca"
                         },
                         "eu-west-2": {
-                            "release": "33.20210104.3.1",
-                            "image": "ami-0035c836f819b3988"
+                            "release": "33.20210117.3.2",
+                            "image": "ami-0f53861e9a2978637"
                         },
                         "eu-west-3": {
-                            "release": "33.20210104.3.1",
-                            "image": "ami-0a046a4426cbd432a"
+                            "release": "33.20210117.3.2",
+                            "image": "ami-0936154a2d093a4f0"
                         },
                         "me-south-1": {
-                            "release": "33.20210104.3.1",
-                            "image": "ami-07164702e176a0686"
+                            "release": "33.20210117.3.2",
+                            "image": "ami-0f5f1cf342419d3ae"
                         },
                         "sa-east-1": {
-                            "release": "33.20210104.3.1",
-                            "image": "ami-0e483e9925d9db132"
+                            "release": "33.20210117.3.2",
+                            "image": "ami-023dd2e3533ac74c7"
                         },
                         "us-east-1": {
-                            "release": "33.20210104.3.1",
-                            "image": "ami-0248eec44bc6adf64"
+                            "release": "33.20210117.3.2",
+                            "image": "ami-035a64a2ef541684b"
                         },
                         "us-east-2": {
-                            "release": "33.20210104.3.1",
-                            "image": "ami-064b5435774585892"
+                            "release": "33.20210117.3.2",
+                            "image": "ami-0aba6c63b62ce66d9"
                         },
                         "us-west-1": {
-                            "release": "33.20210104.3.1",
-                            "image": "ami-00fc9b4f84130e876"
+                            "release": "33.20210117.3.2",
+                            "image": "ami-0a51c47638a47cd48"
                         },
                         "us-west-2": {
-                            "release": "33.20210104.3.1",
-                            "image": "ami-068d3c25e2755f36a"
+                            "release": "33.20210117.3.2",
+                            "image": "ami-05158afedcf9f6f64"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-33-20210104-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-33-20210117-3-2-gcp-x86-64"
                 }
             }
         }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -29,7 +29,7 @@
       }
     },
     {
-      "version": "33.20210104.3.0",
+      "version": "33.20210104.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -37,11 +37,11 @@
       }
     },
     {
-      "version": "33.20210104.3.1",
+      "version": "33.20210117.3.2",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1611862200,
+          "start_epoch": 1612389600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
This includes fixes for both CVE-2021-3156 and CVE-2021-3347.