### PR TITLE
testing: rollout 34.20210518.2.1

### DIFF
--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,194 +1,194 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2021-05-19T15:12:00Z"
+        "last-modified": "2021-05-20T13:39:47Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210518.2.0",
+                    "release": "34.20210518.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "9a3c9996545e25f2fd74541cd2f173c7a1b7f654ef28ebde6fd8005dc4369934",
-                                "uncompressed-sha256": "67dc98a4b4ef04e2fd5ef79167338078d5f270ff33c363fd42ec563186dbe83d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "ae34e7855cb74557abe46273007369f2282305db5a093d635e60f716d4dcf403",
+                                "uncompressed-sha256": "c93695339356afdc1df6125488466fe7010bb374461b714efcdd42c4ffa34164"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210518.2.0",
+                    "release": "34.20210518.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "b2ea8c49e02148b6dd34eae3835244282f7aac1d3bee1de5bb7097365111124e",
-                                "uncompressed-sha256": "5d422e306f4c6b7e892afc94d1227d98ec656ace0ec5f8416e1d0fe9838ad742"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "7ef98bc54f2717a4744d20b392fec8f047d0c25243cf1eac08902d9909e7061f",
+                                "uncompressed-sha256": "ed5ae0fc4e6a0b7c1dcdc62afde616a6f3eb9a7eb5478c19c4a446bc095b59d7"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210518.2.0",
+                    "release": "34.20210518.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "345b49c532e3358d36daa2833900c7a60f5d08ae9ac9d568805795d5a7c90387",
-                                "uncompressed-sha256": "5f838602b710ca38fd516995cb7fce11b4d69e20e89ac23dfd5ab96e0c678e1a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "3755679bc8a6f980cffffae80957472d47f2e2eeded0d0aa138a7b8d53e3e580",
+                                "uncompressed-sha256": "dc3d8ee46bce47a1ae9d0dca6d0addd49b069a2b76cda92144ef56c854c0cb79"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210518.2.0",
+                    "release": "34.20210518.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "aa5fd43344c4de0cccf9e1c40affd4cbc76932e73d7ccb6dfb5dbca8fd3ba933",
-                                "uncompressed-sha256": "722010276c60972946e3cac9525b1af9e3a512df02c58e6a00593a32c4be76a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "01f557a81bdb5c5b1c4f9d4abd85d0218bd34a59a26b3127f2d390c55fae4096",
+                                "uncompressed-sha256": "9a2138cd7887d1e3a4c51bf9bb6fc4e7292444696eef1f2960339c5f3bf392fb"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210518.2.0",
+                    "release": "34.20210518.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "5a569b0a5b2c3e3c4762dc382a39e693988d7a60d2d9f8ad04e0a6ee9a357945",
-                                "uncompressed-sha256": "fc4ed10d556e90c5b1b097b2e9b6ba4f3b2b4b3475ca7a4e7e73c9d141d48c8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "b3a33fe8e380196dc7cd87b3396f69e53e797274fe76a092cabc7e03986b3df2",
+                                "uncompressed-sha256": "5a6fea5eb1cf05626ace06dc10626f7a09c057ed8c9fccf7b44fcd736e9c5132"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210518.2.0",
+                    "release": "34.20210518.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "21839ad44698a35a2e9667dfd716cd6d39b1b28a5dc287c7be31d1cabde37967",
-                                "uncompressed-sha256": "d74eb83fa9bca6dc65ebe33667265b274864792c9c929196855a37fd4da00544"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "5fbb3386686d20e6091ab6284da2f2c8ec0b5f3d108ba380a8395c6b9cc3fdb7",
+                                "uncompressed-sha256": "e1828d45c02dd5fcbcf45bc5f75a07419916bac22ca91f3e3072f7ed3ca96f52"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210518.2.0",
+                    "release": "34.20210518.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "9f647b0ebbbd51cb2571477a5019642cb98ce446b7980c008233a62a72846f7f",
-                                "uncompressed-sha256": "ddc883f3e4e6f65f1ff3e793336fb589c3ade293a5c6ad073dd38c18b0a4aea7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "9941eb6481396f70ee73feac73f5573145494874e6d55cc24018a02ecd7815b6",
+                                "uncompressed-sha256": "d58bdc89cf1f6d9364497fe8ab6048225304eba1d3a0334ef76fc575770570b2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210518.2.0",
+                    "release": "34.20210518.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "ca1a7299d1c3577a518506528eaf5c16e3e43de03650225a2a02f0fbd313ac68",
-                                "uncompressed-sha256": "c9c01bcd116a26a9e0d3d00094ef60fec5fded7109a07680d4a35005c5011088"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "0402848287c597d4f8b7d53e7e9269839b8e1e54609e6cf47a3891a63ee8785b",
+                                "uncompressed-sha256": "8afea1917b55215479054126c95f6ed9c161326a29323dca3d7f09626e4203fd"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-live.x86_64.iso.sig",
-                                "sha256": "32c4ca5cf77efdf4dff4860d6977b2dd9d7957527c8fb0cf1ed30a5c93e6a599"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-live.x86_64.iso.sig",
+                                "sha256": "c962ced84ec31d2904b66365fe05cd96cbca64516f4a99217afa399bdb9ddf23"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-live-kernel-x86_64.sig",
                                 "sha256": "dd20b2b0fac9309757f52dda1e88ee61ab280fe40b82f3e4caa5ca25d89775b0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "bde089cd2b261a9061d2a5bd6708e2a1282e16c7f4a851eb1f9ad48faed63e4e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "b5fdca87ab1331fa33671341489e507cd4d6dd0976b58e085f38e66d671a102c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "a7fba8431fb2da9e30ef14aa0c9031313c2f7648d8aa232471cbe7e52655abc6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "913dc4fd7e3d50b4d142a099a0354f2f53ccbc11908f1e14160811a2bfa7bec6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "848d52a8ac5c194b7bb6456e14aa1a2ed7f8e25af9ad21b1ca8dd3c35afa1c24",
-                                "uncompressed-sha256": "a05c40c92b74daa9a5c9d6dfef9c99e428b16eafbf347d1b4c36e26dde772677"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "e18ed8664de699f694dd2e26f725c1b6159c1e4a3c8bc0f30a58b6cd390d8972",
+                                "uncompressed-sha256": "7f852606ef36aec731c854eca49efd028dc78085b9eaf203dbf0d2e592b2e7a8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210518.2.0",
+                    "release": "34.20210518.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e7ff59df41a4fc2370c842a8aee1591f8f5bb9fcb83e1da34b5ddb1d20e6559f",
-                                "uncompressed-sha256": "1d563ee816a2ce1175f0b2acbee1e5fc6ff1a9ffe80fdb8246f50844f9d1569b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "0d38a63b6dedd5ef061026937beaeac4d7fd16fa4d682ec2187d53221ba165f4",
+                                "uncompressed-sha256": "b8d8d040f2997d049bf88a2c5bbc57498e27254a57bafaebf43b3d32a5dfde1e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210518.2.0",
+                    "release": "34.20210518.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "ed238a2cf14acaca3d01b3a3f54d8d5f4c0d26c777112e65ba3370ba7cc091d9",
-                                "uncompressed-sha256": "7324bda36326ffca710773ee0294190d908ec36ba3a7445a58ba5d4550c7a54c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "d147610d33ca47b666882fb9c545a9c037d305025d84d541e507cc4e7d2b1767",
+                                "uncompressed-sha256": "f11b96bedb4b86139d98bbda17a0695ee257f1ecd5aa9a8187514c7c91d997e0"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210518.2.0",
+                    "release": "34.20210518.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "7cabe4f980b47fcd2e9b69436dacf3553b30ffc734946c139d6878a5733ec1fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "84672a90389843d776ae3b7c03c9b87e07bb86313a7756db812da7f728dbf29f"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210518.2.0",
+                    "release": "34.20210518.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.0/x86_64/fedora-coreos-34.20210518.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "212bbbc026143bea199f0fb4b30030f061d9200adf317c0129c31e76281c8604",
-                                "uncompressed-sha256": "46c470420c604906651c0d288942dc43a54a54f284fba6e07552ac0695f35bee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "28a655f75df6f224f948ba4c7687469cfbee78a964fbc790df685b68ea224cbb",
+                                "uncompressed-sha256": "106ffcea8ccee12341c896aded5a6cf2c4ab94dc708503f3bb76feedc2c6e1a4"
                             }
                         }
                     }
@@ -198,95 +198,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-0b37683da0d075bff"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-00345ce8f3ed9f803"
                         },
                         "ap-east-1": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-0dd3e7c76f1771ca7"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-0ec1ed2f5000e36c7"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-029fe43438e63e565"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-0280fa95b083eb6df"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-0a1fe2ce5ed4a026d"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-07b6f906d63454dc3"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-0eadc65f0520c6b97"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-0f6a31a6bd74e5b96"
                         },
                         "ap-south-1": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-00016509ad9256984"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-0321c3ee94d62b3e3"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-007e89186870b148b"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-07cca68e2efde5b61"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-0b46c8236a0344d79"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-0c5d4289c5a59498a"
                         },
                         "ca-central-1": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-0ca7f76275bd5ea1f"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-05c9f3e98f91cf344"
                         },
                         "eu-central-1": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-04dc7360c87b81ac3"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-05546acbd988e489e"
                         },
                         "eu-north-1": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-000a5551eec3a7454"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-0dcf677d2954beb68"
                         },
                         "eu-south-1": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-03248495fc2375dec"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-0a4700330e79939d5"
                         },
                         "eu-west-1": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-08f1f953114786ad7"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-060a73505926a1bd8"
                         },
                         "eu-west-2": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-0458c1d1941fcea26"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-0361cc19cb1d216f5"
                         },
                         "eu-west-3": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-009ffbfed0003af4e"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-0a2e994b5565b4ee8"
                         },
                         "me-south-1": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-0fe43b69c1a87cd02"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-0e9c4087543b61d3c"
                         },
                         "sa-east-1": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-00c49f048bde49969"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-0d50a0cba84200eb1"
                         },
                         "us-east-1": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-08f57460898579ab2"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-01eaac4a8c06d81ed"
                         },
                         "us-east-2": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-082c7ebc09dba341f"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-02eb0598cea96eac7"
                         },
                         "us-west-1": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-0ce3979906bc1b637"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-0d51216fd71d46561"
                         },
                         "us-west-2": {
-                            "release": "34.20210518.2.0",
-                            "image": "ami-0686a9003748fa20f"
+                            "release": "34.20210518.2.1",
+                            "image": "ami-097f2165e9e3f7c62"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-34-20210518-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210518-2-1-gcp-x86-64"
                 }
             }
         }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2021-05-19T15:12:26Z"
+    "last-modified": "2021-05-20T13:41:32Z"
   },
   "releases": [
     {
@@ -49,6 +49,16 @@
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "34.20210518.2.1",
+      "metadata": {
+        "rollout": {
+          "duration_minutes": 2880,
+          "start_epoch": 1621521000,
+          "start_percentage": 0.0
         }
       }
     }


### PR DESCRIPTION
Contains runc-2:1.0.0-378.rc95.fc34 which has fix for CVE-2021-30465
(symlink exchange attack).