### PR TITLE
Triple rollout on 2021-06-15

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,194 +1,194 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2021-06-01T22:22:46Z"
+        "last-modified": "2021-06-15T13:02:01Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210529.1.0",
+                    "release": "34.20210611.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "1f04d5f775a3937f83ea21752ba8f8ae0204f810679d35ad85dad991961d1bf6",
-                                "uncompressed-sha256": "429daa5d95dda1f8e6e24430c9791caf1d039688dc66b10a90f57768fd239bbe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "71c6c54479ac4bb8decb4a6ac66123f38132a3141d6c7a4097e342431db7a0fd",
+                                "uncompressed-sha256": "6a574501623126b1f69f9c6beb09ff1cbcc7ba7fc502ba48a42d8db5b3ff3033"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210529.1.0",
+                    "release": "34.20210611.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "bf21b8cace23236e7a9e6ccd5933a7c1230c19a8aef7af81d9256ab48296a711",
-                                "uncompressed-sha256": "c429c477fa3d4ef9dcdebcfbbad062f2bc7ba17cce68fda2f18921e539af8783"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "997014d6c42c823f973d3dcf09aba1deed4724768940e94da8db5d869c494ab6",
+                                "uncompressed-sha256": "946afa7e44e1c2d7c45eb2e919cf1a829a1f293b4c89b1484c9151235d8bd746"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210529.1.0",
+                    "release": "34.20210611.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "75fae4666fe76b505a7e92d159feee765bd9d8734f2f9ce8fff1a7ec96c79902",
-                                "uncompressed-sha256": "b9a1d4b3c2a74e9b9f53a0ca7d68c9e01467567eb95cef55b1dd58cc42077223"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "1589c88b53e56e1fb316f2f95d28f0ab5b05629b04978bac44cdb7609db18306",
+                                "uncompressed-sha256": "51ab21b52db99659ce93925e4130cbc7f47658d8373900db1b32a644ce00d0b3"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210529.1.0",
+                    "release": "34.20210611.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "208b8925ba8b514ba1fb2ba4c541208ec361d64d3c2748f58f515f9e982b5681",
-                                "uncompressed-sha256": "c698766f5d51078f9b6e1cf2834b758ece63f4909378eba92cafe9b7d2ae317d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "654a65c3b12eeddfc086c6a920acd683c5c9e06349ac3de1182b1d5b03148b2e",
+                                "uncompressed-sha256": "2394e96582e607b9a77c6cc1eabe717c0fff84811d63f410ad6a7d1b88b19713"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210529.1.0",
+                    "release": "34.20210611.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "36de18da2dffa7dae3ce25ad3ca0956c25e2853b221005f45415c3d2b2083886",
-                                "uncompressed-sha256": "71064b9f036d34c90231e3ef466f893686fcd01979262db3f8b5cbf8af65f7a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "5db77decc2222359f6ce632b426593bc564ad78598dc30e71227b2876dfba92e",
+                                "uncompressed-sha256": "bed260d17d93aa1cfb4810cc49709a80e34743886c0e9a62026ea206017ee09a"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210529.1.0",
+                    "release": "34.20210611.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "057485613efe4c2f2083c675ae7ee4caad2d5c422c5769c3a692534ea63286bc",
-                                "uncompressed-sha256": "49a434fb1ed0d948d2d13fc90891f0337c084fb10b2c850b3bd95383d7d1d96a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "feffd79fffcf0d8ffb7d6949999611b05b98fe92d7a6cc5e18df9fb0aebccc24",
+                                "uncompressed-sha256": "ce5ef04e303382345b7e602d253a46eba41cf19dafa3c10262733bbeced80c97"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210529.1.0",
+                    "release": "34.20210611.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "b374d4b0a28d5a5cf8a442e864eefe4cc723d593bb814f2dfb7eb529ee7b8592",
-                                "uncompressed-sha256": "075f4378bd19823b8e8af5bd9a1bc0556b4166e033bbac88ed1a4a6bc2764303"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "cf16d4ab05ecc2d4ff4c5c7d4dc498db59bdaddeb9762d86b2028609ab3d5574",
+                                "uncompressed-sha256": "923fd927103af335dcd5cd55ba86452404b58f0f0c5bde5ceaa10b3e1c0706d1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210529.1.0",
+                    "release": "34.20210611.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "444999afa345cae5b79c16e14f34316a5e2195e8e69d3cf563817a872fa0134b",
-                                "uncompressed-sha256": "fe9c0eba942d1a19f19e9fa6d5cc4faec996792d84e4cf1ff865498ecebf06ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "eaabd1073bdeb2801d36661854e8668ea156fc6fa1b0d316e0d8baecec854073",
+                                "uncompressed-sha256": "6eefaae9e5282a4d714b35fd88d0fa124e5fc30a3fbe512d435fe3226f693c15"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-live.x86_64.iso.sig",
-                                "sha256": "be39b44287289970eebedc7b507e722464c6961c757a6be9711d3c3f8bf5779b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-live.x86_64.iso.sig",
+                                "sha256": "91de91d457c34568b7f63eb628234dc4d723c25379f7187f0cb119f3eac17a8f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-live-kernel-x86_64.sig",
-                                "sha256": "dfc85a460b70a01331145840c932778271f8c4ab108b6797adb2c3e0cd98b4ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-live-kernel-x86_64.sig",
+                                "sha256": "442c063a0a077fc45d59d804275532e99813e7eaee87b5a3aefdd62a6287b668"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "f05bc1e69636b77533c6ef154b087543db6016bfd8e330fbb8203d1cb999a1c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "ff8522ca60dfb4089e7ba0445432c6490ffa41237295aeb2373bf2051f71cecd"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "cc85ae31a81317b3d722704f385e60dc480021fd1408bd605860e2c4b7398375"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "7f6665483b496c1b7b05b3fc8bf389a1042e69560f9a7d537636e275f1a23819"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "9b7d7bab3d483adce2f5b3eb8787cd3b8b5b26a0b3dde85a161f59d553cecb5a",
-                                "uncompressed-sha256": "8ebed2167e364bf5188a845a1f5948ea4c69d2e6f145fe632ac608d33de81f8d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "3c15c480c7e27aea1c4a5c17cf0882cdb68692b40cdacf3e72d663324fe6515c",
+                                "uncompressed-sha256": "1a998a7049118413994efc848f4794f85fc42ee831aaa7ef77627ad44bdd43ed"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210529.1.0",
+                    "release": "34.20210611.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "11bd03af38393c2bbdc55c9dbc4f386c39d93e318d46bf0db8fca0c2f105f110",
-                                "uncompressed-sha256": "47b8399033c5828c47624125ce76b8a25be1f204834641561fb3b5835495ac42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "2023ab7c4f7d0bf747f904188b93e36cb4f9e077760ab7e96c5336ed32c27e8f",
+                                "uncompressed-sha256": "65a774c2f2cc45e970031efec1b58b37869136be04656d4837543da4c9d00d17"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210529.1.0",
+                    "release": "34.20210611.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "6fa7d7f8f61211a1623e253e82181f96c9b2711bf481021d98c79ef0eaa44486",
-                                "uncompressed-sha256": "f688153f6b85497cdf7da0f828d56b6a0f6108d539b9efef289054d3830fe746"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "a9a7efd2f02d27781dfab6299795d0fdb9bfd674575d58a810ac9e38a642a5da",
+                                "uncompressed-sha256": "0733ceae3488ee3292fe9b240e5d5115efa40e37f5bfc5ba2b4af5fc54b90383"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210529.1.0",
+                    "release": "34.20210611.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "97459c7bb95b9b01454fd51e10cc13528644a5b59cfff36d984e0eac36bd370d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "ec7ecf8f9ccdfffc50db7c1092b08a8f585a83b1cd02081e5d9ab8d2a704842d"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210529.1.0",
+                    "release": "34.20210611.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210529.1.0/x86_64/fedora-coreos-34.20210529.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "bb844821ca0e84064b739b478228a76a80c1af626f455338e05a30f90653624e",
-                                "uncompressed-sha256": "4bf78b1650f007e5ed781958ef628cf31c9489c4d09ca6d08900998b7e76022e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "de5586e3cca3a9af4995152e1ea097ddca9302d8a05fbc76f0d71684a823de39",
+                                "uncompressed-sha256": "2027a1247256d53902e28f7a1052080c90c903adf004055a3345ae48f9c92268"
                             }
                         }
                     }
@@ -198,95 +198,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-0b0bd803479a03c37"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-045c03871a30ca725"
                         },
                         "ap-east-1": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-01564319d54c1d593"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-0b119883d11e8f80b"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-0d64b6f2cda8c515a"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-0617c4ba1e936e740"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-0583113cf57551bc0"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-0445799de8de61a8c"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-0ef8531506fb2e775"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-0753b9d604907564c"
                         },
                         "ap-south-1": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-0ed5b6e68dc30371d"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-03eee78efb8655b6e"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-05bdb921995b170ea"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-0df9336cd175589b7"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-0f3f8f993f5cb7e9b"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-06b180dc729537164"
                         },
                         "ca-central-1": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-0a26184bc05aa527d"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-0c112de76b863daa1"
                         },
                         "eu-central-1": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-008dd6664d2711ec5"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-017795ffa3d7a67e0"
                         },
                         "eu-north-1": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-0820b46a43fe7f514"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-0820f76088f3470a8"
                         },
                         "eu-south-1": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-0760f128dcf63d466"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-06c5b898ca96812c0"
                         },
                         "eu-west-1": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-03567338d82cda803"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-0c4ef402497460886"
                         },
                         "eu-west-2": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-031e6abd0432eb90d"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-024767ce25072b530"
                         },
                         "eu-west-3": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-05a2fa2afdcc44d52"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-0be3d5139f64dfa17"
                         },
                         "me-south-1": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-08c28e2940f6122d7"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-09465c32e43acfa1f"
                         },
                         "sa-east-1": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-0be2790415b9d13a7"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-0a3c71b8eae767ada"
                         },
                         "us-east-1": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-02b91007c7c138119"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-0a94066cec0494062"
                         },
                         "us-east-2": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-0912bf3ca0566733e"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-0b806ee8e86a357c1"
                         },
                         "us-west-1": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-0b66860677a7b745a"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-032038949d6be409f"
                         },
                         "us-west-2": {
-                            "release": "34.20210529.1.0",
-                            "image": "ami-0a57842743df8c18b"
+                            "release": "34.20210611.1.0",
+                            "image": "ami-04c8253d62eade588"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-34-20210529-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210611-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,194 +1,194 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2021-06-01T22:22:58Z"
+        "last-modified": "2021-06-15T13:01:11Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210518.3.0",
+                    "release": "34.20210529.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "90e3f3064c5680074ff282c650fe04edce57274e49135e8bc4044865d2e029ff",
-                                "uncompressed-sha256": "b75b0c787f0891353be5c4001c308f1ee592b464edbe07ece18bd41c8bab902d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "5a3dfd994f9054bafdfdd9ec195405d1026120a28548777ec28aa889a64602ae",
+                                "uncompressed-sha256": "24516c9e7b300886d3ae8e765da6c34aac9f921d7578bcc1a9f03cfe6b709c14"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210518.3.0",
+                    "release": "34.20210529.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "cc8406340da63a50be98889faf7b8504bbdbf7cdee42850c933579c08933c8ef",
-                                "uncompressed-sha256": "e7194fecca49d43fcb45ab0ff67a9b2f90bd3545d46b6c089d66ba0d2284b247"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "5d27c14d45c248318fa4b9f3f4f370609fae876e73c0ca0a39eb7a5315ce1b58",
+                                "uncompressed-sha256": "6c13c8a252c14d9dc2ddbde51751f21ef1ef36d6bf605afc7ff80da42682efd0"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210518.3.0",
+                    "release": "34.20210529.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "832e3ede8c03cff105cbd3f363d8b89a2dc1ad03a24a10a7c2ad8b24da2cd1b6",
-                                "uncompressed-sha256": "3300d247679753f50c24bc876e894c87573f401798fdf5f210fe099cd52351d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "76264cfc2e8b43039165a68cf901640ec22313651f93bb598c529f6367a2d0da",
+                                "uncompressed-sha256": "d7dfd005f3e49b0548a8195008ce10c4df38c033404e3382d3e24a741e0bc393"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210518.3.0",
+                    "release": "34.20210529.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "37ef98c3579046e8a306d076edacbe6a8bea74e2cc35375ec6ef7a945c39b093",
-                                "uncompressed-sha256": "b3049acae89bd30253f6f8e8eaaa36e0382b47a74c28ff19145511913d409394"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "e9332286a3e5d59d81d90087492f9512251ebfb1894ca8749e6e285c9b640565",
+                                "uncompressed-sha256": "f381c0d15a09c8dd9079e469fe6a7e89cb2a2fa3fbfc92e8fe8cab40955b2a90"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210518.3.0",
+                    "release": "34.20210529.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "1a4aa4950a9b78fe5154d731e3d528afd7564499f4ed497f7c07493b6d8684a7",
-                                "uncompressed-sha256": "aa3ed7929d46920e91259eb3e11cdd810034fecce51232e04ba3e27abc96ff25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "3d0981598152a26d39b06ccb469dd02c4a56db7edd682fcb9640cd183bd9fafc",
+                                "uncompressed-sha256": "22891e54fbc8294d5c161bd30091af4575e7884cd5b8f98ce62a1465f72a1733"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210518.3.0",
+                    "release": "34.20210529.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "b38d7b9fd13329b6edffff2310b24ca80df250aaff4f14f48ad735aa25f0acc6",
-                                "uncompressed-sha256": "3165d4f08b53f0c99663c2c1f561ee3867c3b3db63fa6ec584a355fc1748903a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "7f4279504b84ae9245defe78c7446ce97587fdd57d78917c7b80878a22887cd3",
+                                "uncompressed-sha256": "03043832765e77fc1a0efada4a8c8297512625869e6389eef62db31490e98f9b"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210518.3.0",
+                    "release": "34.20210529.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "1f0012cd637e4275795572b5924ad563ccf79598d3498ff86e915fe0b6f4f03b",
-                                "uncompressed-sha256": "a6a8fb673aeb993fd6382abf912c2dae88def056a98e62a7cc52fd8e507149e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "69d68f768e5994e29b0cd9246b84a7ac6bf659a27efbed68e52239922a77dc22",
+                                "uncompressed-sha256": "9387cdd290856307ee96d18a0cc1e05be164262c9ad499279ac294fb26e6a697"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210518.3.0",
+                    "release": "34.20210529.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "1facb37577cb6248e714b6cf8efc80e9c216541d90527c83a051634c7c78c502",
-                                "uncompressed-sha256": "b002d71e57eb7e1bfab2b3c0152881663ee600f73e3002d0bd83bf7e599dd0f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "7c7554aee94b9783114f37d710cd2530fc401e874da29a1066272fea4baa562c",
+                                "uncompressed-sha256": "8deee2008c44d18d71d00505094bf42d0fab70c66a43a6c60f49f56e256a1b06"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-live.x86_64.iso.sig",
-                                "sha256": "acbf3cd5b25da7a1fb6862485a6a38064dd8f14dc0398137d371abb9b148eaed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-live.x86_64.iso.sig",
+                                "sha256": "6bec8c1e67747c4d2fd8dca8bb833b74879d9c60c99d9edd4c4f17e2830ed6f0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-live-kernel-x86_64.sig",
-                                "sha256": "dd20b2b0fac9309757f52dda1e88ee61ab280fe40b82f3e4caa5ca25d89775b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-live-kernel-x86_64.sig",
+                                "sha256": "dfc85a460b70a01331145840c932778271f8c4ab108b6797adb2c3e0cd98b4ec"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "efdc9dbe43178c0235b76ef693464b02efb1d50ff322cd1239d154f2848a190e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "333a0cd004687eeaef68be7e59187fc7b045e506f5f17e51e971dbd77c3545b2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "78102494831341fa50dfc1e8b26b2297767dba61bc881239cecd59dd121ce7aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "5eac1506df192ebf1a0d9ce75328a24a8283e671ada74cd94592264fb063b9f9"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "31477028ff10369a66ccb613a98f4a97a82fddd5c5554dfbc1b7f2ffa377c01b",
-                                "uncompressed-sha256": "95284d465bbafa42884f9dbe40aa16a8a3852cda8ee29ddd1f243865e7ae0f3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "6689c64d37d198295d27e92ca8b2b94d6b9c16776fde9e5b771004281bf3deff",
+                                "uncompressed-sha256": "09b1e42984d6e1729d29671708809c5fc3c0594b20c2dd41d5e45dbd26a4b02b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210518.3.0",
+                    "release": "34.20210529.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "ad16c0fe4212546795570513f56b112d06dd5cd271ac2470e8377b1fa98b8a57",
-                                "uncompressed-sha256": "c3f333a66ac4cdbe2890eae9b273fbd83dedcc37f0001d04b0146b76ab8dcf6a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "4a398a9eda48cf9ee654b8b56b757cb29f9f8a152f627b834c0fc129a8f9b37d",
+                                "uncompressed-sha256": "c86d0826300b403f528ea6f1bb81ac6ec9d1b73def80f3c9035730ea0bc5121d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210518.3.0",
+                    "release": "34.20210529.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "76910943b727f588d4cb34dd4bbd82b80797718ed6b3b3bbf6a0951c87e3254e",
-                                "uncompressed-sha256": "30adfcefb41cc813fd0f7f3ddfcc2e9d02b6b947ca8d1d795658c71730e836a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "8ab0de6e43e7fe4257e62634be6e2feeb2299f70e55c8816f093df3369078eb0",
+                                "uncompressed-sha256": "e6f266d24ec373893d567641478772a3116659d9cf0a96779556bcda8875d98c"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210518.3.0",
+                    "release": "34.20210529.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "87433d99229ccf32e6c1ae3225bc1d39c8c4ba79e392cd38e53d844121b84525"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "05a694a286d5d71251d809e9b576e246515ca26721fab4f0ecd2f2bbcfd7caea"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210518.3.0",
+                    "release": "34.20210529.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210518.3.0/x86_64/fedora-coreos-34.20210518.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "3b3f818784dcc787daf1c0772430e0c851d2647fd957a8d87fd5ab64b37784a1",
-                                "uncompressed-sha256": "d01e925a7221e92e737f525e0c10afd5b91e39a0a573d295eb0c47b1624eb964"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "38abf97f6b9a373664622b6e644af5c57aaf5b6590bb66e3113456c7c0930b60",
+                                "uncompressed-sha256": "4df7a9fb5cb5e99adab1ea2f27493a369f234735037bd52bc4102b9662791baa"
                             }
                         }
                     }
@@ -198,95 +198,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-06c96d24608e629c0"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-0d9658cc46b2bba75"
                         },
                         "ap-east-1": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-0372ba3bbe7687b14"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-0af9744b58d7daa93"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-03894a14941c52b30"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-0ab94428891479ef1"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-0d4ae05e9fdec5d97"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-04c85baa47dd9c4ae"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-09767fdf43805533a"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-0116ced9f83bef9a9"
                         },
                         "ap-south-1": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-0bdd68aa25fd10884"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-0e80532558cb43d70"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-091234cd666f426cd"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-0aceb3ded26bfd022"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-071662fd1239cfa44"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-00845f21cfc217cb1"
                         },
                         "ca-central-1": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-08300f655b9d341c6"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-0279d7469dbeb3cf2"
                         },
                         "eu-central-1": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-0daabf1b4e2b138c4"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-045bd5ce8740f23d1"
                         },
                         "eu-north-1": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-00f8790cc3ce86403"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-071f4d145de085a56"
                         },
                         "eu-south-1": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-0b4581fd5e4d1934b"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-065c0013c4f9acc5c"
                         },
                         "eu-west-1": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-0a1df5aef9f735d3e"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-05ce2fe4e1af941c2"
                         },
                         "eu-west-2": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-074d1190fdf54de5d"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-0bfe0b6d09a0a2407"
                         },
                         "eu-west-3": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-0eed8276b81f88646"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-0e87d20b7fbaac4ae"
                         },
                         "me-south-1": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-0cc7e55080040072d"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-08e8257805c57fa2b"
                         },
                         "sa-east-1": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-07a62a31d660412a6"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-058d1fc91de23643c"
                         },
                         "us-east-1": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-05f4509194dbfaf92"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-0e07f67b2ba23f47d"
                         },
                         "us-east-2": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-09a886cdcac1c1ae1"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-0c543290aeb1a985c"
                         },
                         "us-west-1": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-0eb0d64dcb6c67afc"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-05059380788ea2210"
                         },
                         "us-west-2": {
-                            "release": "34.20210518.3.0",
-                            "image": "ami-0937de56fee16b912"
+                            "release": "34.20210529.3.0",
+                            "image": "ami-0ddcec2fee61b8915"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-34-20210518-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210529-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,194 +1,194 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2021-06-01T22:22:20Z"
+        "last-modified": "2021-06-15T13:01:46Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210529.2.0",
+                    "release": "34.20210611.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "c79c837d2d7a5fd7624d9c03806bc566eb3be0f3fa3d6c43c0b8176998093721",
-                                "uncompressed-sha256": "a49a8c33c9c8cb8dbb037b07a664b6b6974640c2acd2099e2f852a56dd3af01d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "923e8e9e12f7ce10194aed1efa9617100ea9138472518b04a76aa744a4d0ea98",
+                                "uncompressed-sha256": "0c6f86da1bd8771153c1820ecef55e7c99dc2d9e5cab584f77638ee191272adc"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210529.2.0",
+                    "release": "34.20210611.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "f718dbd06d6cd394a588c56d9c630a0ec5c59bfc6e39b097fa851b6afcda9bab",
-                                "uncompressed-sha256": "084c5efdd520551af2b55223c392322edd896ae0e063ecdeb2809c05434e03e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "78f61d52de2ecf917fc9c5892c4dc8e2751320669866e9e8fc6b469ec1a52944",
+                                "uncompressed-sha256": "6d4a066f2aaee52932b2a906d7e9f3b8e0ea9b03ec694a3b072a46ff76b6b79a"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210529.2.0",
+                    "release": "34.20210611.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "ed3e06963fc39628bfaf715b0ec39a06ba5cda88f36ad58db843d2e0b2be25e7",
-                                "uncompressed-sha256": "44c2e1a8d4ce7ff293d7563d62084e5dbc23dad080585ea95d41a61acc817c72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "126b9806979cf1e96c1685d3066f5995fc60504a5251cc0919607d3196bd618b",
+                                "uncompressed-sha256": "2d3859b58a745847771b8ef2207e8a22cee613531fdb66fbb5b0d151a97222b3"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210529.2.0",
+                    "release": "34.20210611.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "0d65665c2fcd2da4cbd952175309f81e814dacb7f015a32feeca8c8b48478402",
-                                "uncompressed-sha256": "e08f2b35bf42eb56ab1cbf7c7437e850623d25c842cba83b105f494d4e9fbe45"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "b1d18d9834bfa0f00c923fadd9d054b9cd8c83b7d355e2d28d4cc3a3780c0d9f",
+                                "uncompressed-sha256": "75c1b578760caeaa1e0790f1ec2ca1f85a38a4e387a9ff039fd4136232b2dd94"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210529.2.0",
+                    "release": "34.20210611.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "669af1901cbfdda6712662d70b9266d2ab776fe552b455116570eb18d46fe8bb",
-                                "uncompressed-sha256": "ed194cdde3ba020e03711a8af483dbdff06c2a952cd9412039c776adc8a36330"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "a1873c44df42ede3e4126c7629904c754f7aaa03b76565069a9c5139730b81b2",
+                                "uncompressed-sha256": "3e4f847ec862b7daa0946cede60e114d28d034429e3ccd05ef1a65208d5f39dc"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210529.2.0",
+                    "release": "34.20210611.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "d80c5dab59ef4f0ffb88ebea1250e5f34b0df3105412fd718da3bd9b66dc2d18",
-                                "uncompressed-sha256": "afd8d14fc060b55b9e9d9bbe98a0c2c158b0756af64eae9df20da6b4783e98e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "59594cefbc967742ff948250accf8001e5d515566da7b2866117fb4317c82e18",
+                                "uncompressed-sha256": "dd42438fd8ed834534b5424bd80bae30ed6967ea2ac11c5a57828158f0d2c7ff"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210529.2.0",
+                    "release": "34.20210611.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "59572001a8946aee2ba509501a826cdcd0d4643acf2125c4e5684343998c6a61",
-                                "uncompressed-sha256": "b386db7272b098cc441b283e488cf7d8e1c8964cb80ca28da3d4e4447e822b3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "d222ed2bd95d8ad8442904697d76e5300a3d8caf8f7353879c3dbeb172601aa2",
+                                "uncompressed-sha256": "32e54186c28cb17ab0332f47c79ef444a0cbeaf1bf370e64b1cf8e61df0a8698"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210529.2.0",
+                    "release": "34.20210611.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "311f0eb69d64235bdca25ac184a6e6ad2396ffd2ba70d640bbd4e6f420faf4e2",
-                                "uncompressed-sha256": "ded7eab5b42d6cbf171c17ecdc8558939e6a6a406471ae3128f6fa3319eb154a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "cac7b57c7aae5b20402e1501d9d7e8ebb07418c4898654895af69ca7bb7dfc4b",
+                                "uncompressed-sha256": "0fc690db302de3da962ac40ba55a48bff262ae47d03ad5566689001f25456452"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-live.x86_64.iso.sig",
-                                "sha256": "3712b1ba66a7f632c92921d8666c289ce83299788bc0037a3465814650402a10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-live.x86_64.iso.sig",
+                                "sha256": "1b51b58ed50dba3acd69cbfdf980dab2c8d8664bcccef70c8e666953e6483969"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-live-kernel-x86_64.sig",
-                                "sha256": "dfc85a460b70a01331145840c932778271f8c4ab108b6797adb2c3e0cd98b4ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-live-kernel-x86_64.sig",
+                                "sha256": "442c063a0a077fc45d59d804275532e99813e7eaee87b5a3aefdd62a6287b668"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "3e59c8473c858293a07e1b998b5adc3b718b49f286e211478a4dcdf9c8d509ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "c549754427223f2cf92e8af74e5cf854594ad2cd1845cb6d490d3ef101facb0e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "53c24ff061041bb4f9f52c8d3aca017649c07f1c136346cb82a7fe521193c7a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "dd7d41bdf63c1a6d9f020eae8ea4d0261e765c9d11c989fa3a816827256da114"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f356b4bb67cfef1675cb3913e3e686f025866999241cd32388efd8265338f75b",
-                                "uncompressed-sha256": "27253c9dc231de190a2afd47e63bf04f409f7d830f050430ca1f9a88ccbc867c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "d3baed4f885107f99e5e97145a3855687f986bd59446560bcd92c52509d1e11d",
+                                "uncompressed-sha256": "864925eb1fe732ef46de1f3cca4f81f2c78e16befe2bf62a61d01f4f28d1372a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210529.2.0",
+                    "release": "34.20210611.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "163240cc6e38166a96618944c0043a01c4ca7cca7ab6922b95b8cbbae6cdc800",
-                                "uncompressed-sha256": "c22b580bba7ce267c0dd7a8fd2f631ae5b7954fd77818c87b6c68a00d8fdc6ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "bb51435bcd81c5638166e0906c0436f11f84e911deeeafd25c14a546891d7458",
+                                "uncompressed-sha256": "08c0cf466340182eda9977f9b88ba3035c6969c49ec22ece5c3aa9b31400fe81"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210529.2.0",
+                    "release": "34.20210611.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "b5fb45010e48d8248a1ac2bc79d01ffd5aad20f7207a4c011fe6075c3568520f",
-                                "uncompressed-sha256": "08d4dd3cbbec1fd9a287eed793d6ba395b606cfe0ac443688fa4ff036590e03c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "68bb4a9db904eae4ef9e832757d519fb10da5430f20e366fb1f040e40600cdbd",
+                                "uncompressed-sha256": "b5b155bcb5324f30f70fcb732729cda3e0ee094b3743f9acd6a0a2129f18781a"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210529.2.0",
+                    "release": "34.20210611.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "80fcc67466d786a553c8f3e3648f469864509aed106f35136a52118728d1b013"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "a6347452aeac4e61f91820cb3fc1e95a0766355f9488ac10f2638db404486fe0"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210529.2.0",
+                    "release": "34.20210611.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210529.2.0/x86_64/fedora-coreos-34.20210529.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "9b8e0f245fd2bd0120578b31aa1a11f4994dba4fcaf1e33ce73ca7c110637737",
-                                "uncompressed-sha256": "128d7298f8f651019be40e55083c048ac6e35918c49f68a92b4514247dc079c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "3ac7eadfb5380fefbecb2a77e471add90e5017027e6c86dddf15fa19c45fc879",
+                                "uncompressed-sha256": "424f48f6c73de941ce0a020e343f068fbd508b02b1721fb736c306325cd24d46"
                             }
                         }
                     }
@@ -198,95 +198,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-0be58a6357a6fad95"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-0595a41a9036ff1b5"
                         },
                         "ap-east-1": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-00114103df8ad1697"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-0d64a6d53c18fe821"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-053ce3b5390867dd7"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-01f21ff714cbd13fe"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-030b7074a5d6246db"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-0c07fc05ec20f5a4d"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-09b5f4604f6652b42"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-0d350146365a3e99f"
                         },
                         "ap-south-1": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-0508c7cc3cfd01a1f"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-0cf70b8df182aae11"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-0f97a2a3ebf188078"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-0a23b1f38b242d0d1"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-0f1731bc27008b6c0"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-0c31a788cc9516b25"
                         },
                         "ca-central-1": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-0f8a4f3e5c3e48b49"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-0c17c488061ec1fee"
                         },
                         "eu-central-1": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-0fbb39979716a611c"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-026cb53190f09100b"
                         },
                         "eu-north-1": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-0adf6c6a17bdbc709"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-033580dc57c177f79"
                         },
                         "eu-south-1": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-038da8a7956797148"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-0c8e0cb3b7e57eeaa"
                         },
                         "eu-west-1": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-0f12216dbd45e96db"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-00391f682d6b1c690"
                         },
                         "eu-west-2": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-04cb7f968c51836f9"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-01ad0911912125001"
                         },
                         "eu-west-3": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-00e9df34e2336a96e"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-0f7fa00ac7331acc1"
                         },
                         "me-south-1": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-01b1f3ae7a15d4bfe"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-0d1d4c549f18dfcc5"
                         },
                         "sa-east-1": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-0309cc4a6b8f5fb77"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-0eed4f6280d7393ad"
                         },
                         "us-east-1": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-0874588a8f0420e41"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-00d64eec143b95153"
                         },
                         "us-east-2": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-03fc905e37d532098"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-0ee315881b48a629f"
                         },
                         "us-west-1": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-0137c2aadb3b45f42"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-0f1b3a1765b8c13b5"
                         },
                         "us-west-2": {
-                            "release": "34.20210529.2.0",
-                            "image": "ami-02ff046c7fbe71d7b"
+                            "release": "34.20210611.2.0",
+                            "image": "ami-099651d09827184da"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-34-20210529-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210611-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2021-06-01T22:19:31Z"
+    "last-modified": "2021-06-15T13:02:01Z"
   },
   "releases": [
     {
@@ -29,7 +29,7 @@
       }
     },
     {
-      "version": "34.20210518.1.0",
+      "version": "34.20210529.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -37,11 +37,14 @@
       }
     },
     {
-      "version": "34.20210529.1.0",
+      "version": "34.20210611.1.0",
       "metadata": {
+        "barrier": {
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/829"
+        },
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1622642400,
+          "start_epoch": 1623765600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2021-06-01T22:19:31Z"
+    "last-modified": "2021-06-15T13:01:11Z"
   },
   "releases": [
     {
@@ -37,7 +37,7 @@
       }
     },
     {
-      "version": "34.20210427.3.0",
+      "version": "34.20210518.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -45,11 +45,11 @@
       }
     },
     {
-      "version": "34.20210518.3.0",
+      "version": "34.20210529.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1622642400,
+          "start_epoch": 1623765600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2021-06-01T22:19:31Z"
+    "last-modified": "2021-06-15T13:01:46Z"
   },
   "releases": [
     {
@@ -53,7 +53,7 @@
       }
     },
     {
-      "version": "34.20210518.2.1",
+      "version": "34.20210529.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -61,11 +61,14 @@
       }
     },
     {
-      "version": "34.20210529.2.0",
+      "version": "34.20210611.2.0",
       "metadata": {
+        "barrier": {
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/829"
+        },
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1622642400,
+          "start_epoch": 1623765600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
* stable: 34.20210529.3.0
* testing: 34.20210611.2.0
  - adds barrier due to https://github.com/coreos/fedora-coreos-tracker/issues/829
* next: 34.20210611.1.0
  - adds barrier due to https://github.com/coreos/fedora-coreos-tracker/issues/829