### PR TITLE
Triple rollout

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,194 +1,194 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2021-08-10T07:24:24Z"
+        "last-modified": "2021-08-24T06:31:02Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210808.1.0",
+                    "release": "34.20210821.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "f73dbc4d487aa1907104edd5a68df15c540c4fcc706fe48fd12113aaaacfe6a0",
-                                "uncompressed-sha256": "d67ec2401b377c50e9341b36da99861fef4318e6136483cdf84c09df468a57c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "bb3d8edf53b01895d01a2ac3b5aeda72bcf99f21f46cdc093949f151f348bcec",
+                                "uncompressed-sha256": "9647b7f8e3198d4726a005c19e4637cee4691cde02fb16a6a15455f4c5765096"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210808.1.0",
+                    "release": "34.20210821.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "91a89656c8ecaae40ba92434a565a57b925977e4e4bfd2af91f33d95d4db32ce",
-                                "uncompressed-sha256": "b7665e527c52e33c57c94554d42af5e43710b14c65327ee35e9be278f5b42e6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "d90ac877492d03028164b734fd491f98201b501b40fb88d9f0f7a07192b17cb6",
+                                "uncompressed-sha256": "02a898ba30f304880828e9e3c64d55aef5624fdad6596a7533c354adf97c1d40"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210808.1.0",
+                    "release": "34.20210821.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "b467652673ffaa0c19359b0846b177e4ea7ac81f9d9ce067a800824472c7c1c0",
-                                "uncompressed-sha256": "3bf7df97cf08a6d152547a2d3861e8ff6719209742f9caac28679e9769e8de87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "6bdc672cb2154620a7c7192f66e485bd7808bef15508139126de670b0fc21b56",
+                                "uncompressed-sha256": "27c81d412024d603326878251355117628ef939d3b8087a164bca35544594bb6"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210808.1.0",
+                    "release": "34.20210821.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "d82fa49332fbd335cc9ab472c3dc26b764ca37d6b0037674ac97e835b58501c0",
-                                "uncompressed-sha256": "1dd252a4486339d215e74b9f363b2223e7d0fcf7e96c4d1015a364de309318a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "4ab83986590191032ddcf9213c1d0c24d2e99cc9239e0a46b8b52bd0f82f2542",
+                                "uncompressed-sha256": "6ad82e2043295b8f4a9589aa1ea722490d63cbb9ef75662e58c6eb808cf6dad9"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210808.1.0",
+                    "release": "34.20210821.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "e1bc269ae372c632edc7f45026ff2b30f572bea502a1fa5e3b7732c39917d777",
-                                "uncompressed-sha256": "03f10a9ea5ba039caf919c1b0fc3c440d314f8172dffdbfdc471bc7e31b3d627"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "68e21893301a91107f62b21a36c21714a3ca08676f26e127a223af5cdbed3d72",
+                                "uncompressed-sha256": "7c43dfc1d2e3a62fb0d4c04b02a32a1d6e3b655ee863a7514998b2694ab23618"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210808.1.0",
+                    "release": "34.20210821.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "929062875357fab21b8ada67cebab73f4dcd052c2211b2b203b0bee2dc23db45",
-                                "uncompressed-sha256": "a47afcdeb0e3b137a279bf26238f9cb50abe18e66620d5da148a9ba8410b2b53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "370d6e44dbb9b3ca6dcd8dd62e3d16691d7bfdc37996bcc298409b83a11cd745",
+                                "uncompressed-sha256": "57c178f0b3ab106e2d9f38c0067cc4725328acc7c71947f038c0876b0a839413"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210808.1.0",
+                    "release": "34.20210821.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a70b5988b612bf19255cd3e09492eec2003bd84289e50f7517804cd18c9a59d7",
-                                "uncompressed-sha256": "dce2ccf3cb946fc51f497dbe522aa8b205227a9f98ee72eaf1d3b390aa7d2648"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "e6030556f763dc8ebb5a5ef593e56f39e60a7474edbe768fd544a249f657403b",
+                                "uncompressed-sha256": "2c6a6af8aaf85e7531ecdb0b3d92d51878e74c7755bbd6646706dae7b4f9f1c3"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210808.1.0",
+                    "release": "34.20210821.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "1c43e6346a71841c1ebf86cc5c537812f52bf83706ab2f32be067b345b841793",
-                                "uncompressed-sha256": "39e98dd3a68b03525785835964d923c4601c48b71b3df7a823e260b638e3d2ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "887852024cf38777d137b72d7e54909e06d5d3384d32b0e8381b6bf73afe836b",
+                                "uncompressed-sha256": "0b95b2e174691939dcbad452ece4896dfaf6cc0d8cffce2f94d2e29fe0a97465"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-live.x86_64.iso.sig",
-                                "sha256": "e260c3417fb4e0645d647a2917573720bc23fbf97ac2b05a7850bcf905a92e54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-live.x86_64.iso.sig",
+                                "sha256": "fc6eb0e30a1209fea774f00202acc4755ee693ef2daa1c0b2f3f67ffeb29bac4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-live-kernel-x86_64.sig",
-                                "sha256": "e229061d84a3e83a53bb2361f82b255dc3c9a760b3c6127ca47117ae3c075672"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-live-kernel-x86_64.sig",
+                                "sha256": "a100553f9aa2ebd5f134f807cac26b6ad4cb7ac1bb5aef850d847021bd7f07ca"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "c782544c02516fed10ab1f91aeb5e34ad9224842786b56e4ba8e28c1fe12ec8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "4a982172dc78ac5294bd9ef023bfcd454c7759723c9a91c24f0d8d99b23775f1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "d5f2110320dd42f4875d6d9dea54e76f73f2e4b64b02d694106a3a23c168aa21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "ba85408f28b74d64e93ba74c7504d515a45d962eff1c4eab8a1569e6b425b0b6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "c5a1616e5e1d8c0c949c0ce536346d9086001e363e4cf8ae0074d2aabdbe2ff6",
-                                "uncompressed-sha256": "784437f9c762c5891c3da47da3352ba196f4151009d6aa7e5da85fea6b2c2afd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "a03202d42979dbeb10819fdfc04dcd9c650298bebc6cd74f94f4ada03c23ded2",
+                                "uncompressed-sha256": "2a14510cae0ae023aa8a57b14997056a3627fb1e55e17f6d4cf43a24c92f51bb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210808.1.0",
+                    "release": "34.20210821.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e8403a79919b53021f9e9c8dab1f58f10ec9fd280c180286b774320fb82d324a",
-                                "uncompressed-sha256": "5f59830b506ab1d6ef0b5a0e58462073203f9356021c9fb5d91e1310449e15eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "e8dd87d9f175c29235d16d795dd9316451a4473000dbb7993de93012ddf3d4bf",
+                                "uncompressed-sha256": "9a9d0e92c7d95d7288c5f25581c7fd72b291ce6ab5b10c4790a2528f4cf1019a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210808.1.0",
+                    "release": "34.20210821.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "7216804e0b4507c19cdbae703fd111c35f320fc052de9d51b4ded8a2ea655ba7",
-                                "uncompressed-sha256": "c188a40b2ead6fbc870a207c25d6aa3750ca11f8a8f85c3a93320148579060a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "58eb2116b5f702dce035da5acda08292f01861088f1f1f8c79bf6d74cb5a0f63",
+                                "uncompressed-sha256": "53483d3377733818e0e81dc7313e27602c3f419ce75398042a94f586a7ef7aa4"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210808.1.0",
+                    "release": "34.20210821.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "41f0100fd15f54db240d87896616c88007a8a1fce1ae2470cb2e47e132c4aa09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "2d5c1ec61e46582c2023aa137a8b650426a1f33883619435b0fc6345a31f0052"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210808.1.0",
+                    "release": "34.20210821.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210808.1.0/x86_64/fedora-coreos-34.20210808.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "9713c23cf978e4a2e3254dbca9e644d9c9d09fff3151b17979171e4bbbc71576",
-                                "uncompressed-sha256": "d79ebe667776de80a794f2c7ecb93c83e1a8078741cfdc7ba47dcffda0044b64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210821.1.1/x86_64/fedora-coreos-34.20210821.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "6f5bc2cfdb3006e1861ed68267990ee333524ffc6f6e44b198febe2474ea6072",
+                                "uncompressed-sha256": "ecb7e12b770cb74c8c37884e511cfb24374914c2cb7a4d34d35ac3c99830819c"
                             }
                         }
                     }
@@ -198,95 +198,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-0ea82df0334d26dce"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-07a098286ba2a32e5"
                         },
                         "ap-east-1": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-09c6c64bba6a46e5d"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-01babb2bc9bd6c066"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-0d23a860a7f364915"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-073c6d323358d6345"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-025ea7d138d851588"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-07eaa25a24ba53fc3"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-09d7902ae4275fd17"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-05fbabf94bdc49f78"
                         },
                         "ap-south-1": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-0ceb852185a1833ee"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-087743b4bca32ba4f"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-00e2da25ea1c2e20b"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-0a275c509a41430f6"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-06b7e15b7de163920"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-0360ddc8f2dd03d0c"
                         },
                         "ca-central-1": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-0d4c337a7bd0b8934"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-064f6b21a3dd80742"
                         },
                         "eu-central-1": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-0f0d25841efe99191"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-066c3141c8ac31dda"
                         },
                         "eu-north-1": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-047f2ba63bf7dcd4c"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-01bae3800e379c427"
                         },
                         "eu-south-1": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-0ac98b8431a9e873f"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-09b3e91f0d6eeeb37"
                         },
                         "eu-west-1": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-06ce1fac1aaef41fc"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-00b98305387a367cd"
                         },
                         "eu-west-2": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-0eb712715718d9caa"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-094c472a5cdd91b88"
                         },
                         "eu-west-3": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-0c5af6841c9124fa1"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-0bb210fdd4bafc04c"
                         },
                         "me-south-1": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-022f4094a03b35863"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-0f3a3dcb15189c500"
                         },
                         "sa-east-1": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-0d2753d0bd948c2a2"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-0df578f556cbea033"
                         },
                         "us-east-1": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-0293ffa4b53e1a5a2"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-04ed8c8b65aec1834"
                         },
                         "us-east-2": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-01ba6edc187ed4440"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-09e7ca07ec8aa6983"
                         },
                         "us-west-1": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-09beda7987d5f220c"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-04ae4a92c4fc6cce2"
                         },
                         "us-west-2": {
-                            "release": "34.20210808.1.0",
-                            "image": "ami-0b8176387bb3e497d"
+                            "release": "34.20210821.1.1",
+                            "image": "ami-0ac6954112df2660a"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-34-20210808-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210821-1-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,194 +1,194 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2021-08-10T07:14:05Z"
+        "last-modified": "2021-08-24T05:57:23Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210725.3.0",
+                    "release": "34.20210808.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "aa4c5417485f4c4c967eed134e01ca74db6155aab272223ed2831ef0a86194cd",
-                                "uncompressed-sha256": "f31898ac2e538dc4d717a9563c013b5c37924cc8eca88d85453a73be287929df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "9bebacb23690e8d5d6389285ddd0b62504b145f5d0c1f64c8880d43335b5d985",
+                                "uncompressed-sha256": "57e59d318b797aa39cd981bf50f41be2f142a23a93c5f73e87f3b970bc4930c5"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210725.3.0",
+                    "release": "34.20210808.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "cd5634902fcc9e3710a2ba54a6308d2543ccf3fc7bf3206b93920ddc696cae44",
-                                "uncompressed-sha256": "7a7c5f4b110b3f6140de737113bc44afb49402b0aa947f672c8eabaf431fa1fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "8a0874ef6a6f209f2c6558042fd49727b1a75bfdc31c4dd45dddab9b7719a08b",
+                                "uncompressed-sha256": "0af20f9e2a6b514d688316b5a09742fc02e19dc1ca1c9507356627218690a539"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210725.3.0",
+                    "release": "34.20210808.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "88e8f0a4b506681f89a02728e7b904c2c6d26c045db393226f30819ce790de21",
-                                "uncompressed-sha256": "6bf2bdbbbcb0ab8f237f1d6637ca183d3765c640895ff77cd375ff4690f3a851"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "a6462638c4c1eb877a2395bd8861b2127c0c175f36574322c2a28d1aab89698a",
+                                "uncompressed-sha256": "28bbf2c05863458a7c87d90c95e9fc04ec3004546d04436ed4a2de68e6010aae"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210725.3.0",
+                    "release": "34.20210808.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "b37ee18364cbe030b2c18be9f79d7b9ce65ee49f5bf0030a4d00b6c6c052aa53",
-                                "uncompressed-sha256": "9f73bf6e79426bd8f19612e8fb5663ee2eed27be43b22dad1f8b32d850a10818"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "57aa06a43a6c7e3ba32112ace8dca3497008112596f93967c50c1753ab6fc864",
+                                "uncompressed-sha256": "ddb4fa87728a42abf737f594169c32198d5d369d0147668ac3587af3a65b362c"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210725.3.0",
+                    "release": "34.20210808.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "1f2ec123fbd7f2db81ed242ba4c7846c9102547faaed16ad774d9305843c54d2",
-                                "uncompressed-sha256": "42b9a37961db84811765809a7a165747b852e3d8692599070ee936b27b03d8f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "cdf083bdf61117c07c121cb5cf3c90dded7f803cc1061b7653c2562aa6279d28",
+                                "uncompressed-sha256": "288ac6ca25552c4e53b45ff795b0059ec5195e8bd7098ba6f685859247716697"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210725.3.0",
+                    "release": "34.20210808.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "25f5b602f5d6e4288f22a42dd5940551c9cf455352418c4bce1cdb465fee3e9c",
-                                "uncompressed-sha256": "f14158b8e79ec8c3b30d4a59f302c17347326cb6b077b91627d5ad5c02cbac4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "9f8b9d57524c3b134a8ff8f257a7e4565206023ec7b293ae3ba210880cf647a8",
+                                "uncompressed-sha256": "87955febc832fd0949160272d2e15cf12efb8718e7cc617b4f6cb8db0324eacb"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210725.3.0",
+                    "release": "34.20210808.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "d5d6b50097d70bdd08273dd498dd46b3aebd9b60937ce8593050dfb4c6236ae2",
-                                "uncompressed-sha256": "dc86dcc81b595715a2e9b17661ba1a988ec29fbf243db7c3c4479a7582060ff9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "9744514b63fa3f265aa3deaf2f4bec55cbce7b9ce23d695ff8fe145f6cdf1c9d",
+                                "uncompressed-sha256": "9b5a98cb23b39609c38f3cc67738492d84f2c1e73fb4941895fe3ae1d72e1844"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210725.3.0",
+                    "release": "34.20210808.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "1c3c7d6e7a4bf597e8c4a0c5c8ff2b86172524d89cb31f22344c74718bf8ad3c",
-                                "uncompressed-sha256": "19b9cb36e2147e0fc058721acfc16c944b06c90f9d0035369170111665500288"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "390de0273f74b539ed6eacfbfa80dec1eb0319466eb8b0413c4ef2de36cd7a8b",
+                                "uncompressed-sha256": "2586215f5e07fa7673e9f5a9d1d5be061725ffaa34b2104da78b48658e86065c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-live.x86_64.iso.sig",
-                                "sha256": "4ebb1142734675ea5cc1c05e320c5645635b7613e9111edd9a306d30586730e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-live.x86_64.iso.sig",
+                                "sha256": "4774e25d4512ae5879b9d0e92ca629a8172b1e44501167d0d497ff27e352d4be"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-live-kernel-x86_64.sig",
-                                "sha256": "3166c98d325ff3b06e092683060b512bc6f72dc354e424c1634186492b032db5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-live-kernel-x86_64.sig",
+                                "sha256": "e229061d84a3e83a53bb2361f82b255dc3c9a760b3c6127ca47117ae3c075672"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "4dd69640cc39fce7b3b03885563fd024f1237951961832cc78356b06c54976cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "7b9159e13ff332798603a80f71db4ccf2d6662d4cffc7106c5e4c6352b0610ed"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "ca19c65f7f072ed1df1b9889913cc8aa9f1d6629a00fe7f45625a98c90ff8bd4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "57b0c4415498cbd33aa6d5c045cc8179d3a88c7f3d24efae6adc4663c110974c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "7bd74da42d53fd6c42098d57ba61b3bb5549c4c2d147f8bd78a46c452cccdc93",
-                                "uncompressed-sha256": "a963e02261a30ddbd2d37841bcce8813b66d8ded9e64b05e5d4b30c510417e2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "49af93873cc188dbc2b1596814e03e599ec2790c65b208647532223530c6385c",
+                                "uncompressed-sha256": "4764cbaf4841410f6c997d5202c1470d3b4923eccbfbe28994944ff3e2088a78"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210725.3.0",
+                    "release": "34.20210808.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "f5fe560c450fe9d4d7912314250c274a7bcd5bca17265909e4a4ca9573e90458",
-                                "uncompressed-sha256": "13bc363d3eeff9ae2381322b9ea01745cbd967614fea76b118639113a5246301"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "9fed62293487e628e2a564bd9e5404664b72cf2553f6469443e9f8c61d3cc915",
+                                "uncompressed-sha256": "5aeb9e1f13ebb2f5f9ef6adc66c62cc3a714cdf453a46ceb2457b2108cca073e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210725.3.0",
+                    "release": "34.20210808.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "17a406257f362a8b0b77caab9d0cc5d504b11aa71057f4166bcb5cc3bcf739e5",
-                                "uncompressed-sha256": "f26636e0c64be59d7e3c451d8af0bfe9ece01a3e0888bb06ce991d6394ecc497"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "16da74c62e4d6780380a3a4b0e01f9b95bbc40688acfa2712b99ebf6c70a26e9",
+                                "uncompressed-sha256": "8cc59d4defa1f0ae109e449a97160658076c2632828ae1aec8a9f2fc1b2d3372"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210725.3.0",
+                    "release": "34.20210808.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "7e56f74b9bcfaaae345739996dace9caab7bb3ac492fff198cc333ef2c2c1449"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "4a1c72264423d1b0330d07a940558dc2da2a7f8e3e6ef51d3f59d452b487db98"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210725.3.0",
+                    "release": "34.20210808.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210725.3.0/x86_64/fedora-coreos-34.20210725.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "27b380acb5b6c8746756b7765f7892dded3bd1a906d321b5b4b4debafc529b28",
-                                "uncompressed-sha256": "6c1d5167f8d114be7ec9840f6c45da10e0b954ba660388b1f062bbc7c0c83104"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "b7fd75ad103d64ac307ceb7052897311f7ba957da0920ff4d1bd4f0ce49f71a9",
+                                "uncompressed-sha256": "284baaa53b04de3295839d33e6eb6e676315706b8e55b954fa572ce9b83e3e2d"
                             }
                         }
                     }
@@ -198,95 +198,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-09fea3a1a9a64f92a"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-0b98b2ea34c1a4d7f"
                         },
                         "ap-east-1": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-0f3789a49c9c648b7"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-082786de1d9223e4c"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-07accb68b41fe0dcc"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-0fb3fe0d65150261d"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-06cf48d52b757aa81"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-0c0ee3af47eb9598c"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-0d2ae434a92e77b63"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-09257b9584354c716"
                         },
                         "ap-south-1": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-05f6c4104475239f8"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-099944151b6fd2486"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-0fbd2396f9cd93494"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-0d3793bca856bdc39"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-0697ecadab5711f9b"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-01c3c04359970b528"
                         },
                         "ca-central-1": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-0594d3795531cc7ea"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-047f0cc3e1d113253"
                         },
                         "eu-central-1": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-09b0b39e23a402085"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-0a55c7be31e80cc58"
                         },
                         "eu-north-1": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-004d8526bb98d8a67"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-0382aafd88b416985"
                         },
                         "eu-south-1": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-0c74b3e6e9690b2dc"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-0959fe9ce997137fb"
                         },
                         "eu-west-1": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-062fd65ec69e47ef3"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-0068d09f6c489852a"
                         },
                         "eu-west-2": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-0c1c76c70a6dcfc67"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-00a8f3c74770b3f65"
                         },
                         "eu-west-3": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-0ba545eb005937cf2"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-060bfa489c12f2c65"
                         },
                         "me-south-1": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-090c03f4b624266c3"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-02bbc28b7742bb8a4"
                         },
                         "sa-east-1": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-02945f0c74ba815e0"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-03e96030ca9bdf343"
                         },
                         "us-east-1": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-053b1e0d641726217"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-08f244a17989e56b6"
                         },
                         "us-east-2": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-093cd002d946cc0d6"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-050f4781955e5f76f"
                         },
                         "us-west-1": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-0da9441b71b3ecf8f"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-0ec499c7a1bfd6a0e"
                         },
                         "us-west-2": {
-                            "release": "34.20210725.3.0",
-                            "image": "ami-0745d4c5939d7abe9"
+                            "release": "34.20210808.3.0",
+                            "image": "ami-02e64ce7ea9b916c5"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-34-20210725-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210808-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,194 +1,194 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2021-08-10T07:20:48Z"
+        "last-modified": "2021-08-24T06:01:00Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210808.2.0",
+                    "release": "34.20210821.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "77ee6a85cc9d7ae9cc9c4f85996933c45fbc6ffcfa4b6940abc9634963e3d16e",
-                                "uncompressed-sha256": "e59ab7979a44133d46642b8d9ea1fa7eee691984e998c14edac35cec7f510f34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "3516b52e1cc3e2ea919a8bc130cfcdd46da7e3c32c284aa2842471a8c41cc050",
+                                "uncompressed-sha256": "b6d33fc206baa7985673cd7e0418e871e58ecf0e2970c5741bc57ad60b53a700"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210808.2.0",
+                    "release": "34.20210821.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "fc64541655802b7f8e41dfe3ade2dbd6140aa602731e2d9ff26e86817db46769",
-                                "uncompressed-sha256": "86e91c199c0f2674ee8b5d7adc8409809c3c48fb08f6c5e41d0c3c9ad1154172"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "a46eb15fe0b8a879afa083f4f2a9e168af05c11f6bceaeea8c5ddab9fa9d2a24",
+                                "uncompressed-sha256": "6ea354b7be39c22697bdb975ebec6e4b4dd813db4c3614631487fa45580ca740"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210808.2.0",
+                    "release": "34.20210821.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "5a65fed741c0b36f42a9a65106000ff469457eda4cdef9a2c671d5d159f7ab5e",
-                                "uncompressed-sha256": "f2c12699a5b3238290f1e570eca83459089da7c6cd96a872643b0ae465cbd827"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "7f3e3b3a3ec3549e19f108a78d78f7e79d891d9b47f60697063d968c0d7c0085",
+                                "uncompressed-sha256": "50c35fb8e25b6b19d28915dac71123a78de7ac982a3da9ec493c8217d273ed1a"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210808.2.0",
+                    "release": "34.20210821.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "091b4e66419ae13525600419d173e20315e574fcbf7cf60e47f9771a143976e0",
-                                "uncompressed-sha256": "a7d875157cc83b954345836f351810a9ccb0ee13da96d621d1103fa89ed1908a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "935d1fbf5f2e67ddc1f8bb89638883ec1f730815835cfe1247efb5453968bd8d",
+                                "uncompressed-sha256": "5104d1b20f283559f09b2b4d9e739db6aac35f2a547e48d582c8781f99af7e78"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210808.2.0",
+                    "release": "34.20210821.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "89f953b96dd579d68fe83f6f5d7b8328358e397a2c0b0c75ac89d48362ad06b3",
-                                "uncompressed-sha256": "2dc30b93815579146a3cb71a95b129dcb353ae161b465f59ab644207e0be906d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "78cc69b8726b7d1b0376e6536e575b358827597ad8edefc705a6f1dd86ebffe5",
+                                "uncompressed-sha256": "ceb6c040c4f86da583896c999cabfe8545bae7ed7b8b5f9364f334a1dae73522"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210808.2.0",
+                    "release": "34.20210821.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "85a9deb0ad9917dc6c2eb52149102620762113ff9c7103233538e8d39b18132a",
-                                "uncompressed-sha256": "8d8a4bcf07c2db86ec297c9c443301afc34426385bf7c2af10847b27cd470591"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "a20d6d0ffb3d2ee4a89f5d0341f63f6fc331e36264e2bae4132e28b5c8153507",
+                                "uncompressed-sha256": "3558f9f63b1225cd7d0e9c150f4c17abaf7dd5b2608fe4b30cdc06541f048271"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210808.2.0",
+                    "release": "34.20210821.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "8a166ffbcfda752b9f0bb1e06b529a234216ab78b59cb12229f5c63c3bb6de7a",
-                                "uncompressed-sha256": "d22579198252bdc2ef96e6826ed584305bb84374062fc1e181b3095d803eb554"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "5c6dfbab464e95bac106dce67d614b9281fa032199bc7b5fb82a726891b04898",
+                                "uncompressed-sha256": "585b471016459a3976f48ed9f4e0d1e917c41f70448fab5db63f1e02583e882d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210808.2.0",
+                    "release": "34.20210821.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "5c6d05848dc2b71c084313cd70be3ac0696c2eaa590a3284772cebec933ca2cb",
-                                "uncompressed-sha256": "d90ad64cf06f13021612659d37503ceeec3d0f4b1bbbd0fb20618258975f1a4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "6f035f17e42e22ab47e78cd4f9aeacb79a7dba566ef31c060b0d8b5176023cef",
+                                "uncompressed-sha256": "a25880ed10a22fb400ae94334064b27889203f1ea24b74cf257e9a7be6060a44"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-live.x86_64.iso.sig",
-                                "sha256": "8ec901fcb5bf9f05cf8046cbe7bce29e36600b7ec61165577c1b3c565b85425c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-live.x86_64.iso.sig",
+                                "sha256": "e63460137a183196eba0a6336daf48dcb066212044275906046303dd4d1698a5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-live-kernel-x86_64.sig",
-                                "sha256": "e229061d84a3e83a53bb2361f82b255dc3c9a760b3c6127ca47117ae3c075672"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-live-kernel-x86_64.sig",
+                                "sha256": "a100553f9aa2ebd5f134f807cac26b6ad4cb7ac1bb5aef850d847021bd7f07ca"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "42fbdf7fb6a7f061125d95bbe92e722aeee6b108df6b675b05956d2af7ccd406"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "5ed6a08348ce8df5cb17fdfc897223737445aaaa0d79ff5e8c412478786761ae"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "0610481dfffe9bc92f26871f3b290c9ea7b227566c1712fe0ec368aa51e6568f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "1a5cc5648d589977ca85480308c9bc6b34b829af1ad0b2ea2d1a22fe3aca2ef1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "33ff080a98759a7fdba603eef08346ac971ab30405ab3c227005d370fa57f339",
-                                "uncompressed-sha256": "9724450602652a211a7a669eecfb4e39a3e39be182fd11e645a50a6d4d509587"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "77a325eb5f07eb59b1282344398d3312bbcdd1d1ecc9dacbc1f7930ad2c58276",
+                                "uncompressed-sha256": "8c41d05a7bc5057245e7dff00f460897832f5fb2230c115ead4e5aad493d1ee2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210808.2.0",
+                    "release": "34.20210821.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "b6715c5b399d2ef1fc125804aad1bbd6245873074e7fa0897ae10271cd5237fd",
-                                "uncompressed-sha256": "9e89e817ed9b27d33f5709f224efb7b889913c2a8835a0677754eb3b5aa95a87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "0b62198dd7c5a58e4ab4d65b0c8b51d9243d2f6cfb6f3b7f167efc524a26a888",
+                                "uncompressed-sha256": "77d26384d459cbc5ea60f79ff8781a4e5cef9f6df6dfb4b92ec4c10b8e7929ed"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210808.2.0",
+                    "release": "34.20210821.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "9d97ec2eb518644f72a781fc964750550625d4e00da8c5370b61eda9c6ee2777",
-                                "uncompressed-sha256": "e1c2284d58b12f4ffb47bb5a573cc91e7f4c78fe507caf167a18f18db2f9c477"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "c013f2f0c095cb112cd33d6705596ff2247f687b14f3570ef911b5ff7d4f875d",
+                                "uncompressed-sha256": "197d76635bd8868076ab0e44297c07ad271f1b5f9f20a7f9b1bbb0b88578c847"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210808.2.0",
+                    "release": "34.20210821.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "7c3bf081e01782b883edd804ce7a584a64515ad1585a3f0ad0c9d4eba0a2f25f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "99e82d4cb9e28b7428f62472cc24e9c3d33dda2af947770e1ef51c7383b348d5"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210808.2.0",
+                    "release": "34.20210821.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210808.2.0/x86_64/fedora-coreos-34.20210808.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "16d7af275cb4fbabe7ae449346207d1ab94fb17e2bfeae95bda818b718245a9b",
-                                "uncompressed-sha256": "7422094bab5220a9960eaabbeb402ce4cc3fef1cc6242dda36ea2f1f43262c8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "1981be95e36eb76785f77fc0f75bd38d21559db8e3527dfd405870a7b1959275",
+                                "uncompressed-sha256": "80e50366cc01ce0be60e98962756d60e4ffe0ca8703cf20a646c71ec0c9039ae"
                             }
                         }
                     }
@@ -198,95 +198,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-0f3969f6edf37b3c3"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-0806a8bf6ad5236ae"
                         },
                         "ap-east-1": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-02a1d9e21d436f884"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-0991c8a0aaa6df3d6"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-01e91b02e5b1010d2"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-0d8ac3f83f77f5b07"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-00048f29458c5a818"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-04ffbe8af3ba9f5c9"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-09caa5b219d7981bf"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-055da6ee268930c11"
                         },
                         "ap-south-1": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-0b1c66dc15fe9100c"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-0a58ce93c0b4e0d43"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-0b59063fe29adf884"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-0e51a575e4e2148c0"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-01b9951ecd96d72a0"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-0e6d4394c49df8d21"
                         },
                         "ca-central-1": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-092d8b27d712e8aa9"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-04cdc3a5f1649c8ba"
                         },
                         "eu-central-1": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-0826e89027ae68985"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-016073cf2536d826c"
                         },
                         "eu-north-1": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-0b18555773cec84c7"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-01c699afa096e7bf7"
                         },
                         "eu-south-1": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-04d40b3089c2f5f61"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-0697bb942c443ec16"
                         },
                         "eu-west-1": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-00efa29d9742b9552"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-08a6f5a9d860c6d40"
                         },
                         "eu-west-2": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-0c0f7938fb2b6868f"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-01b8790fa63e6d372"
                         },
                         "eu-west-3": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-099c5cb953b09675d"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-00c2648f70451e7d7"
                         },
                         "me-south-1": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-0136378eae9f7d0b0"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-03f664569c34c0f2b"
                         },
                         "sa-east-1": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-061a530542e2287d3"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-0450435ebea20ef38"
                         },
                         "us-east-1": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-0413df3ef8447fee9"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-0da0b5f31d5363ad6"
                         },
                         "us-east-2": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-0fbf9b80bc93e7d6a"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-08473fc77ebb54159"
                         },
                         "us-west-1": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-01d644c45138e8e2f"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-04c13c0724fb794dc"
                         },
                         "us-west-2": {
-                            "release": "34.20210808.2.0",
-                            "image": "ami-02911b23216709e99"
+                            "release": "34.20210821.2.0",
+                            "image": "ami-0d67c555e19ce8ac8"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-34-20210808-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210821-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2021-08-10T07:25:00Z"
+    "last-modified": "2021-08-24T06:31:30Z"
   },
   "releases": [
     {
@@ -37,7 +37,7 @@
       }
     },
     {
-      "version": "34.20210725.1.0",
+      "version": "34.20210808.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -45,11 +45,11 @@
       }
     },
     {
-      "version": "34.20210808.1.0",
+      "version": "34.20210821.1.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1628607600,
+          "start_epoch": 1629819000,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2021-08-10T07:15:46Z"
+    "last-modified": "2021-08-24T05:58:46Z"
   },
   "releases": [
     {
@@ -45,7 +45,7 @@
       }
     },
     {
-      "version": "34.20210711.3.0",
+      "version": "34.20210725.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -53,11 +53,11 @@
       }
     },
     {
-      "version": "34.20210725.3.0",
+      "version": "34.20210808.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1628607600,
+          "start_epoch": 1629819000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2021-08-10T07:21:26Z"
+    "last-modified": "2021-08-24T06:01:22Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "34.20210725.2.0",
+      "version": "34.20210808.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "34.20210808.2.0",
+      "version": "34.20210821.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1628607600,
+          "start_epoch": 1629819000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
```
stable
    version: 34.20210808.3.0 (latest)
    start: 2021-08-24 15:30:00+00:00 UTC (in 8:53:59)
           2021-08-24 11:30:00-04:00 Raleigh/New York/Toronto
           2021-08-24 17:30:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)
testing
    version: 34.20210821.2.0 (latest)
    start: 2021-08-24 15:30:00+00:00 UTC (in 8:53:59)
           2021-08-24 11:30:00-04:00 Raleigh/New York/Toronto
           2021-08-24 17:30:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)
next
    version: 34.20210821.1.1 (latest)
    start: 2021-08-24 15:30:00+00:00 UTC (in 8:53:59)
           2021-08-24 11:30:00-04:00 Raleigh/New York/Toronto
           2021-08-24 17:30:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)
```