### PR TITLE
Triple rollout

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,192 +1,193 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2021-04-28T13:46:09Z"
+        "last-modified": "2021-05-05T09:16:08Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210427.1.0",
+                    "release": "34.20210503.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "b2a54c222455706dde50c3ebfbd2f0b956981957a245490f14b7858deeb41f23",
-                                "uncompressed-sha256": "a537bf829f340594a64e851de1f2bd3cc10743921327169b9ba5dc3b78ed63ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "48cb274f36d435d2bf2a17220af7726f9c3f021b1c8cd41f820560567fab37a1",
+                                "uncompressed-sha256": "6a63eedb483dfbfc381c3b4d75fa944711627c803f0395b9552e24ff815a7d5e"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210427.1.0",
+                    "release": "34.20210503.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "013e9495312e985cf93afbdc84c2a16e59c7bc96fba6387fa8e577f5d24b4224",
-                                "uncompressed-sha256": "3bc950f47922594b77e7a0965e87375ce9119a1fe214e99c091a5c0bdb3745c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "3016647740c18a2fa90449cc8fc2c56c4265dfc09d6f859f4c0949d8b80343b4",
+                                "uncompressed-sha256": "fbb0a8ade0b838be995bc06c53fa430c880dd160a7768a5858297d13e3003537"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210427.1.0",
+                    "release": "34.20210503.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "6042627d20589a36fbeb80a806b51bb9d1de6b7b7f26aa62d0bafd38e000e922",
-                                "uncompressed-sha256": "8a364aead885119eb9475a51409a0fe86cf52ddc3c0e79b863a0041935eaf002"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "fef5c6d2e69daad123ca52545f145bf2e4aac8cf900cf725c3db5a4c597a1086",
+                                "uncompressed-sha256": "7e5b7de80023fce3d8ac5e8582c0f642b095594da2f9eab4201aca36095a0ca3"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210427.1.0",
+                    "release": "34.20210503.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "d70c6fe0327ee61b24102f6d63c3a92e94d5ba31d154a924fb93ae6426793210"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "784ea97248525bef43670da3510aa9cf224f19cc5ba32a4ed3a18b2245c1ee25",
+                                "uncompressed-sha256": "4b89c2114e2b7367d69013c6dd09a7864bf083cc799007585f956e751f6e0f47"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210427.1.0",
+                    "release": "34.20210503.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "08664ff0db73729287bbffbc7e2e1e981f3baff12791a3ead7850f5cc21432ef",
-                                "uncompressed-sha256": "13fc4c69463922323d065eab77967de1f07ac8a40f5d1053eaad7261a5aa3041"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "83723607426ccea4d2641b2ab4827f7bb383d6b77a6a469b7800895ab3c7f160",
+                                "uncompressed-sha256": "96ef58e949b15ac57324ccddd320b057efe590155cca92f784c9addbea1aa952"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210427.1.0",
+                    "release": "34.20210503.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "70288d889aa530f9e5c4de3948f4b23ab0158bdde8b69df823b059e17c767c6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "865c29ffb0e5fae93d48901e1775d728ef4b3c0412d877095a5d7a7694042a56"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210427.1.0",
+                    "release": "34.20210503.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "458467a4fd7e3b42133ced06f63e67ef69b9cb8af75a48b394d1f2e988acd218",
-                                "uncompressed-sha256": "69448f5a2184c4c4e4fd1172d4b6f4b2a13f007f522467bff0ede7b65bd4e537"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "b0eaa361f0105c38ede31d2f53868e3142d43caf8202a9a506a7acca7f58f23c",
+                                "uncompressed-sha256": "32ccec8efba7af605f105f3d2c6f022128c585adeaa545a3f12c6bf4086f8a84"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210427.1.0",
+                    "release": "34.20210503.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "d534634dda3617987b473b758973d28ba1281508074c41d10260860569c25631",
-                                "uncompressed-sha256": "5f28d6a1bd925bfa660b5c0a47bc49ce0d037024ea33451c8531ffdf592c1326"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "030cefef95ae472acfa79ba777b3ca32aae0767ec5abfd090f4e2dc340191465",
+                                "uncompressed-sha256": "f047e9fde53067a55af98042851e9659b8321d19b3e0f54576a9f9e57aad2c0e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-live.x86_64.iso.sig",
-                                "sha256": "25bdd74a4b2a981390b2c56e5c6cac3608c937dbfa9d204d67e2133eea940d9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-live.x86_64.iso.sig",
+                                "sha256": "753e509ba516d4a63599596262c124b486a9e26d95222cc04c7654bc5a7e8983"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-live-kernel-x86_64.sig",
-                                "sha256": "6e49ff24a43c9e678f7a2c901e3339dcc2490023c91a698503d08fc4532a4d55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-live-kernel-x86_64.sig",
+                                "sha256": "43752b38c9dd7bace1aa0c8c273adaf4e2a62f3bbb4eea5e2a7c7e78444b3813"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "b94478715536e87bcb5a9ba7eacd5cbc03c375d711e6d5617bfdb615c725c4c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "9178ca1f2a1fd2a5d110aa981ce9ee019e06b071b302d2289e78b3b8b6d3d621"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "3d682fb54cfc24001f43627ebb56a664b1bc4d3cbe61422163d9a015d2546e81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "f00b19ea87681405e96c7d77393af2be790d92faf660ed664983adc659e22c65"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "7aa7313935767e072b67bda3710f31610c988c38f9347ab0a2858076796fe698",
-                                "uncompressed-sha256": "266dda997a0856b0049fb90f08cc2590eada3a8f49fa3aa1354d28edd3e2ca93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "6859f78a533d89a9f99ed5c9df7409d755e7d89f18b428d48b1713e1bad40f93",
+                                "uncompressed-sha256": "7eb439bff26913d5854b14b1eb7eb63bfcadfe4897cc8fe97b1a8fd70099155b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210427.1.0",
+                    "release": "34.20210503.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "305b4156ba03c2df87fdd19f572e80b023f35bb606d11a57305ca0ceb48988f9",
-                                "uncompressed-sha256": "14d6f55f33bd7949bb915ee1f2d7895e95e321f57ab9fd3b714aaf752afc4d85"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "d4d28d7026cb791e0c53ea51d467dfa3a077241223c1d5f72a606991ba843cdc",
+                                "uncompressed-sha256": "eeb2d64455b0fc6edaaef58c6b4cf68de6163553a068ad41eac582bba0cf63ca"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210427.1.0",
+                    "release": "34.20210503.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "78e0d198c44b3507b524400b0de7b9c71e56d62b613c7f8e316ab521fb44f194",
-                                "uncompressed-sha256": "4855b65cc3a497cfe3e242700ee7e9a71ada29c73ed1a913002fae7eb29cc40f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "a1ddec829c8fb0c0c39140b110cac56cb1737960333f0efe988bfebb1b1787b9",
+                                "uncompressed-sha256": "30e9d5dc56898fba1ccb2a2eafaf37a9233c70388e5afac5647482ab57bda50b"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210427.1.0",
+                    "release": "34.20210503.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "92b58ad0c851b65b8b6c7555155aa377a60f47715e267d1f8540fc8c81994d53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "b7c6bd25d60111c6aa68e29c7a5021f5bffeb9971e3362c1e5a0c50c398b48ee"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210427.1.0",
+                    "release": "34.20210503.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210427.1.0/x86_64/fedora-coreos-34.20210427.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "dec6f5b6e4113d41f6e820b9ba02b7072e68805260ef5116a2e71204d04934b7",
-                                "uncompressed-sha256": "8a5911561470567ccf8fac517cdb34d838781c1fb3a65d9aeac4e70d10ed085f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210503.1.0/x86_64/fedora-coreos-34.20210503.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "024f2083c0bf606060d02ea975e1cb940ddd920aae002679cfe1e247e4870f13",
+                                "uncompressed-sha256": "149241cc43f5a8cf13c7e2d789b87f73e289b6a5a4e7989ccf6f7c9eb23dcfdc"
                             }
                         }
                     }
@@ -196,95 +197,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-0bd6f2efd3de5a719"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-040c72f24ea89c1c7"
                         },
                         "ap-east-1": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-0e4251e5ff86f867f"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-0befc5b9d9d5394e6"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-0585a61ef6afe956b"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-03413790c2dd51639"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-0e65c5d0c8760ef95"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-0b5bb7bc1c9f21202"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-06d136380ccb38441"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-0074ca62bd51b5f96"
                         },
                         "ap-south-1": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-0718539c44dc2ef1c"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-0d2f7da4e246ea04a"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-0c4496e8a2598d644"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-06c8a030267de23d0"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-00af5ec95b33790b1"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-0e7ec21f580b44906"
                         },
                         "ca-central-1": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-05bfad8ea9c71301e"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-07bced863ec01901e"
                         },
                         "eu-central-1": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-0e00ae3c0cfc03362"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-0ef188d2acafac8d1"
                         },
                         "eu-north-1": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-0f0068749e2e6926a"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-0fa3e314967a2e917"
                         },
                         "eu-south-1": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-09ce2c74219307ff7"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-047cd55ec7ee55bfe"
                         },
                         "eu-west-1": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-0d82a11f22affbb5a"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-0de7df4bfbe29db76"
                         },
                         "eu-west-2": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-0dde2c29842dd7d45"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-0758a6ee000ae525c"
                         },
                         "eu-west-3": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-00c760fc9a1371b06"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-06049e9323e144073"
                         },
                         "me-south-1": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-0fdb5213883786c25"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-01b8cd09b1499aed7"
                         },
                         "sa-east-1": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-01f4122a3b1c1e3f8"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-0874312c5223f2bc2"
                         },
                         "us-east-1": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-0243dd6c06f7460dc"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-025d264aeaa3f501a"
                         },
                         "us-east-2": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-068d7bb50bf25dee7"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-0ff676ab9a0cf8013"
                         },
                         "us-west-1": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-0d149d4c4131c6753"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-08f9b081a3d1094e2"
                         },
                         "us-west-2": {
-                            "release": "34.20210427.1.0",
-                            "image": "ami-08bff059bc4b607ea"
+                            "release": "34.20210503.1.0",
+                            "image": "ami-0645e589aac8384c6"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-34-20210427-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210503-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,192 +1,193 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2021-04-28T13:46:31Z"
+        "last-modified": "2021-05-05T08:57:10Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "33.20210412.3.0",
+                    "release": "33.20210426.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "35e80ce08915e58459537b46e75236f4eec7c2974933d9a32de6922fbce84eea",
-                                "uncompressed-sha256": "e23666a4e8c15bb80d2cbe2eff254037df0052d486c3841892c50025d40547a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "e48fcf3fab8035069353db1f2733af28c2a01b7e1ce77da8d5c163bc87d3627f",
+                                "uncompressed-sha256": "221664d191064430a4fbc18f9f6b9d1aa923ce6b8f927836e38602d31afa8261"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "33.20210412.3.0",
+                    "release": "33.20210426.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "2dc2bd028edd52213c9a3a2ecc818307c2c5a0a13165747cbfeead4b8391e25b",
-                                "uncompressed-sha256": "cc7f0061511bb9949e81aa4d8678ad8eed2b0a3ced956fa64b851502be7dfbbd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "84add43fcba1a82e2654433e765f0addf91380bc84d6380a09d860131eee06ab",
+                                "uncompressed-sha256": "a1585d7c59f73e27030537c5764b16d6ce13f4167737e3f17eed1207e1ca3e34"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "33.20210412.3.0",
+                    "release": "33.20210426.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "9eaa0504ba6c33bd5baf21335ada861b5e01e8628ba40bc04050a436b3626a05",
-                                "uncompressed-sha256": "2593ac3d4e152fbbde9d7a5b1f0f69746a807148e1dbf64aa4f657da170dcece"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e311f180b9a6ae59d4ea0d4d2281c35913e89c2230c4545e40c772d2bd010cdf",
+                                "uncompressed-sha256": "966b3cb1c53c2d5eeedd0e56c6d5cffbfcf69cdd953e5bacd43896db8e4ea5ec"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "33.20210412.3.0",
+                    "release": "33.20210426.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "2b0c7a697005f00bd99edd2c3bae80f258287843de6dc4e5d79b6ec1b6afb863"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "141174adbaad5540d35363de565b706716e54eefe01682ee0e8623cce5375ee7",
+                                "uncompressed-sha256": "5a2ee807de4bfce0314fd8cb8e2767363c3b97d8ad3c29935901eba23f276fe0"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "33.20210412.3.0",
+                    "release": "33.20210426.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "4acb935fb4ef51c971172f4c71c81ba5fdf659aaad25be6fee83b83a6387cc32",
-                                "uncompressed-sha256": "459ace6388d56fc90281de7ee97dd4cc4cfa61143a894d24d3cf0ccf235ff07e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e2913aec2bc38fcdcddaf2ad20ace81edde1b4d9031e12db05eb419d477313e8",
+                                "uncompressed-sha256": "8994da5aecd1e905746fef713f120c5a39f23f0525334e955e1e107a9bd3c427"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "33.20210412.3.0",
+                    "release": "33.20210426.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "76fcc10bbba4517678217a81f95095702e83dc8ed3a2bc2d10062de214b55396"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "b6606bd3dd73e4da82c3ec12910b62013fb0aa5eac9c1b59408099d52aa22cda"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "33.20210412.3.0",
+                    "release": "33.20210426.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "aa1db0898fb88aae956343b99ca70975bd821050f274a79f63d18a2e2a489e26",
-                                "uncompressed-sha256": "cd7d5b979e15336e4c9b44f25cf86927fe4780b5775c2d02fe4f71827d820d4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "28491659d218a21fb9994867ecbaf2bd0abd54bf45051bf6ac137e6f5833ef99",
+                                "uncompressed-sha256": "f2bf070b0d2fd423f52751f08d2212e7490b4d297a333b286510d522e525b479"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "33.20210412.3.0",
+                    "release": "33.20210426.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "c99e07bbdcb72615830985ddd1d63ab21779b874248952f15fd937ade5593c1c",
-                                "uncompressed-sha256": "8d6508b36095b78c6d306b0857a4a6272f5c25515a5c2f591f434290d63d88e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "e961daf500bb58adb8144c93f189e9c74cbdfe0203456c1b36579090299ab4d4",
+                                "uncompressed-sha256": "e5e01f84ef866922d327d80106afa459c9245f8f5a9c01de703d63dfacfc07d8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-live.x86_64.iso.sig",
-                                "sha256": "97b7aed0086509c2187a4a9f91199aba7c430a5f9aface4e7b06cbcc664a0b4d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-live.x86_64.iso.sig",
+                                "sha256": "f578f217b7b0114315ff36a04f999511a33868355cf6dd0c30fb394fdc958a1e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-live-kernel-x86_64.sig",
-                                "sha256": "28314d6a50610dd342684d6edd19f386b8b8ee150f924775d81408be1987c3d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-live-kernel-x86_64.sig",
+                                "sha256": "2663c6dc08a1197f19c4b6a1f835f461bdcac1f3c534705d8b540dbd21a7fc31"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "5c7c0cc0a8c5d7a1894599ea1d1f5311a1cba0c8530decf9481d7e6cfc1873b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "3007bce9d154248d0b4ce2c8e5d51af6d4a442010f48ef4942377d106a22b169"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "50e63eddc657b24b86d53fbc267441d5e7e7c43eaac58ad9998dadd6141dc0b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "0d593f2f552d0dc39dc38d9bc6ec17a737688c93e5cffb630012c80949bdfa6f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "6d18380dad77b8670767bb082bb6f55ae4381b2b1d4a7405d8a9cdb6e6678263",
-                                "uncompressed-sha256": "c8335d11257d33f7c68ce9720fd35ce0dfd008695348b58c7882d504eed974ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "ee406a6fa21be56465e97d7a0360087cd0f70e4e21d0529ec8f51400bdf00bba",
+                                "uncompressed-sha256": "be48fda9c0f3277fe75cb3cebb576b505dadc21475c75eaea8c31650a11f6cc1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "33.20210412.3.0",
+                    "release": "33.20210426.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "2270ae870cb036d650bb496c94c3fc815126daaa6bebf5b43c348da00e788dab",
-                                "uncompressed-sha256": "5c7e9e072ed6adc4f70ee78deaf5bde76426afcc35f620dad31d8b3eb697e16d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "c5919233c381e1ee7dabed8721e5fed8b1d9fc13ea668b5942c988bb1ac40a22",
+                                "uncompressed-sha256": "518d829a98d0fa20cd8886ed552196899bef661a1aa2b7816d8335fb16e2c595"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "33.20210412.3.0",
+                    "release": "33.20210426.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "8dce159f743c777fe9c429648e8a16928b55d0c1bc8e599a82ba71870fdc5e5a",
-                                "uncompressed-sha256": "a21be448bb0ceee7a373cae232c4cadd979c3db844521d3c10888e42c405c684"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "6aecb241004139c704a0bd70b6668ae032278d72c5d256f287e82278bbc6e91b",
+                                "uncompressed-sha256": "798d7fb39d86e6e305d46b05c359aac542909a5bf81277758fdd12549d4b442b"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "33.20210412.3.0",
+                    "release": "33.20210426.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "0a6c622006e2a13444fc1145970b8a54f52901817165c74b9d265d8ccfc9135d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "f59f0408f96fe500c489da74e818e0e6c23b8532a01a1b5478905bf20c0b47d5"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "33.20210412.3.0",
+                    "release": "33.20210426.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210412.3.0/x86_64/fedora-coreos-33.20210412.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "6c6a42c8399881e1ecb0ba088b389b4e20a394dacc3dab91f221fe18e5006557",
-                                "uncompressed-sha256": "835f97b63f18031f0eb830ee8766c6be8fec1e52f689156e761a92cd3573f4bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20210426.3.0/x86_64/fedora-coreos-33.20210426.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "eb9cd528468477f3761ae3cec8c6272e6fd4fe318b0145e79af073f8beca91ea",
+                                "uncompressed-sha256": "6b939afa0ecc3a0d7797bdab618e1ce6cc673155a968cf303295a2bbfa57cf37"
                             }
                         }
                     }
@@ -196,95 +197,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-09d422b66ac91ab2a"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-08b8632597fe150a9"
                         },
                         "ap-east-1": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-05fdddb8ebfcdbbbd"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-0b867d7e1bc6a5136"
                         },
                         "ap-northeast-1": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-0ecf122c9a4ec0c2f"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-07aeefdb531077286"
                         },
                         "ap-northeast-2": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-08fd2b5b39b93b5ff"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-039c28f8c6ed1f521"
                         },
                         "ap-northeast-3": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-023a068f639e4d9dc"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-09fdabb18e6ace86b"
                         },
                         "ap-south-1": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-0bc108bb69dab2855"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-04de87e23ce041ec6"
                         },
                         "ap-southeast-1": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-025fce39a4b9582a8"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-068afcfd4bb0854e4"
                         },
                         "ap-southeast-2": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-09186d20538071e92"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-0aed0f332d6d7b775"
                         },
                         "ca-central-1": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-0a186cd7e55176be2"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-067e3c5f712fd3fc2"
                         },
                         "eu-central-1": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-06a0c31e4cba0c54d"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-0b3b37d1a4033a78b"
                         },
                         "eu-north-1": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-01f6afff2c77bc11c"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-03472f6a7985d8283"
                         },
                         "eu-south-1": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-083a448ad9aff02c2"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-0ee34fec91c840b65"
                         },
                         "eu-west-1": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-05b16c9ca91b37d57"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-012183da1a79e80e7"
                         },
                         "eu-west-2": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-0a5a690659a4e53bb"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-0eb72a81b0340b261"
                         },
                         "eu-west-3": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-0ca82f640eae28513"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-04421a6caaa6b53f7"
                         },
                         "me-south-1": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-0f4a9bb1ea0c84082"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-0c021047c85721161"
                         },
                         "sa-east-1": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-0194168b04da77dfa"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-04c5072ad5f48e310"
                         },
                         "us-east-1": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-09e2e5104f310ffb5"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-05efddcad7371ce6e"
                         },
                         "us-east-2": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-02e593ebdf420390c"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-09f105aeb31bf091b"
                         },
                         "us-west-1": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-0cb601c6edd617238"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-04606d31c26919da9"
                         },
                         "us-west-2": {
-                            "release": "33.20210412.3.0",
-                            "image": "ami-0fcfe7120a4492fb9"
+                            "release": "33.20210426.3.0",
+                            "image": "ami-0b19f46b4577a4d75"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-33-20210412-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-33-20210426-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,192 +1,193 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2021-04-28T13:46:22Z"
+        "last-modified": "2021-05-05T09:03:12Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "33.20210426.2.0",
+                    "release": "34.20210427.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "056a76f0b5d4de37d1ee52da8d708add0b965ae9840b1df621df57366e91df70",
-                                "uncompressed-sha256": "0369bb4fe3ec729a2a9cc906da065711249c3062d73aea1244e4cb638bde06d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d0765e304fbcd7893f6aba94b1ccd1e706592a2b3a375c41e9c3b2dff156ac50",
+                                "uncompressed-sha256": "ae8b6b901f14bc445fb3968c586add766ad4de68176e236567f4b4e98b7265ae"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "33.20210426.2.0",
+                    "release": "34.20210427.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "c6c57dc8a9128534364714f8464227b18650b3ae4089da554c764db77175bf43",
-                                "uncompressed-sha256": "bf764515d5c389f06e61876bf9675519cac2b8e0e077cc258534a6cfa37594d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "5cd6ac9d288b60f0bf6773d774aa69b2d168e5259c0ef7af351949d85096e010",
+                                "uncompressed-sha256": "6212ed686195d00f4078ef9e8ab26bd96042041bf9fde12f00e1b951b0e27360"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "33.20210426.2.0",
+                    "release": "34.20210427.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "6a39036ee2ca544969c441f520c11fd3b2c284d3bb57a18514f19ec603d18839",
-                                "uncompressed-sha256": "19af2fd18b734e62e37ee789e6fc0056070511a91edfcc6b0d52e7243be2deb5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "6f318fa41a3a1d4b0259e97712371421efd65398322386e346dcb910833cdd47",
+                                "uncompressed-sha256": "56b582182e337d1ad4cc32dd8be34d8104b2ca9cdc5df3d600a5951161fec722"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "33.20210426.2.0",
+                    "release": "34.20210427.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "80a1f8628fd0559cc34eb32543b8f82016df57fbacb9df62f46a565313ce49fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "40cf75d005be45187194cc723549f221e84e2ca068a300c7d68624a13e059df1",
+                                "uncompressed-sha256": "d363f4885d15b48f89d4596d06b4917122d7e55d2f19bfe28cf98889805a02aa"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "33.20210426.2.0",
+                    "release": "34.20210427.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "6289c4eca7e0575e1743ded44b3262ad7a6afd7d6fc36bd52982047e5243f3a1",
-                                "uncompressed-sha256": "77f70bb9f6ffe3d09d132fd88e57266fdae29282efe83139c74f2b5d454875c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e03e3bae12e3d4422793be28ec27db922783ffb004d96f263e57329140ca5b1b",
+                                "uncompressed-sha256": "d983dd54d889fedc34012a663fae2de18fe035f6d2c9168b6838a503599f8660"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "33.20210426.2.0",
+                    "release": "34.20210427.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "e6037cbcc595d9baa2ea4cb3051a4f986636627789b5947770cd96cd0b8aa1af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "26017c3cdf2f9d37f320f624ab80e24c8a9929eb0aa61877329b7b7b1a81b0fc"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "33.20210426.2.0",
+                    "release": "34.20210427.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "87f0faa28427e8adc2ce1a1a4f78810fcb024b7895750f7f8a700215f7aec33a",
-                                "uncompressed-sha256": "4f47085a9610dff775d245de622b38c5c79d0774af2a4dc56704d7c12a429be9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "3bd07e8e8f6baf8af52a7feced376d67e6f709c67741ceb4820d8339de0881c3",
+                                "uncompressed-sha256": "ba4211a846fab17a1ca386e751e640e20e8fe87d566904e4d0aa28c0d5b7d208"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "33.20210426.2.0",
+                    "release": "34.20210427.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "0380368cddcf0ce6ff3b9659d6aa11f8f0db1d3c49b357f9cc8509b55450b59d",
-                                "uncompressed-sha256": "2afd9a1844869b724a39a9b898f55908d50d923b7db1de17dcde94223fc268e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "1e9eab6e7f3a6c3e10890b2953f09b52bbf59e78d98b3e0335299fd3a80ce947",
+                                "uncompressed-sha256": "386225cabfa1564c3ff18590fff0ce28d6058bff1f41f99d54097d3596aeebac"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-live.x86_64.iso.sig",
-                                "sha256": "b4fa535ebed5089950553ddf60cd879caa9dee8d7e881f480e10345525b5e8c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-live.x86_64.iso.sig",
+                                "sha256": "65e45d28ea68ba9416f92cc0a0152b49865abab9bffad1c3af9cb37713ea3a40"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-live-kernel-x86_64.sig",
-                                "sha256": "2663c6dc08a1197f19c4b6a1f835f461bdcac1f3c534705d8b540dbd21a7fc31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-live-kernel-x86_64.sig",
+                                "sha256": "6e49ff24a43c9e678f7a2c901e3339dcc2490023c91a698503d08fc4532a4d55"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "57f00f7a07b11b1e746a427e1e16f210ce19aba58058fdfed730385e8535e212"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "5931f258feba2da19d93e740808f9538c7772e438d1b550e5aef19ebc5249b2e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "9bfaaefa32df2865a6386c27328498b909062db384ecb73716d669746ea64f6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "6a3bc8f5c14e4f355506bf40573f78d2fce47d7aff208ab89c65ca8ae40471bf"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "7391b9e2f03697af7f17e5e03df0540a0cfaa4895af97d45fcc93d2853f0ad97",
-                                "uncompressed-sha256": "4a57d598a693b8a5790f1abea4fb895abce2870a24bd61d069afb12bbf03a883"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "1e18eb53b1a8b2c87b95b22961e6a8bdfd7fedb7e881378c33a65bb491b2e7df",
+                                "uncompressed-sha256": "9d8f4d0e3890348d5382a25c524b02b5c06b88f089cf33c51357bae2237faeb9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "33.20210426.2.0",
+                    "release": "34.20210427.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "2c85bae46466f88274276f786980de0a08281e8a48bc9001c37b18e752f447bc",
-                                "uncompressed-sha256": "61f6396e1d0db02982179af8c52195797a45cabb1d457fe3fab7c987c05cd874"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "af29c10d2a09a72300e7fa01cb84acfc3eaa9b23d874af7499590a94730651ad",
+                                "uncompressed-sha256": "165108d81d437181ce058ab45955961b5e54bd92b8205d26b67ea412565c36fc"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "33.20210426.2.0",
+                    "release": "34.20210427.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "8ca4209943486e9a8062f6e6882c93afd6e2db695f370f535b962253a14a9ae8",
-                                "uncompressed-sha256": "4c1fff15860dbc777ef49cb2c9f63c98a0b8be6655af7b68173f52c38376929a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "06b21169557e75492b5872e9b1f82bbb48126f0e2f9e0e4d0c38048a065f555f",
+                                "uncompressed-sha256": "6f4dc95cea3849610fea2809362fe575724c358046bba465898d78080db8b429"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "33.20210426.2.0",
+                    "release": "34.20210427.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "f474be982bc108b478619d4de7b66fb9a7aabf0f2c3ea39bb71db6fff6a3e7bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "44fd5c9885112cc5da01f7745a7b28eacca70cbfa920208a1f0519f9447fcd56"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "33.20210426.2.0",
+                    "release": "34.20210427.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/33.20210426.2.0/x86_64/fedora-coreos-33.20210426.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "b5d3f58d628f7cb54b82b73c6be7229d1f4822076a9b373684b9e81ed9fffb0a",
-                                "uncompressed-sha256": "fff41bc47c4781fce6f2da0363a8216ee42999088b08d9963a36e3f43a5e40c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210427.2.0/x86_64/fedora-coreos-34.20210427.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "3808dbedf80c411f741fc5948e5b5687983ac5ee4e7927cf7e188dc23994be7b",
+                                "uncompressed-sha256": "b0db59fc83264c3cccf19be1a2abb5636423399d8295b033334c7c673061d4f9"
                             }
                         }
                     }
@@ -196,95 +197,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-0127fe0d78c373ed9"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-08e1ffe7e34ebb9a7"
                         },
                         "ap-east-1": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-06bfd4964755831de"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-0d4aa1a428966e4ce"
                         },
                         "ap-northeast-1": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-00f5d334bbecc1ec1"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-0ddf0783d79c2e4c6"
                         },
                         "ap-northeast-2": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-0316df87d65a0d452"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-0b031d13710566b17"
                         },
                         "ap-northeast-3": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-0694f836009419b4b"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-056fc53ad70bc51b8"
                         },
                         "ap-south-1": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-040c45b222aae6b77"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-0143e95e69be2903b"
                         },
                         "ap-southeast-1": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-0acf6c4f339a3091c"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-0a306c3e72baece83"
                         },
                         "ap-southeast-2": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-0f7cc8af38dbeac59"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-08f17c2fa4efda164"
                         },
                         "ca-central-1": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-08ac13d18100136b9"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-071f7703bb33b969e"
                         },
                         "eu-central-1": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-040071172040dceac"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-0ad104169d2d86cd3"
                         },
                         "eu-north-1": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-010d054ea166a0f9a"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-0057d5b3c92fd22f1"
                         },
                         "eu-south-1": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-00f473c01cc1eaca5"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-0946a9ffeefa4b7a5"
                         },
                         "eu-west-1": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-04e4b570b8b97dc81"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-0b690e28939739d51"
                         },
                         "eu-west-2": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-0d453c9a47d212ad6"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-0aa2532805e84388b"
                         },
                         "eu-west-3": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-022ba28dc312eaa71"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-0ebf87239d8952536"
                         },
                         "me-south-1": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-090a5d519fcd05fa4"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-075e5712af4c18904"
                         },
                         "sa-east-1": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-04586454f26813ea7"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-0c32d117a26b8da4c"
                         },
                         "us-east-1": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-0b859b4eb314060c0"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-0cdafc27cd2e98f00"
                         },
                         "us-east-2": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-0b73dc84a1d1ad582"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-0a38dc47e1bdcff8b"
                         },
                         "us-west-1": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-07efa0c6ad4b15826"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-0ef19e5236ec67b38"
                         },
                         "us-west-2": {
-                            "release": "33.20210426.2.0",
-                            "image": "ami-0b303093a891fc743"
+                            "release": "34.20210427.2.0",
+                            "image": "ami-05c57193743cb9a55"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-33-20210426-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210427-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -21,7 +21,7 @@
       }
     },
     {
-      "version": "34.20210418.1.0",
+      "version": "34.20210427.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -29,11 +29,11 @@
       }
     },
     {
-      "version": "34.20210427.1.0",
+      "version": "34.20210503.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1619623800,
+          "start_epoch": 1620223200,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -29,7 +29,7 @@
       }
     },
     {
-      "version": "33.20210328.3.0",
+      "version": "33.20210412.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -37,11 +37,11 @@
       }
     },
     {
-      "version": "33.20210412.3.0",
+      "version": "33.20210426.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1619623800,
+          "start_epoch": 1620223200,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -45,7 +45,7 @@
       }
     },
     {
-      "version": "33.20210412.2.0",
+      "version": "33.20210426.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -53,11 +53,11 @@
       }
     },
     {
-      "version": "33.20210426.2.0",
+      "version": "34.20210427.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1619623800,
+          "start_epoch": 1620223200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
https://github.com/coreos/fedora-coreos-streams/issues/301
https://github.com/coreos/fedora-coreos-streams/issues/302
https://github.com/coreos/fedora-coreos-streams/issues/303

```
stable
    version: 33.20210426.3.0
    start: 2021-05-05 14:00:00+00:00 UTC (in 0:48:19)
           2021-05-05 10:00:00-04:00 Raleigh/New York/Toronto
           2021-05-05 16:00:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)
next
    version: 34.20210503.1.0
    start: 2021-05-05 14:00:00+00:00 UTC (in 0:48:19)
           2021-05-05 10:00:00-04:00 Raleigh/New York/Toronto
           2021-05-05 16:00:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)
testing
    version: 34.20210427.2.0
    start: 2021-05-05 14:00:00+00:00 UTC (in 0:48:19)
           2021-05-05 10:00:00-04:00 Raleigh/New York/Toronto
           2021-05-05 16:00:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)
```