### PR TITLE
updates: add update barriers for N-2 (F32) for key rotation

### DIFF
--- a/updates/next.json
+++ b/updates/next.json
@@ -14,6 +14,14 @@
       }
     },
     {
+      "version": "32.20200923.1.0",
+      "metadata": {
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
+        }
+      }
+    },
+    {
       "version": "33.20201020.1.0",
       "metadata": {
         "barrier": {

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -21,6 +21,14 @@
       }
     },
     {
+      "version": "32.20201104.3.0",
+      "metadata": {
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
+        }
+      }
+    },
+    {
       "version": "33.20201201.3.0",
       "metadata": {
         "barrier": {

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -37,6 +37,14 @@
       }
     },
     {
+      "version": "32.20201104.2.0",
+      "metadata": {
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
+        }
+      }
+    },
+    {
       "version": "33.20201116.2.0",
       "metadata": {
         "barrier": {


### PR DESCRIPTION
This update barrier is pretty much useless because of
https://github.com/coreos/fedora-coreos-tracker/issues/749, but we
decided to put them in place anyway just to keep following the process.

As far as the process goes. See past discussion on this topic:

- https://github.com/coreos/fedora-coreos-tracker/issues/480#issuecomment-631724629
- https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/