### PR TITLE
stable, testing, next: regenerate stream metadata to include azure stack

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,7 +1,8 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2021-09-07T04:20:12Z"
+        "last-modified": "2021-09-16T16:15:30Z",
+        "generator": "fedora-coreos-stream-generator v0.1.0-5-gb145af2"
     },
     "architectures": {
         "aarch64": {
@@ -219,6 +220,19 @@
                                 "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-azure.x86_64.vhd.xz.sig",
                                 "sha256": "7349ac02ab0d26077bd3c3d9e85c956d50d6b91ced81dccbbb52ab54f1c4a8d1",
                                 "uncompressed-sha256": "9e66f3ed670fbce2c8042aa1912e999d0435e3423aaaada52871528ed1ed9ecb"
+                            }
+                        }
+                    }
+                },
+                "azurestack": {
+                    "release": "34.20210904.1.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "ca2ce728185ebda3dfc88badc9357bf355ffae580321bf51cca9bdddffd4fcc7",
+                                "uncompressed-sha256": "f8f77c41db3dab0d63fffa3e510b1e181017a411258312483a5d8dcfab1365ee"
                             }
                         }
                     }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,7 +1,8 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2021-09-07T16:27:58Z"
+        "last-modified": "2021-09-16T16:16:50Z",
+        "generator": "fedora-coreos-stream-generator v0.1.0-5-gb145af2"
     },
     "architectures": {
         "aarch64": {
@@ -219,6 +220,19 @@
                                 "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-azure.x86_64.vhd.xz.sig",
                                 "sha256": "aaba2862ca997ee6cf58ecf8ed4cda6542e8f8631ba6aea461ef40e538b4aefc",
                                 "uncompressed-sha256": "4149f1c07a1988dcc25d8ede8c202ed64815e9b0f0386b19b2cea61855b31c14"
+                            }
+                        }
+                    }
+                },
+                "azurestack": {
+                    "release": "34.20210821.3.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "06d9eb8cf04cc27cbd9f314bdb231fa7bc5665cd5996763f0b542afb7492c2b9",
+                                "uncompressed-sha256": "bb3b9b8c6943815e8386c88dfe07f2539f35aa8f57a822921ae3fa11bc5720f6"
                             }
                         }
                     }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,7 +1,8 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2021-09-07T17:08:30Z"
+        "last-modified": "2021-09-16T16:17:27Z",
+        "generator": "fedora-coreos-stream-generator v0.1.0-5-gb145af2"
     },
     "architectures": {
         "aarch64": {
@@ -219,6 +220,19 @@
                                 "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-azure.x86_64.vhd.xz.sig",
                                 "sha256": "af42c6dd95f6ef9b8c8aa4d318d6bafe458ecde2ef7d97623389bae27afad176",
                                 "uncompressed-sha256": "762331b083cc5b44d96c65910451155c986cb2061d0e1dad44383317bbb6d89e"
+                            }
+                        }
+                    }
+                },
+                "azurestack": {
+                    "release": "34.20210904.2.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "7fb0034bd11c003a1879a1fd10e23fcc16692f4a98c35b635a74c2ac0aae6eae",
+                                "uncompressed-sha256": "12b3f7d5f0655bc9d2c0075eea9f01837d30379f2588c9001cf67b40d7169456"
                             }
                         }
                     }


### PR DESCRIPTION
During the previous rollout, stream-metadata-go had not been bumped. This
resulted in some important changes to be missing from generated metadata 
in the previous rollout (such as parsing of azure stack artifact metadata).
Lets regenerate the data using the latest version of stream-metadata-go.

related: https://github.com/coreos/fedora-coreos-tracker/issues/960  