### PR TITLE
Rollout for testing and stable streams

### DIFF
--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,194 +1,91 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2021-08-24T05:57:23Z"
+        "last-modified": "2021-09-07T16:27:58Z"
     },
     "architectures": {
-        "x86_64": {
+        "aarch64": {
             "artifacts": {
-                "aliyun": {
-                    "release": "34.20210808.3.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "9bebacb23690e8d5d6389285ddd0b62504b145f5d0c1f64c8880d43335b5d985",
-                                "uncompressed-sha256": "57e59d318b797aa39cd981bf50f41be2f142a23a93c5f73e87f3b970bc4930c5"
-                            }
-                        }
-                    }
-                },
                 "aws": {
-                    "release": "34.20210808.3.0",
+                    "release": "34.20210821.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "8a0874ef6a6f209f2c6558042fd49727b1a75bfdc31c4dd45dddab9b7719a08b",
-                                "uncompressed-sha256": "0af20f9e2a6b514d688316b5a09742fc02e19dc1ca1c9507356627218690a539"
-                            }
-                        }
-                    }
-                },
-                "azure": {
-                    "release": "34.20210808.3.0",
-                    "formats": {
-                        "vhd.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "a6462638c4c1eb877a2395bd8861b2127c0c175f36574322c2a28d1aab89698a",
-                                "uncompressed-sha256": "28bbf2c05863458a7c87d90c95e9fc04ec3004546d04436ed4a2de68e6010aae"
-                            }
-                        }
-                    }
-                },
-                "digitalocean": {
-                    "release": "34.20210808.3.0",
-                    "formats": {
-                        "qcow2.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "57aa06a43a6c7e3ba32112ace8dca3497008112596f93967c50c1753ab6fc864",
-                                "uncompressed-sha256": "ddb4fa87728a42abf737f594169c32198d5d369d0147668ac3587af3a65b362c"
-                            }
-                        }
-                    }
-                },
-                "exoscale": {
-                    "release": "34.20210808.3.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "cdf083bdf61117c07c121cb5cf3c90dded7f803cc1061b7653c2562aa6279d28",
-                                "uncompressed-sha256": "288ac6ca25552c4e53b45ff795b0059ec5195e8bd7098ba6f685859247716697"
-                            }
-                        }
-                    }
-                },
-                "gcp": {
-                    "release": "34.20210808.3.0",
-                    "formats": {
-                        "tar.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "9f8b9d57524c3b134a8ff8f257a7e4565206023ec7b293ae3ba210880cf647a8",
-                                "uncompressed-sha256": "87955febc832fd0949160272d2e15cf12efb8718e7cc617b4f6cb8db0324eacb"
-                            }
-                        }
-                    }
-                },
-                "ibmcloud": {
-                    "release": "34.20210808.3.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "9744514b63fa3f265aa3deaf2f4bec55cbce7b9ce23d695ff8fe145f6cdf1c9d",
-                                "uncompressed-sha256": "9b5a98cb23b39609c38f3cc67738492d84f2c1e73fb4941895fe3ae1d72e1844"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "c422dfde56c2029eb2df04561f6ef8857e946935fa0b82b3ba4fe4cb7b66e798",
+                                "uncompressed-sha256": "abe705aaa511fcbeff8f47085aae12fd60bd3e9db705a7a60502a43db17d0060"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210808.3.0",
+                    "release": "34.20210821.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "390de0273f74b539ed6eacfbfa80dec1eb0319466eb8b0413c4ef2de36cd7a8b",
-                                "uncompressed-sha256": "2586215f5e07fa7673e9f5a9d1d5be061725ffaa34b2104da78b48658e86065c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "34a3f4100b9341eecab12e182bc24e7bc42649b938a08cbfe5c21158287ea03f",
+                                "uncompressed-sha256": "2d0fee93290546663bcd83b3c528350faf36205ee319e675285e95657c0d9db8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-live.x86_64.iso.sig",
-                                "sha256": "4774e25d4512ae5879b9d0e92ca629a8172b1e44501167d0d497ff27e352d4be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-live.aarch64.iso.sig",
+                                "sha256": "12245ecb20d5342ddd2ca3c9ace87bd830559cc0fcf1695b8cb73d2a3f5434cf"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-live-kernel-x86_64.sig",
-                                "sha256": "e229061d84a3e83a53bb2361f82b255dc3c9a760b3c6127ca47117ae3c075672"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-live-kernel-aarch64.sig",
+                                "sha256": "0fc3fe26f04840fcadc0fd24b02abf04b365a09a96945b1d74e325c9f5e75411"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "7b9159e13ff332798603a80f71db4ccf2d6662d4cffc7106c5e4c6352b0610ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "1a0e4b20c1a2d6417835984b52645a4773ba46000cba68a9cd586e2bac06e404"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "57b0c4415498cbd33aa6d5c045cc8179d3a88c7f3d24efae6adc4663c110974c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "bf3583fd373636d8120d486dfd62ac85398bde057af8e566f688b978c613c16a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "49af93873cc188dbc2b1596814e03e599ec2790c65b208647532223530c6385c",
-                                "uncompressed-sha256": "4764cbaf4841410f6c997d5202c1470d3b4923eccbfbe28994944ff3e2088a78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "7b50a2a62b9df0003ba10ca59eeefa6c214aa99bf21edd0ec1e63167e487e6af",
+                                "uncompressed-sha256": "fdfe2a8a3c2634c55ff403a0da1fba72ad427561e6de83f1e66059398fa6b207"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210808.3.0",
+                    "release": "34.20210821.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "9fed62293487e628e2a564bd9e5404664b72cf2553f6469443e9f8c61d3cc915",
-                                "uncompressed-sha256": "5aeb9e1f13ebb2f5f9ef6adc66c62cc3a714cdf453a46ceb2457b2108cca073e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c193f406f498e09ff7ff54391b42b9ac9481155e27425f0f4139e48b6122e511",
+                                "uncompressed-sha256": "2a11aa62550810f70ff132834f9a5f83e6921ef832b5e6d6d02296d648cfc4a5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210808.3.0",
+                    "release": "34.20210821.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "16da74c62e4d6780380a3a4b0e01f9b95bbc40688acfa2712b99ebf6c70a26e9",
-                                "uncompressed-sha256": "8cc59d4defa1f0ae109e449a97160658076c2632828ae1aec8a9f2fc1b2d3372"
-                            }
-                        }
-                    }
-                },
-                "vmware": {
-                    "release": "34.20210808.3.0",
-                    "formats": {
-                        "ova": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "4a1c72264423d1b0330d07a940558dc2da2a7f8e3e6ef51d3f59d452b487db98"
-                            }
-                        }
-                    }
-                },
-                "vultr": {
-                    "release": "34.20210808.3.0",
-                    "formats": {
-                        "raw.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210808.3.0/x86_64/fedora-coreos-34.20210808.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "b7fd75ad103d64ac307ceb7052897311f7ba957da0920ff4d1bd4f0ce49f71a9",
-                                "uncompressed-sha256": "284baaa53b04de3295839d33e6eb6e676315706b8e55b954fa572ce9b83e3e2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "9de9e6d3b6f31b812034a72265bacf42e6ad9e0935630169d3485e3ef20d5dfb",
+                                "uncompressed-sha256": "c872169d1a1ee3038e78a269f8d604e78262090892fd8cb1376df56410bde2ec"
                             }
                         }
                     }
@@ -198,95 +95,376 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-0b98b2ea34c1a4d7f"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-0bde2bde601a1d640"
                         },
                         "ap-east-1": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-082786de1d9223e4c"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-05d93271c94d74feb"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-0fb3fe0d65150261d"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-0391339ec29cb3e42"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-0c0ee3af47eb9598c"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-00f197de801ab41ba"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-09257b9584354c716"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-08769df4bb2eba99e"
                         },
                         "ap-south-1": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-099944151b6fd2486"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-003caaaef262fb5b4"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-0d3793bca856bdc39"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-0089fcac7a6ce9c82"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-01c3c04359970b528"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-07978e1a2f0280714"
                         },
                         "ca-central-1": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-047f0cc3e1d113253"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-0b9c2d5294b889d44"
                         },
                         "eu-central-1": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-0a55c7be31e80cc58"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-032f6f6d340911309"
                         },
                         "eu-north-1": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-0382aafd88b416985"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-065df82b2b5d40103"
                         },
                         "eu-south-1": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-0959fe9ce997137fb"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-0f032302d14c66b72"
                         },
                         "eu-west-1": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-0068d09f6c489852a"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-0211ffe4a0a5a352c"
                         },
                         "eu-west-2": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-00a8f3c74770b3f65"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-06de3c6b106427133"
                         },
                         "eu-west-3": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-060bfa489c12f2c65"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-0160b50c808c22698"
                         },
                         "me-south-1": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-02bbc28b7742bb8a4"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-0c83614fb7d6da392"
                         },
                         "sa-east-1": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-03e96030ca9bdf343"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-015255dad1c628b54"
                         },
                         "us-east-1": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-08f244a17989e56b6"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-0df737d22f586800c"
                         },
                         "us-east-2": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-050f4781955e5f76f"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-07d9abc83405ce5b1"
                         },
                         "us-west-1": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-0ec499c7a1bfd6a0e"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-02de2cc30fc97785f"
                         },
                         "us-west-2": {
-                            "release": "34.20210808.3.0",
-                            "image": "ami-02e64ce7ea9b916c5"
+                            "release": "34.20210821.3.0",
+                            "image": "ami-02760313f49df3a92"
+                        }
+                    }
+                }
+            }
+        },
+        "x86_64": {
+            "artifacts": {
+                "aliyun": {
+                    "release": "34.20210821.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "70189fbd4c4b96d3999d4a1b462a6211f11f5ff3196043105fc9d282bf934880",
+                                "uncompressed-sha256": "9ca84b52ea1182b72572153587099367e566f629d9e32c64cc6583c9b36e44bc"
+                            }
+                        }
+                    }
+                },
+                "aws": {
+                    "release": "34.20210821.3.0",
+                    "formats": {
+                        "vmdk.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "3ad485fe94fd7f119f35a45176fc7702ee226bf4ef8f68053697d77c3ac4b409",
+                                "uncompressed-sha256": "fa095a9a87dcdcfe3bdf9bdce774490d794659113eb9dfdb7799f2379f150395"
+                            }
+                        }
+                    }
+                },
+                "azure": {
+                    "release": "34.20210821.3.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "aaba2862ca997ee6cf58ecf8ed4cda6542e8f8631ba6aea461ef40e538b4aefc",
+                                "uncompressed-sha256": "4149f1c07a1988dcc25d8ede8c202ed64815e9b0f0386b19b2cea61855b31c14"
+                            }
+                        }
+                    }
+                },
+                "digitalocean": {
+                    "release": "34.20210821.3.0",
+                    "formats": {
+                        "qcow2.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "417c6ef412e208e97409419b9d2de07fc5d2bab7a48c0bad5ddb023ed7141849",
+                                "uncompressed-sha256": "25d09cad19b7acdd2681e23d2a423e2b79d26000d12a035ff9380e29ac6c9caf"
+                            }
+                        }
+                    }
+                },
+                "exoscale": {
+                    "release": "34.20210821.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "3529286e5f6eaff60142206e2e16892a28e555519149d9342d9da1a82b1a3012",
+                                "uncompressed-sha256": "281cf865fc7393b652672c638f228398976573f7aad9c2f6436a1cd2e7377c12"
+                            }
+                        }
+                    }
+                },
+                "gcp": {
+                    "release": "34.20210821.3.0",
+                    "formats": {
+                        "tar.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "ff79db40a6c8dcf63e3a9060458d30d745b26977d71c57939afa2986cb1977fd",
+                                "uncompressed-sha256": "161066ab26bde78dcf0436ea61c57fa51aab5fdbd099829c3ed3f1dd1e0717ae"
+                            }
+                        }
+                    }
+                },
+                "ibmcloud": {
+                    "release": "34.20210821.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "1d31c6b621397bc569f000068f92e406909b89c193fe6d01c8e069d673bc7116",
+                                "uncompressed-sha256": "a7f2c04865250fedaa6a6301d262d17088a0433b82783e01d6cd574633a6337a"
+                            }
+                        }
+                    }
+                },
+                "metal": {
+                    "release": "34.20210821.3.0",
+                    "formats": {
+                        "4k.raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "ba56601b10e7480ee4afa4e70d294f9b464f361b001c8feac7a81307cec46c11",
+                                "uncompressed-sha256": "e3d1be928efafa26e48a97b1d0a7d7f9380e75469922ccb34501cd4d25727256"
+                            }
+                        },
+                        "iso": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-live.x86_64.iso.sig",
+                                "sha256": "49e5288595bbd49447cc77b3fba6798b8e4cb21c44c76312cdb8435346a2097b"
+                            }
+                        },
+                        "pxe": {
+                            "kernel": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-live-kernel-x86_64.sig",
+                                "sha256": "a100553f9aa2ebd5f134f807cac26b6ad4cb7ac1bb5aef850d847021bd7f07ca"
+                            },
+                            "initramfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "acc9c1fa372d33f9421836100495820b4b59f2cc52c0fcf2b44fec0f0e01cbee"
+                            },
+                            "rootfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "1e7afbec2d1f7cc409e403fbfd4fbdccf076f4a98b8dc63d13360589e77d9a6c"
+                            }
+                        },
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "48068d17619c3496729ed296c7e488683a8a0e9e49881dc93f1369026284dc60",
+                                "uncompressed-sha256": "157ffe3aa5f99af71e5386045df51c8c743e5047949f30950c5004543c775909"
+                            }
+                        }
+                    }
+                },
+                "openstack": {
+                    "release": "34.20210821.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "92f2bca6524a304143307164a85a9c2122d2c3422f54079dd782fae20ab00b24",
+                                "uncompressed-sha256": "80a9b0f9a7f1fcac64a207ec802e158e2be7461b5b4213a74a4bd9a32a50a301"
+                            }
+                        }
+                    }
+                },
+                "qemu": {
+                    "release": "34.20210821.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "642fbdc27cef6efff8f7546efa53b20ef30f8ffc08ba977df7ffca1ec9a7ac8e",
+                                "uncompressed-sha256": "6323943c6c4ab1274431330faab3a359f1d958e67aad056aef4abc9df3363824"
+                            }
+                        }
+                    }
+                },
+                "vmware": {
+                    "release": "34.20210821.3.0",
+                    "formats": {
+                        "ova": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "f5f4ba31e7913920104ab4faccee392895a008a4c00d13c14a76d1ca26da751a"
+                            }
+                        }
+                    }
+                },
+                "vultr": {
+                    "release": "34.20210821.3.0",
+                    "formats": {
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "5f57fe5fda24fefa559125530c60e091c9a59766a872cc0e3765f1e255f77c8a",
+                                "uncompressed-sha256": "be6aeb1df0899a973110683ebbd91f92089b1deb7f280974302919cbc138c60b"
+                            }
+                        }
+                    }
+                }
+            },
+            "images": {
+                "aws": {
+                    "regions": {
+                        "af-south-1": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-0488288ef40242f4f"
+                        },
+                        "ap-east-1": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-073dc97b1970a203a"
+                        },
+                        "ap-northeast-1": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-0151aec678c93e680"
+                        },
+                        "ap-northeast-2": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-0851775fb4dff19af"
+                        },
+                        "ap-northeast-3": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-067daa6f839d6f982"
+                        },
+                        "ap-south-1": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-05a81df62665aeff4"
+                        },
+                        "ap-southeast-1": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-05bcaed4343b6f31a"
+                        },
+                        "ap-southeast-2": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-02b32d52b9288e255"
+                        },
+                        "ca-central-1": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-0df350f1651cd544b"
+                        },
+                        "eu-central-1": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-0608f6ebe8f1d7bfa"
+                        },
+                        "eu-north-1": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-037e60a41946a97cc"
+                        },
+                        "eu-south-1": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-07636b38676bea5aa"
+                        },
+                        "eu-west-1": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-024b4d04fcd7bc451"
+                        },
+                        "eu-west-2": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-07f187c879dcd24cd"
+                        },
+                        "eu-west-3": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-0c18396959d497787"
+                        },
+                        "me-south-1": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-0fd9425d966eea869"
+                        },
+                        "sa-east-1": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-0a1380cff6141d66f"
+                        },
+                        "us-east-1": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-00469a94375c094bb"
+                        },
+                        "us-east-2": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-0663f60fae16c2567"
+                        },
+                        "us-west-1": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-0083451ac2358a03c"
+                        },
+                        "us-west-2": {
+                            "release": "34.20210821.3.0",
+                            "image": "ami-0f8b956470d0f9de4"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-34-20210808-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210821-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,194 +1,91 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2021-08-24T06:01:00Z"
+        "last-modified": "2021-09-07T17:08:30Z"
     },
     "architectures": {
-        "x86_64": {
+        "aarch64": {
             "artifacts": {
-                "aliyun": {
-                    "release": "34.20210821.2.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "3516b52e1cc3e2ea919a8bc130cfcdd46da7e3c32c284aa2842471a8c41cc050",
-                                "uncompressed-sha256": "b6d33fc206baa7985673cd7e0418e871e58ecf0e2970c5741bc57ad60b53a700"
-                            }
-                        }
-                    }
-                },
                 "aws": {
-                    "release": "34.20210821.2.0",
+                    "release": "34.20210904.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "a46eb15fe0b8a879afa083f4f2a9e168af05c11f6bceaeea8c5ddab9fa9d2a24",
-                                "uncompressed-sha256": "6ea354b7be39c22697bdb975ebec6e4b4dd813db4c3614631487fa45580ca740"
-                            }
-                        }
-                    }
-                },
-                "azure": {
-                    "release": "34.20210821.2.0",
-                    "formats": {
-                        "vhd.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7f3e3b3a3ec3549e19f108a78d78f7e79d891d9b47f60697063d968c0d7c0085",
-                                "uncompressed-sha256": "50c35fb8e25b6b19d28915dac71123a78de7ac982a3da9ec493c8217d273ed1a"
-                            }
-                        }
-                    }
-                },
-                "digitalocean": {
-                    "release": "34.20210821.2.0",
-                    "formats": {
-                        "qcow2.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "935d1fbf5f2e67ddc1f8bb89638883ec1f730815835cfe1247efb5453968bd8d",
-                                "uncompressed-sha256": "5104d1b20f283559f09b2b4d9e739db6aac35f2a547e48d582c8781f99af7e78"
-                            }
-                        }
-                    }
-                },
-                "exoscale": {
-                    "release": "34.20210821.2.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "78cc69b8726b7d1b0376e6536e575b358827597ad8edefc705a6f1dd86ebffe5",
-                                "uncompressed-sha256": "ceb6c040c4f86da583896c999cabfe8545bae7ed7b8b5f9364f334a1dae73522"
-                            }
-                        }
-                    }
-                },
-                "gcp": {
-                    "release": "34.20210821.2.0",
-                    "formats": {
-                        "tar.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "a20d6d0ffb3d2ee4a89f5d0341f63f6fc331e36264e2bae4132e28b5c8153507",
-                                "uncompressed-sha256": "3558f9f63b1225cd7d0e9c150f4c17abaf7dd5b2608fe4b30cdc06541f048271"
-                            }
-                        }
-                    }
-                },
-                "ibmcloud": {
-                    "release": "34.20210821.2.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "5c6dfbab464e95bac106dce67d614b9281fa032199bc7b5fb82a726891b04898",
-                                "uncompressed-sha256": "585b471016459a3976f48ed9f4e0d1e917c41f70448fab5db63f1e02583e882d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "8ecdab06717c10d8f4735932e27df71d17c05088c0013d9f8bbb6770d960b6bd",
+                                "uncompressed-sha256": "e5bdcb6301dc9bc6c251e243c446f16333ad5d0a97aa8de04826e505cdc04254"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210821.2.0",
+                    "release": "34.20210904.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "6f035f17e42e22ab47e78cd4f9aeacb79a7dba566ef31c060b0d8b5176023cef",
-                                "uncompressed-sha256": "a25880ed10a22fb400ae94334064b27889203f1ea24b74cf257e9a7be6060a44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "79e80af42199ad1d72daf689e29904f613e401365de869133d1a633745b4a52e",
+                                "uncompressed-sha256": "9967ae644a983a9b827bb74f175a21e3ee60860d53a2f49dc6057f0a6a6b8c39"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-live.x86_64.iso.sig",
-                                "sha256": "e63460137a183196eba0a6336daf48dcb066212044275906046303dd4d1698a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-live.aarch64.iso.sig",
+                                "sha256": "a2e18332999f49316f289bd66f1abbba54f775ad8084694e6116bd1d2c7e3a40"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-live-kernel-x86_64.sig",
-                                "sha256": "a100553f9aa2ebd5f134f807cac26b6ad4cb7ac1bb5aef850d847021bd7f07ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-live-kernel-aarch64.sig",
+                                "sha256": "fa96c183ae9df2605aca4832c4a245350be338205045750a8f200e3a7dfda51c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "5ed6a08348ce8df5cb17fdfc897223737445aaaa0d79ff5e8c412478786761ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "a5efcbf749a828281575779f5fc11bd3dbbd6d80378643e9a5854de40906bb9e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "1a5cc5648d589977ca85480308c9bc6b34b829af1ad0b2ea2d1a22fe3aca2ef1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "cceaefe50e6f5b34edfd172b8b6327f3fa8f3c4bab8ccbce2735087857c7d14d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "77a325eb5f07eb59b1282344398d3312bbcdd1d1ecc9dacbc1f7930ad2c58276",
-                                "uncompressed-sha256": "8c41d05a7bc5057245e7dff00f460897832f5fb2230c115ead4e5aad493d1ee2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "041d8bf3f227d7efb09a147bfe676ea1689a0491b776721ddb738f9246b279a1",
+                                "uncompressed-sha256": "d6446cd4790e529e6add1b137f4c568d132e89e05a71604fe012e0a2734061ff"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210821.2.0",
+                    "release": "34.20210904.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "0b62198dd7c5a58e4ab4d65b0c8b51d9243d2f6cfb6f3b7f167efc524a26a888",
-                                "uncompressed-sha256": "77d26384d459cbc5ea60f79ff8781a4e5cef9f6df6dfb4b92ec4c10b8e7929ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "359f0dc05a2df49a4958feba1e020a58ce90742ba3ef0b8177dd578f54f7435c",
+                                "uncompressed-sha256": "d7cdadb1b4eadcb743217c288075efce0cf81d88cb680a2dbe877fa4ccd94993"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210821.2.0",
+                    "release": "34.20210904.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "c013f2f0c095cb112cd33d6705596ff2247f687b14f3570ef911b5ff7d4f875d",
-                                "uncompressed-sha256": "197d76635bd8868076ab0e44297c07ad271f1b5f9f20a7f9b1bbb0b88578c847"
-                            }
-                        }
-                    }
-                },
-                "vmware": {
-                    "release": "34.20210821.2.0",
-                    "formats": {
-                        "ova": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "99e82d4cb9e28b7428f62472cc24e9c3d33dda2af947770e1ef51c7383b348d5"
-                            }
-                        }
-                    }
-                },
-                "vultr": {
-                    "release": "34.20210821.2.0",
-                    "formats": {
-                        "raw.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210821.2.0/x86_64/fedora-coreos-34.20210821.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "1981be95e36eb76785f77fc0f75bd38d21559db8e3527dfd405870a7b1959275",
-                                "uncompressed-sha256": "80e50366cc01ce0be60e98962756d60e4ffe0ca8703cf20a646c71ec0c9039ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "960b88bc626ba61320ed0e1fbb3f5ecadce386e2b5cebb9421bbf27a4650b292",
+                                "uncompressed-sha256": "83ef805c968419c8b6a2dbe5a9a440a2182cd8c96badee65a1b87e91615848f9"
                             }
                         }
                     }
@@ -198,95 +95,376 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-0806a8bf6ad5236ae"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0d364915e149fc08c"
                         },
                         "ap-east-1": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-0991c8a0aaa6df3d6"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-05065bb42e7e5ebc1"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-0d8ac3f83f77f5b07"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0e67b3a9d5776105f"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-04ffbe8af3ba9f5c9"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0b8b0ed835861fbea"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-055da6ee268930c11"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0d36a8e0946d25b45"
                         },
                         "ap-south-1": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-0a58ce93c0b4e0d43"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-054e31bd65fb5bf00"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-0e51a575e4e2148c0"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-02da3b7c6a6620e52"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-0e6d4394c49df8d21"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-084276ffc8b1d483f"
                         },
                         "ca-central-1": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-04cdc3a5f1649c8ba"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-00428b92ccfe37a19"
                         },
                         "eu-central-1": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-016073cf2536d826c"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-01e2a8626f175ecf0"
                         },
                         "eu-north-1": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-01c699afa096e7bf7"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-055892bf301fe95f1"
                         },
                         "eu-south-1": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-0697bb942c443ec16"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-02b4987780972f465"
                         },
                         "eu-west-1": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-08a6f5a9d860c6d40"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-01cd97a508e77d145"
                         },
                         "eu-west-2": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-01b8790fa63e6d372"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0bb3519a6ec49e1ef"
                         },
                         "eu-west-3": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-00c2648f70451e7d7"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0fdc320908ad946b7"
                         },
                         "me-south-1": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-03f664569c34c0f2b"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-039ac475fd669ebb8"
                         },
                         "sa-east-1": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-0450435ebea20ef38"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0a9c29db7e3d8a738"
                         },
                         "us-east-1": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-0da0b5f31d5363ad6"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-03c39b2c945cb44ea"
                         },
                         "us-east-2": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-08473fc77ebb54159"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-07e1e820623770b08"
                         },
                         "us-west-1": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-04c13c0724fb794dc"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-037866acc1c5369d5"
                         },
                         "us-west-2": {
-                            "release": "34.20210821.2.0",
-                            "image": "ami-0d67c555e19ce8ac8"
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0b082a3d0e6fe4315"
+                        }
+                    }
+                }
+            }
+        },
+        "x86_64": {
+            "artifacts": {
+                "aliyun": {
+                    "release": "34.20210904.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "0cb14043bf5648502cd8264ac224703db1f7cb3ce927369d4be409ac398bd7b1",
+                                "uncompressed-sha256": "3d76c5e576d369408a6e2599b700c93da125c9bb0356344238e9db3b076f6a2b"
+                            }
+                        }
+                    }
+                },
+                "aws": {
+                    "release": "34.20210904.2.0",
+                    "formats": {
+                        "vmdk.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "706f7be9d52f1d8a1b6c9d89fd40cd789532a46874a9e0805b0add0b0a3434ec",
+                                "uncompressed-sha256": "462611cb0db943006ef2c2357e46a014cd11517dc7b98aee18ffe31dbae0046c"
+                            }
+                        }
+                    }
+                },
+                "azure": {
+                    "release": "34.20210904.2.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "af42c6dd95f6ef9b8c8aa4d318d6bafe458ecde2ef7d97623389bae27afad176",
+                                "uncompressed-sha256": "762331b083cc5b44d96c65910451155c986cb2061d0e1dad44383317bbb6d89e"
+                            }
+                        }
+                    }
+                },
+                "digitalocean": {
+                    "release": "34.20210904.2.0",
+                    "formats": {
+                        "qcow2.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "9acfba508280caf6f15fe1576b485981f7ed94acf69280032c07b351404a7bbb",
+                                "uncompressed-sha256": "af836a381e99e8d1610d0c86d5b7fca037451553243405dab518292dbd709e5b"
+                            }
+                        }
+                    }
+                },
+                "exoscale": {
+                    "release": "34.20210904.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "cbb71675814d15bb8109321e667f7ccd995f55afe03f7626f3b8dfc7f19d4168",
+                                "uncompressed-sha256": "9bfcc2c8269bda4a65805aaa373d72fc35e7210891791516c87f1dfc1908c30d"
+                            }
+                        }
+                    }
+                },
+                "gcp": {
+                    "release": "34.20210904.2.0",
+                    "formats": {
+                        "tar.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "be5fb7c84f41c9c56bb8dd7e2e225ec9e03171fd3e5c3839c8115925508d922a",
+                                "uncompressed-sha256": "0d16ea0e1e585b1cc9535e30c656f61076bc744d6231f96bf5771360d0c6c694"
+                            }
+                        }
+                    }
+                },
+                "ibmcloud": {
+                    "release": "34.20210904.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "5a17451e6b598b1be8df1cbf224046a2e27e222bb253f0f61c9881ae72d989fd",
+                                "uncompressed-sha256": "abe0c809952b9c3711955032d9e168f797c0d89dff634a3cae29b1acebcc831d"
+                            }
+                        }
+                    }
+                },
+                "metal": {
+                    "release": "34.20210904.2.0",
+                    "formats": {
+                        "4k.raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "4549a9ea2f6246120ce8bd53189002c3490bab4c0d7f327fb547aa868a07558b",
+                                "uncompressed-sha256": "c6c44b58b178949b8c87c903b190ad19eda56c6226bccd14f6887162619a275b"
+                            }
+                        },
+                        "iso": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-live.x86_64.iso.sig",
+                                "sha256": "4d4eb0f146934fbd4cb17580ff8048be6e3bec20967cd79ec281322e1e8856a9"
+                            }
+                        },
+                        "pxe": {
+                            "kernel": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-live-kernel-x86_64.sig",
+                                "sha256": "1f62afb48c611eb246f7535a3ef3d23f5b0ae93041de5d37fb4618d52bc8c35a"
+                            },
+                            "initramfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "af74b2cbd5cff86c5a17f137d7919534b2682e66290ed419222801699dbfb032"
+                            },
+                            "rootfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "f0b8106d59909efaeb2b0edf37eb193fd4eb7c371244e4adf60f65863bc552b2"
+                            }
+                        },
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "d9ca20619db0c9e5b6b3e8095235d8d3b0f9206a9643ac14b5344cc7469216bc",
+                                "uncompressed-sha256": "188d7a34e5ed3e71beae803335f861bafec987d59febf8b6e1cc36800b431593"
+                            }
+                        }
+                    }
+                },
+                "openstack": {
+                    "release": "34.20210904.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "dfd19a678d0ef318b2d491fa156b3b9ef080fe509777d695fd1d7a55ff18cc45",
+                                "uncompressed-sha256": "b58491ebf8b6121ad15753185ad5dd00cd9fe75cc09f7a62efa9ce4226af8f2f"
+                            }
+                        }
+                    }
+                },
+                "qemu": {
+                    "release": "34.20210904.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "7a8b5822809f84605b88698728e73ca89dbccbedb87debeee4371e9400b9142f",
+                                "uncompressed-sha256": "7b3b2b06f0d5c1452e70ae77414270d516e58115350904e2f83c373698dabd55"
+                            }
+                        }
+                    }
+                },
+                "vmware": {
+                    "release": "34.20210904.2.0",
+                    "formats": {
+                        "ova": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "fdff8a923d01b7e0070e650bda899fba79c22e3804ed38267253ce3d3e0739a1"
+                            }
+                        }
+                    }
+                },
+                "vultr": {
+                    "release": "34.20210904.2.0",
+                    "formats": {
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "350ec1d3980bd18f21f1a7029f684e106fe7dbee9ace99303d8fb11c79967e32",
+                                "uncompressed-sha256": "5c36bc1b16a92bf9c9531d0de216a531aa0c75278e8145664bfefa52d66ef5fa"
+                            }
+                        }
+                    }
+                }
+            },
+            "images": {
+                "aws": {
+                    "regions": {
+                        "af-south-1": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0dd82c4d84a2e58c7"
+                        },
+                        "ap-east-1": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-016a56073b83b04e3"
+                        },
+                        "ap-northeast-1": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0795b233a41eda957"
+                        },
+                        "ap-northeast-2": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-08caf09eb37612b95"
+                        },
+                        "ap-northeast-3": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-01892167333e57d82"
+                        },
+                        "ap-south-1": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-05ea5ee0622ee3fef"
+                        },
+                        "ap-southeast-1": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-08d987494f5a28dcd"
+                        },
+                        "ap-southeast-2": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0c75d5c1fceafd5cb"
+                        },
+                        "ca-central-1": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0296ec6419a1cb3aa"
+                        },
+                        "eu-central-1": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0fa5fa0929173bada"
+                        },
+                        "eu-north-1": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-04be5853fd7c19297"
+                        },
+                        "eu-south-1": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0a5c5c26657eaaaae"
+                        },
+                        "eu-west-1": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0a7d419562195c0c5"
+                        },
+                        "eu-west-2": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0281bf8ea3f8c9df3"
+                        },
+                        "eu-west-3": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0000dbe118e307155"
+                        },
+                        "me-south-1": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0fa7526f74366f395"
+                        },
+                        "sa-east-1": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0b8ab6e96cdbf5c34"
+                        },
+                        "us-east-1": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-00ab51eb2af60e684"
+                        },
+                        "us-east-2": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0107c4e7008d49354"
+                        },
+                        "us-west-1": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0125e834d546f82a7"
+                        },
+                        "us-west-2": {
+                            "release": "34.20210904.2.0",
+                            "image": "ami-0ea45f7e95a6cccc1"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-34-20210821-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210904-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2021-08-24T05:58:46Z"
+    "last-modified": "2021-09-07T16:27:58Z"
   },
   "releases": [
     {
@@ -45,7 +45,7 @@
       }
     },
     {
-      "version": "34.20210725.3.0",
+      "version": "34.20210808.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -53,11 +53,11 @@
       }
     },
     {
-      "version": "34.20210808.3.0",
+      "version": "34.20210821.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1629819000,
+          "start_epoch": 1631044800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2021-08-24T06:01:22Z"
+    "last-modified": "2021-09-07T17:08:30Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "34.20210808.2.0",
+      "version": "34.20210821.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "34.20210821.2.0",
+      "version": "34.20210904.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1629819000,
+          "start_epoch": 1631044800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
stable: rollout 34.20210821.3.0
testing: rollout 34.20210904.2.0

This release also includes aarch64 artifacts.