### PR TITLE
promote-config: promote next-devel to next

### DIFF
--- a/.github/workflows/promote-config.yml
+++ b/.github/workflows/promote-config.yml
@@ -25,9 +25,7 @@ jobs:
           elif [ "${target_stream}" == testing ]; then
             src_stream=testing-devel
           elif [ "${target_stream}" == next ]; then
-            # promote from testing-devel while we are in lockstep
-            # https://github.com/coreos/fedora-coreos-pipeline/pull/343
-            src_stream=testing-devel
+            src_stream=next-devel
           fi
           echo "target_stream=${title%:*}" >> $GITHUB_ENV
           echo "src_stream=${src_stream}" >> $GITHUB_ENV


### PR DESCRIPTION
Fedora 35 Beta is now GO. Start shipping from `next-devel`.