### PR TITLE
templates: no longer manually start Jenkins build

### DIFF
--- a/ISSUE_TEMPLATE/next.md
+++ b/ISSUE_TEMPLATE/next.md
@@ -4,15 +4,12 @@ Name this issue `next: new release on YYYY-MM-DD` with today's date. Once the pi
 
 # Pre-release
 
-## Promote next-devel changes to next
+## Promote and build
 
 - [ ] Add the `ok-to-promote` label to the issue
 - [ ] Review the promotion PR opened by the bot against the `next` branch on https://github.com/coreos/fedora-coreos-config
 - [ ] Once CI has passed, merge it
-
-## Build
-
-- [ ] Start a [pipeline build](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/fedora-coreos/job/fedora-coreos-fedora-coreos-pipeline/build?delay=0sec) (select `next`, leave all other defaults)
+- [ ] Verify that a [pipeline build](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/fedora-coreos/job/fedora-coreos-fedora-coreos-pipeline) was started
 - [ ] Post a link to the job as a comment to this issue
 - [ ] Wait for the job to finish
 

--- a/ISSUE_TEMPLATE/stable.md
+++ b/ISSUE_TEMPLATE/stable.md
@@ -4,15 +4,12 @@ Name this issue `stable: new release on YYYY-MM-DD` with today's date. Once the 
 
 # Pre-release
 
-## Promote testing changes to stable
+## Promote and build
 
 - [ ] Add the `ok-to-promote` label to the issue
 - [ ] Review the promotion PR opened by the bot against the `stable` branch on https://github.com/coreos/fedora-coreos-config
 - [ ] Once CI has passed, merge it
-
-## Build
-
-- [ ] Start a [pipeline build](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/fedora-coreos/job/fedora-coreos-fedora-coreos-pipeline/build?delay=0sec) (select `stable`, leave all other defaults)
+- [ ] Verify that a [pipeline build](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/fedora-coreos/job/fedora-coreos-fedora-coreos-pipeline) was started
 - [ ] Post a link to the job as a comment to this issue
 - [ ] Wait for the job to finish
 

--- a/ISSUE_TEMPLATE/testing.md
+++ b/ISSUE_TEMPLATE/testing.md
@@ -4,15 +4,12 @@ Name this issue `testing: new release on YYYY-MM-DD` with today's date. Once the
 
 # Pre-release
 
-## Promote testing-devel changes to testing
+## Promote and build
 
 - [ ] Add the `ok-to-promote` label to the issue
 - [ ] Review the promotion PR opened by the bot against the `testing` branch on https://github.com/coreos/fedora-coreos-config
 - [ ] Once CI has passed, merge it
-
-## Build
-
-- [ ] Start a [pipeline build](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/fedora-coreos/job/fedora-coreos-fedora-coreos-pipeline/build?delay=0sec) (select `testing`, leave all other defaults)
+- [ ] Verify that a [pipeline build](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/fedora-coreos/job/fedora-coreos-fedora-coreos-pipeline) was started
 - [ ] Post a link to the job as a comment to this issue
 - [ ] Wait for the job to finish
 


### PR DESCRIPTION
This is done automatically now. So for now, tweak the steps to just
verify that a build started.

In the future, this will be streamlined further so that Jenkins itself
will surface that a build started.