### PR TITLE
promote-config.yml: use testing-devel for next promotion

### DIFF
--- a/.github/workflows/promote-config.yml
+++ b/.github/workflows/promote-config.yml
@@ -21,7 +21,9 @@ jobs:
           elif [ "${target_stream}" == testing ]; then
             src_stream=testing-devel
           elif [ "${target_stream}" == next ]; then
-            src_stream=next-devel
+            # promote from testing-devel while we are in lockstep
+            # https://github.com/coreos/fedora-coreos-pipeline/pull/343
+            src_stream=testing-devel
           fi
           echo "target_stream=${title%:*}" >> $GITHUB_ENV
           echo "src_stream=${src_stream}" >> $GITHUB_ENV


### PR DESCRIPTION
We're disabling `next-devel` for now while it's in lockstep with
`testing-devel`.

xref: https://github.com/coreos/fedora-coreos-pipeline/pull/343