### PR TITLE
workflows: limit permissions to reading repo contents and issues

### DIFF
--- a/.github/workflows/promote-config.yml
+++ b/.github/workflows/promote-config.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [labeled]
 
+permissions:
+  contents: read
+  issues: read
+
 jobs:
   promote-config:
     name: Open promotion pull request


### PR DESCRIPTION
I'm not sure whether issue permission is needed, but be conservative to avoid breakage.