### PR TITLE
templates: stop manual pull test from previous QEMU image

### DIFF
--- a/ISSUE_TEMPLATE/next.md
+++ b/ISSUE_TEMPLATE/next.md
@@ -44,11 +44,6 @@ upgrade` will have the new update.
 - [ ] Run the [release job](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/fedora-coreos/job/fedora-coreos-fedora-coreos-pipeline-release/build?delay=0sec), filling in for parameters `next` and the new version ID
 - [ ] Post a link to the job as a comment to this issue
 - [ ] Wait for job to finish
-- [ ] Verify that the OSTree commit and its signature are present and valid by booting a VM at the previous release (e.g. `cosa run --qemu-image /path/to/previous.qcow2`) and verifying that `rpm-ostree upgrade --bypass-driver` works and `rpm-ostree status` shows a valid signature.
-    - [ ] x86_64
-    - [ ] aarch64 (optional)
-        - Can easily bring up instance from previous release in stream with:
-            - `cosa kola spawn -b fcos --stream next --arch=aarch64 -p aws --aws-credentials-file /srv/creds`
 
 At this point, Cincinnati will see the new release on its next refresh and create a corresponding node in the graph without edges pointing to it yet.
 

--- a/ISSUE_TEMPLATE/stable.md
+++ b/ISSUE_TEMPLATE/stable.md
@@ -44,11 +44,6 @@ upgrade` will have the new update.
 - [ ] Run the [release job](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/fedora-coreos/job/fedora-coreos-fedora-coreos-pipeline-release/build?delay=0sec), filling in for parameters `stable` and the new version ID
 - [ ] Post a link to the job as a comment to this issue
 - [ ] Wait for job to finish
-- [ ] Verify that the OSTree commit and its signature are present and valid by booting a VM at the previous release (e.g. `cosa run --qemu-image /path/to/previous.qcow2`) and verifying that `rpm-ostree upgrade --bypass-driver` works and `rpm-ostree status` shows a valid signature.
-    - [ ] x86_64
-    - [ ] aarch64 (optional)
-        - Can easily bring up instance from previous release in stream with:
-            - `cosa kola spawn -b fcos --stream stable --arch=aarch64 -p aws --aws-credentials-file /srv/creds`
 
 At this point, Cincinnati will see the new release on its next refresh and create a corresponding node in the graph without edges pointing to it yet.
 

--- a/ISSUE_TEMPLATE/testing.md
+++ b/ISSUE_TEMPLATE/testing.md
@@ -44,11 +44,6 @@ upgrade` will have the new update.
 - [ ] Run the [release job](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/fedora-coreos/job/fedora-coreos-fedora-coreos-pipeline-release/build?delay=0sec), filling in for parameters `testing` and the new version ID
 - [ ] Post a link to the job as a comment to this issue
 - [ ] Wait for job to finish
-- [ ] Verify that the OSTree commit and its signature are present and valid by booting a VM at the previous release (e.g. `cosa run --qemu-image /path/to/previous.qcow2`) and verifying that `rpm-ostree upgrade --bypass-driver` works and `rpm-ostree status` shows a valid signature.
-    - [ ] x86_64
-    - [ ] aarch64 (optional)
-        - Can easily bring up instance from previous release in stream with:
-            - `cosa kola spawn -b fcos --stream testing --arch=aarch64 -p aws --aws-credentials-file /srv/creds`
 
 At this point, Cincinnati will see the new release on its next refresh and create a corresponding node in the graph without edges pointing to it yet.
 


### PR DESCRIPTION
This is part of the release job now:
https://github.com/coreos/fedora-coreos-pipeline/pull/365