### PR TITLE
testing: stop rollout of 34.20210518.2.0

### DIFF
--- a/updates/testing.json
+++ b/updates/testing.json
@@ -51,16 +51,6 @@
           "start_percentage": 1.0
         }
       }
-    },
-    {
-      "version": "34.20210518.2.0",
-      "metadata": {
-        "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1621441800,
-          "start_percentage": 0.0
-        }
-      }
     }
   ]
 }


### PR DESCRIPTION
We're going to respin it for runc's CVE-2021-30465 (symlink exchange
attack). Might as well try to minimize the number of nodes that will
reboot again.

See: https://github.com/coreos/fedora-coreos-streams/issues/317