### PR TITLE
Triple update on 2021-06-29

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,194 +1,194 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2021-06-15T13:02:01Z"
+        "last-modified": "2021-06-29T10:21:47Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210611.1.0",
+                    "release": "34.20210626.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "71c6c54479ac4bb8decb4a6ac66123f38132a3141d6c7a4097e342431db7a0fd",
-                                "uncompressed-sha256": "6a574501623126b1f69f9c6beb09ff1cbcc7ba7fc502ba48a42d8db5b3ff3033"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "6ad9b8dcab7d249385c1555cb81a0975ff513208969064bf9b13892edc087ae2",
+                                "uncompressed-sha256": "2d7d18789a3af0a7d0275f5ab813a4a467a854fa601f537ba16d6c16014697f4"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210611.1.0",
+                    "release": "34.20210626.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "997014d6c42c823f973d3dcf09aba1deed4724768940e94da8db5d869c494ab6",
-                                "uncompressed-sha256": "946afa7e44e1c2d7c45eb2e919cf1a829a1f293b4c89b1484c9151235d8bd746"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "e139fdbc993daaeb46d0ebde521b1cbd30cedb96f32754ee59f22ac41c0ab7d9",
+                                "uncompressed-sha256": "78061f2819c5dd3351bd2c3430669225af582c2742264e51a227b4e47b7785ad"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210611.1.0",
+                    "release": "34.20210626.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "1589c88b53e56e1fb316f2f95d28f0ab5b05629b04978bac44cdb7609db18306",
-                                "uncompressed-sha256": "51ab21b52db99659ce93925e4130cbc7f47658d8373900db1b32a644ce00d0b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "a0f213157520d5c6fc90f5fcdb882d8072349eb799150feb9d3d90ae62795b0e",
+                                "uncompressed-sha256": "f5b7e485e918f0e92dd1f55814e86ac56cff155aef5653677150e0b148220d7c"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210611.1.0",
+                    "release": "34.20210626.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "654a65c3b12eeddfc086c6a920acd683c5c9e06349ac3de1182b1d5b03148b2e",
-                                "uncompressed-sha256": "2394e96582e607b9a77c6cc1eabe717c0fff84811d63f410ad6a7d1b88b19713"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "530a095e636c17378ea3a67ecdb4edb41b0a97a1956d64c56cbde0551088fcc8",
+                                "uncompressed-sha256": "d102d26f3b62524d33480509a7e38862f314904ebca5d633cb643cd8574ec125"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210611.1.0",
+                    "release": "34.20210626.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "5db77decc2222359f6ce632b426593bc564ad78598dc30e71227b2876dfba92e",
-                                "uncompressed-sha256": "bed260d17d93aa1cfb4810cc49709a80e34743886c0e9a62026ea206017ee09a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "92d2ed7c2ed57a8231366ab00e3395b4a6544164be78ef484f8dd626a4e46fb4",
+                                "uncompressed-sha256": "2ce3c9a1956c88f257302fe78e0e6b3217322b5db278013431aa7c41468ef84b"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210611.1.0",
+                    "release": "34.20210626.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "feffd79fffcf0d8ffb7d6949999611b05b98fe92d7a6cc5e18df9fb0aebccc24",
-                                "uncompressed-sha256": "ce5ef04e303382345b7e602d253a46eba41cf19dafa3c10262733bbeced80c97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "a4e538c7236a9976cf3bc9ce36e99e663876f62f0dc54bed6de7c88f977acb85",
+                                "uncompressed-sha256": "b92eb82f0ca180a27b40432bc7ecdfa32c0aec39be07f539715d6e3ce935ea39"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210611.1.0",
+                    "release": "34.20210626.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "cf16d4ab05ecc2d4ff4c5c7d4dc498db59bdaddeb9762d86b2028609ab3d5574",
-                                "uncompressed-sha256": "923fd927103af335dcd5cd55ba86452404b58f0f0c5bde5ceaa10b3e1c0706d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "7b58c456e98666437a83c6c0450d9c7bc6bb93fa2e3261785a53930200c6b014",
+                                "uncompressed-sha256": "3b95f6e3ec8bff029ba4535364f241ce103fc9da56e3ead9693ccbf8800b03ff"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210611.1.0",
+                    "release": "34.20210626.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "eaabd1073bdeb2801d36661854e8668ea156fc6fa1b0d316e0d8baecec854073",
-                                "uncompressed-sha256": "6eefaae9e5282a4d714b35fd88d0fa124e5fc30a3fbe512d435fe3226f693c15"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "100ffbbd6f405ff5eafde764b37be26e128dd0f0f43fe7926632f0644bd3944a",
+                                "uncompressed-sha256": "9cd4d5c2d5b94c22258c3b0d6aa055c3c79446787aa802b1676279ec82321c37"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-live.x86_64.iso.sig",
-                                "sha256": "91de91d457c34568b7f63eb628234dc4d723c25379f7187f0cb119f3eac17a8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-live.x86_64.iso.sig",
+                                "sha256": "9e3018484b2de83fc4464a9d236ef378c34493b6e38265d7bedf71868543beb0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-live-kernel-x86_64.sig",
-                                "sha256": "442c063a0a077fc45d59d804275532e99813e7eaee87b5a3aefdd62a6287b668"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-live-kernel-x86_64.sig",
+                                "sha256": "e4b5cac76b9f5991a488f2f8d178d82f70cce3457f62986c0136ba19a0463aa5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "ff8522ca60dfb4089e7ba0445432c6490ffa41237295aeb2373bf2051f71cecd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "890009177cc852e0613dad9a18807d8e13a65fdf42cbd340628a49eae92eb1e0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "7f6665483b496c1b7b05b3fc8bf389a1042e69560f9a7d537636e275f1a23819"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "42f079434a0f4bfa50810048b8010d2478c5c7f8f438db33303399f4b126326e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "3c15c480c7e27aea1c4a5c17cf0882cdb68692b40cdacf3e72d663324fe6515c",
-                                "uncompressed-sha256": "1a998a7049118413994efc848f4794f85fc42ee831aaa7ef77627ad44bdd43ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "80920fc744abcc0012f92f877dc8b0ab9bf1f827afcbcfe41cb08420df744994",
+                                "uncompressed-sha256": "637ae1d30267bdb9356e962410007250b85e7c03904482907720f25662015f6e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210611.1.0",
+                    "release": "34.20210626.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "2023ab7c4f7d0bf747f904188b93e36cb4f9e077760ab7e96c5336ed32c27e8f",
-                                "uncompressed-sha256": "65a774c2f2cc45e970031efec1b58b37869136be04656d4837543da4c9d00d17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "a39dc81dcbd14c958198cd6af5f5f317040ac0d22dd86b8229651bb5eb9a1657",
+                                "uncompressed-sha256": "f4311a8fc3d6e31ecd29eaa8466550df0abdd5989fa337a72e552cc563156055"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210611.1.0",
+                    "release": "34.20210626.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "a9a7efd2f02d27781dfab6299795d0fdb9bfd674575d58a810ac9e38a642a5da",
-                                "uncompressed-sha256": "0733ceae3488ee3292fe9b240e5d5115efa40e37f5bfc5ba2b4af5fc54b90383"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "b54fe896e42722215cf63ffdd10c4bddfc4731ba9431920d268c8d38026edf5a",
+                                "uncompressed-sha256": "d299427de350d34ef1587bf1ae02806dde6437191cb817705f484548bc07eb3c"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210611.1.0",
+                    "release": "34.20210626.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "ec7ecf8f9ccdfffc50db7c1092b08a8f585a83b1cd02081e5d9ab8d2a704842d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "028288b78859b499badcab5fd0bfc15242fbb12cddda3ca866f61610753723f5"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210611.1.0",
+                    "release": "34.20210626.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210611.1.0/x86_64/fedora-coreos-34.20210611.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "de5586e3cca3a9af4995152e1ea097ddca9302d8a05fbc76f0d71684a823de39",
-                                "uncompressed-sha256": "2027a1247256d53902e28f7a1052080c90c903adf004055a3345ae48f9c92268"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "235e822a0891933d47409e0aa93abbea53d731f5fbcaf767ae8a293d4ff33619",
+                                "uncompressed-sha256": "ba2ebe517f17ba4b1e606d76653a55a9f407f85eaf78a6f42f897cbc4f50762d"
                             }
                         }
                     }
@@ -198,95 +198,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-045c03871a30ca725"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-0055a332043a335fa"
                         },
                         "ap-east-1": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-0b119883d11e8f80b"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-038050f38cff43a1c"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-0617c4ba1e936e740"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-0643e77681e5e0761"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-0445799de8de61a8c"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-03a55a95123b3015e"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-0753b9d604907564c"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-05ef9d9493ec8a8ee"
                         },
                         "ap-south-1": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-03eee78efb8655b6e"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-0ea299f2ed61895e7"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-0df9336cd175589b7"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-0cb473a5d5bee695b"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-06b180dc729537164"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-048ca90cd22cff299"
                         },
                         "ca-central-1": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-0c112de76b863daa1"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-0fc9d206b849bd223"
                         },
                         "eu-central-1": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-017795ffa3d7a67e0"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-0fc283621c36a6c60"
                         },
                         "eu-north-1": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-0820f76088f3470a8"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-0d8f09075eea31b5c"
                         },
                         "eu-south-1": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-06c5b898ca96812c0"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-009046e8bf7cb8367"
                         },
                         "eu-west-1": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-0c4ef402497460886"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-0b8c130b52590c7d7"
                         },
                         "eu-west-2": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-024767ce25072b530"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-074e5cb02a5b36eab"
                         },
                         "eu-west-3": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-0be3d5139f64dfa17"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-0b71a4a60538971e4"
                         },
                         "me-south-1": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-09465c32e43acfa1f"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-0803285d1da8486ae"
                         },
                         "sa-east-1": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-0a3c71b8eae767ada"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-0ef790f82ce8fe611"
                         },
                         "us-east-1": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-0a94066cec0494062"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-0faa25bccd0fbfde2"
                         },
                         "us-east-2": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-0b806ee8e86a357c1"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-0f1ebc6b87b3481dd"
                         },
                         "us-west-1": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-032038949d6be409f"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-0f39b781300e81a1f"
                         },
                         "us-west-2": {
-                            "release": "34.20210611.1.0",
-                            "image": "ami-04c8253d62eade588"
+                            "release": "34.20210626.1.0",
+                            "image": "ami-0c904a33ddec6ff0d"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-34-20210611-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210626-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,194 +1,194 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2021-06-15T13:01:11Z"
+        "last-modified": "2021-06-29T10:20:31Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210529.3.0",
+                    "release": "34.20210611.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "5a3dfd994f9054bafdfdd9ec195405d1026120a28548777ec28aa889a64602ae",
-                                "uncompressed-sha256": "24516c9e7b300886d3ae8e765da6c34aac9f921d7578bcc1a9f03cfe6b709c14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d06f9e4b95cdf63399ea33b1b025c31b8c6ca306186f56c1c6058facbe1e713a",
+                                "uncompressed-sha256": "8d0a7396ba8a2ef6241c50dc388571eefb610d20474300750d4f2b43c4f39f54"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210529.3.0",
+                    "release": "34.20210611.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "5d27c14d45c248318fa4b9f3f4f370609fae876e73c0ca0a39eb7a5315ce1b58",
-                                "uncompressed-sha256": "6c13c8a252c14d9dc2ddbde51751f21ef1ef36d6bf605afc7ff80da42682efd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "e4265b558a810fe155b1382e0f449623c97ad05f5db8d403a8c39e17ef1231f4",
+                                "uncompressed-sha256": "900d39e7dc3233d195d2bda246df6d01bbed6e3d16640e57ff365dd197d8a707"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210529.3.0",
+                    "release": "34.20210611.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "76264cfc2e8b43039165a68cf901640ec22313651f93bb598c529f6367a2d0da",
-                                "uncompressed-sha256": "d7dfd005f3e49b0548a8195008ce10c4df38c033404e3382d3e24a741e0bc393"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "f1a9246cc06351cc336d99503a6908977e270f39476076d0d98cb31fe74cd5bd",
+                                "uncompressed-sha256": "29077dd5aba77a3b804fdac71dd9970fd0fee4d85043f2215f962d9c78609fd3"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210529.3.0",
+                    "release": "34.20210611.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "e9332286a3e5d59d81d90087492f9512251ebfb1894ca8749e6e285c9b640565",
-                                "uncompressed-sha256": "f381c0d15a09c8dd9079e469fe6a7e89cb2a2fa3fbfc92e8fe8cab40955b2a90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "af97c547be7f62aea814cdba9bd33aace0537a740f00adbaf253cbe03f24d17b",
+                                "uncompressed-sha256": "7eb37fefcaafd8a9b90bd78d5820283ae49d4507ad554b112008b202acaddcca"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210529.3.0",
+                    "release": "34.20210611.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "3d0981598152a26d39b06ccb469dd02c4a56db7edd682fcb9640cd183bd9fafc",
-                                "uncompressed-sha256": "22891e54fbc8294d5c161bd30091af4575e7884cd5b8f98ce62a1465f72a1733"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "c84fde3e9d18f3555b51aa8e5151a20937a512fdcb65f602dae0f1f06d6835bf",
+                                "uncompressed-sha256": "829539126ee086a17feaf541794fce6f5eba53733a050f072a0833d3bbc79488"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210529.3.0",
+                    "release": "34.20210611.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "7f4279504b84ae9245defe78c7446ce97587fdd57d78917c7b80878a22887cd3",
-                                "uncompressed-sha256": "03043832765e77fc1a0efada4a8c8297512625869e6389eef62db31490e98f9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f177f926c6ad2c5b64b410a9accc692348950d95603783d6d9ba0f8477fe2b33",
+                                "uncompressed-sha256": "b36657d096a5a7dc7d5391bb1da876d7c6a2f6d306a6f0713f0a147bb8d6f744"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210529.3.0",
+                    "release": "34.20210611.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "69d68f768e5994e29b0cd9246b84a7ac6bf659a27efbed68e52239922a77dc22",
-                                "uncompressed-sha256": "9387cdd290856307ee96d18a0cc1e05be164262c9ad499279ac294fb26e6a697"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "f4d784ae39732a0d79f7ff7f50df422707c2ba3bd25300c13313121f513e9abc",
+                                "uncompressed-sha256": "0cad3503c3339f9524310b94989633a9c0d578e28f3d5c443d4af4cc55556665"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210529.3.0",
+                    "release": "34.20210611.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "7c7554aee94b9783114f37d710cd2530fc401e874da29a1066272fea4baa562c",
-                                "uncompressed-sha256": "8deee2008c44d18d71d00505094bf42d0fab70c66a43a6c60f49f56e256a1b06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "c57d2e88cf3b4dcb4303a676bb93b5a414e5b83993b82737d61096b5f81eca09",
+                                "uncompressed-sha256": "a49d6c869dfcc30b272a3a35f25282f1481f12bf257cabf44f990214f972d5b0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-live.x86_64.iso.sig",
-                                "sha256": "6bec8c1e67747c4d2fd8dca8bb833b74879d9c60c99d9edd4c4f17e2830ed6f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-live.x86_64.iso.sig",
+                                "sha256": "ddbbc69071edb9f0e19c2a55d0ae34f7c0a33b082f8a142edce3fce78c7b423a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-live-kernel-x86_64.sig",
-                                "sha256": "dfc85a460b70a01331145840c932778271f8c4ab108b6797adb2c3e0cd98b4ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-live-kernel-x86_64.sig",
+                                "sha256": "442c063a0a077fc45d59d804275532e99813e7eaee87b5a3aefdd62a6287b668"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "333a0cd004687eeaef68be7e59187fc7b045e506f5f17e51e971dbd77c3545b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "c514138e118a521a67a8e61f6dc287e3641ad211f36d0fd40410f36311c6c8f7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "5eac1506df192ebf1a0d9ce75328a24a8283e671ada74cd94592264fb063b9f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "5549fc6495406ec3c66cbe331d2ea07f768f9bb765b05e020854b5d20ceb1aa8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "6689c64d37d198295d27e92ca8b2b94d6b9c16776fde9e5b771004281bf3deff",
-                                "uncompressed-sha256": "09b1e42984d6e1729d29671708809c5fc3c0594b20c2dd41d5e45dbd26a4b02b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "c1839371311aaf52c64f83beec3660be95cbf6a50518d953f56560a7dba558f6",
+                                "uncompressed-sha256": "d819e21a492672ef6398a9954c19d6e51b3f2c91da24539836196a894e5fe4e2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210529.3.0",
+                    "release": "34.20210611.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "4a398a9eda48cf9ee654b8b56b757cb29f9f8a152f627b834c0fc129a8f9b37d",
-                                "uncompressed-sha256": "c86d0826300b403f528ea6f1bb81ac6ec9d1b73def80f3c9035730ea0bc5121d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "898aec6030b015ea4ac023639ee5889b3b826e093d30f8e140eb4a91ef3df771",
+                                "uncompressed-sha256": "781cf76a990376c134be8fcf925d15e52199739959ff715f0d89d3bb3d3c616c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210529.3.0",
+                    "release": "34.20210611.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "8ab0de6e43e7fe4257e62634be6e2feeb2299f70e55c8816f093df3369078eb0",
-                                "uncompressed-sha256": "e6f266d24ec373893d567641478772a3116659d9cf0a96779556bcda8875d98c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "9a362a7b13e213d8fb01d4c371c3f99893e6a418a60eff650b734c9683f1b06f",
+                                "uncompressed-sha256": "7e358c905664fcb65d99c4ed755a1be2f09291da6288ef818c0a348507a087c3"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210529.3.0",
+                    "release": "34.20210611.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "05a694a286d5d71251d809e9b576e246515ca26721fab4f0ecd2f2bbcfd7caea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "83ddeecad881d4d10dd482637ef358a419f81b331b61f3f7e268dbf3fb9bcb79"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210529.3.0",
+                    "release": "34.20210611.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210529.3.0/x86_64/fedora-coreos-34.20210529.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "38abf97f6b9a373664622b6e644af5c57aaf5b6590bb66e3113456c7c0930b60",
-                                "uncompressed-sha256": "4df7a9fb5cb5e99adab1ea2f27493a369f234735037bd52bc4102b9662791baa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "5a1d83ad2ec7f20e28b4a4d8b1dbb4fd36b298a1c70ec24c77521e4135c843ab",
+                                "uncompressed-sha256": "fce9ab78adbb57571f964bb6df52b5016931aec7f9620c3101d13207f3a75830"
                             }
                         }
                     }
@@ -198,95 +198,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-0d9658cc46b2bba75"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-0f85904f1eece9be4"
                         },
                         "ap-east-1": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-0af9744b58d7daa93"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-086e63f5ec79e871f"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-0ab94428891479ef1"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-0edc9b77ec0874af2"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-04c85baa47dd9c4ae"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-045941f3f3b40279e"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-0116ced9f83bef9a9"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-053fc90293e75b741"
                         },
                         "ap-south-1": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-0e80532558cb43d70"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-0f6c9569ffafa3c45"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-0aceb3ded26bfd022"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-037ad7fa7ba5ac2bb"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-00845f21cfc217cb1"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-0d4b3acab30fd5a14"
                         },
                         "ca-central-1": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-0279d7469dbeb3cf2"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-02872e5ac2ddb0b16"
                         },
                         "eu-central-1": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-045bd5ce8740f23d1"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-0623bcfdf5ed6bd8f"
                         },
                         "eu-north-1": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-071f4d145de085a56"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-095571310fb53a8e8"
                         },
                         "eu-south-1": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-065c0013c4f9acc5c"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-040c6e8df21ddfe4b"
                         },
                         "eu-west-1": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-05ce2fe4e1af941c2"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-0982ca2ae194642ee"
                         },
                         "eu-west-2": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-0bfe0b6d09a0a2407"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-0ceb66edf0dbfbff9"
                         },
                         "eu-west-3": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-0e87d20b7fbaac4ae"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-0c32288e18a905d94"
                         },
                         "me-south-1": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-08e8257805c57fa2b"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-0b8de51051c7c5112"
                         },
                         "sa-east-1": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-058d1fc91de23643c"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-09f3248646cf93b7a"
                         },
                         "us-east-1": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-0e07f67b2ba23f47d"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-09b4202f59cdad6b2"
                         },
                         "us-east-2": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-0c543290aeb1a985c"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-0181add94216f0eed"
                         },
                         "us-west-1": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-05059380788ea2210"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-0e027e5590a693bfe"
                         },
                         "us-west-2": {
-                            "release": "34.20210529.3.0",
-                            "image": "ami-0ddcec2fee61b8915"
+                            "release": "34.20210611.3.0",
+                            "image": "ami-0d97468e42613f2fa"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-34-20210529-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210611-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,194 +1,194 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2021-06-15T13:01:46Z"
+        "last-modified": "2021-06-29T10:21:17Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210611.2.0",
+                    "release": "34.20210626.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "923e8e9e12f7ce10194aed1efa9617100ea9138472518b04a76aa744a4d0ea98",
-                                "uncompressed-sha256": "0c6f86da1bd8771153c1820ecef55e7c99dc2d9e5cab584f77638ee191272adc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8a5ac227de31c2b7cdccc7b546e3e165a915e7d5c5535ac7022ad8148ae7bc5b",
+                                "uncompressed-sha256": "12b6fc9de963fd9318e50532dcae3efa706bfb1b2a02e532f230b796cd6f2570"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210611.2.0",
+                    "release": "34.20210626.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "78f61d52de2ecf917fc9c5892c4dc8e2751320669866e9e8fc6b469ec1a52944",
-                                "uncompressed-sha256": "6d4a066f2aaee52932b2a906d7e9f3b8e0ea9b03ec694a3b072a46ff76b6b79a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "39ed71217a276e6bcbdeccd3cbbfd67a34d09101bfb9e7a2b6cc048c03fb23d7",
+                                "uncompressed-sha256": "4fbfde923d7b0e243f20ab81124bee20ef4e21b9842421b18926c4db1d8857a3"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210611.2.0",
+                    "release": "34.20210626.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "126b9806979cf1e96c1685d3066f5995fc60504a5251cc0919607d3196bd618b",
-                                "uncompressed-sha256": "2d3859b58a745847771b8ef2207e8a22cee613531fdb66fbb5b0d151a97222b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "eb9ef79c36d99d22656c3308992524304fe4959807af374c962fbd162f19f046",
+                                "uncompressed-sha256": "1669e2f28260762278571569e5465fad07dff7d8391e19dbd1364ef0a90d3719"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210611.2.0",
+                    "release": "34.20210626.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "b1d18d9834bfa0f00c923fadd9d054b9cd8c83b7d355e2d28d4cc3a3780c0d9f",
-                                "uncompressed-sha256": "75c1b578760caeaa1e0790f1ec2ca1f85a38a4e387a9ff039fd4136232b2dd94"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "00ca38e6fe69738a22ad58dce6b023d043f51db8198a056cc87c553d04f5fbb5",
+                                "uncompressed-sha256": "fdad83ec1519c9ee6ec6056c6962f8e7652c5789d6b18463dedd32aaaae302b4"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210611.2.0",
+                    "release": "34.20210626.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a1873c44df42ede3e4126c7629904c754f7aaa03b76565069a9c5139730b81b2",
-                                "uncompressed-sha256": "3e4f847ec862b7daa0946cede60e114d28d034429e3ccd05ef1a65208d5f39dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "09c084cc040af5fd1d1012f5ed52f67da5b373d19ada3b5d8ccef7c649e76cde",
+                                "uncompressed-sha256": "7c4ac26830489429e35192ba11379b94873b652424fe9505241fb47074d29521"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210611.2.0",
+                    "release": "34.20210626.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "59594cefbc967742ff948250accf8001e5d515566da7b2866117fb4317c82e18",
-                                "uncompressed-sha256": "dd42438fd8ed834534b5424bd80bae30ed6967ea2ac11c5a57828158f0d2c7ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "1c73752a3686f580fa86dd1a1f1a4bc12c616e431f8d01d2ccc2fe9c7d048935",
+                                "uncompressed-sha256": "c32629174d753571351d632af3c4ed7bd48f536733cb8f4902f583753338d3e3"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210611.2.0",
+                    "release": "34.20210626.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "d222ed2bd95d8ad8442904697d76e5300a3d8caf8f7353879c3dbeb172601aa2",
-                                "uncompressed-sha256": "32e54186c28cb17ab0332f47c79ef444a0cbeaf1bf370e64b1cf8e61df0a8698"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "da7abcc7666187851a62636e98d56d519417ce8ba56e6dd14b6e17c3200dd119",
+                                "uncompressed-sha256": "3e3f59e6b8ab3493e1ed7f2dfb046fe5a5bc91a16f40df5fd55a7021903e1be8"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210611.2.0",
+                    "release": "34.20210626.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "cac7b57c7aae5b20402e1501d9d7e8ebb07418c4898654895af69ca7bb7dfc4b",
-                                "uncompressed-sha256": "0fc690db302de3da962ac40ba55a48bff262ae47d03ad5566689001f25456452"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "de374a7234ff93117cd44c2c580cd621f74f08ff13af25cfe0e45ceb774fb35e",
+                                "uncompressed-sha256": "a2d8d87fc46e0ab0ba778684afb041fa795847d59c3ab56e58de58d5597df871"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-live.x86_64.iso.sig",
-                                "sha256": "1b51b58ed50dba3acd69cbfdf980dab2c8d8664bcccef70c8e666953e6483969"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live.x86_64.iso.sig",
+                                "sha256": "598587080f2a96770d660e3d42dbdb1059aabca9d8eaaeb5222b68b92e26d225"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-live-kernel-x86_64.sig",
-                                "sha256": "442c063a0a077fc45d59d804275532e99813e7eaee87b5a3aefdd62a6287b668"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live-kernel-x86_64.sig",
+                                "sha256": "e4b5cac76b9f5991a488f2f8d178d82f70cce3457f62986c0136ba19a0463aa5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "c549754427223f2cf92e8af74e5cf854594ad2cd1845cb6d490d3ef101facb0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "e17f6082861fefced56d908af54a3a43832823fa9447dfac5327e9ff250dbc83"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "dd7d41bdf63c1a6d9f020eae8ea4d0261e765c9d11c989fa3a816827256da114"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "043472e6e1b8bbb7f3907b5df5ae890dedb765424b763dff6e8bf8657b9739c2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "d3baed4f885107f99e5e97145a3855687f986bd59446560bcd92c52509d1e11d",
-                                "uncompressed-sha256": "864925eb1fe732ef46de1f3cca4f81f2c78e16befe2bf62a61d01f4f28d1372a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "156cfd20264af88b1efe41ea41f8eb929a0fc98704293ec7f5a1f1524658ade6",
+                                "uncompressed-sha256": "0502afe6689566ec5661cd39435f82e864a1d057eacb50fa4889925c2b552571"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210611.2.0",
+                    "release": "34.20210626.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "bb51435bcd81c5638166e0906c0436f11f84e911deeeafd25c14a546891d7458",
-                                "uncompressed-sha256": "08c0cf466340182eda9977f9b88ba3035c6969c49ec22ece5c3aa9b31400fe81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "a83fc15db3e2274fc3e9f3909c08d2784e1e3a9352276fa30954f62a49e2ded7",
+                                "uncompressed-sha256": "24cc37d752028c8f78dd4aed66e13eb294e9a07c0e1c506ccabc33459faccff1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210611.2.0",
+                    "release": "34.20210626.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "68bb4a9db904eae4ef9e832757d519fb10da5430f20e366fb1f040e40600cdbd",
-                                "uncompressed-sha256": "b5b155bcb5324f30f70fcb732729cda3e0ee094b3743f9acd6a0a2129f18781a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "6f1e5e38eb9dac07466433665cda204bfee2cad144acba0aba9af75e76b27919",
+                                "uncompressed-sha256": "490ab7341a4a7fffda5fbf56bf022ddc71161af492d0eb9cbce2239318d1d064"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210611.2.0",
+                    "release": "34.20210626.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "a6347452aeac4e61f91820cb3fc1e95a0766355f9488ac10f2638db404486fe0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "7a178acb5a43b26c31631cbbf928f471e639641d179c779197e7d763b9110414"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210611.2.0",
+                    "release": "34.20210626.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210611.2.0/x86_64/fedora-coreos-34.20210611.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "3ac7eadfb5380fefbecb2a77e471add90e5017027e6c86dddf15fa19c45fc879",
-                                "uncompressed-sha256": "424f48f6c73de941ce0a020e343f068fbd508b02b1721fb736c306325cd24d46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "4e42cc1fb80329646969da90fca7153ffae26952b663012e1b90b351d5715693",
+                                "uncompressed-sha256": "3c601db2b2a9a1231d91b53bbda4fa765661de8a81a2abc6fa1f69180c42202b"
                             }
                         }
                     }
@@ -198,95 +198,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-0595a41a9036ff1b5"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-06ce6cd7ae14d4e36"
                         },
                         "ap-east-1": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-0d64a6d53c18fe821"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-0c523b93e7931c390"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-01f21ff714cbd13fe"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-0b1bc3f2c1bc08b69"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-0c07fc05ec20f5a4d"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-03345d33cb26bc661"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-0d350146365a3e99f"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-01e001d8864b4f29d"
                         },
                         "ap-south-1": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-0cf70b8df182aae11"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-0fce67cf8e9812a76"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-0a23b1f38b242d0d1"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-0674b758a90e82f9d"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-0c31a788cc9516b25"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-02234d79a973a5f53"
                         },
                         "ca-central-1": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-0c17c488061ec1fee"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-08c1b1b41febd498c"
                         },
                         "eu-central-1": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-026cb53190f09100b"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-05d1ebfc450ec9f1e"
                         },
                         "eu-north-1": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-033580dc57c177f79"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-0c304efcf489e8a4f"
                         },
                         "eu-south-1": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-0c8e0cb3b7e57eeaa"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-049e141bcf79024c5"
                         },
                         "eu-west-1": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-00391f682d6b1c690"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-07a6835aaad9cc5ca"
                         },
                         "eu-west-2": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-01ad0911912125001"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-06c4d4769614a43e0"
                         },
                         "eu-west-3": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-0f7fa00ac7331acc1"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-06e938ee9a84c2d3e"
                         },
                         "me-south-1": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-0d1d4c549f18dfcc5"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-00e6941c14327860a"
                         },
                         "sa-east-1": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-0eed4f6280d7393ad"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-0fed26dc669439cdd"
                         },
                         "us-east-1": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-00d64eec143b95153"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-0dcce6fefedc4780c"
                         },
                         "us-east-2": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-0ee315881b48a629f"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-0227bf3374a60ff8b"
                         },
                         "us-west-1": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-0f1b3a1765b8c13b5"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-081afa57703a058b9"
                         },
                         "us-west-2": {
-                            "release": "34.20210611.2.0",
-                            "image": "ami-099651d09827184da"
+                            "release": "34.20210626.2.0",
+                            "image": "ami-07597603ac267ab05"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-34-20210611-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210626-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2021-06-15T13:02:01Z"
+    "last-modified": "2021-06-29T10:24:49Z"
   },
   "releases": [
     {
@@ -29,22 +29,22 @@
       }
     },
     {
-      "version": "34.20210529.1.0",
-      "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        }
-      }
-    },
-    {
       "version": "34.20210611.1.0",
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/829"
         },
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "34.20210626.1.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1623765600,
+          "start_epoch": 1624977000,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2021-06-15T13:01:11Z"
+    "last-modified": "2021-06-29T10:24:49Z"
   },
   "releases": [
     {
@@ -37,7 +37,7 @@
       }
     },
     {
-      "version": "34.20210518.3.0",
+      "version": "34.20210529.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -45,11 +45,14 @@
       }
     },
     {
-      "version": "34.20210529.3.0",
+      "version": "34.20210611.3.0",
       "metadata": {
+        "barrier": {
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/829"
+        },
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1623765600,
+          "start_epoch": 1624977000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2021-06-15T13:01:46Z"
+    "last-modified": "2021-06-29T10:24:49Z"
   },
   "releases": [
     {
@@ -53,22 +53,22 @@
       }
     },
     {
-      "version": "34.20210529.2.0",
-      "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        }
-      }
-    },
-    {
       "version": "34.20210611.2.0",
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/829"
         },
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "34.20210626.2.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1623765600,
+          "start_epoch": 1624977000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Rollouts scheduled on `2021/06/29 14:30UTC`:
* stable:  `34.20210611.3.0`
* testing: `34.20210626.2.0`
* next: `34.20210626.1.0`