### PR TITLE
Roll out next 34.20210711.1.2 and testing 34.20210711.2.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,194 +1,194 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2021-07-14T21:58:53Z"
+        "last-modified": "2021-07-21T17:17:38Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210711.1.1",
+                    "release": "34.20210711.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "10b5d0b79c68abab4f081eb4be7d2b8ffaa44829679d6a62cefbaed350ea4810",
-                                "uncompressed-sha256": "8f96b99a64e847b137450ad2d9cb1555aa0349ea8f67698f0737c6ee3be4f322"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "3a0874ae57ac0e091923405635aa81b9315f6a413a054e7a1af63a66cde52db3",
+                                "uncompressed-sha256": "7df044e7dc4dfeb9452e9acea8d699b651c6a5daee8c14cf6652c37cc5d4180e"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210711.1.1",
+                    "release": "34.20210711.1.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "2ba573fe4d965d5935b3a592d01945b64375ea362400904ef1cf6b6cf4110298",
-                                "uncompressed-sha256": "cc8ee7f1f7d4d2cc63deacbef0cb2319d296c36971a0dbc907bc65d973c94f17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "23bcfc2a3ce18e2180fb1225c6f7c75fefc988f34b18c6598c0ca1bcfc1bad66",
+                                "uncompressed-sha256": "b554f082edd6afc364795820fbe740d8232b80fd1707ce0d723536fcc542ae2a"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210711.1.1",
+                    "release": "34.20210711.1.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "9474563f57385a12626e8a7199dc557be0faadfa753242f23645fc2043d4ffd7",
-                                "uncompressed-sha256": "40cc68a4aab0977cfe577ddfd5bb63cf9ed966e87569eeeb48ac06ce802ebd82"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "3e8e244131144848c16f33a620ac80196ecb5bc8e888926e99b143854260b443",
+                                "uncompressed-sha256": "6aff3276ee0b2e92894815fc1388391c39e3e14b6ecb82c49477603957328cd6"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210711.1.1",
+                    "release": "34.20210711.1.2",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "e91003885e113370a20fe7f09972fc574f90b3271883f874bdaba2810ec8a018",
-                                "uncompressed-sha256": "193590441ea1db8728b579cf9967495e0188cfbc8228a0ffdb8efd83aef6c8cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "bde65fe966d77b7e809d8cd05acfa5d663725d5f7cc46d7dd84e1b7d09569a8b",
+                                "uncompressed-sha256": "61ac880cf3f84aaf8d091a186eb3b8f92ddd9416ab135896d11ae123fb7620db"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210711.1.1",
+                    "release": "34.20210711.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "25a0f97ac3136ebec9ea805f5d27b4a3cbd9c20f699af00fa05058648931dc48",
-                                "uncompressed-sha256": "8ac547eb70ff04d02b5ab09e19be354db240653da770ce0891ca5835a878dd50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "f6bef5fc0a4a9c50af606af8e38418bbcffde22e0f4e31ce12b7998e800c7dcd",
+                                "uncompressed-sha256": "6166072eb08e53b1b0eb5c0467f76994e7307dd4912d46a608b3ede5e10e14b0"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210711.1.1",
+                    "release": "34.20210711.1.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "76a728e1348a6900fbcff4e55959b7a04d7ff805fd8e80e9e1ce4555805bcbd2",
-                                "uncompressed-sha256": "db8c051e57ab5945b6f30e7840f6c0fd16921148e10c840608f0f0864ba638ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "3ea55a9bf300c6fc926f7f10924933a2e0dd30d34405bbf85814841a82b7b7e2",
+                                "uncompressed-sha256": "61603a01c2b762aff030dad293a1c35010a2e3436b27ef6e0ff2049556a0e416"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210711.1.1",
+                    "release": "34.20210711.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "910ee133d59b2c5457448cca1b809b309f525bdeb22f782b56323564708a50b6",
-                                "uncompressed-sha256": "b4b4a2e827a098d7e0c35ead7c12c86d797e72022adf39b1a7f9124d852ed40b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "bbc5b37a65f1f8b57313ce2db57f061dc90b7dcb5167b01acdc6cac42af3a83b",
+                                "uncompressed-sha256": "aa3e2cc35864df9dfc2fac7c294797b61f14591950935b8debfdc0f8a779eeae"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210711.1.1",
+                    "release": "34.20210711.1.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "fcf506c6409ac2757355d1e1ffdf3ada32edfdb26d483ae476652a1c496f8980",
-                                "uncompressed-sha256": "cba9ef618ae2429e64602c985a3514ab909a639c2a8416e68be1e9896b5cca18"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "b5666f65febdacc76b1a315cc0da5b69a6342d6f5c85b53a3509a59ce9631336",
+                                "uncompressed-sha256": "d29f470cb1de62f795d6130175ec44f8e3993db1a6aaeb9b7ed6bc41593d6428"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-live.x86_64.iso.sig",
-                                "sha256": "c8013e09abb926513f57080cb9af22bc613683b095e85d5c08cc57145058200f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-live.x86_64.iso.sig",
+                                "sha256": "cd4bc04bc4f5fb36d87983f7d25bd907a3645bc8b3cfaaa1bcf05c7399238ece"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-live-kernel-x86_64.sig",
-                                "sha256": "2419668fb64d059c7f711808aa4c539a85655f0dc989c068b54f8b8c34bdf2df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-live-kernel-x86_64.sig",
+                                "sha256": "145c126c7818b96b0c13daab1df333ac263587f437135f65419dfaa144b64482"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "e01b97d48a57f9be031ee32f3e541c5f3f60079582f1a4578437963256cfe2f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "56c03e337ca47948813a7618c88bba38ce56112e30fa163f6d99fd91f813f0d0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "5f477878c8864065ee7ae4b91b3d46fd02b61f99d7ee060658635bf5b422b260"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-live-rootfs.x86_64.img.sig",
+                                "sha256": "97c1d64655e5cc953a61430abc80428e32543d28464c4b3b49b585104dd232a5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "64bf401ad4ac548f85ddd3feda853d729350cab220c1bd4999f5c7d9e5765d9b",
-                                "uncompressed-sha256": "d159c75bebb064a659eed823eec544b1be2bce79b407c89aa284034c201d5927"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "7f20cf9ccf28fec4931c0a4e1c1b72af2b089bca2aa1b1fae1cb8a08a6e077a8",
+                                "uncompressed-sha256": "15906345a9703834a5b1fc6a028acaaccde07178d818c37eaed51561bf39e20f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210711.1.1",
+                    "release": "34.20210711.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "654d347c803abce8fe0bae9af44f213cea7550ed72900ac5269cd4b27511d6a5",
-                                "uncompressed-sha256": "8b8fbcb64bc588086f9188de0bd986a9aab002abe4d01ea4a324d3d691f56b13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "b356584c46c1e1f1e495a055be1adaf6c0039ca47bdeecdf4316437ddfba90b9",
+                                "uncompressed-sha256": "209d0343a68afe562d1721baee92bfac755ae9bca8e7cf7523a15d7181b5811f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210711.1.1",
+                    "release": "34.20210711.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "1270efc413f0e20971b43e0fafdb1e34578086a071fe884d9ed738ef78ba71c8",
-                                "uncompressed-sha256": "14651fbab157f68868a5a4f1ffe3f81e0746a37166acc866cd85eb01329e68a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "f51a73057a0a50d169a3d00ba962948c85232c851bee28fc9adf5fb550a40011",
+                                "uncompressed-sha256": "28d7f1a0b6b6e24560c20fe110d88a6e435debe3ee75c3e65b7833533035369f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210711.1.1",
+                    "release": "34.20210711.1.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "df4dab4dd95a651f7d6a30e2b0a611c03fa743608ec928c5f86f1994a29d54fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-vmware.x86_64.ova.sig",
+                                "sha256": "30bfe344707bc346311f07a2ca29bdd45ebc63e0b30eb9aa7ba34d8d5d168fda"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210711.1.1",
+                    "release": "34.20210711.1.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.1/x86_64/fedora-coreos-34.20210711.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "f66617ddf2be6d35687bb4cb74451da5e009ab694ec2a91650e08d3a7577267a",
-                                "uncompressed-sha256": "c9bf19ed88905b3a54757be269127eedb77383d71fd6ce7452c708ff1f7d9461"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-vultr.x86_64.raw.xz.sig",
+                                "sha256": "26957692cfaaac1e922c85fdd888767e57cb733c9b165a1bf50296fe0ccaec80",
+                                "uncompressed-sha256": "faa44cb0f22a61a8e77334c9bfa8a8db8d99849830fe2ffca939fca9fc6e6514"
                             }
                         }
                     }
@@ -198,95 +198,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-0c42a79767b790a15"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-0a41755b90eb7dbd3"
                         },
                         "ap-east-1": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-00c9571e15f7d2330"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-03fa90a5e10e9d112"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-073419fdf7e380238"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-0dca0bf28fe434dc8"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-0c2b30daf3512cdc6"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-088449a621bf3e327"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-05535147cb876fde1"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-0195821363e38b7cf"
                         },
                         "ap-south-1": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-08e0eaac74def5d4f"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-042ebcf275f0b9dd0"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-0999f25ec92ce0cfc"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-09a15d1cf80e06a3d"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-0ca9823dd15a290a4"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-0f37417e3b85709b9"
                         },
                         "ca-central-1": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-06b43775ecb44b4ca"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-00237b53a59092a5a"
                         },
                         "eu-central-1": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-0236df179c94c4734"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-0e25dc4da76dfa4e2"
                         },
                         "eu-north-1": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-01ae1b7ca6dc37cb3"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-06a6d9a3fa1131b2a"
                         },
                         "eu-south-1": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-09cd9e39cab2aa253"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-062e402813c0410b5"
                         },
                         "eu-west-1": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-00f1f29860ce0f83c"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-05b23546be3c7bd4c"
                         },
                         "eu-west-2": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-06bdedf216ff78e88"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-0ca9c0dcd0200b524"
                         },
                         "eu-west-3": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-01f25a975a5c14d1c"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-0250255c7c48f8627"
                         },
                         "me-south-1": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-004293d20c115aeb8"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-08987166eb7993e75"
                         },
                         "sa-east-1": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-0bedde971b5df3918"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-0665cea95b9890f84"
                         },
                         "us-east-1": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-05e346cee79bf73f3"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-041a07d84570ff286"
                         },
                         "us-east-2": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-0b7a8bb92c142074b"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-038af22bc23f273c6"
                         },
                         "us-west-1": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-08bf4ada7cb118daa"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-0677292da34064ef8"
                         },
                         "us-west-2": {
-                            "release": "34.20210711.1.1",
-                            "image": "ami-0ef6b0ac22c13c9ba"
+                            "release": "34.20210711.1.2",
+                            "image": "ami-0962ee2145dea8d13"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-34-20210711-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210711-1-2-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,194 +1,194 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2021-07-14T21:55:54Z"
+        "last-modified": "2021-07-21T17:17:49Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210711.2.0",
+                    "release": "34.20210711.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "bcd428d103d65de33008ddbb1af61ebcea8b7058f8f6d575a6bd6803e8ec18fa",
-                                "uncompressed-sha256": "5fe8c50d8bc4583a2ed6e653de6ad8dac44c28b9728e20ae2b2716e9139864e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "6dea52c9f455876745371c8388170d860b415b5ca155a1e8b8311ad718bf451a",
+                                "uncompressed-sha256": "9476fa0c3fa4c68440b79f380a89c6156238e7bdeaf019e67299bc707e54fbe5"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210711.2.0",
+                    "release": "34.20210711.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "3859b9c2f98e8662ef8d13252c03573e9af88ec7482b7136930420a189883274",
-                                "uncompressed-sha256": "e570a255009607539e2356c396abca214380144bb8f6a04d595b37901450abc5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "9221fd5d82ab5ea5761692dfbaaa15f523b21f2bfca32d7ef0c065af2743b782",
+                                "uncompressed-sha256": "56ff395cf0dfb1b28cf48189ce3fd1a36202113f6a5b02081927f81a9c467cf4"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210711.2.0",
+                    "release": "34.20210711.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7256f060bd6195f5601a978e70968495bbb233e1d1e827d1705ba6384b9f4620",
-                                "uncompressed-sha256": "f8f5c0f472616e0ff25aceda9c4a34ffc76b5bf593f85d816b31676c4455fdf7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "4b93ca7debb303e4e343de1e9c074e8ed91401a3e88ecefa31d996547a67204c",
+                                "uncompressed-sha256": "12e3c5e3bea1b4c7707236f2b3ff4012e0563d660c896e649433e0aa8f275419"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210711.2.0",
+                    "release": "34.20210711.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "dc4a7012bf584b192e8242d424824b11aab04abfafccdf74fd01691f89ec5efe",
-                                "uncompressed-sha256": "5f2106f01fbdb483b5cf0ee9a7316b5f136a8e4050d608bf9044fe381729b367"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "c2445a152577e49dcab10eb54ac8b2fe1bab303fe3fa444d103a426d0b10d2df",
+                                "uncompressed-sha256": "1e6cacf17a73d99e9f5316e49e7c2773308a1622168e0773c0d389c929429665"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210711.2.0",
+                    "release": "34.20210711.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "787ed39f8ceb94e86968f352ecdefc93b32ece3b410f9f6eb5fc768ceed34bb6",
-                                "uncompressed-sha256": "c603a5fe54da7f904868cc86bd7cf0f705043a6d8e1564819101b196777e31ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "ef9a6d2e7f3be5e731e407102574d679f0f46dea7263a7c15b3235064478fe91",
+                                "uncompressed-sha256": "4fa679a7604650a7acfa03d903c6d6ff567e900a7bdda526a4e346b8dd70d8db"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210711.2.0",
+                    "release": "34.20210711.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "4363eca72da2a5bbbad7cdf22f50581404a0bd4ec7ebeb9151a3f78a47aed7bd",
-                                "uncompressed-sha256": "14b99281843395428dbf53c864ac06bf87e11a73bd63a677c5563dce3260f2c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "942faefd10dfc45102b42cb8306c94708da3ff753538d81ed476426ce7e822dd",
+                                "uncompressed-sha256": "4a9e2fd13b576ff43dec8b73860ccda93bec6bb4f08bc0edc78dfc6ad632679b"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210711.2.0",
+                    "release": "34.20210711.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "111621dc2ec96152f8b393247a42fd2aa9212ea71f0f863eeda6763ceefe7a56",
-                                "uncompressed-sha256": "4db9aee80e536bd56236c44658764d63b21cd13d17a1ac611247329d429d222d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "045a7e5cb90f1d85054971fe9c4cf269a361aebda98aefd29a488ef687d632b6",
+                                "uncompressed-sha256": "9b64c8d6a0fcc04faeeddd2aafd1b25c606900bfac24f33517e868ca63d2d8cf"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210711.2.0",
+                    "release": "34.20210711.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "81d48fb88561a0294ff4e6ca4a9cafd689cb649a89439e19713c09b181d56c99",
-                                "uncompressed-sha256": "099059fcb904c2af458917dc1e66ae54f439f9829f349bea0333c40de9d21e03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "ef512b23693b078b22ba741c668778f9a9332d1cefe94eabe7a4dfd7ab01ec9d",
+                                "uncompressed-sha256": "f577c4f542c5396d12bab0205f49767cc73f26176901d2c4e814f0b288a25bb9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-live.x86_64.iso.sig",
-                                "sha256": "515acd0e6425f88c854d20507d67a139fa6eca492b80aea8fc87cd98db90271f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-live.x86_64.iso.sig",
+                                "sha256": "8b02f80125b76889a10b88b6471645b2017a752e3b5e6c44d122c6b11fd51d0d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-live-kernel-x86_64.sig",
-                                "sha256": "2419668fb64d059c7f711808aa4c539a85655f0dc989c068b54f8b8c34bdf2df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-live-kernel-x86_64.sig",
+                                "sha256": "145c126c7818b96b0c13daab1df333ac263587f437135f65419dfaa144b64482"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "b22ba9395244c20108ab0069c7504cb456c8dd8a7e015960a2a41c2cb7391518"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "e8d14e80e390d9375da67414dafa40e8bc38c24f107e1992a4fca43682ac537c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "1640b9b7b7ddc78c215ea4972739651eb19e1a4d8ba6705cdd285c1b184caf0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "83204317bae3b28e5fbd2ff8b1b61169942ee354f8ee0efb4f6b761e11d96dd9"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "86f4c1bec425636c3d3f33732ea9697727c18435ea6a0ddc0a5fff8cebe4c3a0",
-                                "uncompressed-sha256": "a6d390f5c23e908181092f57af4659ea5059546e81ae905ca168df491b107ee5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "d790dbb990c9b5ce25dd03a6aa9300d574f5f3dc7e84d888709b422cfc44bd53",
+                                "uncompressed-sha256": "420f40d2d2145964200b8f7146b48d0e4e005df04efa2d4850ce6437d2972712"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210711.2.0",
+                    "release": "34.20210711.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "02fdf78a42ee1c14c2a8a79d23f02c0acb4248d469c8438fc241e96920ea6459",
-                                "uncompressed-sha256": "1888cf21fc7da788b6ce2120c38655361e27c708e9b74f3f522ab69ebb9a4d30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "eb2ca6581028c6a027edfa5dcaeb84a73de4df34974a05548b4e9e08cea8b422",
+                                "uncompressed-sha256": "3e8e52af5d3112b6af9672886c0334aaa9b8053d1952d7c1573ffa64008d861c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210711.2.0",
+                    "release": "34.20210711.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "3f5158a60888047f0edcf962e19bc31e967ee6b377c068883d02f3e9af7cffcc",
-                                "uncompressed-sha256": "54d9e1900c8fef4f1457f0c418552e916a6a0476f69861a9171b3c89975dc516"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "b41379798098ab61ef2e16a6fb522fffbeb38129e094f602464589c896333bef",
+                                "uncompressed-sha256": "5be76ccc55c6be0dab4e7c6e255da8aa71853ff91e8a95a9903f3d38ee93c164"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210711.2.0",
+                    "release": "34.20210711.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "76abc2b9b16df6fa1cdfa9d5f7c2bb5cad5798b01dcf46f3b0d0a25c17b338ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "aaefd74dcd54c4b839c883b3e82250bfa7d806a63958ddaa8dbe33e56d1355b5"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210711.2.0",
+                    "release": "34.20210711.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.0/x86_64/fedora-coreos-34.20210711.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "59068db8f2c574b33f3a871cd5db334cd4c23f6ea0403e517bded2e3f1076ce5",
-                                "uncompressed-sha256": "98f616af6cc0067b5fc5b8fc567dee10e8ac1a66f5da59089720e0e7ceb2b3e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "35a28fe868f7fc369214e5e8847844a29c3daf624428fcb1d3f6e3cdec28b5e3",
+                                "uncompressed-sha256": "8cc5441b89e1b8bff07dbfa6a952553c50a491e605bed8bfbc7c4df80a92feca"
                             }
                         }
                     }
@@ -198,95 +198,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-078de3c0d533f3496"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-0e3b34344aff6f028"
                         },
                         "ap-east-1": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-06445087ebf40a46e"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-041788101b7ccc9c6"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-02e4ac564c673b383"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-0f05c09320b88f305"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-0e06b0d76f6b30485"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-0983d885262e1baea"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-0568a8e35891738fc"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-0039c41a9a8bf4e06"
                         },
                         "ap-south-1": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-0a2c3101b6fb4ffd2"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-00489031f6804a518"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-03e84e7c09d32d3e5"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-0f6d2550260917396"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-0c8723d930a3766e4"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-0a96577282e2893d1"
                         },
                         "ca-central-1": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-010ab702ef91c2fcc"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-0897e92330e27f282"
                         },
                         "eu-central-1": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-066361f250711c23f"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-0814eea3b850a45ce"
                         },
                         "eu-north-1": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-0de3ca248030708f7"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-02d94059b7b45a239"
                         },
                         "eu-south-1": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-0d9f70a5450b25dc3"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-0fa1665188fe749ef"
                         },
                         "eu-west-1": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-06c0a57ed8e7a48da"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-0b35c099018a40547"
                         },
                         "eu-west-2": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-09b9361a33fb4ac0a"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-0e6c285d470dfa74d"
                         },
                         "eu-west-3": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-0ecca79eda5ec02f4"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-0b6bb9ecb14a9a1e0"
                         },
                         "me-south-1": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-0526d6a9c19edc8ec"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-09d8bf1a2d76ef982"
                         },
                         "sa-east-1": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-0858f8b897c1152d6"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-0e757e2ecf3aba0bb"
                         },
                         "us-east-1": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-08ef21fab575270e4"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-0afa383cbf228a19e"
                         },
                         "us-east-2": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-0ec4630f6b4c29d1a"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-0543848ce9c52c261"
                         },
                         "us-west-1": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-0379aca04d2750b1f"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-022b85169bc7d16c2"
                         },
                         "us-west-2": {
-                            "release": "34.20210711.2.0",
-                            "image": "ami-0d4aa493c08e87950"
+                            "release": "34.20210711.2.1",
+                            "image": "ami-04e59f60c00509038"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-34-20210711-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210711-2-1-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2021-07-14T21:58:53Z"
+    "last-modified": "2021-07-21T17:18:09Z"
   },
   "releases": [
     {
@@ -37,7 +37,7 @@
       }
     },
     {
-      "version": "34.20210626.1.0",
+      "version": "34.20210711.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -45,11 +45,11 @@
       }
     },
     {
-      "version": "34.20210711.1.1",
+      "version": "34.20210711.1.2",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1626366600,
+          "duration_minutes": 1440,
+          "start_epoch": 1626890400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2021-07-14T21:55:54Z"
+    "last-modified": "2021-07-21T17:18:09Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "34.20210626.2.0",
+      "version": "34.20210711.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "34.20210711.2.0",
+      "version": "34.20210711.2.1",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1626366600,
+          "duration_minutes": 1440,
+          "start_epoch": 1626890400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
```
next
    version: 34.20210711.1.2
    start: 2021-07-21 18:00:00+00:00 UTC (in 0:26:40)
           2021-07-21 14:00:00-04:00 Raleigh/New York/Toronto
           2021-07-21 20:00:00+02:00 Berlin/France/Poland
    duration: 1440m (24.0h)
testing
    version: 34.20210711.2.1
    start: 2021-07-21 18:00:00+00:00 UTC (in 0:26:36)
           2021-07-21 14:00:00-04:00 Raleigh/New York/Toronto
           2021-07-21 20:00:00+02:00 Berlin/France/Poland
    duration: 1440m (24.0h)
```