### PR TITLE
Triple rollout on 2021-07-14

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,194 +1,194 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2021-06-29T10:21:47Z"
+        "last-modified": "2021-07-14T21:58:53Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210626.1.0",
+                    "release": "34.20210711.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "6ad9b8dcab7d249385c1555cb81a0975ff513208969064bf9b13892edc087ae2",
-                                "uncompressed-sha256": "2d7d18789a3af0a7d0275f5ab813a4a467a854fa601f537ba16d6c16014697f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "10b5d0b79c68abab4f081eb4be7d2b8ffaa44829679d6a62cefbaed350ea4810",
+                                "uncompressed-sha256": "8f96b99a64e847b137450ad2d9cb1555aa0349ea8f67698f0737c6ee3be4f322"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210626.1.0",
+                    "release": "34.20210711.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "e139fdbc993daaeb46d0ebde521b1cbd30cedb96f32754ee59f22ac41c0ab7d9",
-                                "uncompressed-sha256": "78061f2819c5dd3351bd2c3430669225af582c2742264e51a227b4e47b7785ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "2ba573fe4d965d5935b3a592d01945b64375ea362400904ef1cf6b6cf4110298",
+                                "uncompressed-sha256": "cc8ee7f1f7d4d2cc63deacbef0cb2319d296c36971a0dbc907bc65d973c94f17"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210626.1.0",
+                    "release": "34.20210711.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "a0f213157520d5c6fc90f5fcdb882d8072349eb799150feb9d3d90ae62795b0e",
-                                "uncompressed-sha256": "f5b7e485e918f0e92dd1f55814e86ac56cff155aef5653677150e0b148220d7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "9474563f57385a12626e8a7199dc557be0faadfa753242f23645fc2043d4ffd7",
+                                "uncompressed-sha256": "40cc68a4aab0977cfe577ddfd5bb63cf9ed966e87569eeeb48ac06ce802ebd82"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210626.1.0",
+                    "release": "34.20210711.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "530a095e636c17378ea3a67ecdb4edb41b0a97a1956d64c56cbde0551088fcc8",
-                                "uncompressed-sha256": "d102d26f3b62524d33480509a7e38862f314904ebca5d633cb643cd8574ec125"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "e91003885e113370a20fe7f09972fc574f90b3271883f874bdaba2810ec8a018",
+                                "uncompressed-sha256": "193590441ea1db8728b579cf9967495e0188cfbc8228a0ffdb8efd83aef6c8cb"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210626.1.0",
+                    "release": "34.20210711.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "92d2ed7c2ed57a8231366ab00e3395b4a6544164be78ef484f8dd626a4e46fb4",
-                                "uncompressed-sha256": "2ce3c9a1956c88f257302fe78e0e6b3217322b5db278013431aa7c41468ef84b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "25a0f97ac3136ebec9ea805f5d27b4a3cbd9c20f699af00fa05058648931dc48",
+                                "uncompressed-sha256": "8ac547eb70ff04d02b5ab09e19be354db240653da770ce0891ca5835a878dd50"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210626.1.0",
+                    "release": "34.20210711.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "a4e538c7236a9976cf3bc9ce36e99e663876f62f0dc54bed6de7c88f977acb85",
-                                "uncompressed-sha256": "b92eb82f0ca180a27b40432bc7ecdfa32c0aec39be07f539715d6e3ce935ea39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "76a728e1348a6900fbcff4e55959b7a04d7ff805fd8e80e9e1ce4555805bcbd2",
+                                "uncompressed-sha256": "db8c051e57ab5945b6f30e7840f6c0fd16921148e10c840608f0f0864ba638ff"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210626.1.0",
+                    "release": "34.20210711.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "7b58c456e98666437a83c6c0450d9c7bc6bb93fa2e3261785a53930200c6b014",
-                                "uncompressed-sha256": "3b95f6e3ec8bff029ba4535364f241ce103fc9da56e3ead9693ccbf8800b03ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "910ee133d59b2c5457448cca1b809b309f525bdeb22f782b56323564708a50b6",
+                                "uncompressed-sha256": "b4b4a2e827a098d7e0c35ead7c12c86d797e72022adf39b1a7f9124d852ed40b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210626.1.0",
+                    "release": "34.20210711.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "100ffbbd6f405ff5eafde764b37be26e128dd0f0f43fe7926632f0644bd3944a",
-                                "uncompressed-sha256": "9cd4d5c2d5b94c22258c3b0d6aa055c3c79446787aa802b1676279ec82321c37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "fcf506c6409ac2757355d1e1ffdf3ada32edfdb26d483ae476652a1c496f8980",
+                                "uncompressed-sha256": "cba9ef618ae2429e64602c985a3514ab909a639c2a8416e68be1e9896b5cca18"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-live.x86_64.iso.sig",
-                                "sha256": "9e3018484b2de83fc4464a9d236ef378c34493b6e38265d7bedf71868543beb0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-live.x86_64.iso.sig",
+                                "sha256": "c8013e09abb926513f57080cb9af22bc613683b095e85d5c08cc57145058200f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-live-kernel-x86_64.sig",
-                                "sha256": "e4b5cac76b9f5991a488f2f8d178d82f70cce3457f62986c0136ba19a0463aa5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-live-kernel-x86_64.sig",
+                                "sha256": "2419668fb64d059c7f711808aa4c539a85655f0dc989c068b54f8b8c34bdf2df"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "890009177cc852e0613dad9a18807d8e13a65fdf42cbd340628a49eae92eb1e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "e01b97d48a57f9be031ee32f3e541c5f3f60079582f1a4578437963256cfe2f2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "42f079434a0f4bfa50810048b8010d2478c5c7f8f438db33303399f4b126326e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "5f477878c8864065ee7ae4b91b3d46fd02b61f99d7ee060658635bf5b422b260"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "80920fc744abcc0012f92f877dc8b0ab9bf1f827afcbcfe41cb08420df744994",
-                                "uncompressed-sha256": "637ae1d30267bdb9356e962410007250b85e7c03904482907720f25662015f6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "64bf401ad4ac548f85ddd3feda853d729350cab220c1bd4999f5c7d9e5765d9b",
+                                "uncompressed-sha256": "d159c75bebb064a659eed823eec544b1be2bce79b407c89aa284034c201d5927"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210626.1.0",
+                    "release": "34.20210711.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "a39dc81dcbd14c958198cd6af5f5f317040ac0d22dd86b8229651bb5eb9a1657",
-                                "uncompressed-sha256": "f4311a8fc3d6e31ecd29eaa8466550df0abdd5989fa337a72e552cc563156055"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "654d347c803abce8fe0bae9af44f213cea7550ed72900ac5269cd4b27511d6a5",
+                                "uncompressed-sha256": "8b8fbcb64bc588086f9188de0bd986a9aab002abe4d01ea4a324d3d691f56b13"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210626.1.0",
+                    "release": "34.20210711.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "b54fe896e42722215cf63ffdd10c4bddfc4731ba9431920d268c8d38026edf5a",
-                                "uncompressed-sha256": "d299427de350d34ef1587bf1ae02806dde6437191cb817705f484548bc07eb3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "1270efc413f0e20971b43e0fafdb1e34578086a071fe884d9ed738ef78ba71c8",
+                                "uncompressed-sha256": "14651fbab157f68868a5a4f1ffe3f81e0746a37166acc866cd85eb01329e68a1"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210626.1.0",
+                    "release": "34.20210711.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "028288b78859b499badcab5fd0bfc15242fbb12cddda3ca866f61610753723f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "df4dab4dd95a651f7d6a30e2b0a611c03fa743608ec928c5f86f1994a29d54fa"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210626.1.0",
+                    "release": "34.20210711.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210626.1.0/x86_64/fedora-coreos-34.20210626.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "235e822a0891933d47409e0aa93abbea53d731f5fbcaf767ae8a293d4ff33619",
-                                "uncompressed-sha256": "ba2ebe517f17ba4b1e606d76653a55a9f407f85eaf78a6f42f897cbc4f50762d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "f66617ddf2be6d35687bb4cb74451da5e009ab694ec2a91650e08d3a7577267a",
+                                "uncompressed-sha256": "c9bf19ed88905b3a54757be269127eedb77383d71fd6ce7452c708ff1f7d9461"
                             }
                         }
                     }
@@ -198,95 +198,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-0055a332043a335fa"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-0c42a79767b790a15"
                         },
                         "ap-east-1": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-038050f38cff43a1c"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-00c9571e15f7d2330"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-0643e77681e5e0761"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-073419fdf7e380238"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-03a55a95123b3015e"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-0c2b30daf3512cdc6"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-05ef9d9493ec8a8ee"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-05535147cb876fde1"
                         },
                         "ap-south-1": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-0ea299f2ed61895e7"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-08e0eaac74def5d4f"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-0cb473a5d5bee695b"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-0999f25ec92ce0cfc"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-048ca90cd22cff299"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-0ca9823dd15a290a4"
                         },
                         "ca-central-1": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-0fc9d206b849bd223"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-06b43775ecb44b4ca"
                         },
                         "eu-central-1": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-0fc283621c36a6c60"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-0236df179c94c4734"
                         },
                         "eu-north-1": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-0d8f09075eea31b5c"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-01ae1b7ca6dc37cb3"
                         },
                         "eu-south-1": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-009046e8bf7cb8367"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-09cd9e39cab2aa253"
                         },
                         "eu-west-1": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-0b8c130b52590c7d7"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-00f1f29860ce0f83c"
                         },
                         "eu-west-2": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-074e5cb02a5b36eab"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-06bdedf216ff78e88"
                         },
                         "eu-west-3": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-0b71a4a60538971e4"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-01f25a975a5c14d1c"
                         },
                         "me-south-1": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-0803285d1da8486ae"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-004293d20c115aeb8"
                         },
                         "sa-east-1": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-0ef790f82ce8fe611"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-0bedde971b5df3918"
                         },
                         "us-east-1": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-0faa25bccd0fbfde2"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-05e346cee79bf73f3"
                         },
                         "us-east-2": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-0f1ebc6b87b3481dd"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-0b7a8bb92c142074b"
                         },
                         "us-west-1": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-0f39b781300e81a1f"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-08bf4ada7cb118daa"
                         },
                         "us-west-2": {
-                            "release": "34.20210626.1.0",
-                            "image": "ami-0c904a33ddec6ff0d"
+                            "release": "34.20210711.1.1",
+                            "image": "ami-0ef6b0ac22c13c9ba"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-34-20210626-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210711-1-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,194 +1,194 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2021-06-29T10:20:31Z"
+        "last-modified": "2021-07-14T21:50:43Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210611.3.0",
+                    "release": "34.20210626.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "d06f9e4b95cdf63399ea33b1b025c31b8c6ca306186f56c1c6058facbe1e713a",
-                                "uncompressed-sha256": "8d0a7396ba8a2ef6241c50dc388571eefb610d20474300750d4f2b43c4f39f54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "579f145159d36d86b769797baf8420d531b0108fe683b53929464e7ba8c4aba5",
+                                "uncompressed-sha256": "51e4d35ea09d453eb4128dfd98365cc722c2244bf5e207ba9df4235022889650"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210611.3.0",
+                    "release": "34.20210626.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "e4265b558a810fe155b1382e0f449623c97ad05f5db8d403a8c39e17ef1231f4",
-                                "uncompressed-sha256": "900d39e7dc3233d195d2bda246df6d01bbed6e3d16640e57ff365dd197d8a707"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "1f5d995f4b2d45eb05d7c3060a52c77cc411412fa2e2d9e0bdeadd98f8ca40b5",
+                                "uncompressed-sha256": "b84880acccfb8e5fb3b7b3343ed7f7b2aaff023960b581fe6229b446b1332664"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210611.3.0",
+                    "release": "34.20210626.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "f1a9246cc06351cc336d99503a6908977e270f39476076d0d98cb31fe74cd5bd",
-                                "uncompressed-sha256": "29077dd5aba77a3b804fdac71dd9970fd0fee4d85043f2215f962d9c78609fd3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e89e4e43e16ccc60f6ad52ebcd3430d9d1a50d6f2750d6c19788d0d820e07e6d",
+                                "uncompressed-sha256": "62085a62b381964f88a56df976d8305c03c0d73e37510723587d031792ddcc30"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210611.3.0",
+                    "release": "34.20210626.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "af97c547be7f62aea814cdba9bd33aace0537a740f00adbaf253cbe03f24d17b",
-                                "uncompressed-sha256": "7eb37fefcaafd8a9b90bd78d5820283ae49d4507ad554b112008b202acaddcca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "4a9823aa4d7afe8d547eee2251a89755dd72ffb4e652d52df78b5ea0d4937c34",
+                                "uncompressed-sha256": "43278955c49125b3a777490cc7ccbe6fe880386a325bd4166c7c1a7dc194e0af"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210611.3.0",
+                    "release": "34.20210626.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "c84fde3e9d18f3555b51aa8e5151a20937a512fdcb65f602dae0f1f06d6835bf",
-                                "uncompressed-sha256": "829539126ee086a17feaf541794fce6f5eba53733a050f072a0833d3bbc79488"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "3877a91c4887d469264a6908d1d9c1a2eaf3ac5df666b6f8d9399f43d799f35b",
+                                "uncompressed-sha256": "6c7879873dca4ba0fc0af04f6f90ac0c41075d0e9c88ec3f2e90a75e0467e8b6"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210611.3.0",
+                    "release": "34.20210626.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "f177f926c6ad2c5b64b410a9accc692348950d95603783d6d9ba0f8477fe2b33",
-                                "uncompressed-sha256": "b36657d096a5a7dc7d5391bb1da876d7c6a2f6d306a6f0713f0a147bb8d6f744"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "425b3ddf913151f118852394f5c33ecd2445294c4f9dac81a5a9f0b34c2cb476",
+                                "uncompressed-sha256": "20fe4983e19ee4dc62e17b8710f60259cf2c9e3f739f76482d1412138c292524"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210611.3.0",
+                    "release": "34.20210626.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "f4d784ae39732a0d79f7ff7f50df422707c2ba3bd25300c13313121f513e9abc",
-                                "uncompressed-sha256": "0cad3503c3339f9524310b94989633a9c0d578e28f3d5c443d4af4cc55556665"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "006b96c01d077c62f579c34d7b8158c703c80a8a0ccbfbf6519770dc716f42e9",
+                                "uncompressed-sha256": "f38e75b7e6e3c466ab0d532654ed07683bca8a387435d0f4be2f9801785d4c6a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210611.3.0",
+                    "release": "34.20210626.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "c57d2e88cf3b4dcb4303a676bb93b5a414e5b83993b82737d61096b5f81eca09",
-                                "uncompressed-sha256": "a49d6c869dfcc30b272a3a35f25282f1481f12bf257cabf44f990214f972d5b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "38dbe2eec68f18cd998dd659f82f9b1a10b77cef38d1eb231b98afd01662337e",
+                                "uncompressed-sha256": "5609f162c7ba9ceac47c34eabd972e2999869716d79e1fbd3d9cd69211fa3f4f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-live.x86_64.iso.sig",
-                                "sha256": "ddbbc69071edb9f0e19c2a55d0ae34f7c0a33b082f8a142edce3fce78c7b423a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live.x86_64.iso.sig",
+                                "sha256": "3ab9eee817051825ff7963de24dcd31a807f620f27cb6eb23ad71c598b60d0d4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-live-kernel-x86_64.sig",
-                                "sha256": "442c063a0a077fc45d59d804275532e99813e7eaee87b5a3aefdd62a6287b668"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live-kernel-x86_64.sig",
+                                "sha256": "e4b5cac76b9f5991a488f2f8d178d82f70cce3457f62986c0136ba19a0463aa5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "c514138e118a521a67a8e61f6dc287e3641ad211f36d0fd40410f36311c6c8f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "6bd515d56bb32d169d241a8b667a18ea87093e704996abc59ae0786912935578"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "5549fc6495406ec3c66cbe331d2ea07f768f9bb765b05e020854b5d20ceb1aa8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "7d370e7cb0190d8d1c4871021d181d637b891a7ff76b478069ed9b1f4715fade"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "c1839371311aaf52c64f83beec3660be95cbf6a50518d953f56560a7dba558f6",
-                                "uncompressed-sha256": "d819e21a492672ef6398a9954c19d6e51b3f2c91da24539836196a894e5fe4e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "33e57b0df4001d86fd7e186d20e07bf951f6f6a053177ef3c7a31b1484d5bc8b",
+                                "uncompressed-sha256": "9ada6809945fc972757aa8c16ed55c2c2e137c557cb4e7d580dde6f2b3748e5c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210611.3.0",
+                    "release": "34.20210626.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "898aec6030b015ea4ac023639ee5889b3b826e093d30f8e140eb4a91ef3df771",
-                                "uncompressed-sha256": "781cf76a990376c134be8fcf925d15e52199739959ff715f0d89d3bb3d3c616c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "65706172925a57dbd3fd9dc63b846ce41c83aa0ae34159701d2050faba4921ca",
+                                "uncompressed-sha256": "c2364a4ddb747d23263dec398d956799d2362983fb8fc257a5ab1d87b604683d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210611.3.0",
+                    "release": "34.20210626.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "9a362a7b13e213d8fb01d4c371c3f99893e6a418a60eff650b734c9683f1b06f",
-                                "uncompressed-sha256": "7e358c905664fcb65d99c4ed755a1be2f09291da6288ef818c0a348507a087c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "f1e6984e356822f419c217c95a58fb059c8629e3fa1989278d3e7c1a68cf32d2",
+                                "uncompressed-sha256": "acecea6dd7b6d99a554cd381c15390a41affbde46ee16c8eb9a66e7aa7653f7f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210611.3.0",
+                    "release": "34.20210626.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "83ddeecad881d4d10dd482637ef358a419f81b331b61f3f7e268dbf3fb9bcb79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "39847867bd44d26529a9927cb654ecfe110e765dd03ef24320c8d357091e8664"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210611.3.0",
+                    "release": "34.20210626.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "5a1d83ad2ec7f20e28b4a4d8b1dbb4fd36b298a1c70ec24c77521e4135c843ab",
-                                "uncompressed-sha256": "fce9ab78adbb57571f964bb6df52b5016931aec7f9620c3101d13207f3a75830"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "b8c88e6262fd08ad1e23808b8aea3c7934c6d71cf0281244d398b047f9258240",
+                                "uncompressed-sha256": "b0e7cfee0d4653821973d6a6af41729a0bb04c7783fb80a950a84ccf76fb5cb4"
                             }
                         }
                     }
@@ -198,95 +198,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-0f85904f1eece9be4"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-0e78e6cb9666e4866"
                         },
                         "ap-east-1": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-086e63f5ec79e871f"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-09585374e960d19e7"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-0edc9b77ec0874af2"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-07d0591c7f35e1c50"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-045941f3f3b40279e"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-06b9ade598c46aad5"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-053fc90293e75b741"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-0e660991a6256edf8"
                         },
                         "ap-south-1": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-0f6c9569ffafa3c45"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-0de887f898b8b9edf"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-037ad7fa7ba5ac2bb"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-03c5b518d836e0f10"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-0d4b3acab30fd5a14"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-02126f543e5642165"
                         },
                         "ca-central-1": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-02872e5ac2ddb0b16"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-04053e5d27a0fed44"
                         },
                         "eu-central-1": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-0623bcfdf5ed6bd8f"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-0352f1e0f3e503d23"
                         },
                         "eu-north-1": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-095571310fb53a8e8"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-0f859448095dc6195"
                         },
                         "eu-south-1": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-040c6e8df21ddfe4b"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-07990eb903597defa"
                         },
                         "eu-west-1": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-0982ca2ae194642ee"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-052aea8dab8614f0b"
                         },
                         "eu-west-2": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-0ceb66edf0dbfbff9"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-080a4f7c443bbc5a3"
                         },
                         "eu-west-3": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-0c32288e18a905d94"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-03190e74e2b49cb29"
                         },
                         "me-south-1": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-0b8de51051c7c5112"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-0f764a1c27bfceed9"
                         },
                         "sa-east-1": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-09f3248646cf93b7a"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-0d92d7edb61886f94"
                         },
                         "us-east-1": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-09b4202f59cdad6b2"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-08e8ce95b14176032"
                         },
                         "us-east-2": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-0181add94216f0eed"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-08b1cffdb1cc1e8ea"
                         },
                         "us-west-1": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-0e027e5590a693bfe"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-0dd2cb185e6859e3b"
                         },
                         "us-west-2": {
-                            "release": "34.20210611.3.0",
-                            "image": "ami-0d97468e42613f2fa"
+                            "release": "34.20210626.3.1",
+                            "image": "ami-076e11761838586ea"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-34-20210611-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210626-3-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,194 +1,194 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2021-06-29T10:21:17Z"
+        "last-modified": "2021-07-14T21:55:54Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210711.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "8a5ac227de31c2b7cdccc7b546e3e165a915e7d5c5535ac7022ad8148ae7bc5b",
-                                "uncompressed-sha256": "12b6fc9de963fd9318e50532dcae3efa706bfb1b2a02e532f230b796cd6f2570"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "bcd428d103d65de33008ddbb1af61ebcea8b7058f8f6d575a6bd6803e8ec18fa",
+                                "uncompressed-sha256": "5fe8c50d8bc4583a2ed6e653de6ad8dac44c28b9728e20ae2b2716e9139864e4"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210711.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "39ed71217a276e6bcbdeccd3cbbfd67a34d09101bfb9e7a2b6cc048c03fb23d7",
-                                "uncompressed-sha256": "4fbfde923d7b0e243f20ab81124bee20ef4e21b9842421b18926c4db1d8857a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "3859b9c2f98e8662ef8d13252c03573e9af88ec7482b7136930420a189883274",
+                                "uncompressed-sha256": "e570a255009607539e2356c396abca214380144bb8f6a04d595b37901450abc5"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210711.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "eb9ef79c36d99d22656c3308992524304fe4959807af374c962fbd162f19f046",
-                                "uncompressed-sha256": "1669e2f28260762278571569e5465fad07dff7d8391e19dbd1364ef0a90d3719"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "7256f060bd6195f5601a978e70968495bbb233e1d1e827d1705ba6384b9f4620",
+                                "uncompressed-sha256": "f8f5c0f472616e0ff25aceda9c4a34ffc76b5bf593f85d816b31676c4455fdf7"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210711.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "00ca38e6fe69738a22ad58dce6b023d043f51db8198a056cc87c553d04f5fbb5",
-                                "uncompressed-sha256": "fdad83ec1519c9ee6ec6056c6962f8e7652c5789d6b18463dedd32aaaae302b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "dc4a7012bf584b192e8242d424824b11aab04abfafccdf74fd01691f89ec5efe",
+                                "uncompressed-sha256": "5f2106f01fbdb483b5cf0ee9a7316b5f136a8e4050d608bf9044fe381729b367"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210711.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "09c084cc040af5fd1d1012f5ed52f67da5b373d19ada3b5d8ccef7c649e76cde",
-                                "uncompressed-sha256": "7c4ac26830489429e35192ba11379b94873b652424fe9505241fb47074d29521"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "787ed39f8ceb94e86968f352ecdefc93b32ece3b410f9f6eb5fc768ceed34bb6",
+                                "uncompressed-sha256": "c603a5fe54da7f904868cc86bd7cf0f705043a6d8e1564819101b196777e31ef"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210711.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "1c73752a3686f580fa86dd1a1f1a4bc12c616e431f8d01d2ccc2fe9c7d048935",
-                                "uncompressed-sha256": "c32629174d753571351d632af3c4ed7bd48f536733cb8f4902f583753338d3e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "4363eca72da2a5bbbad7cdf22f50581404a0bd4ec7ebeb9151a3f78a47aed7bd",
+                                "uncompressed-sha256": "14b99281843395428dbf53c864ac06bf87e11a73bd63a677c5563dce3260f2c9"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210711.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "da7abcc7666187851a62636e98d56d519417ce8ba56e6dd14b6e17c3200dd119",
-                                "uncompressed-sha256": "3e3f59e6b8ab3493e1ed7f2dfb046fe5a5bc91a16f40df5fd55a7021903e1be8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "111621dc2ec96152f8b393247a42fd2aa9212ea71f0f863eeda6763ceefe7a56",
+                                "uncompressed-sha256": "4db9aee80e536bd56236c44658764d63b21cd13d17a1ac611247329d429d222d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210711.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "de374a7234ff93117cd44c2c580cd621f74f08ff13af25cfe0e45ceb774fb35e",
-                                "uncompressed-sha256": "a2d8d87fc46e0ab0ba778684afb041fa795847d59c3ab56e58de58d5597df871"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "81d48fb88561a0294ff4e6ca4a9cafd689cb649a89439e19713c09b181d56c99",
+                                "uncompressed-sha256": "099059fcb904c2af458917dc1e66ae54f439f9829f349bea0333c40de9d21e03"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live.x86_64.iso.sig",
-                                "sha256": "598587080f2a96770d660e3d42dbdb1059aabca9d8eaaeb5222b68b92e26d225"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-live.x86_64.iso.sig",
+                                "sha256": "515acd0e6425f88c854d20507d67a139fa6eca492b80aea8fc87cd98db90271f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live-kernel-x86_64.sig",
-                                "sha256": "e4b5cac76b9f5991a488f2f8d178d82f70cce3457f62986c0136ba19a0463aa5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-live-kernel-x86_64.sig",
+                                "sha256": "2419668fb64d059c7f711808aa4c539a85655f0dc989c068b54f8b8c34bdf2df"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "e17f6082861fefced56d908af54a3a43832823fa9447dfac5327e9ff250dbc83"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "b22ba9395244c20108ab0069c7504cb456c8dd8a7e015960a2a41c2cb7391518"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "043472e6e1b8bbb7f3907b5df5ae890dedb765424b763dff6e8bf8657b9739c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "1640b9b7b7ddc78c215ea4972739651eb19e1a4d8ba6705cdd285c1b184caf0f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "156cfd20264af88b1efe41ea41f8eb929a0fc98704293ec7f5a1f1524658ade6",
-                                "uncompressed-sha256": "0502afe6689566ec5661cd39435f82e864a1d057eacb50fa4889925c2b552571"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "86f4c1bec425636c3d3f33732ea9697727c18435ea6a0ddc0a5fff8cebe4c3a0",
+                                "uncompressed-sha256": "a6d390f5c23e908181092f57af4659ea5059546e81ae905ca168df491b107ee5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210711.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "a83fc15db3e2274fc3e9f3909c08d2784e1e3a9352276fa30954f62a49e2ded7",
-                                "uncompressed-sha256": "24cc37d752028c8f78dd4aed66e13eb294e9a07c0e1c506ccabc33459faccff1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "02fdf78a42ee1c14c2a8a79d23f02c0acb4248d469c8438fc241e96920ea6459",
+                                "uncompressed-sha256": "1888cf21fc7da788b6ce2120c38655361e27c708e9b74f3f522ab69ebb9a4d30"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210711.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "6f1e5e38eb9dac07466433665cda204bfee2cad144acba0aba9af75e76b27919",
-                                "uncompressed-sha256": "490ab7341a4a7fffda5fbf56bf022ddc71161af492d0eb9cbce2239318d1d064"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "3f5158a60888047f0edcf962e19bc31e967ee6b377c068883d02f3e9af7cffcc",
+                                "uncompressed-sha256": "54d9e1900c8fef4f1457f0c418552e916a6a0476f69861a9171b3c89975dc516"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210711.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "7a178acb5a43b26c31631cbbf928f471e639641d179c779197e7d763b9110414"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "76abc2b9b16df6fa1cdfa9d5f7c2bb5cad5798b01dcf46f3b0d0a25c17b338ca"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210711.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "4e42cc1fb80329646969da90fca7153ffae26952b663012e1b90b351d5715693",
-                                "uncompressed-sha256": "3c601db2b2a9a1231d91b53bbda4fa765661de8a81a2abc6fa1f69180c42202b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "59068db8f2c574b33f3a871cd5db334cd4c23f6ea0403e517bded2e3f1076ce5",
+                                "uncompressed-sha256": "98f616af6cc0067b5fc5b8fc567dee10e8ac1a66f5da59089720e0e7ceb2b3e2"
                             }
                         }
                     }
@@ -198,95 +198,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-06ce6cd7ae14d4e36"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-078de3c0d533f3496"
                         },
                         "ap-east-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-0c523b93e7931c390"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-06445087ebf40a46e"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-0b1bc3f2c1bc08b69"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-02e4ac564c673b383"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-03345d33cb26bc661"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-0e06b0d76f6b30485"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-01e001d8864b4f29d"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-0568a8e35891738fc"
                         },
                         "ap-south-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-0fce67cf8e9812a76"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-0a2c3101b6fb4ffd2"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-0674b758a90e82f9d"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-03e84e7c09d32d3e5"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-02234d79a973a5f53"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-0c8723d930a3766e4"
                         },
                         "ca-central-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-08c1b1b41febd498c"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-010ab702ef91c2fcc"
                         },
                         "eu-central-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-05d1ebfc450ec9f1e"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-066361f250711c23f"
                         },
                         "eu-north-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-0c304efcf489e8a4f"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-0de3ca248030708f7"
                         },
                         "eu-south-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-049e141bcf79024c5"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-0d9f70a5450b25dc3"
                         },
                         "eu-west-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-07a6835aaad9cc5ca"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-06c0a57ed8e7a48da"
                         },
                         "eu-west-2": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-06c4d4769614a43e0"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-09b9361a33fb4ac0a"
                         },
                         "eu-west-3": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-06e938ee9a84c2d3e"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-0ecca79eda5ec02f4"
                         },
                         "me-south-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-00e6941c14327860a"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-0526d6a9c19edc8ec"
                         },
                         "sa-east-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-0fed26dc669439cdd"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-0858f8b897c1152d6"
                         },
                         "us-east-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-0dcce6fefedc4780c"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-08ef21fab575270e4"
                         },
                         "us-east-2": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-0227bf3374a60ff8b"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-0ec4630f6b4c29d1a"
                         },
                         "us-west-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-081afa57703a058b9"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-0379aca04d2750b1f"
                         },
                         "us-west-2": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-07597603ac267ab05"
+                            "release": "34.20210711.2.0",
+                            "image": "ami-0d4aa493c08e87950"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-34-20210626-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210711-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2021-06-29T10:24:49Z"
+    "last-modified": "2021-07-14T21:58:53Z"
   },
   "releases": [
     {
@@ -33,9 +33,6 @@
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/829"
-        },
-        "rollout": {
-          "start_percentage": 1.0
         }
       }
     },
@@ -43,8 +40,16 @@
       "version": "34.20210626.1.0",
       "metadata": {
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "34.20210711.1.1",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1624977000,
+          "start_epoch": 1626366600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2021-06-29T10:24:49Z"
+    "last-modified": "2021-07-14T21:50:43Z"
   },
   "releases": [
     {
@@ -37,22 +37,22 @@
       }
     },
     {
-      "version": "34.20210529.3.0",
-      "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        }
-      }
-    },
-    {
       "version": "34.20210611.3.0",
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/829"
         },
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "34.20210626.3.1",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1624977000,
+          "start_epoch": 1626366600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2021-06-29T10:24:49Z"
+    "last-modified": "2021-07-14T21:55:54Z"
   },
   "releases": [
     {
@@ -57,9 +57,6 @@
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/829"
-        },
-        "rollout": {
-          "start_percentage": 1.0
         }
       }
     },
@@ -67,8 +64,16 @@
       "version": "34.20210626.2.0",
       "metadata": {
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "34.20210711.2.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1624977000,
+          "start_epoch": 1626366600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
- stable (34.20210626.3.1)
- testing(34.20210711.2.0)
- next (34.20210711.1.1)