### PR TITLE
Triple rollout

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,194 +1,194 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2021-05-20T11:37:42Z"
+        "last-modified": "2021-06-01T22:22:46Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210518.1.0",
+                    "release": "34.20210529.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "951195da1866b2f781e72c99e075f669ce2334025ebe1d3947a0b380cbce85cb",
-                                "uncompressed-sha256": "a09e763c50cbd618fb3074597a0162b548d972542fc3a6f8848fac15b5952e32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "1f04d5f775a3937f83ea21752ba8f8ae0204f810679d35ad85dad991961d1bf6",
+                                "uncompressed-sha256": "429daa5d95dda1f8e6e24430c9791caf1d039688dc66b10a90f57768fd239bbe"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210518.1.0",
+                    "release": "34.20210529.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "b851bbb350640353c7d926346477f5a24b69abef64b8f4d7922ab924bfcddc46",
-                                "uncompressed-sha256": "34dfb062bf9de6d581871ef8fc51619f6c51559e6397445591d9e76d65a50763"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "bf21b8cace23236e7a9e6ccd5933a7c1230c19a8aef7af81d9256ab48296a711",
+                                "uncompressed-sha256": "c429c477fa3d4ef9dcdebcfbbad062f2bc7ba17cce68fda2f18921e539af8783"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210518.1.0",
+                    "release": "34.20210529.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "456c7d4af519d6187944af7f7aa272bdb5aaeb67eadde14559a9b2566d86af3f",
-                                "uncompressed-sha256": "0c8ffc4e98364d85cb561bc925bdd8b000ebd76396209c157d42f1fa38aad9a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "75fae4666fe76b505a7e92d159feee765bd9d8734f2f9ce8fff1a7ec96c79902",
+                                "uncompressed-sha256": "b9a1d4b3c2a74e9b9f53a0ca7d68c9e01467567eb95cef55b1dd58cc42077223"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210518.1.0",
+                    "release": "34.20210529.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "5976f4aa095a17bc3f6a5344548f9de7fb081a687c04308434297653b2a47913",
-                                "uncompressed-sha256": "b9c28ab1ed54394dbb2bc60503e52a8700b2a59fc63260f93949cdf84feaf933"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "208b8925ba8b514ba1fb2ba4c541208ec361d64d3c2748f58f515f9e982b5681",
+                                "uncompressed-sha256": "c698766f5d51078f9b6e1cf2834b758ece63f4909378eba92cafe9b7d2ae317d"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210518.1.0",
+                    "release": "34.20210529.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "764a715b15dc3fb65cb3321510386044474bae44800ebd61280d921fcde8b36a",
-                                "uncompressed-sha256": "db10c583c32975c96c15738266df0c8789567d6f0c55529867b5b536c0f62c1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "36de18da2dffa7dae3ce25ad3ca0956c25e2853b221005f45415c3d2b2083886",
+                                "uncompressed-sha256": "71064b9f036d34c90231e3ef466f893686fcd01979262db3f8b5cbf8af65f7a4"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210518.1.0",
+                    "release": "34.20210529.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "6e95e683b992640d310f0d8d57a8a0639ecbc5f2f3373564ee028dbd80c6a236",
-                                "uncompressed-sha256": "8f7f50b262aa19c6647ffa9e73ae6dc0c25969c3f1704723cff6ed680e188dec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "057485613efe4c2f2083c675ae7ee4caad2d5c422c5769c3a692534ea63286bc",
+                                "uncompressed-sha256": "49a434fb1ed0d948d2d13fc90891f0337c084fb10b2c850b3bd95383d7d1d96a"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210518.1.0",
+                    "release": "34.20210529.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "e2ca0fe9990c833abd28e355d8d00ac94cd480de08c14b496bcb58fd78ccb839",
-                                "uncompressed-sha256": "fc709d5be8f077efc1debac4c22c51fda6720d9b5bc32cab0d64cebeff7bf4fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "b374d4b0a28d5a5cf8a442e864eefe4cc723d593bb814f2dfb7eb529ee7b8592",
+                                "uncompressed-sha256": "075f4378bd19823b8e8af5bd9a1bc0556b4166e033bbac88ed1a4a6bc2764303"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210518.1.0",
+                    "release": "34.20210529.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "5db8057eb4fc76ea91d6dd25403e08c2047d6f529bf1b87ab13faefd290ba2b6",
-                                "uncompressed-sha256": "3142118abd2b163e31df5599d25d0c806e8795b683bafedcf36ca4d4d127d0f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "444999afa345cae5b79c16e14f34316a5e2195e8e69d3cf563817a872fa0134b",
+                                "uncompressed-sha256": "fe9c0eba942d1a19f19e9fa6d5cc4faec996792d84e4cf1ff865498ecebf06ba"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-live.x86_64.iso.sig",
-                                "sha256": "449042763eda765b81eaa8fc7d7f0266f7cc56e9322204591e0814e9329e6668"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-live.x86_64.iso.sig",
+                                "sha256": "be39b44287289970eebedc7b507e722464c6961c757a6be9711d3c3f8bf5779b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-live-kernel-x86_64.sig",
-                                "sha256": "dd20b2b0fac9309757f52dda1e88ee61ab280fe40b82f3e4caa5ca25d89775b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-live-kernel-x86_64.sig",
+                                "sha256": "dfc85a460b70a01331145840c932778271f8c4ab108b6797adb2c3e0cd98b4ec"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "eb06b84e19cbd7cc8cfddc952f91775c4f2b88b9917da8b9c104ef8d6d2818f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "f05bc1e69636b77533c6ef154b087543db6016bfd8e330fbb8203d1cb999a1c1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "86f7802ec9bd49af28564d4e2ad56454e6c02a9bf62d59bdd2be1709b8806fd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "cc85ae31a81317b3d722704f385e60dc480021fd1408bd605860e2c4b7398375"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "d33430796930a55a2c96f7f8f6658d6f0dbfb0586b51a0392d102f8efce7d6e0",
-                                "uncompressed-sha256": "a59bfc34d73ea7b4d5e1eb4f07e95f172683d65635ef51e4db52bcfd735ad49b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "9b7d7bab3d483adce2f5b3eb8787cd3b8b5b26a0b3dde85a161f59d553cecb5a",
+                                "uncompressed-sha256": "8ebed2167e364bf5188a845a1f5948ea4c69d2e6f145fe632ac608d33de81f8d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210518.1.0",
+                    "release": "34.20210529.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "9eec2c6602365d49a1cbeb3268e000eb05a0a2a7c461fa67ede9ed141381133e",
-                                "uncompressed-sha256": "34ae4e6c5ee4e65317de62e8c9c0979e7b2be258fe822e643584b58f5a6c88ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "11bd03af38393c2bbdc55c9dbc4f386c39d93e318d46bf0db8fca0c2f105f110",
+                                "uncompressed-sha256": "47b8399033c5828c47624125ce76b8a25be1f204834641561fb3b5835495ac42"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210518.1.0",
+                    "release": "34.20210529.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "bfcce8d0687d3a4e3e3db4593b062cf0cacd764d8888e8eea0dda8d841ef3df2",
-                                "uncompressed-sha256": "b2dc67ab240c3b08cc08461686babd64acbdb9ecb5902f5c18e500384b0516fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "6fa7d7f8f61211a1623e253e82181f96c9b2711bf481021d98c79ef0eaa44486",
+                                "uncompressed-sha256": "f688153f6b85497cdf7da0f828d56b6a0f6108d539b9efef289054d3830fe746"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210518.1.0",
+                    "release": "34.20210529.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "6121aa9c502e7c2e9172253ce49c466c736a3f3d60e8748c7cdfbd4e437070e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "97459c7bb95b9b01454fd51e10cc13528644a5b59cfff36d984e0eac36bd370d"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210518.1.0",
+                    "release": "34.20210529.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210518.1.0/x86_64/fedora-coreos-34.20210518.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "a824941ca862416f10b147e35259c4041783bf939e1a26d9a4c225d676836ae7",
-                                "uncompressed-sha256": "ed3d996f106cfef4d0b271a395e8f9413d228d4884bd7a31c9eab09d57e54809"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "bb844821ca0e84064b739b478228a76a80c1af626f455338e05a30f90653624e",
+                                "uncompressed-sha256": "4bf78b1650f007e5ed781958ef628cf31c9489c4d09ca6d08900998b7e76022e"
                             }
                         }
                     }
@@ -198,95 +198,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-0d483c2c48d498207"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-0b0bd803479a03c37"
                         },
                         "ap-east-1": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-0363fcba78b65a0c0"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-01564319d54c1d593"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-0e704256f90ba62ad"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-0d64b6f2cda8c515a"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-097c3c184e712d967"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-0583113cf57551bc0"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-0d1550bfbd31e6a55"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-0ef8531506fb2e775"
                         },
                         "ap-south-1": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-0fdac9d9c9e0c196a"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-0ed5b6e68dc30371d"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-09660a78d672f5f06"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-05bdb921995b170ea"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-09984ed128463ab19"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-0f3f8f993f5cb7e9b"
                         },
                         "ca-central-1": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-0da37af9b299120fc"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-0a26184bc05aa527d"
                         },
                         "eu-central-1": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-06cca048449c84653"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-008dd6664d2711ec5"
                         },
                         "eu-north-1": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-01d70a6ca6b4e713d"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-0820b46a43fe7f514"
                         },
                         "eu-south-1": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-03833de832163eaff"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-0760f128dcf63d466"
                         },
                         "eu-west-1": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-00a6e6b91c102fed8"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-03567338d82cda803"
                         },
                         "eu-west-2": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-0c17cc31519f96392"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-031e6abd0432eb90d"
                         },
                         "eu-west-3": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-041c5ecf7dc219514"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-05a2fa2afdcc44d52"
                         },
                         "me-south-1": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-05d811514a73cae7a"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-08c28e2940f6122d7"
                         },
                         "sa-east-1": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-0445ea438bd7755a6"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-0be2790415b9d13a7"
                         },
                         "us-east-1": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-0acb6682bdfae146d"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-02b91007c7c138119"
                         },
                         "us-east-2": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-010163740226e5aea"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-0912bf3ca0566733e"
                         },
                         "us-west-1": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-02255ee2d648b32d3"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-0b66860677a7b745a"
                         },
                         "us-west-2": {
-                            "release": "34.20210518.1.0",
-                            "image": "ami-0c7e04a7dbaa6038f"
+                            "release": "34.20210529.1.0",
+                            "image": "ami-0a57842743df8c18b"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-34-20210518-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210529-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,194 +1,194 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2021-05-18T15:30:20Z"
+        "last-modified": "2021-06-01T22:22:58Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210427.3.0",
+                    "release": "34.20210518.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "2be5888ecf7a2a2414f9be062a37d26d3221ea6dcc93776511b974b44d7baa91",
-                                "uncompressed-sha256": "c446aaefe42cdd8f26e20f1a51cd9b0aa9e16ba262f514e5940d220b70022fe8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "90e3f3064c5680074ff282c650fe04edce57274e49135e8bc4044865d2e029ff",
+                                "uncompressed-sha256": "b75b0c787f0891353be5c4001c308f1ee592b464edbe07ece18bd41c8bab902d"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210427.3.0",
+                    "release": "34.20210518.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "dc27ab9f5f5d5d1edfd1b501574e579724ec4df7b07ba76613b0cf22fd2aeb3f",
-                                "uncompressed-sha256": "a05f4fbdf65792a4a9d839043df9fe90be6345d143ea701ae3495a28803d52da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "cc8406340da63a50be98889faf7b8504bbdbf7cdee42850c933579c08933c8ef",
+                                "uncompressed-sha256": "e7194fecca49d43fcb45ab0ff67a9b2f90bd3545d46b6c089d66ba0d2284b247"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210427.3.0",
+                    "release": "34.20210518.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "26e2b55ecb87a9e57140d84b388d9fe9e793cd676ff00861d1701bce2b427dfe",
-                                "uncompressed-sha256": "954dd99ed993ac9082ccb85c5c1eca8b6a47031070481f7676f647f483c05b9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "832e3ede8c03cff105cbd3f363d8b89a2dc1ad03a24a10a7c2ad8b24da2cd1b6",
+                                "uncompressed-sha256": "3300d247679753f50c24bc876e894c87573f401798fdf5f210fe099cd52351d6"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210427.3.0",
+                    "release": "34.20210518.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "f7ec4aeebd485515e347f6da5aae03b48dd48a49d53a990c3148492220bde48f",
-                                "uncompressed-sha256": "ca37fb2105f2d4ef7c600615743c886d1c9170921dee2ed6525c1b2e78597723"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "37ef98c3579046e8a306d076edacbe6a8bea74e2cc35375ec6ef7a945c39b093",
+                                "uncompressed-sha256": "b3049acae89bd30253f6f8e8eaaa36e0382b47a74c28ff19145511913d409394"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210427.3.0",
+                    "release": "34.20210518.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "52a326638ecd16894462d75f7421479811942c97ef60014076c5b7609c9d9a65",
-                                "uncompressed-sha256": "bcbf9161d88116ee167eb4ccd3cfb716db19667a40afda20203092b1b49a47c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "1a4aa4950a9b78fe5154d731e3d528afd7564499f4ed497f7c07493b6d8684a7",
+                                "uncompressed-sha256": "aa3ed7929d46920e91259eb3e11cdd810034fecce51232e04ba3e27abc96ff25"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210427.3.0",
+                    "release": "34.20210518.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "0229d78e3ca46a4f3ff4f48639dafdfc2451b3146ebbe7d5da8490596e59fc19",
-                                "uncompressed-sha256": "4c97b5f58502dd5e31032493c8c1da0ee73d8af45e170e09f89d2ea997f3ddc1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "b38d7b9fd13329b6edffff2310b24ca80df250aaff4f14f48ad735aa25f0acc6",
+                                "uncompressed-sha256": "3165d4f08b53f0c99663c2c1f561ee3867c3b3db63fa6ec584a355fc1748903a"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210427.3.0",
+                    "release": "34.20210518.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "83adda7b4bc7e69e8620cb779f8007a8660ca1b6772919ee1020aa3f99065383",
-                                "uncompressed-sha256": "ee3df1e72b4ec1b8eead1177b2ab15088339f157f1ea881c339a7a549e633ad5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "1f0012cd637e4275795572b5924ad563ccf79598d3498ff86e915fe0b6f4f03b",
+                                "uncompressed-sha256": "a6a8fb673aeb993fd6382abf912c2dae88def056a98e62a7cc52fd8e507149e9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210427.3.0",
+                    "release": "34.20210518.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "de496a1d6f498c537cc97894e792adb244c5fddb178e789b1cfeec370e49cbf3",
-                                "uncompressed-sha256": "0fec3fa0893be0afa31ee7136fa26ad61d9d9c44642566ad694e559a8919d891"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "1facb37577cb6248e714b6cf8efc80e9c216541d90527c83a051634c7c78c502",
+                                "uncompressed-sha256": "b002d71e57eb7e1bfab2b3c0152881663ee600f73e3002d0bd83bf7e599dd0f7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-live.x86_64.iso.sig",
-                                "sha256": "b873693bc1effe67df90d152b72215628a0ea3766fb599f7b675fde61bfba714"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-live.x86_64.iso.sig",
+                                "sha256": "acbf3cd5b25da7a1fb6862485a6a38064dd8f14dc0398137d371abb9b148eaed"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-live-kernel-x86_64.sig",
-                                "sha256": "6e49ff24a43c9e678f7a2c901e3339dcc2490023c91a698503d08fc4532a4d55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-live-kernel-x86_64.sig",
+                                "sha256": "dd20b2b0fac9309757f52dda1e88ee61ab280fe40b82f3e4caa5ca25d89775b0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "b1534ea21dcb6526401f9cabc54d69674a1e0cb2753371be99fcc6eb9764206e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "efdc9dbe43178c0235b76ef693464b02efb1d50ff322cd1239d154f2848a190e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "7edde206d64f1580fb0e81e0ab9a238cc7a383d809c319c6e1ea90f46d169f28"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "78102494831341fa50dfc1e8b26b2297767dba61bc881239cecd59dd121ce7aa"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "a15ac45c4b6d88a478b4191bb5884548d08260d738ea41ba3cc5e6efab1f28d9",
-                                "uncompressed-sha256": "c3c310c9758737275d47111606fe6f85107c4661bb4d88a7fe8e960bbb393f12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "31477028ff10369a66ccb613a98f4a97a82fddd5c5554dfbc1b7f2ffa377c01b",
+                                "uncompressed-sha256": "95284d465bbafa42884f9dbe40aa16a8a3852cda8ee29ddd1f243865e7ae0f3c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210427.3.0",
+                    "release": "34.20210518.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "428b825c46f954211b71e1932625ec5c83300e79defa73f7b4da258fa43cfa0e",
-                                "uncompressed-sha256": "55ef751cca6f46cf7a603a18786479b14cf5a8060df4ef03839581ada0f5324c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "ad16c0fe4212546795570513f56b112d06dd5cd271ac2470e8377b1fa98b8a57",
+                                "uncompressed-sha256": "c3f333a66ac4cdbe2890eae9b273fbd83dedcc37f0001d04b0146b76ab8dcf6a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210427.3.0",
+                    "release": "34.20210518.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "9cb480f4f4d43da7fe6cf5b1c37328d8657d92564d5460a51fbe3a5eab049ad6",
-                                "uncompressed-sha256": "29431e737805811e0158485850078a9275d3651c45f0588d7ee2be492fe3a4c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "76910943b727f588d4cb34dd4bbd82b80797718ed6b3b3bbf6a0951c87e3254e",
+                                "uncompressed-sha256": "30adfcefb41cc813fd0f7f3ddfcc2e9d02b6b947ca8d1d795658c71730e836a3"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210427.3.0",
+                    "release": "34.20210518.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "df9ee557d61ff242abdc9b9c384ab6bf2440b2c77dd8e734bf3e34d254c6125c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "87433d99229ccf32e6c1ae3225bc1d39c8c4ba79e392cd38e53d844121b84525"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210427.3.0",
+                    "release": "34.20210518.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210427.3.0/x86_64/fedora-coreos-34.20210427.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "2d0db91502c1f93f0b1311a382a89eef91bf448de9d3f551740da80ed99e646a",
-                                "uncompressed-sha256": "8747285620b2355df5efe4c47b96852634351b6b121988b657a4b0f146beea5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "3b3f818784dcc787daf1c0772430e0c851d2647fd957a8d87fd5ab64b37784a1",
+                                "uncompressed-sha256": "d01e925a7221e92e737f525e0c10afd5b91e39a0a573d295eb0c47b1624eb964"
                             }
                         }
                     }
@@ -198,95 +198,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-0062fca586ffd141a"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-06c96d24608e629c0"
                         },
                         "ap-east-1": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-0b15f59d39ab4a7d3"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-0372ba3bbe7687b14"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-0377105a9164e015f"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-03894a14941c52b30"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-04ef3c87a33f87c17"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-0d4ae05e9fdec5d97"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-02f572e432f44c123"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-09767fdf43805533a"
                         },
                         "ap-south-1": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-0bb942107acd70913"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-0bdd68aa25fd10884"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-041662d161e7d2fec"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-091234cd666f426cd"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-0bddbc590baf03154"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-071662fd1239cfa44"
                         },
                         "ca-central-1": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-0668ab4a3f5b5ab6b"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-08300f655b9d341c6"
                         },
                         "eu-central-1": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-03724688bcc7d3666"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-0daabf1b4e2b138c4"
                         },
                         "eu-north-1": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-02bdc2da8074bcdcb"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-00f8790cc3ce86403"
                         },
                         "eu-south-1": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-0f6ab0bac05486463"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-0b4581fd5e4d1934b"
                         },
                         "eu-west-1": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-0f81229d136a3c1f9"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-0a1df5aef9f735d3e"
                         },
                         "eu-west-2": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-025d1c8a1e6800e5a"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-074d1190fdf54de5d"
                         },
                         "eu-west-3": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-029a91560c4198683"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-0eed8276b81f88646"
                         },
                         "me-south-1": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-03e1adbc2923c71c0"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-0cc7e55080040072d"
                         },
                         "sa-east-1": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-08ac49996226faedd"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-07a62a31d660412a6"
                         },
                         "us-east-1": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-0b1366e3765063df0"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-05f4509194dbfaf92"
                         },
                         "us-east-2": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-00d6966745b4fd929"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-09a886cdcac1c1ae1"
                         },
                         "us-west-1": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-01e62ec89474341c9"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-0eb0d64dcb6c67afc"
                         },
                         "us-west-2": {
-                            "release": "34.20210427.3.0",
-                            "image": "ami-0fe05e34ff7b6e4ff"
+                            "release": "34.20210518.3.0",
+                            "image": "ami-0937de56fee16b912"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-34-20210427-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210518-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,194 +1,194 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2021-05-20T13:39:47Z"
+        "last-modified": "2021-06-01T22:22:20Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210518.2.1",
+                    "release": "34.20210529.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "ae34e7855cb74557abe46273007369f2282305db5a093d635e60f716d4dcf403",
-                                "uncompressed-sha256": "c93695339356afdc1df6125488466fe7010bb374461b714efcdd42c4ffa34164"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "c79c837d2d7a5fd7624d9c03806bc566eb3be0f3fa3d6c43c0b8176998093721",
+                                "uncompressed-sha256": "a49a8c33c9c8cb8dbb037b07a664b6b6974640c2acd2099e2f852a56dd3af01d"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210518.2.1",
+                    "release": "34.20210529.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "7ef98bc54f2717a4744d20b392fec8f047d0c25243cf1eac08902d9909e7061f",
-                                "uncompressed-sha256": "ed5ae0fc4e6a0b7c1dcdc62afde616a6f3eb9a7eb5478c19c4a446bc095b59d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "f718dbd06d6cd394a588c56d9c630a0ec5c59bfc6e39b097fa851b6afcda9bab",
+                                "uncompressed-sha256": "084c5efdd520551af2b55223c392322edd896ae0e063ecdeb2809c05434e03e8"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210518.2.1",
+                    "release": "34.20210529.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "3755679bc8a6f980cffffae80957472d47f2e2eeded0d0aa138a7b8d53e3e580",
-                                "uncompressed-sha256": "dc3d8ee46bce47a1ae9d0dca6d0addd49b069a2b76cda92144ef56c854c0cb79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "ed3e06963fc39628bfaf715b0ec39a06ba5cda88f36ad58db843d2e0b2be25e7",
+                                "uncompressed-sha256": "44c2e1a8d4ce7ff293d7563d62084e5dbc23dad080585ea95d41a61acc817c72"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210518.2.1",
+                    "release": "34.20210529.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "01f557a81bdb5c5b1c4f9d4abd85d0218bd34a59a26b3127f2d390c55fae4096",
-                                "uncompressed-sha256": "9a2138cd7887d1e3a4c51bf9bb6fc4e7292444696eef1f2960339c5f3bf392fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "0d65665c2fcd2da4cbd952175309f81e814dacb7f015a32feeca8c8b48478402",
+                                "uncompressed-sha256": "e08f2b35bf42eb56ab1cbf7c7437e850623d25c842cba83b105f494d4e9fbe45"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210518.2.1",
+                    "release": "34.20210529.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "b3a33fe8e380196dc7cd87b3396f69e53e797274fe76a092cabc7e03986b3df2",
-                                "uncompressed-sha256": "5a6fea5eb1cf05626ace06dc10626f7a09c057ed8c9fccf7b44fcd736e9c5132"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "669af1901cbfdda6712662d70b9266d2ab776fe552b455116570eb18d46fe8bb",
+                                "uncompressed-sha256": "ed194cdde3ba020e03711a8af483dbdff06c2a952cd9412039c776adc8a36330"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210518.2.1",
+                    "release": "34.20210529.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "5fbb3386686d20e6091ab6284da2f2c8ec0b5f3d108ba380a8395c6b9cc3fdb7",
-                                "uncompressed-sha256": "e1828d45c02dd5fcbcf45bc5f75a07419916bac22ca91f3e3072f7ed3ca96f52"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "d80c5dab59ef4f0ffb88ebea1250e5f34b0df3105412fd718da3bd9b66dc2d18",
+                                "uncompressed-sha256": "afd8d14fc060b55b9e9d9bbe98a0c2c158b0756af64eae9df20da6b4783e98e9"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210518.2.1",
+                    "release": "34.20210529.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "9941eb6481396f70ee73feac73f5573145494874e6d55cc24018a02ecd7815b6",
-                                "uncompressed-sha256": "d58bdc89cf1f6d9364497fe8ab6048225304eba1d3a0334ef76fc575770570b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "59572001a8946aee2ba509501a826cdcd0d4643acf2125c4e5684343998c6a61",
+                                "uncompressed-sha256": "b386db7272b098cc441b283e488cf7d8e1c8964cb80ca28da3d4e4447e822b3b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210518.2.1",
+                    "release": "34.20210529.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "0402848287c597d4f8b7d53e7e9269839b8e1e54609e6cf47a3891a63ee8785b",
-                                "uncompressed-sha256": "8afea1917b55215479054126c95f6ed9c161326a29323dca3d7f09626e4203fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "311f0eb69d64235bdca25ac184a6e6ad2396ffd2ba70d640bbd4e6f420faf4e2",
+                                "uncompressed-sha256": "ded7eab5b42d6cbf171c17ecdc8558939e6a6a406471ae3128f6fa3319eb154a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-live.x86_64.iso.sig",
-                                "sha256": "c962ced84ec31d2904b66365fe05cd96cbca64516f4a99217afa399bdb9ddf23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-live.x86_64.iso.sig",
+                                "sha256": "3712b1ba66a7f632c92921d8666c289ce83299788bc0037a3465814650402a10"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-live-kernel-x86_64.sig",
-                                "sha256": "dd20b2b0fac9309757f52dda1e88ee61ab280fe40b82f3e4caa5ca25d89775b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-live-kernel-x86_64.sig",
+                                "sha256": "dfc85a460b70a01331145840c932778271f8c4ab108b6797adb2c3e0cd98b4ec"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "b5fdca87ab1331fa33671341489e507cd4d6dd0976b58e085f38e66d671a102c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "3e59c8473c858293a07e1b998b5adc3b718b49f286e211478a4dcdf9c8d509ac"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "913dc4fd7e3d50b4d142a099a0354f2f53ccbc11908f1e14160811a2bfa7bec6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "53c24ff061041bb4f9f52c8d3aca017649c07f1c136346cb82a7fe521193c7a4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "e18ed8664de699f694dd2e26f725c1b6159c1e4a3c8bc0f30a58b6cd390d8972",
-                                "uncompressed-sha256": "7f852606ef36aec731c854eca49efd028dc78085b9eaf203dbf0d2e592b2e7a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "f356b4bb67cfef1675cb3913e3e686f025866999241cd32388efd8265338f75b",
+                                "uncompressed-sha256": "27253c9dc231de190a2afd47e63bf04f409f7d830f050430ca1f9a88ccbc867c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210518.2.1",
+                    "release": "34.20210529.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "0d38a63b6dedd5ef061026937beaeac4d7fd16fa4d682ec2187d53221ba165f4",
-                                "uncompressed-sha256": "b8d8d040f2997d049bf88a2c5bbc57498e27254a57bafaebf43b3d32a5dfde1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "163240cc6e38166a96618944c0043a01c4ca7cca7ab6922b95b8cbbae6cdc800",
+                                "uncompressed-sha256": "c22b580bba7ce267c0dd7a8fd2f631ae5b7954fd77818c87b6c68a00d8fdc6ee"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210518.2.1",
+                    "release": "34.20210529.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "d147610d33ca47b666882fb9c545a9c037d305025d84d541e507cc4e7d2b1767",
-                                "uncompressed-sha256": "f11b96bedb4b86139d98bbda17a0695ee257f1ecd5aa9a8187514c7c91d997e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "b5fb45010e48d8248a1ac2bc79d01ffd5aad20f7207a4c011fe6075c3568520f",
+                                "uncompressed-sha256": "08d4dd3cbbec1fd9a287eed793d6ba395b606cfe0ac443688fa4ff036590e03c"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210518.2.1",
+                    "release": "34.20210529.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "84672a90389843d776ae3b7c03c9b87e07bb86313a7756db812da7f728dbf29f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "80fcc67466d786a553c8f3e3648f469864509aed106f35136a52118728d1b013"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210518.2.1",
+                    "release": "34.20210529.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210518.2.1/x86_64/fedora-coreos-34.20210518.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "28a655f75df6f224f948ba4c7687469cfbee78a964fbc790df685b68ea224cbb",
-                                "uncompressed-sha256": "106ffcea8ccee12341c896aded5a6cf2c4ab94dc708503f3bb76feedc2c6e1a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "9b8e0f245fd2bd0120578b31aa1a11f4994dba4fcaf1e33ce73ca7c110637737",
+                                "uncompressed-sha256": "128d7298f8f651019be40e55083c048ac6e35918c49f68a92b4514247dc079c4"
                             }
                         }
                     }
@@ -198,95 +198,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-00345ce8f3ed9f803"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-0be58a6357a6fad95"
                         },
                         "ap-east-1": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-0ec1ed2f5000e36c7"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-00114103df8ad1697"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-0280fa95b083eb6df"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-053ce3b5390867dd7"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-07b6f906d63454dc3"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-030b7074a5d6246db"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-0f6a31a6bd74e5b96"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-09b5f4604f6652b42"
                         },
                         "ap-south-1": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-0321c3ee94d62b3e3"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-0508c7cc3cfd01a1f"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-07cca68e2efde5b61"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-0f97a2a3ebf188078"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-0c5d4289c5a59498a"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-0f1731bc27008b6c0"
                         },
                         "ca-central-1": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-05c9f3e98f91cf344"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-0f8a4f3e5c3e48b49"
                         },
                         "eu-central-1": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-05546acbd988e489e"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-0fbb39979716a611c"
                         },
                         "eu-north-1": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-0dcf677d2954beb68"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-0adf6c6a17bdbc709"
                         },
                         "eu-south-1": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-0a4700330e79939d5"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-038da8a7956797148"
                         },
                         "eu-west-1": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-060a73505926a1bd8"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-0f12216dbd45e96db"
                         },
                         "eu-west-2": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-0361cc19cb1d216f5"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-04cb7f968c51836f9"
                         },
                         "eu-west-3": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-0a2e994b5565b4ee8"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-00e9df34e2336a96e"
                         },
                         "me-south-1": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-0e9c4087543b61d3c"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-01b1f3ae7a15d4bfe"
                         },
                         "sa-east-1": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-0d50a0cba84200eb1"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-0309cc4a6b8f5fb77"
                         },
                         "us-east-1": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-01eaac4a8c06d81ed"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-0874588a8f0420e41"
                         },
                         "us-east-2": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-02eb0598cea96eac7"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-03fc905e37d532098"
                         },
                         "us-west-1": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-0d51216fd71d46561"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-0137c2aadb3b45f42"
                         },
                         "us-west-2": {
-                            "release": "34.20210518.2.1",
-                            "image": "ami-097f2165e9e3f7c62"
+                            "release": "34.20210529.2.0",
+                            "image": "ami-02ff046c7fbe71d7b"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-34-20210518-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210529-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,8 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2021-05-20T11:37:58Z"
-
+    "last-modified": "2021-06-01T22:19:31Z"
   },
   "releases": [
     {
@@ -30,7 +29,7 @@
       }
     },
     {
-      "version": "34.20210503.1.1",
+      "version": "34.20210518.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -38,11 +37,11 @@
       }
     },
     {
-      "version": "34.20210518.1.0",
+      "version": "34.20210529.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1621521000,
+          "start_epoch": 1622642400,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2021-05-18T15:27:50Z"
+    "last-modified": "2021-06-01T22:19:31Z"
   },
   "releases": [
     {
@@ -37,7 +37,7 @@
       }
     },
     {
-      "version": "33.20210426.3.0",
+      "version": "34.20210427.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -45,11 +45,11 @@
       }
     },
     {
-      "version": "34.20210427.3.0",
+      "version": "34.20210518.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1621355400,
+          "start_epoch": 1622642400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2021-05-20T13:41:32Z"
+    "last-modified": "2021-06-01T22:19:31Z"
   },
   "releases": [
     {
@@ -53,7 +53,7 @@
       }
     },
     {
-      "version": "34.20210427.2.1",
+      "version": "34.20210518.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -61,11 +61,11 @@
       }
     },
     {
-      "version": "34.20210518.2.1",
+      "version": "34.20210529.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1621521000,
+          "start_epoch": 1622642400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
https://github.com/coreos/fedora-coreos-streams/issues/320: 34.20210529.1.0
https://github.com/coreos/fedora-coreos-streams/issues/316: 34.20210529.2.0
https://github.com/coreos/fedora-coreos-streams/issues/314: 34.20210518.3.0

```
next
    version: 34.20210529.1.0
    start: 2021-06-02 14:00:00+00:00 UTC (in 15:27:12)
           2021-06-02 10:00:00-04:00 Raleigh/New York/Toronto
           2021-06-02 16:00:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)
testing
    version: 34.20210529.2.0
    start: 2021-06-02 14:00:00+00:00 UTC (in 15:27:09)
           2021-06-02 10:00:00-04:00 Raleigh/New York/Toronto
           2021-06-02 16:00:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)
stable
    version: 34.20210518.3.0
    start: 2021-06-02 14:00:00+00:00 UTC (in 15:27:06)
           2021-06-02 10:00:00-04:00 Raleigh/New York/Toronto
           2021-06-02 16:00:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)
```