### PR TITLE
Use GitHub Actions to promote configs

### DIFF
--- a/.github/workflows/promote-config.yml
+++ b/.github/workflows/promote-config.yml
@@ -1,0 +1,57 @@
+name: promote-config
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  promote-config:
+    name: Open promotion pull request
+    if: ${{ github.event.label.name == 'ok-to-promote' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract stream name
+        run: |
+          # XXX: consider using separate labels per stream in the future
+          title="${{ github.event.issue.title }}"
+          target_stream=${title%:*}
+          # XXX: fold into promote-config.sh
+          if [ "${target_stream}" == stable ]; then
+            src_stream=testing
+          elif [ "${target_stream}" == testing ]; then
+            src_stream=testing-devel
+          elif [ "${target_stream}" == next ]; then
+            src_stream=next-devel
+          fi
+          echo "target_stream=${title%:*}" >> $GITHUB_ENV
+          echo "src_stream=${src_stream}" >> $GITHUB_ENV
+      - name: Checkout fedora-coreos-config
+        uses: actions/checkout@v2
+        with:
+          repository: coreos/fedora-coreos-config
+          ref: ${{ env.target_stream }}
+          path: fcos
+          token: ${{ secrets.COREOSBOT_RELENG_TOKEN }}
+      - name: Checkout fedora-coreos-releng-automation
+        uses: actions/checkout@v2
+        with:
+          repository: coreos/fedora-coreos-releng-automation
+          path: fcos-releng-auto
+      - name: Prepare pull request
+        run: |
+          cd fcos
+          git config user.name 'CoreOS Bot'
+          git config user.email coreosbot@fedoraproject.org
+          ../fcos-releng-auto/scripts/promote-config.sh ${src_stream}
+          echo "commit_title=$(git log --pretty=format:%s -1 HEAD)" >> $GITHUB_ENV
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v3.8.2
+        with:
+          token: ${{ secrets.COREOSBOT_RELENG_TOKEN }}
+          path: fcos
+          branch: ${{ env.target_stream }}-promotion
+          push-to-fork: coreosbot-releng/fedora-coreos-config
+          title: "[${{ env.target_stream }}] ${{ env.commit_title }}"
+          body: "Triggered by @${{ github.event.sender.login }} in ${{ github.event.issue.html_url }}."
+          committer: "CoreOS Bot <coreosbot@fedoraproject.org>"
+          author: "CoreOS Bot <coreosbot@fedoraproject.org>"

--- a/ISSUE_TEMPLATE/next.md
+++ b/ISSUE_TEMPLATE/next.md
@@ -6,17 +6,8 @@ Name this issue `next: new release on YYYY-MM-DD` with today's date. Once the pi
 
 ## Promote next-devel changes to next
 
-From the checkout for `fedora-coreos-config` (replace `upstream` below with
-whichever remote name tracks `coreos/`):
-
-- [ ] `git fetch upstream`
-- [ ] `git checkout next`
-- [ ] `git reset --hard upstream/next`
-- [ ] `/path/to/fedora-coreos-releng-automation/scripts/promote-config.sh next-devel`
-- [ ] Sanity check promotion with `git show`
-- [ ] Open PR against the `next` branch on https://github.com/coreos/fedora-coreos-config
-- [ ] Post a link to the PR as a comment to this issue
-- [ ] Ideally have at least one other person check it and approve
+- [ ] Add the `ok-to-promote` label to the issue
+- [ ] Review the promotion PR opened by the bot against the `next` branch on https://github.com/coreos/fedora-coreos-config
 - [ ] Once CI has passed, merge it
 
 ## Build

--- a/ISSUE_TEMPLATE/stable.md
+++ b/ISSUE_TEMPLATE/stable.md
@@ -6,17 +6,8 @@ Name this issue `stable: new release on YYYY-MM-DD` with today's date. Once the 
 
 ## Promote testing changes to stable
 
-From the checkout for `fedora-coreos-config` (replace `upstream` below with
-whichever remote name tracks `coreos/`):
-
-- [ ] `git fetch upstream`
-- [ ] `git checkout stable`
-- [ ] `git reset --hard upstream/stable`
-- [ ] `/path/to/fedora-coreos-releng-automation/scripts/promote-config.sh testing`
-- [ ] Sanity check promotion with `git show`
-- [ ] Open PR against the `stable` branch on https://github.com/coreos/fedora-coreos-config
-- [ ] Post a link to the PR as a comment to this issue
-- [ ] Ideally have at least one other person check it and approve
+- [ ] Add the `ok-to-promote` label to the issue
+- [ ] Review the promotion PR opened by the bot against the `stable` branch on https://github.com/coreos/fedora-coreos-config
 - [ ] Once CI has passed, merge it
 
 ## Build

--- a/ISSUE_TEMPLATE/testing.md
+++ b/ISSUE_TEMPLATE/testing.md
@@ -6,17 +6,8 @@ Name this issue `testing: new release on YYYY-MM-DD` with today's date. Once the
 
 ## Promote testing-devel changes to testing
 
-From the checkout for `fedora-coreos-config` (replace `upstream` below with
-whichever remote name tracks `coreos/`):
-
-- [ ] `git fetch upstream`
-- [ ] `git checkout testing`
-- [ ] `git reset --hard upstream/testing`
-- [ ] `/path/to/fedora-coreos-releng-automation/scripts/promote-config.sh testing-devel`
-- [ ] Sanity check promotion with `git show`
-- [ ] Open PR against the `testing` branch on https://github.com/coreos/fedora-coreos-config
-- [ ] Post a link to the PR as a comment to this issue
-- [ ] Ideally have at least one other person check it and approve
+- [ ] Add the `ok-to-promote` label to the issue
+- [ ] Review the promotion PR opened by the bot against the `testing` branch on https://github.com/coreos/fedora-coreos-config
 - [ ] Once CI has passed, merge it
 
 ## Build


### PR DESCRIPTION
This is the first step in simplifying the release process. Allow users
to simply add the `ok-to-promote` label on the issue which in turn
triggers an action to run the promotion script and open a PR.