### PR TITLE
Triple update on 2021-04-14

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,192 +1,192 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2021-04-08T16:13:55Z"
+        "last-modified": "2021-04-14T12:30:24Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210328.1.1",
+                    "release": "34.20210413.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "c6acc8afe99667ddc56e1158cf341576604f3e2fe8525b895fd78db668c3f4ff",
-                                "uncompressed-sha256": "2233678578dbeb63134303e58f79981c5415516619fed3e1a2c12e4855d041a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "061d8a0266d501e713f65c57ae665dcb1ef6412e874684330feb0fbe550331b4",
+                                "uncompressed-sha256": "23310d4e8e692a13e5ea471804c08103706f62a0c2950cc9dc271c9b5e55218a"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210328.1.1",
+                    "release": "34.20210413.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "ec6d218f688518cfb4a2fbb728335bb2a3de94e1bbcbcadfff908220c777cf10",
-                                "uncompressed-sha256": "8ad1bf193a861fb4685002157c075d7e7be73d4ed10b878d8c503345256b437b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "ccaf468a81e0c305b0b0b927cf32f9a2c0589f119f2f3c148eae33d616efa0b0",
+                                "uncompressed-sha256": "b8e2120b9c61ff88345293b5005054b06714cfe332691fb1efe4a90a9db057b6"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210328.1.1",
+                    "release": "34.20210413.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "d59822da7a76b10e0d64f932cac9c2a654e4846981abffb45c689b6af0ed4b38",
-                                "uncompressed-sha256": "fef9bc0ed8def9ea7b25ce62936d12a3567175716e4064fce9b2859512bbd055"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e0b2c79caa69c928a2a3c5a955b9407e894a196b105b1ef687b7e35f0b292bc0",
+                                "uncompressed-sha256": "6cc497bbbff8870776aedfd273edeb13e62085f7adf681c7c0168ece4e9706be"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210328.1.1",
+                    "release": "34.20210413.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "3595674fb886b999ca93a4bdba6649f498d167c34b1801fe26d7f83d46073348"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "4d492b8208102b484113f1d30251d13833fd3f90097c220172934e371b7ff555"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210328.1.1",
+                    "release": "34.20210413.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "6908187e51472d6c3239d5ac67a821f96e2fe6b3f2932a96ea1b3d602eb8bbfe",
-                                "uncompressed-sha256": "f3c4e0b876fc40b69b0a8a26eefee7a69eb7c7c044142de2016a70027842269c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "3f7e35d11e1c1050c22530f4794aa6bab02594d927fdaa10e688a864de20e334",
+                                "uncompressed-sha256": "fe8dba0c4928ef630bc6a45747a7fc18d8bd087da58dde5b58c04998585ef8f1"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210328.1.1",
+                    "release": "34.20210413.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "23caddf9fa2a797e0b730984fe035dc6cf3ddc2fb55263796cc972d16f673a27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "9664dd3b42ddbb55b3940978a263becdf337a0c04b5db6c964ad13e4ae903975"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210328.1.1",
+                    "release": "34.20210413.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "e8ee0780005e7f55d021e398c32db84eac509e5fc4becb71b437d4fa29e53ea3",
-                                "uncompressed-sha256": "4b650f9ef4453d9c0566076ee2ae8f7690384c6f4368e436bc2b8a022979e5a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "c972b06fb462023be22269ce95b95ae34e0ed0b7d7247f502c7adbaeca6e2d16",
+                                "uncompressed-sha256": "80d01b9aff23f2d5811f9720501a73a2e1d7ab0b86b4321e12b37f8dec186707"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210328.1.1",
+                    "release": "34.20210413.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "d21fa139d454a5750edb94afdf34228441bad0e21d2ebe9d401bfe1cef40afcc",
-                                "uncompressed-sha256": "068559aeff8c3ec8d7d083982dec93c9aefdcfe197c732343219643eed055885"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "1a72557ae470a827d0214a79ae36b1a0e2726caab491cc64f5440039a785c5ed",
+                                "uncompressed-sha256": "158b3f38d98a9fea9afa3980403d01be56d90a25696c6a6ed155149c527c2338"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-live.x86_64.iso.sig",
-                                "sha256": "4d75d94adb60d3800074ef556e1ae3df0d50d772f22a5e1efaab340e5f198b19"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-live.x86_64.iso.sig",
+                                "sha256": "f932089607540a1d4f78414ceb35b680efe08fb4bcb41e9285a13706ce637aa8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-live-kernel-x86_64.sig",
-                                "sha256": "11bfb2275e663c3b3faee01a6f3e2f05fe6abed6921a9c1c43211999f01870de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-live-kernel-x86_64.sig",
+                                "sha256": "3f04c5781589517128681db40f9193a2d7f611b905e31751224b048fbf5b529d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "ee1fcd54e5c4d43368987ff4b1c47d0b8447faad086c6674c2b1778442990a63"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "883e43e4f2ed36b81a217ca11839000bd97b0a0327a1ad465b3ba5a4622fee6a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "4ab625afe2132a75820ee4f789bec4c79b5086922c41324ec0e70562645e8232"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "e546e08eadf8d5e10af4e98a2c5b4336af51342829048bf45989ed5ffaf43014"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "de0f22a444e6b954c90e22174a0b9d042ddb036c2276f65cd3d077c23582dff6",
-                                "uncompressed-sha256": "8ce3d9cc13127432be54ec0059039ef619f0038556db383c81cf281b31f131e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "755303996c50806061b66e8fe7dbe6b60c27cadaa232c84a308bb852eac26156",
+                                "uncompressed-sha256": "d2378f6a14beb76f37e731599c912820ce03088fc149613ed75092667b6d2aa5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210328.1.1",
+                    "release": "34.20210413.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "606f4a299486770cbdd564af21c44b0a45ff918eea245048e0894b9a4932c2cd",
-                                "uncompressed-sha256": "f3d95168984eee8a944006038b6921f2989f5045fffb0a5cafb99b6e50c2b537"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "7bb6869a865f41d5e878550991e0c046d2cdbe8b2298dcdc9f63d6e49f59bd6f",
+                                "uncompressed-sha256": "35ee59143e45a214f9101c87a90795d4f1669961c24edb3474ae0fe6d8af83d0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210328.1.1",
+                    "release": "34.20210413.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "ab0734b55f0b3789f25304678dc7c267fb9b2685b44967e2435f64ddd423512c",
-                                "uncompressed-sha256": "6fffbdb3f15536cc348764bf428d532f945aeb145c109f6f87ee1f8abd5ddc95"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "fa7dbf45bdef9cdc939f9d8df6926514f97605c15f56901bbea844fd45571532",
+                                "uncompressed-sha256": "19f5c456e6e5aa14a7e573aa545521726a9a84a05c3a05f537538fe458ec8da4"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210328.1.1",
+                    "release": "34.20210413.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "b6644d7221fc378ba056306db13c4abeb0c1880e2660531bc7811c01c92ced06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "275392d09f9d7d97ef417ade04f8c8f1e4f215eb6de651044ccb7b464085f7a3"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210328.1.1",
+                    "release": "34.20210413.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210328.1.1/x86_64/fedora-coreos-34.20210328.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "74a15d961572579a96796de9af7b8fd4d1f0472a423936fe615c242c34e4760c",
-                                "uncompressed-sha256": "9d01d5903849c67bd1c16dcd5d312488ac3bec8435562bf358175a839da8b011"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210413.1.0/x86_64/fedora-coreos-34.20210413.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "fb6f9855ee257441f8b5c73e51203996ff13bfc6274fe4e66e991291d4710d43",
+                                "uncompressed-sha256": "0884e80654cc186fcb245a497097f771cf357361f55c94091ee881873bae79d0"
                             }
                         }
                     }
@@ -196,95 +196,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-0b0f6e7c5672daff1"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-00d21e623b0d4370c"
                         },
                         "ap-east-1": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-0a683d8fd13856714"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-07867956cf1c3b565"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-0b7b6ecdd9ddca2c3"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-0ae0b277c8ecb7d34"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-069eee16d4472eacc"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-0416d46eb894e899e"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-07fc898f29ad701b4"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-0102d0ce06dad4767"
                         },
                         "ap-south-1": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-096e702a54d89a4ba"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-0f4c6173d9f456b38"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-0dd43175cd19af055"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-00173c2d697c52e06"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-07ca33e72b857092c"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-0b3a3fba6fdf1dbe8"
                         },
                         "ca-central-1": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-0b2bc996218c3a27a"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-04dbd29f1cab55efb"
                         },
                         "eu-central-1": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-07d7f90489516c4aa"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-05e6a2f23b90d74d6"
                         },
                         "eu-north-1": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-002e1869338f81e5a"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-0d4a3a00af78c5880"
                         },
                         "eu-south-1": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-041d70c02f7e2ef20"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-05c1c1a303fc9130e"
                         },
                         "eu-west-1": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-07b70f65ba285bb07"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-0cfa4ac9025f6f233"
                         },
                         "eu-west-2": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-0fe546ac98d2a85cb"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-0d0ba97db4e6ebac9"
                         },
                         "eu-west-3": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-0172ac9b67eea4642"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-056be48d98601b0db"
                         },
                         "me-south-1": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-085650c1a9bccac8a"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-0386d0bbf27b50c51"
                         },
                         "sa-east-1": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-0187073481520918b"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-0f834e3d821c94e62"
                         },
                         "us-east-1": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-008c525689b7acf0f"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-0a8ff2994171bfef2"
                         },
                         "us-east-2": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-0918bd2fb8562f013"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-095f09c19a662a95a"
                         },
                         "us-west-1": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-034bef94e75dbd031"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-0e944510a3416b8b6"
                         },
                         "us-west-2": {
-                            "release": "34.20210328.1.1",
-                            "image": "ami-0e5972b77ffa60a8d"
+                            "release": "34.20210413.1.0",
+                            "image": "ami-035b267234d68bd64"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-34-20210328-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210413-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,192 +1,192 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2021-03-30T09:22:37Z"
+        "last-modified": "2021-04-14T12:30:02Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "33.20210314.3.0",
+                    "release": "33.20210328.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "3f53b3791cce1b1e3bb1eb564a9764358eb3164849173f3676e27a62c6a0a258",
-                                "uncompressed-sha256": "a6871f789742f26c513582365cbe08af6cc2ce4e17093499dfffdb3d7820720a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "103a61a4961d5273413c130b77a78ee0395a93cb3d05d0714197694e33ddeabd",
+                                "uncompressed-sha256": "7ff8f04f4f0e4163956f8391cf77b666d7840aec81acde56b7b00274ad89f900"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "33.20210314.3.0",
+                    "release": "33.20210328.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "db4215630ee11322cf4aecbb9804efb164785d7691db59c9056e6499af0d102c",
-                                "uncompressed-sha256": "4900f0df067db034075094f0991991f664f646368a8852bb830d6dfb34b118cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "05c466a153262c5f412b8ef457f6f70135c428119b4463aa2bc95da1514ed776",
+                                "uncompressed-sha256": "a871a2e8e934070ba6f75309c8a86d8c4f4e5a42551ac45805d0191111c44deb"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "33.20210314.3.0",
+                    "release": "33.20210328.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "ee2ff2665aee30ca1db83967452ab48e7a65ec37e267e988729ffdb8bb941f9f",
-                                "uncompressed-sha256": "c9fc3111e1b078b4e2c76d1182180b9fb67fa53b46fe0081d0c6ffa1c6568cc6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "5cdfeaf29309f7505c76f0d0264df71357753e52f2f4a3a0da8f07b7542e4a0e",
+                                "uncompressed-sha256": "cbe8db95198a72f0225c9f4fc9f06b6941d86f5dd51df7185c3e40a5ee764487"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "33.20210314.3.0",
+                    "release": "33.20210328.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "626a1217fa28a8d378543500841789a192b442e913af34592127f37105e22223"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "68ee22a032ca6b3064518bb115ed327d8ce5a173c953db5b64aac3a88dac240f"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "33.20210314.3.0",
+                    "release": "33.20210328.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "907ca9ede29acc9c814aef26ee37ad82a60397746edf149dbbca03f4423224af",
-                                "uncompressed-sha256": "3c14c749390e47486808d34a2221eef55baabbf8a49029609cf43f56e3e71351"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "709bc91eb97ca9cf95307ca15af00f2f85fc00756c3c67ea885d95cfbdb39e23",
+                                "uncompressed-sha256": "bae6bc3496c5847dc76db7d3bd2dfcd982ef49ca36ad9ce819c9bdbe1234c859"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "33.20210314.3.0",
+                    "release": "33.20210328.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "b5d87fd3e949169289a782c2ac625904cfea95b23f4148682a2e426d5847d1aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f323ee425da4832e00c01d1b002ddd0fb77b6cb976e90f8c0ac77d19d5211e21"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "33.20210314.3.0",
+                    "release": "33.20210328.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "7db28e75ad9210d36f7891035a6acdfa38aa001fb79ef13581d50b0b05fe0981",
-                                "uncompressed-sha256": "0ab6aec2a2531628e5f9d6a8fcdf395d9498de481d7dc9e473c094ea0e73e05b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "31e6ef5ec4ccf1bc1a11fdb048b38001cbeae2dfa265e9e240b721e426678f8d",
+                                "uncompressed-sha256": "c4791a94abc86fbc80919237d380d4bdab2ed1e4abfd882e38ff33a60500657b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "33.20210314.3.0",
+                    "release": "33.20210328.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "1c770926df62a46b48db2fbd7cf1dddb0ea6c5c5c77cd3e3760a3948cd61c74d",
-                                "uncompressed-sha256": "43ec410f032b12a7cca4c3699ed4b9200047fc65a7ae9f1623f21386cf3dc694"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "39b57908b77b9f18a7edefaa210210f98cd5857d04924caadf3ad6b133ea5651",
+                                "uncompressed-sha256": "a512c950f141f9125da7c9d4d0c4cbb365126c32c3416fd18af3fb2e955e9c52"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-live.x86_64.iso.sig",
-                                "sha256": "5a853a66b6060613421b1e255805c32df0fa383ae3631cb7da4a614dc64225b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-live.x86_64.iso.sig",
+                                "sha256": "685fa6f19133410c127d2a31c52750becc9fe1a3bfc9231df20daf52914953d5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-live-kernel-x86_64.sig",
                                 "sha256": "28314d6a50610dd342684d6edd19f386b8b8ee150f924775d81408be1987c3d8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "94a367211ae69c49cd16a50d67ff758cea10b846c3c0173a51e99521d6c75bfc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "ef0fcd53f8031e68066be6211fa0226034354cfe9ae2d7e97394a94f29271f18"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "68ff29e6265bbbb82940bd1a182dbc7bf2a628db9e15035f2adced4dc2cc3a2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "0045d65f54e3db27cbcac8fe07d20b5735725028489583c3e774d71af6c1fa91"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "7642edde450b9d6ea856c40c2b59ee4a9466ea256f92f4c930a3010a889dcf21",
-                                "uncompressed-sha256": "abe2fb3bd9982e08b3532d13f93c68811e38f58a216a5d4cd38ae05aa9947257"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "36d90fb4d72b908e83dddc7669337ecc7d100d845dd181d601ac24e602593f0b",
+                                "uncompressed-sha256": "69e7ede2c522c49ea3c71aee29604c767e0976cc0a7f8a8d241bb9895117df6c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "33.20210314.3.0",
+                    "release": "33.20210328.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "10b87c71eaf234a72f2a48f8e3c5260a33820750fe129e2fdbb71db0198cc799",
-                                "uncompressed-sha256": "38d49e970deb3a49a5011cbbbe967c1867872f483e1b3269353184d342dbc6c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "545a7412fb6344e7b42f0a66b0f0cc1c194270afadce5eef6e737cab58220afe",
+                                "uncompressed-sha256": "e8398373c6e1ff85ea99751f3b9d81d3484a99fb00b5a46620e72386aeab4893"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "33.20210314.3.0",
+                    "release": "33.20210328.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "98dc4c4cde3086d0b63999cdcc113979764cb2aeaa5392d55f53a91817fb9546",
-                                "uncompressed-sha256": "07ee9e105d06a93b9509b81a6496c7736c808f9aa35df3f3df41fe856a139c99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e8cc3a9d8993a530799dad6504582b45a8fd9caa0cf5f269782d7857f054ef76",
+                                "uncompressed-sha256": "69b5d60216bdc85d189e735a956d2d9535ea9fd03df2763d3cb1003ea174c043"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "33.20210314.3.0",
+                    "release": "33.20210328.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "5e381bfafeba4e8175d58ad4f044b48aa68d2371b405f4a516423fa669dd0a3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "073edc974133c624862b61f53d2ef9c1fb3c7cf5e45e5d36b8f739b49a38c06e"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "33.20210314.3.0",
+                    "release": "33.20210328.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210314.3.0/x86_64/fedora-coreos-33.20210314.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "b6d2d602f693c6070d668d0c46b87f746ef5909c4b360257cefd753c6604c06a",
-                                "uncompressed-sha256": "4b5189bcdceb7ff3080920395eeef1f84cd781c04d609edd53729c419c6577a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210328.3.0/x86_64/fedora-coreos-33.20210328.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "b7c28c289326da915a2e7ea527101952be3499479e3354abf92941c510678902",
+                                "uncompressed-sha256": "9b942de51d7192823240b9cf9296bc840bf038af25befc0fbab90c6f375adfaf"
                             }
                         }
                     }
@@ -196,95 +196,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-038fdfaaa74c64eb4"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-025d3b139c95a9474"
                         },
                         "ap-east-1": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-041783c41a41542d8"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-041f9e2ff07053b92"
                         },
                         "ap-northeast-1": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-0ec384100deb8bb2e"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-066a36ebc2aa8021c"
                         },
                         "ap-northeast-2": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-0e0abe690d0100ef8"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-0b4e624bc64993b89"
                         },
                         "ap-northeast-3": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-02b2bf9b833118818"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-0fe8c71e9bd86c073"
                         },
                         "ap-south-1": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-01e7093b9fc7ef1bb"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-0de1fe88236f151db"
                         },
                         "ap-southeast-1": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-0609b885410fe5d80"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-0b110ca9c5a2f6629"
                         },
                         "ap-southeast-2": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-08ca084011bb30ee8"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-02daeaff982fd3a87"
                         },
                         "ca-central-1": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-0151f208ffe67bb56"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-0530be3fc92db5bab"
                         },
                         "eu-central-1": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-0ee30a95d4f427687"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-08c0be6a8de0bcefe"
                         },
                         "eu-north-1": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-0f3eb79e6e450de22"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-0b371455ca548c317"
                         },
                         "eu-south-1": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-052a5d98002dfe57f"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-0459b1f0dbfad30b5"
                         },
                         "eu-west-1": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-0ad230f82ce8831ce"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-0a51e683a138f3586"
                         },
                         "eu-west-2": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-07e186b7266ef35d0"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-02a65f809dc714883"
                         },
                         "eu-west-3": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-0e068865af3d2ce57"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-02c15aed7b8f3b354"
                         },
                         "me-south-1": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-016f67da45cb6071e"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-0fba3614113c24170"
                         },
                         "sa-east-1": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-0dfd9a3953d199a6b"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-0bac531baddbe91db"
                         },
                         "us-east-1": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-0dae15eb3de85195c"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-06af204ec574cc791"
                         },
                         "us-east-2": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-0a946844cf93a601c"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-0add6cf28b19eaeb4"
                         },
                         "us-west-1": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-0a153a74a6c0822a1"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-06ff90e253676e9de"
                         },
                         "us-west-2": {
-                            "release": "33.20210314.3.0",
-                            "image": "ami-0fc77ef15bb557b0c"
+                            "release": "33.20210328.3.0",
+                            "image": "ami-0712ba86bd5df2cdc"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-33-20210314-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-33-20210328-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,192 +1,192 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2021-04-08T16:13:51Z"
+        "last-modified": "2021-04-14T12:30:15Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "33.20210328.2.1",
+                    "release": "33.20210412.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "8bd0de7eb2f7a019399b453d88505b274a83fc906a4bf8ccd64abf193aa56e8a",
-                                "uncompressed-sha256": "7128776fd957d872d1d7a1445746ceae3ceda43dffe21dd58d4b830c24cdbcd3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "7862e9e5de97547194f854c76506528624b36e44231654bd10f6f1db8d8dedcf",
+                                "uncompressed-sha256": "8b59121dcc67c324ec5c1682bd137c0fbd2e597e9292d9786fbf12516d625b23"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "33.20210328.2.1",
+                    "release": "33.20210412.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "d0458c6356f4d390f5506632e3d12abad63ebf3c3c609b12a202c54b71097922",
-                                "uncompressed-sha256": "08085294c9ae8e92c580db6e63d1d5a4fd6a6a614944558645153b1d747869b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "dfe3fca6658b84804d5f34e128064ebb888d258b9e3f31be7c860b1f296bed88",
+                                "uncompressed-sha256": "cab84a516dbdb3d1f45c7fa65f6d873c2f749995d20e80ae95c12c4332fabece"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "33.20210328.2.1",
+                    "release": "33.20210412.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "68b5debca7c65e0ec6efe41eea50eeae90632ae6563f63e985293e374b4c5c5f",
-                                "uncompressed-sha256": "5c4a73f2026b226d202ecf0e7a3e63892f222637627eccb5f23ca1de6ddaaa1b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "fded87f393ea4cc8e392b671e8a5fba0843e0bfdb81e75e2a0c1268f0b11ea91",
+                                "uncompressed-sha256": "74245ee45fd106010d2116ce8a3c9aca2f9bf4cb450aeb36a257801374ff7417"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "33.20210328.2.1",
+                    "release": "33.20210412.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "557bc0a3f79af1c665951884f57bb6167fc9646c59ed124c8fa164a00b5d7d5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "8244b1e4af8698eac8f13b47d9ba4f98ec4b375ce6ebcad91dcf9a172ad0476f"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "33.20210328.2.1",
+                    "release": "33.20210412.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "523fc59bd7e9a79e2c48f7f894f2f9296954dce5ea878db5a3fa91359e529eca",
-                                "uncompressed-sha256": "1482c2309784356543efa0e20245be31033d32a6f6a765af2ef285067c69b1ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "3d127be1e30d924900f338f10ed2314dce0cc66510ac5b252350fd3df94bfb20",
+                                "uncompressed-sha256": "b54d86fabc6c7e6aff1f1e1e645051f21f4dba3ffe1ae2aaf4711f329cb0540b"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "33.20210328.2.1",
+                    "release": "33.20210412.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "a75f7f0717251115728d776f50c618dc224991ee050e2ac2f0cf20c369abe50b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "42aaac93fce8084c979721cada553ed2342b10d7d04e5a1230940b9fb53e9d44"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "33.20210328.2.1",
+                    "release": "33.20210412.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "41fab4fd08f17c80939d14adf4571f2c54034c994c4c99632babd78a8a3057b2",
-                                "uncompressed-sha256": "45d0ca99350f4fe285345d576218bb608dfdb5f386faab35d942d52be94a6cb5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "ecfbfd6e7e27bda5af3048a33e6a0a9879d51c0ed1547164479e8aaa1d011b0c",
+                                "uncompressed-sha256": "4ca55409a84d0457ed89bc6c51dd5fcd42fd8021485e1eaf3650f4470520f22f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "33.20210328.2.1",
+                    "release": "33.20210412.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "fb83e367dfb987209b9e46e1a40071501f53a73db4f9136d760ef8aafa942795",
-                                "uncompressed-sha256": "9080889be4dc7e4d163c7467a74251d26a14f54d5bb60c47f5b0d13327aebecb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "b29c6d9fb1756132319882b111cd9bc1d269b26a0acc2deb2bb890523f05ea57",
+                                "uncompressed-sha256": "727acb07aa51d41e77a600295edf6990a3dd3f29d8ff898a7106ad47138a360e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-live.x86_64.iso.sig",
-                                "sha256": "edd2361ab278d119f13c4d598e5e5d0bf62e748ac0a6fa23453a08e9317f475e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-live.x86_64.iso.sig",
+                                "sha256": "9a48db0369620a850ee280254bbdcac661be1c3f9b76769aaf0eb9f6093c7461"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-live-kernel-x86_64.sig",
                                 "sha256": "28314d6a50610dd342684d6edd19f386b8b8ee150f924775d81408be1987c3d8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "8b23344976f6514b4ffc05fff4f770a296a3a5017afbac9ffc427fd41d60573a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "3426877e5b97dcd363c1c8f4c1dc122dd659f11236b6896917ccbc098d9c17dc"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "2d129a999266f9d13fc05b9d18a54ad352ed84c197c88c132aa8303db7e7ed1c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "45f72f8b5645dcef678db6829a101db85ec33091d4424534efd73d285499ba0c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "551b510107626527885409448858737dbb82f10b124a6ecde98bc4e1a2c77e7d",
-                                "uncompressed-sha256": "9193b139bdf199676c518d27fdcabc76ad51a9739d53750dbb3ffe1c4dea8f0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "002764381ebf2fa0f3e51c53170b51026c78e2844fb02c063966cc67cf0d944a",
+                                "uncompressed-sha256": "fe2f5bbf67fbc575fd65a7681f8746693b50927ab13ca7a80aa9ab316740c7f8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "33.20210328.2.1",
+                    "release": "33.20210412.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "5fd213228008ce4dd62191b27359a955cded23d29375552ca5a1fd0ee9c05f21",
-                                "uncompressed-sha256": "479876793c253afe6cbad2ea123f496070198734fff2db6389f364b57c223e8d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "805f8806c647a11bef909f990c5c0a3669b2579ab38ad27906675443c208214f",
+                                "uncompressed-sha256": "28bd9d8ea94fac6230f6a075fd006cbec86538f7915e6b5a370b6a685b8d5e1e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "33.20210328.2.1",
+                    "release": "33.20210412.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "d146a16b74b3618562c0475a0d9271989c7e35df060f92bbee3f6790fe667f91",
-                                "uncompressed-sha256": "b161861ac27a5677dc77ae3da8bb2e1976bed53c5546722a017e7574fb151b62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "47086c1f96f9b62278c0eb2c396d269704dd27324d89da22727cf006dcbabb59",
+                                "uncompressed-sha256": "a74f6827d7bd53c75b185598b1be1fd2b57e7330274579edf8f9df071d52044d"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "33.20210328.2.1",
+                    "release": "33.20210412.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "3aa72b37803cefca6816307113149a2ed6bf028ef1a50b9316372b952114b577"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "410025eaaebaebaced24a2a6d7990e8f582b7d5cef550e3148b6ee30cf6ba256"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "33.20210328.2.1",
+                    "release": "33.20210412.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210328.2.1/x86_64/fedora-coreos-33.20210328.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "fe3ca162cd748cf1c662251866b98086bd71487460858708e1cc05c4265c702a",
-                                "uncompressed-sha256": "46e1d41451827bb415b75c91823e8c98e8a2bcd9d4218623c3bb76aedba0b078"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210412.2.0/x86_64/fedora-coreos-33.20210412.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "df7032c569066132110c6b89dacf2a4945c24c4f591f67ae406a96eddd3395a7",
+                                "uncompressed-sha256": "28ce6a49ed5b7ee620c9d862c523d1858fcf5450ae880c3f8d217d9bebfabade"
                             }
                         }
                     }
@@ -196,95 +196,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-0c1088a9e1d25e89e"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-010abdfe6d219e19e"
                         },
                         "ap-east-1": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-0b815ac512d380939"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-095d1206385396305"
                         },
                         "ap-northeast-1": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-0ad3c923ef5c4d78b"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-0f733e7c21bb4b594"
                         },
                         "ap-northeast-2": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-01f32227bcd3a7a34"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-0f42afe4086389c14"
                         },
                         "ap-northeast-3": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-0b829351679dcc465"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-0cdb80ba69c7bba68"
                         },
                         "ap-south-1": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-0e18b40207098a7c1"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-04a4000f0f228df66"
                         },
                         "ap-southeast-1": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-0280497a53bcd2c26"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-02aef89e3304eb3ee"
                         },
                         "ap-southeast-2": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-005f8255feace3174"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-0b598dbee566283c3"
                         },
                         "ca-central-1": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-03a3d7fde98bb8ec4"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-0a3a71e61d1d7ead7"
                         },
                         "eu-central-1": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-017aa25ad2314ef76"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-06136027de141fa57"
                         },
                         "eu-north-1": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-0813bf0561f4af01a"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-00ba601b8841b9f9a"
                         },
                         "eu-south-1": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-0cb350e286b9ae525"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-05dd8d01503c46144"
                         },
                         "eu-west-1": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-0ea087c444689b1fd"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-0ae48c0c4e82684dc"
                         },
                         "eu-west-2": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-0d2e7422793a04969"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-0ecee246cd478fbde"
                         },
                         "eu-west-3": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-0eee5ceeef195e72b"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-0853fe5b9a1fbe232"
                         },
                         "me-south-1": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-065bbec4ca4ab00ce"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-05ce6349a0b3bd6b7"
                         },
                         "sa-east-1": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-09b043b7266bcf8f4"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-0ead1fd91158c1554"
                         },
                         "us-east-1": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-025f6060a1ea16d97"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-055b04276b5dd6ede"
                         },
                         "us-east-2": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-0c44fd4996cee7638"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-0c6bef6cf5fdad742"
                         },
                         "us-west-1": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-0bca6b287f209ace3"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-04a0f8374661a94ef"
                         },
                         "us-west-2": {
-                            "release": "33.20210328.2.1",
-                            "image": "ami-0cd401647706d7f16"
+                            "release": "33.20210412.2.0",
+                            "image": "ami-0727ad64c992fbea3"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-33-20210328-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-33-20210412-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2021-04-08T16:20:28Z"
+    "last-modified": "2021-04-14T12:24:58Z"
   },
   "releases": [
     {
@@ -21,7 +21,7 @@
       }
     },
     {
-      "version": "34.20210328.1.0",
+      "version": "34.20210328.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -29,11 +29,11 @@
       }
     },
     {
-      "version": "34.20210328.1.1",
+      "version": "34.20210413.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1617906600,
+          "start_epoch": 1618410600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2021-03-30T09:22:37Z"
+    "last-modified": "2021-04-14T12:24:58Z"
   },
   "releases": [
     {
@@ -29,7 +29,7 @@
       }
     },
     {
-      "version": "33.20210301.3.1",
+      "version": "33.20210314.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -37,11 +37,11 @@
       }
     },
     {
-      "version": "33.20210314.3.0",
+      "version": "33.20210328.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1617112800,
+          "start_epoch": 1618410600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2021-04-08T16:20:28Z"
+    "last-modified": "2021-04-14T12:24:58Z"
   },
   "releases": [
     {
@@ -45,7 +45,7 @@
       }
     },
     {
-      "version": "33.20210328.2.0",
+      "version": "33.20210328.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -53,11 +53,11 @@
       }
     },
     {
-      "version": "33.20210328.2.1",
+      "version": "33.20210412.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1617906600,
+          "start_epoch": 1618410600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Rollouts scheduled on `2021/04/14 14:30UTC`:
* stable:  `33.20210328.3.0`
* testing: `33.20210412.2.0`
* next: `34.20210413.1.0`