### PR TITLE
Triple rollout on 2021-07-28

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,194 +1,207 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2021-07-21T17:17:38Z"
+        "last-modified": "2021-07-28T11:05:09Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210711.1.2",
+                    "release": "34.20210725.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "3a0874ae57ac0e091923405635aa81b9315f6a413a054e7a1af63a66cde52db3",
-                                "uncompressed-sha256": "7df044e7dc4dfeb9452e9acea8d699b651c6a5daee8c14cf6652c37cc5d4180e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "cf6bab275ac1ea649c4ef63c373ed8fc4fb43c96b4bcb9a4412eb2740d82dec8",
+                                "uncompressed-sha256": "07015112ee4b99f2d8f812b3edcdce100af356ce39c77c9d1ae304253e97cddd"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210711.1.2",
+                    "release": "34.20210725.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "23bcfc2a3ce18e2180fb1225c6f7c75fefc988f34b18c6598c0ca1bcfc1bad66",
-                                "uncompressed-sha256": "b554f082edd6afc364795820fbe740d8232b80fd1707ce0d723536fcc542ae2a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "f570d350af6bf89f1ffa41f72753e5f8b6cd5b5a3a5386833739274c54516ea0",
+                                "uncompressed-sha256": "2993aede06b6abba3ffeb4eb09241d103c4413f3b14e9d1efba12d5803442ed2"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210711.1.2",
+                    "release": "34.20210725.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-azure.x86_64.vhd.xz.sig",
-                                "sha256": "3e8e244131144848c16f33a620ac80196ecb5bc8e888926e99b143854260b443",
-                                "uncompressed-sha256": "6aff3276ee0b2e92894815fc1388391c39e3e14b6ecb82c49477603957328cd6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "0dcbb477205f14ac5309bc4e66306ce0a20beea1ffbd1e745af36bf7bfe81496",
+                                "uncompressed-sha256": "10cc9a5c06fb7a82f387e12ed5c83272ef4dabccf560ced8dc1c556017399099"
+                            }
+                        }
+                    }
+                },
+                "azurestack": {
+                    "release": "34.20210725.1.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "25e175b5e59f5943651af62ba6b437dd9d996ff388484a79cbd682b4095adab6",
+                                "uncompressed-sha256": "dc46cceb9a2ea4624332bd6adffa660b3cc1fd4c4d8bc830afbb4688f7d727ed"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210711.1.2",
+                    "release": "34.20210725.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "bde65fe966d77b7e809d8cd05acfa5d663725d5f7cc46d7dd84e1b7d09569a8b",
-                                "uncompressed-sha256": "61ac880cf3f84aaf8d091a186eb3b8f92ddd9416ab135896d11ae123fb7620db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "b2b5be1e30c4a507ff78a16737420bb03ed240f2c8debb6383f88db0d1e5b136",
+                                "uncompressed-sha256": "f690dcc5a7f0ec3a805eea5b1e4f3298f573a2299346e3dde3ea40db683eacb0"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210711.1.2",
+                    "release": "34.20210725.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "f6bef5fc0a4a9c50af606af8e38418bbcffde22e0f4e31ce12b7998e800c7dcd",
-                                "uncompressed-sha256": "6166072eb08e53b1b0eb5c0467f76994e7307dd4912d46a608b3ede5e10e14b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "8801b350c650c9d5993da5afc2a9a79a7ab238a6cbdd7ab988971c67ff038ca7",
+                                "uncompressed-sha256": "f800bbc478a32dc94d5d42b83fa845073407f1970507952ee92efe1ebb2c5ac6"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210711.1.2",
+                    "release": "34.20210725.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-gcp.x86_64.tar.gz.sig",
-                                "sha256": "3ea55a9bf300c6fc926f7f10924933a2e0dd30d34405bbf85814841a82b7b7e2",
-                                "uncompressed-sha256": "61603a01c2b762aff030dad293a1c35010a2e3436b27ef6e0ff2049556a0e416"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "ce9c4ef9191802d78940cd62c00ca8ffcc8a8d49f145e30f4ff052d9b44d3985",
+                                "uncompressed-sha256": "4b9feb995e56cffdbbe6d724882d0cc74050baf04380e0c47a393e3b427c5865"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210711.1.2",
+                    "release": "34.20210725.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "bbc5b37a65f1f8b57313ce2db57f061dc90b7dcb5167b01acdc6cac42af3a83b",
-                                "uncompressed-sha256": "aa3e2cc35864df9dfc2fac7c294797b61f14591950935b8debfdc0f8a779eeae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "19e6bfbf9b559e8124d765a1447e4db148f862926c6c29ccff5f98f853cdaf7c",
+                                "uncompressed-sha256": "882cd932e0ed692998371d7781cde5227b76ffdae11de5e61a7e6b343e6d838a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210711.1.2",
+                    "release": "34.20210725.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "b5666f65febdacc76b1a315cc0da5b69a6342d6f5c85b53a3509a59ce9631336",
-                                "uncompressed-sha256": "d29f470cb1de62f795d6130175ec44f8e3993db1a6aaeb9b7ed6bc41593d6428"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "dd3760ceca29c0d3c2a8034f2f45d00a23fd0446f54357f31c1f5b4188fac8f8",
+                                "uncompressed-sha256": "d8906fe6cedd8d8addc2d40577100fc7247c46b261eeca7c6027233dedc84319"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-live.x86_64.iso.sig",
-                                "sha256": "cd4bc04bc4f5fb36d87983f7d25bd907a3645bc8b3cfaaa1bcf05c7399238ece"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-live.x86_64.iso.sig",
+                                "sha256": "d0df9d28fbf68aaabf238536a4241236c871b757ccd3a18e3321983813679359"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-live-kernel-x86_64.sig",
-                                "sha256": "145c126c7818b96b0c13daab1df333ac263587f437135f65419dfaa144b64482"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-live-kernel-x86_64.sig",
+                                "sha256": "3166c98d325ff3b06e092683060b512bc6f72dc354e424c1634186492b032db5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-live-initramfs.x86_64.img.sig",
-                                "sha256": "56c03e337ca47948813a7618c88bba38ce56112e30fa163f6d99fd91f813f0d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "a215a9365c3ece14d453a747e17139e61933ee3a768208e74fd989f5fc5486d4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-live-rootfs.x86_64.img.sig",
-                                "sha256": "97c1d64655e5cc953a61430abc80428e32543d28464c4b3b49b585104dd232a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "c544a29709f6d0f3eab21c3ff174073c3a602f16916fe188b0cc47f5f3647240"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-metal.x86_64.raw.xz.sig",
-                                "sha256": "7f20cf9ccf28fec4931c0a4e1c1b72af2b089bca2aa1b1fae1cb8a08a6e077a8",
-                                "uncompressed-sha256": "15906345a9703834a5b1fc6a028acaaccde07178d818c37eaed51561bf39e20f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "a12fb096a74c66bf705212dbcf497704d89dac7f78c085cda89866fa7242561c",
+                                "uncompressed-sha256": "31764acf94e5c4e7a3832bb3cd3c6df0dacbdd5f640a5a4e09805538eef5ed10"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210711.1.2",
+                    "release": "34.20210725.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "b356584c46c1e1f1e495a055be1adaf6c0039ca47bdeecdf4316437ddfba90b9",
-                                "uncompressed-sha256": "209d0343a68afe562d1721baee92bfac755ae9bca8e7cf7523a15d7181b5811f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "7c60b29ad2f7dde5916ca740271fdb2a7ebbe2fd1fe40de1edbbad47a4813365",
+                                "uncompressed-sha256": "3e0764349733791e2f0fd0f0183654365e7b31c0a5264d3fe90f66f85ab224a7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210711.1.2",
+                    "release": "34.20210725.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "f51a73057a0a50d169a3d00ba962948c85232c851bee28fc9adf5fb550a40011",
-                                "uncompressed-sha256": "28d7f1a0b6b6e24560c20fe110d88a6e435debe3ee75c3e65b7833533035369f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "66e0b6dcb592bc0fb2d46553dfb9d91664f59b3fab2d2bf42f476197de5d4780",
+                                "uncompressed-sha256": "efc71396bce5b12f50cb33b4f9c56b0e0bd75a00587724d785f259c6be4335da"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210711.1.2",
+                    "release": "34.20210725.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-vmware.x86_64.ova.sig",
-                                "sha256": "30bfe344707bc346311f07a2ca29bdd45ebc63e0b30eb9aa7ba34d8d5d168fda"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "1062a8dffa1407c9fa356c3ae2e39f5b5c8d9023e0caee15eac35da98df75f68"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210711.1.2",
+                    "release": "34.20210725.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210711.1.2/x86_64/fedora-coreos-34.20210711.1.2-vultr.x86_64.raw.xz.sig",
-                                "sha256": "26957692cfaaac1e922c85fdd888767e57cb733c9b165a1bf50296fe0ccaec80",
-                                "uncompressed-sha256": "faa44cb0f22a61a8e77334c9bfa8a8db8d99849830fe2ffca939fca9fc6e6514"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210725.1.0/x86_64/fedora-coreos-34.20210725.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "af1cff8686e6e405a06e875b72b1214aee0d823cdb208279bfa7c859b1435753",
+                                "uncompressed-sha256": "267c2d56dde816ce9c0f26e571bbffa4835e8811045a94cce105160b178dc0ee"
                             }
                         }
                     }
@@ -198,95 +211,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-0a41755b90eb7dbd3"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-0d1cb1fdd85b015ea"
                         },
                         "ap-east-1": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-03fa90a5e10e9d112"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-089445432d43cc5d1"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-0dca0bf28fe434dc8"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-0717e7c32773edcc9"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-088449a621bf3e327"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-061d134c02f26d66f"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-0195821363e38b7cf"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-02404b8a653b75484"
                         },
                         "ap-south-1": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-042ebcf275f0b9dd0"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-032523f9d4f466010"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-09a15d1cf80e06a3d"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-0bc449f6cbdab39dc"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-0f37417e3b85709b9"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-0880a3dbf084d4f25"
                         },
                         "ca-central-1": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-00237b53a59092a5a"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-0417b25f8f41402cb"
                         },
                         "eu-central-1": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-0e25dc4da76dfa4e2"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-0bb9a0c69fd6a4ba3"
                         },
                         "eu-north-1": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-06a6d9a3fa1131b2a"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-084903e5db42a1784"
                         },
                         "eu-south-1": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-062e402813c0410b5"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-08db03c2bdf2c84a1"
                         },
                         "eu-west-1": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-05b23546be3c7bd4c"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-097ff96b472552258"
                         },
                         "eu-west-2": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-0ca9c0dcd0200b524"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-026efd4945d57a879"
                         },
                         "eu-west-3": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-0250255c7c48f8627"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-0b5784ddc4938fad8"
                         },
                         "me-south-1": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-08987166eb7993e75"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-0f45be8a1597d5d90"
                         },
                         "sa-east-1": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-0665cea95b9890f84"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-083973881a4a4eb16"
                         },
                         "us-east-1": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-041a07d84570ff286"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-03b5e8950103d6082"
                         },
                         "us-east-2": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-038af22bc23f273c6"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-055fbd3262c2ae132"
                         },
                         "us-west-1": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-0677292da34064ef8"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-0cb02ae9972bb7b5d"
                         },
                         "us-west-2": {
-                            "release": "34.20210711.1.2",
-                            "image": "ami-0962ee2145dea8d13"
+                            "release": "34.20210725.1.0",
+                            "image": "ami-06f4bd5d7cd028732"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-34-20210711-1-2-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210725-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,194 +1,207 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2021-07-22T01:21:03Z"
+        "last-modified": "2021-07-28T11:04:55Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210626.3.2",
+                    "release": "34.20210711.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "3008154eddde7ca7baf39add4c2dc5f693a2b42be505e83e28975a92b9774dcb",
-                                "uncompressed-sha256": "9e88de0d30508bf2b0ba7d60dc454b5c4d15860a6d176b224cca5a1a0982230d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "902ed80757a91b2a24196f7788e386b15dfcc20c05ba055d210c7c069419d1c4",
+                                "uncompressed-sha256": "b170a94c1d4626ab57c4a1b0b7b3004007630379a422e03da19ecc388afe3e47"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210626.3.2",
+                    "release": "34.20210711.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "8f1e37aea482f0384e109f5ce660384ea7df2d483f7d70a112f5b3b2522ea076",
-                                "uncompressed-sha256": "91a42931f676b22a702dc5aa54928ec05ef16049f6f98cc3bf8dea99e66ee601"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "393eacd802a101a38321b895dba8c04ef39c711acdf2e09e10a7a73645679767",
+                                "uncompressed-sha256": "2d4a1bd6d6a47be2b3a78a665bccc14a969b5c4bdf6e510b415186f751e85ac9"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210626.3.2",
+                    "release": "34.20210711.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7e5f73ce5964ef7f26b20a348baea8ebb2a9646994afab40dbec54fba84dab5d",
-                                "uncompressed-sha256": "de86bd80abad80481d75f96ddda8cf8e1354c881a156b6afacfca6659a66f6a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "eab7860adbc502723ab7808139c8972b182b4fa180146f7c1c7efa844a4523ab",
+                                "uncompressed-sha256": "3dcc3cdb776454307793ca565e266545b090c17491a334e25a03e9a81d936378"
+                            }
+                        }
+                    }
+                },
+                "azurestack": {
+                    "release": "34.20210711.3.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "7bde6785329edb8987aaca9b1b67c46f0755e0f8c661583052ee881b95d78634",
+                                "uncompressed-sha256": "b31e55e54de72e4080fa0e7d7c3388f06e85229c58fca88016fbfb051d970c56"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210626.3.2",
+                    "release": "34.20210711.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "ae6226312767bfc0150fbcfc2eb0f5abe904b2ef36680b3b4a5bc002a4cc6904",
-                                "uncompressed-sha256": "c2b695a4a6a2be25d719b2bdb0027b9c4456aa5dc9789921f1de6408d37eaf01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "d7b1e57b8ba7dc2e1faa200539a54488e24481d5265b0e66a031840e6258b606",
+                                "uncompressed-sha256": "d360ca52bf29557612066dbe6d0a9b6ee76b0e330c9e36121cb9290db8aeab31"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210626.3.2",
+                    "release": "34.20210711.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "ec9c6acae005522358c1083fd1e3f0f1978bbc6b6a5304b79e3270b825df96c5",
-                                "uncompressed-sha256": "8a70d30140991d134f2eb544ab2e71df5d8fdb56df0249eb926508a4a7184757"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "08d06c77f758df556c7665c61111d8d072ed569dd67226078294ae09deffa778",
+                                "uncompressed-sha256": "6caa63003b842baeb1f602930a757d204cb1731baeb3263d2f5fb6bf9c1cb4d2"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210626.3.2",
+                    "release": "34.20210711.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-gcp.x86_64.tar.gz.sig",
-                                "sha256": "ffc89dda2c4c6247005c1d403760191b6d26d86fceaef65b2fcb677e1c53ea7e",
-                                "uncompressed-sha256": "d7b9d2acf3a702a3d4e0935f584a7dfc2661b1aaf78f38a460da64e4654bd9e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "630b180799571547e5c2071fd8834344f28b0c7ba4bdf04b4238b1d70f289c66",
+                                "uncompressed-sha256": "fe2c366566820b99959612ec62344d1644fd3f5dffdc0b0f1dd4ca259f503826"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210626.3.2",
+                    "release": "34.20210711.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "efa82673ab164a427e4111199f09321077784356e9e8de2af9a90902a6432d24",
-                                "uncompressed-sha256": "382a6a721225f505402859dcf8524fd01ba80f374ac8cf715f2eac373cf86bdd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "8b8e4bd4e7dc17fc66d12bf24fe4fb96157a770e265d4c256619b9bdfdb9e15e",
+                                "uncompressed-sha256": "35bd2259ab218428235b2c6ed25b2e69f2b6fb13313a6307ef3fc9afc33befe0"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210626.3.2",
+                    "release": "34.20210711.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "ea4c4dbc162b08238ab6f9604b7929eb483d32f14c781c19259da4820a4bc9ff",
-                                "uncompressed-sha256": "a3abca4caf1ee380d523dbcb73b0ca685712ae0f5e3ad14967026e1d5df185c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "aca92c4c9b68c3dcab481b00f5b0a12a2467d67e67d28926dfeaf31834256298",
+                                "uncompressed-sha256": "a3a48856b7ed48b9e8dcbf8f97406a621f9755c390102932d6c7debc67de37bc"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-live.x86_64.iso.sig",
-                                "sha256": "da01be330488653d319995f2d9a065c9f45443f806b50e4b11fd5622d88c3642"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-live.x86_64.iso.sig",
+                                "sha256": "eea145cac96f95ae037f1e74c246da6652f873a1b0a53fd00f102bcf48e2d372"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-live-kernel-x86_64.sig",
                                 "sha256": "145c126c7818b96b0c13daab1df333ac263587f437135f65419dfaa144b64482"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-live-initramfs.x86_64.img.sig",
-                                "sha256": "abb9c2fb3c5a2853b1dd86446ad8e5ac772bbcdad23a864f3435f7225f73bcfa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "44835d440bba5684d8a10a8abeafc71f7403498b1e5d70cf67a0e8c32f367046"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-live-rootfs.x86_64.img.sig",
-                                "sha256": "c79f7f4036fd0926afcb5044d95eb4704f103fb0c2338654d8b791f5e53e8736"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "7b3df571789506fef3a3bd7c48010d64ed139292f2a68b56434c63ab1ebc4b97"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-metal.x86_64.raw.xz.sig",
-                                "sha256": "54f12a7ae9415f2f831394eecdf8e459faa309a0918f87233cb9717469c164e0",
-                                "uncompressed-sha256": "0a801ca2e3651e859a12b64b2add2cc3e4f03f7ab9082ca936748d6938318eb3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "b7cafbe8a3aa414b315b3d83fcf717aacaa6d283125fc8a19ce2c8183f1bfb38",
+                                "uncompressed-sha256": "e07569f444388478056a1c7a5fbb30f03c8779355beb80787338a3347a834c08"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210626.3.2",
+                    "release": "34.20210711.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "7cd197809aaeca42f8d6360e20137b97257b2c3cafcbf16bf5fe5e5440fa0283",
-                                "uncompressed-sha256": "8859186a60065d7e4ea6f644c279d993b2040779c8645a4e9ab0ca3a472b7405"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "6640e24fcb21fdcc6b1412b472adfd58d9b093a9c700ff134757dde8c4fc3b47",
+                                "uncompressed-sha256": "0c7034702363cc04f34c6ef7a7019fabe611c92f34ecb3175fff509b339a05cb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210626.3.2",
+                    "release": "34.20210711.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "b7cda0bd057957b6b3f3f7b036c5907217be561fd632cde7b50c0c9862af451d",
-                                "uncompressed-sha256": "016704f2a3700dd4df9d69c53cfc0d11e14596d065b966bda8b1c8e5a65778e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "212f3b51059d397dec2e283a8f44ac94dc7a648466693345ddb39cb6bbcd5c96",
+                                "uncompressed-sha256": "3a18c0c50b4d8c6c5fcc310801cd91545480a95b386f037e69e0caaf10496221"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210626.3.2",
+                    "release": "34.20210711.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-vmware.x86_64.ova.sig",
-                                "sha256": "48cdb47f3d0595ebf162957abfefebbb0927ab4ece0393b77420c95cf8189265"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "9e4688870239ae1a6e419b6bb79bcb363e5e980890e54909166f97125b55283a"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210626.3.2",
+                    "release": "34.20210711.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.2/x86_64/fedora-coreos-34.20210626.3.2-vultr.x86_64.raw.xz.sig",
-                                "sha256": "1c6161fdc8b709322e353c3b255dcd0e981cdb709fd17b9dc81beae2c8d1497c",
-                                "uncompressed-sha256": "20caeb978f697c5b0a6a5a9ee51e2356d99f689d03e3009fee9f82dcb2721f78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210711.3.0/x86_64/fedora-coreos-34.20210711.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "1f5da23522feeb8290b6ed1c8e489e004dbbd5b6cc14fd6893184bdc36347657",
+                                "uncompressed-sha256": "c62d4c2fa20cd13c4c85ae9353e256e1b2ef5938e39da9d4efec63df1d46fb54"
                             }
                         }
                     }
@@ -198,95 +211,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-0ee16fbb9d630b256"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-0f85133fe28fdacd4"
                         },
                         "ap-east-1": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-087a707301568b95a"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-07c16d0ff9773e7fd"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-0058097f53f7de762"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-0bcbf5c75ae175584"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-0057aa3a4a8525d44"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-0afb4d877b0bf9c56"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-004f2e7f7d2246850"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-09e85cdcdd9014aba"
                         },
                         "ap-south-1": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-0825dba0393a7f286"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-02410910260210abb"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-0bba39a9c142bcdd5"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-0a17735e1895eb711"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-0fdeb1fbc06799d29"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-01385f13ce4167893"
                         },
                         "ca-central-1": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-023101ae234bea2ac"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-0832a47b499a041ad"
                         },
                         "eu-central-1": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-0d2e7b1ac7df5e088"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-0e8a29395404ace80"
                         },
                         "eu-north-1": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-0d8e88f1a6e2643c8"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-033a1cfb8dc87d42b"
                         },
                         "eu-south-1": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-01ef667b7a01ceec8"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-09bc9623e543bcb3a"
                         },
                         "eu-west-1": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-0d672c4094d033a9a"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-0d51fc68859a1fc1f"
                         },
                         "eu-west-2": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-0e08c0464db246762"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-0af32417295618eb7"
                         },
                         "eu-west-3": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-0be37e3e4f704bbe8"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-0844b3646c0efbbf6"
                         },
                         "me-south-1": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-0ac23f86df5287d45"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-0134e3e8aa40087ca"
                         },
                         "sa-east-1": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-0207fa62b0dcab293"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-03018478be1c276fd"
                         },
                         "us-east-1": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-034384858d082f647"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-07540efddc0abaf8c"
                         },
                         "us-east-2": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-030f88689c8a25049"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-0a608a3383c440962"
                         },
                         "us-west-1": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-0ccccf65893cfa1e6"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-0146be3bfae500095"
                         },
                         "us-west-2": {
-                            "release": "34.20210626.3.2",
-                            "image": "ami-07906a2947d6e89b2"
+                            "release": "34.20210711.3.0",
+                            "image": "ami-0fdfeb00a768af0f7"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-34-20210626-3-2-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210711-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,194 +1,207 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2021-07-21T17:17:49Z"
+        "last-modified": "2021-07-28T11:05:01Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210711.2.1",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "6dea52c9f455876745371c8388170d860b415b5ca155a1e8b8311ad718bf451a",
-                                "uncompressed-sha256": "9476fa0c3fa4c68440b79f380a89c6156238e7bdeaf019e67299bc707e54fbe5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d0616160da27cdd8814a5d05609678643423d9e4f76e11e8d76f706ca4bb314d",
+                                "uncompressed-sha256": "3dbbeaac58489eb4e4c2c6075548bb4cff0e403953ba9404c0c3d39cdfd44760"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210711.2.1",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "9221fd5d82ab5ea5761692dfbaaa15f523b21f2bfca32d7ef0c065af2743b782",
-                                "uncompressed-sha256": "56ff395cf0dfb1b28cf48189ce3fd1a36202113f6a5b02081927f81a9c467cf4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "25f03b8b86723651409c44b5e5a98e9fbc1827ababc3b51e00539a5980ba504c",
+                                "uncompressed-sha256": "780d60ec839eb0364cecfdac1b5d122512cb8c3c5ad1248f2e592e7bb10ac718"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210711.2.1",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "4b93ca7debb303e4e343de1e9c074e8ed91401a3e88ecefa31d996547a67204c",
-                                "uncompressed-sha256": "12e3c5e3bea1b4c7707236f2b3ff4012e0563d660c896e649433e0aa8f275419"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e8bd73f9a0203c1c5beedc7cffd49ee358a39ad1be93c16e2c87b7f2913b5bcc",
+                                "uncompressed-sha256": "a67a9427f05ce0400b45003b1c5697f4699435955bf318afc4660a934d6b10a2"
+                            }
+                        }
+                    }
+                },
+                "azurestack": {
+                    "release": "34.20210725.2.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "bbe002f09822234e662ead24bf905de8c9c38636987410887ea851d1e5628aa8",
+                                "uncompressed-sha256": "0222d9fe6ba75035c80e3b61ee2d8cc2aeda085d4f85fe6b79bcd2e8b6ae2e70"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210711.2.1",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c2445a152577e49dcab10eb54ac8b2fe1bab303fe3fa444d103a426d0b10d2df",
-                                "uncompressed-sha256": "1e6cacf17a73d99e9f5316e49e7c2773308a1622168e0773c0d389c929429665"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "36a2a606d517f47e37590d6186e749790214bc7ff759ddf9aec2c5332149bbb0",
+                                "uncompressed-sha256": "5144bb1aa134c9403fdf87c052873f92063166550a070dba877a2a239b3eee40"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210711.2.1",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "ef9a6d2e7f3be5e731e407102574d679f0f46dea7263a7c15b3235064478fe91",
-                                "uncompressed-sha256": "4fa679a7604650a7acfa03d903c6d6ff567e900a7bdda526a4e346b8dd70d8db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "8919a150c5ceae11bbe755bff0292598874f969dcaf0a222817812f5dd1e8976",
+                                "uncompressed-sha256": "1664ad86886a99548b668eb412c4ea3ce675491d9c4337627e8e4e222365bdc0"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210711.2.1",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "942faefd10dfc45102b42cb8306c94708da3ff753538d81ed476426ce7e822dd",
-                                "uncompressed-sha256": "4a9e2fd13b576ff43dec8b73860ccda93bec6bb4f08bc0edc78dfc6ad632679b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f56fffcb62ce6effba5075fe6633ff5f1334250a769d870e0dc5be6f0bd013fe",
+                                "uncompressed-sha256": "fb23cc64310835be53d8d0caeaa652ce69b4676e40c115a02d5438234a2903b9"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210711.2.1",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "045a7e5cb90f1d85054971fe9c4cf269a361aebda98aefd29a488ef687d632b6",
-                                "uncompressed-sha256": "9b64c8d6a0fcc04faeeddd2aafd1b25c606900bfac24f33517e868ca63d2d8cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "b9a192cbf62587fe1afedba0e816f315c56889dda71fcde36c249db3f1715034",
+                                "uncompressed-sha256": "0dbd198fa167066723ef28c39e0081c185573c36d50703dcbefe7827ee787ab9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210711.2.1",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "ef512b23693b078b22ba741c668778f9a9332d1cefe94eabe7a4dfd7ab01ec9d",
-                                "uncompressed-sha256": "f577c4f542c5396d12bab0205f49767cc73f26176901d2c4e814f0b288a25bb9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "c3112558c29d9904e48d26e0a892c9bfb7ecd97265f945f8a272121a90162552",
+                                "uncompressed-sha256": "f4c45ee4496c3a7283bbc352e894864a658cefb256dd4b3d132c45ee4f6670be"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-live.x86_64.iso.sig",
-                                "sha256": "8b02f80125b76889a10b88b6471645b2017a752e3b5e6c44d122c6b11fd51d0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-live.x86_64.iso.sig",
+                                "sha256": "01045f9e5312bd29905237e989a5be1cd76db7e756f89e97243471fc1e264439"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-live-kernel-x86_64.sig",
-                                "sha256": "145c126c7818b96b0c13daab1df333ac263587f437135f65419dfaa144b64482"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-live-kernel-x86_64.sig",
+                                "sha256": "3166c98d325ff3b06e092683060b512bc6f72dc354e424c1634186492b032db5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "e8d14e80e390d9375da67414dafa40e8bc38c24f107e1992a4fca43682ac537c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "746cf3208658e6331682fdff8de15d1772825bbbf27a8de9daed15a58efd25ef"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "83204317bae3b28e5fbd2ff8b1b61169942ee354f8ee0efb4f6b761e11d96dd9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "cc93eef97457efc351b95f8f5b853809065e6d35671455684860d276edab8c10"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "d790dbb990c9b5ce25dd03a6aa9300d574f5f3dc7e84d888709b422cfc44bd53",
-                                "uncompressed-sha256": "420f40d2d2145964200b8f7146b48d0e4e005df04efa2d4850ce6437d2972712"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "e2f6b5f16f78056438d3e409cedbaed19e1becce33b34e0e23a6a7cf44583848",
+                                "uncompressed-sha256": "46dab51f454eb18c03bdb5affc22015b51717f34827efd4461278da33c030c33"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210711.2.1",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "eb2ca6581028c6a027edfa5dcaeb84a73de4df34974a05548b4e9e08cea8b422",
-                                "uncompressed-sha256": "3e8e52af5d3112b6af9672886c0334aaa9b8053d1952d7c1573ffa64008d861c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "cfbfbb0f8a6e7558c73322a7304878737f76bb4ae27b4ff81237a7e169a29bf3",
+                                "uncompressed-sha256": "5fb778e1a494dc79b65e862f01e91465dad985a7d27765981e694161167c7c2c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210711.2.1",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "b41379798098ab61ef2e16a6fb522fffbeb38129e094f602464589c896333bef",
-                                "uncompressed-sha256": "5be76ccc55c6be0dab4e7c6e255da8aa71853ff91e8a95a9903f3d38ee93c164"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "7d8fab929f6e1ae83cc247065098eff632e40a7b5bc0af34c294798e30235a9a",
+                                "uncompressed-sha256": "1c21719ac6dbab16f65399c4950612c456152d629cab425537cde286bfdc1fca"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210711.2.1",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "aaefd74dcd54c4b839c883b3e82250bfa7d806a63958ddaa8dbe33e56d1355b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "a208f6970909a0faa0b8d2154e65f28bae441481f7d1516843a527dacad82e1e"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210711.2.1",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210711.2.1/x86_64/fedora-coreos-34.20210711.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "35a28fe868f7fc369214e5e8847844a29c3daf624428fcb1d3f6e3cdec28b5e3",
-                                "uncompressed-sha256": "8cc5441b89e1b8bff07dbfa6a952553c50a491e605bed8bfbc7c4df80a92feca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "072168bad4fda4670f96434155d92ddbdb031f02145d3f06aae9185da489c0d5",
+                                "uncompressed-sha256": "78ae3508f7585b59de2e9b6f8d0a12933c3b0d485758438a1028cf5f7c97b9fd"
                             }
                         }
                     }
@@ -198,95 +211,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-0e3b34344aff6f028"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0d1c7c28bc45e9b7d"
                         },
                         "ap-east-1": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-041788101b7ccc9c6"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-00f0180441a078114"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-0f05c09320b88f305"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0a57f5c23b68e2ec0"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-0983d885262e1baea"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0961c0e317349f150"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-0039c41a9a8bf4e06"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-016dcfcbe3ff7ea8f"
                         },
                         "ap-south-1": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-00489031f6804a518"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0b39c0eb9657b9291"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-0f6d2550260917396"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-011a9e8c425fb0239"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-0a96577282e2893d1"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-07b0fbdd315c6a4de"
                         },
                         "ca-central-1": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-0897e92330e27f282"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-09d522db754b9ef98"
                         },
                         "eu-central-1": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-0814eea3b850a45ce"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0a435e2284f8f3f76"
                         },
                         "eu-north-1": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-02d94059b7b45a239"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0ae343dbb2436d194"
                         },
                         "eu-south-1": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-0fa1665188fe749ef"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0690eeccf397de8f8"
                         },
                         "eu-west-1": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-0b35c099018a40547"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-07cdf93198cf4b1b0"
                         },
                         "eu-west-2": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-0e6c285d470dfa74d"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-00079da9fcf80f993"
                         },
                         "eu-west-3": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-0b6bb9ecb14a9a1e0"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0d1705af46305bb53"
                         },
                         "me-south-1": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-09d8bf1a2d76ef982"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0bb9ddf97db6b7e9f"
                         },
                         "sa-east-1": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-0e757e2ecf3aba0bb"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-048249320b62238ce"
                         },
                         "us-east-1": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-0afa383cbf228a19e"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-03007921612b483cd"
                         },
                         "us-east-2": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-0543848ce9c52c261"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-09c95dbdf2b784ef2"
                         },
                         "us-west-1": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-022b85169bc7d16c2"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0b6bf028db67ec144"
                         },
                         "us-west-2": {
-                            "release": "34.20210711.2.1",
-                            "image": "ami-04e59f60c00509038"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0362b8d89f7f61971"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-34-20210711-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210725-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2021-07-21T17:18:09Z"
+    "last-modified": "2021-07-28T11:10:56Z"
   },
   "releases": [
     {
@@ -37,7 +37,7 @@
       }
     },
     {
-      "version": "34.20210711.1.1",
+      "version": "34.20210711.1.2",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -45,11 +45,11 @@
       }
     },
     {
-      "version": "34.20210711.1.2",
+      "version": "34.20210725.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1626890400,
+          "duration_minutes": 2880,
+          "start_epoch": 1627488000,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2021-07-22T01:10:05Z"
+    "last-modified": "2021-07-28T11:09:58Z"
   },
   "releases": [
     {
@@ -45,7 +45,7 @@
       }
     },
     {
-      "version": "34.20210626.3.1",
+      "version": "34.20210626.3.2",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -53,11 +53,11 @@
       }
     },
     {
-      "version": "34.20210626.3.2",
+      "version": "34.20210711.3.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1626976800,
+          "duration_minutes": 2880,
+          "start_epoch": 1627488000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2021-07-21T17:18:09Z"
+    "last-modified": "2021-07-28T11:10:13Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "34.20210711.2.0",
+      "version": "34.20210711.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "34.20210711.2.1",
+      "version": "34.20210725.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1626890400,
+          "duration_minutes": 2880,
+          "start_epoch": 1627488000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
```
next
    version: 34.20210725.1.0
    start: 2021-07-28 16:00:00+00:00 UTC (in 4:47:51)
           2021-07-28 12:00:00-04:00 Raleigh/New York/Toronto
           2021-07-28 18:00:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)
testing
    version: 34.20210725.2.0
    start: 2021-07-28 16:00:00+00:00 UTC (in 4:47:51)
           2021-07-28 12:00:00-04:00 Raleigh/New York/Toronto
           2021-07-28 18:00:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)
stable
    version: 34.20210711.3.0
    start: 2021-07-28 16:00:00+00:00 UTC (in 4:47:51)
           2021-07-28 12:00:00-04:00 Raleigh/New York/Toronto
           2021-07-28 18:00:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)
```