### PR TITLE
Triple rollout on 2021-09-20

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2021-09-16T16:15:30Z",
-        "generator": "fedora-coreos-stream-generator v0.1.0-5-gb145af2"
+        "last-modified": "2021-09-21T14:16:55Z",
+        "generator": "fedora-coreos-stream-generator v0.1.0-6-ge7eb37e"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "34.20210904.1.0",
+                    "release": "34.20210919.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/aarch64/fedora-coreos-34.20210904.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/aarch64/fedora-coreos-34.20210904.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "dfe1d21fbce4c1a5085d3bac8e3dd8d2a3daea737e53bdff3ab4c39582fa4b61",
-                                "uncompressed-sha256": "ef89a6fdf670926b3df654d7c9fe6af3297448d64d6b9c8e9bd743e809e101bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/aarch64/fedora-coreos-34.20210919.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/aarch64/fedora-coreos-34.20210919.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "4c86afa23038528bce9a4fd68180e282861058b2ff4a841bd6dbd70e743e6f98",
+                                "uncompressed-sha256": "86ea86567834bb672fde2eefb2938ebd6d31c7c5089f18c15b98868e548d2833"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210904.1.0",
+                    "release": "34.20210919.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/aarch64/fedora-coreos-34.20210904.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/aarch64/fedora-coreos-34.20210904.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "92fddf7cd55a84444eeac39032371a69795151359cdc8edb364ed9f6e8628d0d",
-                                "uncompressed-sha256": "7057f533fe543e7c8d15fe0c9adc1a0239414f038a7f02a727ca992abd2d610e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/aarch64/fedora-coreos-34.20210919.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/aarch64/fedora-coreos-34.20210919.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "0d6fbe5e06a2b990a8f3599ce0f97b61e49caadac24e9354da5525e56d2217e0",
+                                "uncompressed-sha256": "820e92d70db4743dc77e1ae2188a2dc96ebcca1b10a7fa33ec6ee3e34ff56801"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/aarch64/fedora-coreos-34.20210904.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/aarch64/fedora-coreos-34.20210904.1.0-live.aarch64.iso.sig",
-                                "sha256": "52d52992cbb3cd808b6d21c1d4961ae1b91ca51ee4d63f37cc2758651ec5826a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/aarch64/fedora-coreos-34.20210919.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/aarch64/fedora-coreos-34.20210919.1.0-live.aarch64.iso.sig",
+                                "sha256": "bbb7bdc79a3fbe1349d3309b99febd61c35f1fa30db1e458aa106a44326eb726"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/aarch64/fedora-coreos-34.20210904.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/aarch64/fedora-coreos-34.20210904.1.0-live-kernel-aarch64.sig",
-                                "sha256": "fa96c183ae9df2605aca4832c4a245350be338205045750a8f200e3a7dfda51c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/aarch64/fedora-coreos-34.20210919.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/aarch64/fedora-coreos-34.20210919.1.0-live-kernel-aarch64.sig",
+                                "sha256": "91503b64280e195dbbb4ec5bd7c118c14eff482939c38b40ac9f27ef884e1dcb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/aarch64/fedora-coreos-34.20210904.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/aarch64/fedora-coreos-34.20210904.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "8ea4265360b75f7de624759fe355664c10a48b15c79764e8ab62b53f23c491ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/aarch64/fedora-coreos-34.20210919.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/aarch64/fedora-coreos-34.20210919.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "9582dbcff3ada7b6f8eafd01c7aab4b97d3ddb1eaf5928e439505aa15c19d3b6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/aarch64/fedora-coreos-34.20210904.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/aarch64/fedora-coreos-34.20210904.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "8c21665255b84631529675368f87755d555d0f1b8bf9174bf8b343b7d2ef251f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/aarch64/fedora-coreos-34.20210919.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/aarch64/fedora-coreos-34.20210919.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "8ec193a62f264688946d762fcdd60bc136e526092231572d58589f2e51bff62b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/aarch64/fedora-coreos-34.20210904.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/aarch64/fedora-coreos-34.20210904.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "f4c47cbfaa374f698140b8a7e64f2ba2fa9f57b62384908bc4eaa34b24935449",
-                                "uncompressed-sha256": "dc43b81e37b8ad92b0a680fa8a7389fe3263bb3bc741081e6535000af2ae4521"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/aarch64/fedora-coreos-34.20210919.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/aarch64/fedora-coreos-34.20210919.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "93b8148a29c7c9abf695e52a2e5ff982f41557ba7c9f350fe7e811df75f8c1b9",
+                                "uncompressed-sha256": "99ba222bbde9705dce4c9cff5878a52d14a803f094dfbff24618cc77188d4d0e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210904.1.0",
+                    "release": "34.20210919.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/aarch64/fedora-coreos-34.20210904.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/aarch64/fedora-coreos-34.20210904.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "d3fc3d50e3ca3267abfc847446485c2f1849ee47d0c007473180b200eaf552bd",
-                                "uncompressed-sha256": "b48de74f79bd10d3982a768996fe658236a719783fb58cdfb06f06de136b6de7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/aarch64/fedora-coreos-34.20210919.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/aarch64/fedora-coreos-34.20210919.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "be1a4a78fe4a2554f282a407f61b5417df10e37b1592398a8cfc3412a30fd8d3",
+                                "uncompressed-sha256": "08a5b57a04049028b3781da1e6cb9b17faabac475a82ea2f32b87d39ab3761c1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210904.1.0",
+                    "release": "34.20210919.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/aarch64/fedora-coreos-34.20210904.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/aarch64/fedora-coreos-34.20210904.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "e9520e84cd983e7149bd1608baff282b5799583ccdc63ee554d7339ac0ac947e",
-                                "uncompressed-sha256": "c514f96478a30f42d77efce41bd82148996c6a4c143b00a6c4147a886aa0315d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/aarch64/fedora-coreos-34.20210919.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/aarch64/fedora-coreos-34.20210919.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "ce2cfcf2e6cae9d3920f9641235aabcb36cb835a14cc90bc78a27bee48d3a33b",
+                                "uncompressed-sha256": "603bb7fb4aa73d88e1d8c3fbc9a8c16af6aecb679ded7f14aef3554488b1b36b"
                             }
                         }
                     }
@@ -96,88 +96,88 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0c2e0eace4b33d11f"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-0fdc88570ba5e21ef"
                         },
                         "ap-east-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-07412bdd9ced2d1b0"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-04a5a09bede2a4109"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0506c908e075cab2e"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-00f459530f152c7d4"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-01b1002cb76c1ac15"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-04755c926a9c2e6d3"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-003ad6a2e4c24f707"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-04c90244dd83b52a7"
                         },
                         "ap-south-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0bcd74cecf10b13f8"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-04b84b6fe7d8433b9"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-019371e4938a45915"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-0e71a884566700417"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-023645259fef7c7d1"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-0936b5f96cd825aab"
                         },
                         "ca-central-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0555a6cc78ad465cb"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-0803b98c103255904"
                         },
                         "eu-central-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0d3250a68f69615e8"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-09fe18d43bb0e03d9"
                         },
                         "eu-north-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0877d995dd0d3078e"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-05d2ad79d172f7a1a"
                         },
                         "eu-south-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-02ea8227644a3a4d8"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-05fb2ea175af2716a"
                         },
                         "eu-west-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-035f6e385969484c3"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-0e724da6aa28efa2e"
                         },
                         "eu-west-2": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0884c971dd7d4f38f"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-001b157caf3486a4f"
                         },
                         "eu-west-3": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-021f216f025194b21"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-0b248a13c38cbae64"
                         },
                         "me-south-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0c6e85ae5a7b65f51"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-0a8212017c21ab0db"
                         },
                         "sa-east-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-059ae9bcfa416491d"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-06a4770046ae176e3"
                         },
                         "us-east-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0d691850fea5cc6ac"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-08a4ded160bcbcd42"
                         },
                         "us-east-2": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-00ea3f260f470b5da"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-0c6ff4fc3918885f9"
                         },
                         "us-west-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0a8b5f9c460fc50bb"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-0e8010a314db786ee"
                         },
                         "us-west-2": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0a409f79fc5e5c650"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-0e3df8b6597c1254e"
                         }
                     }
                 }
@@ -186,201 +186,201 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210904.1.0",
+                    "release": "34.20210919.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "a893b427089f2a5c2e04e0bbdd7a7cd1e75bd2234cee5a7f3b5359b2a82e20eb",
-                                "uncompressed-sha256": "77a8c5b5a477357ac66fbc62afe9fc6b65f219b5a29b5d3c5d4c2d1401436bc4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "fd89546e4aaaf716e58306be03546e80e75a2218e57c85358e069df8e14c03cd",
+                                "uncompressed-sha256": "c7212ef14f78a18188fb5537cfe04fe822ae1b63badbbca2d1ae248e0aef4d64"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210904.1.0",
+                    "release": "34.20210919.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "a4bddb357d2ea8185a83e32d2f5ba18b4b925937a16f3c0b2ecf5f9d3d5bd0cd",
-                                "uncompressed-sha256": "43a30bf33a15bc004960a00f0e93d0cfd18f15c004b3280bd3f1ab2e5fcd02eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "20e2c5fa0382a0921b8b789a89ef331be80e0bb1089067e59af79162c1fb7207",
+                                "uncompressed-sha256": "a1ee60c531123cd33727a3a816cf72450c5360503b866cf3e0ba9b778dcb8a22"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210904.1.0",
+                    "release": "34.20210919.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7349ac02ab0d26077bd3c3d9e85c956d50d6b91ced81dccbbb52ab54f1c4a8d1",
-                                "uncompressed-sha256": "9e66f3ed670fbce2c8042aa1912e999d0435e3423aaaada52871528ed1ed9ecb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "f348e79481414705e27efd78929f1cf408226be5ea86cee33931931411976706",
+                                "uncompressed-sha256": "5f41762bcb931521b8a3bd25b1adeec748ee5d1b4cf6debf40b85b4dadcb8a5f"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "34.20210904.1.0",
+                    "release": "34.20210919.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "ca2ce728185ebda3dfc88badc9357bf355ffae580321bf51cca9bdddffd4fcc7",
-                                "uncompressed-sha256": "f8f77c41db3dab0d63fffa3e510b1e181017a411258312483a5d8dcfab1365ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "38fb237e94eef9bae5814025bc3aa9024b52a628f2937250c7d354beafe623d1",
+                                "uncompressed-sha256": "188251db585977c1d8addf9fd60d9c1f091405d1c9dcc2d84490ac4ea8aa7b3e"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210904.1.0",
+                    "release": "34.20210919.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "1e51c803be482e56bdb7d5f168a7284fa8c8080b7cf4a5f8fd9197e6b1d3f658",
-                                "uncompressed-sha256": "8ad202196e9f13548fd1b4a2cf2c360731eacb3886c5b345a47eabeda1695084"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "8b00b2e47c8b7c264450700cb7c8e345949033b6de026d41af5d58fd6d8702fc",
+                                "uncompressed-sha256": "3bd148532bb4c6b9242aef76b5a89da081caf1406d325d8c0337fa4cb6d4275d"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210904.1.0",
+                    "release": "34.20210919.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "bda2c0ba18591a99c3d308c15b92f543f0d5a0f1e8d994502a7f9da7863f15ea",
-                                "uncompressed-sha256": "ec0f112fc2652ab1c362e25abfbb0123ab28a2adf4e20d3135167937f08b143e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "c49ab4856824e09582c45da2759e598b55b0a8a4c3df9528154c38bad6bcfd1f",
+                                "uncompressed-sha256": "d803f6a6b432adfe155092aac878f5b20950c7c4865fa636f11c0a3a6c8b099f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210904.1.0",
+                    "release": "34.20210919.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "d04798d05e78496ccee4d1338d7eb0ba92fd83cf260b2d3cfc5e67435e7a5908",
-                                "uncompressed-sha256": "10238240c081140b6d543251419bd2a65af42e0db75f078cbcb352f65871566a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "1552af2d104abe8aafa78a871ef5642d641971442f8227345f26705a555822cb",
+                                "uncompressed-sha256": "ee814dd3b8af0202f757e976cc0927b66ea5e6d029357f48b53226c09fcb0a5f"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210904.1.0",
+                    "release": "34.20210919.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "e39dd3c15263509a62a2e8611a8f6de434fd5b001d43bbe08f2db51dbcbccb68",
-                                "uncompressed-sha256": "a56f1493f4cab22818df49882e9ff620d06750a3d7b7f5157f3141a57eeef546"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "ede27350ffcc753393be1534aeb2cc4f1c0d0d7972f2ce2c9f382c64b5528319",
+                                "uncompressed-sha256": "8a43c3b19423eda63d5a108b694b7288af20844ef9da0e6a0ab31fb2bd18e492"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210904.1.0",
+                    "release": "34.20210919.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "bff3da98e06bd8ed203182478d8d01f97194c889218b944d77b9420406da4598",
-                                "uncompressed-sha256": "999ecc41ebbc89b8cbcd7273baf7d6ae4c0e935779e48000270cdc275c974210"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "39e7c433a845525834db2f7a036084ea445e0803bba177f58d484d9d2cd840d3",
+                                "uncompressed-sha256": "a530292737d92712797ea88e741c99cb0d5f39967b172f928ec73a5810ece1b6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-live.x86_64.iso.sig",
-                                "sha256": "737f427c25a97925764edd5be0c926d23c3c0e2f1c3fe73eb5dd4d12e58e643f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-live.x86_64.iso.sig",
+                                "sha256": "87cc864c0f44c972b339b85a05a6392f1b848777e8b4b72e286fd34c89fbeee1"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-live-kernel-x86_64.sig",
-                                "sha256": "1f62afb48c611eb246f7535a3ef3d23f5b0ae93041de5d37fb4618d52bc8c35a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-live-kernel-x86_64.sig",
+                                "sha256": "04a2faa363a1bb4edf357c272b57d2d431cbd2afab160971bc2883ae9fefd5ae"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "f8bd686cae528fa6f8a7694f4e44ca15620f5dd09da93e3db967b1a7d4054116"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "0ab4da9b6eb7ddb3482c03a304eb43b3735edffce39335d51d65fcb00a38eb95"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "2a70053064183650f455b2769485f4e5528f9f465e89ce3f0cda1d46781970bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "dba63cd35cd447cf072bf28f58a1a9c7c467f5df54426ccbedcfcf825fbcd7ee"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "b6e94844e95e95e8f555321220ce0301e70b0c66e180ad4fc89cc281908db4cb",
-                                "uncompressed-sha256": "e4832ad53ccb74910d1f5f403f24900222b9f0da9d07e3d85cea38b87d51f348"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "74e2c40b99871be0f843600cacea951a66198cd097a6ef8d7c82133ad3d7c563",
+                                "uncompressed-sha256": "079c20233aa8c69306757bfcafa1db96f43cd5b17bbce37eecdd5e76d20c1d43"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210904.1.0",
+                    "release": "34.20210919.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "0dce4997517d0b3d040c749b06e2350d47faba75e456058e9468eab70f9d2a95",
-                                "uncompressed-sha256": "91aaae019b1887a48eb77173c9d134d7ce2e760fc3b6c90ab8667e42e5d7cef6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "37481ef42d4a751746fc87a2a2061d62da9e3445ca33236371a9cc14a11307e8",
+                                "uncompressed-sha256": "e7f51cc0690a19b579334839b3617f281225f59d92fe988b8db58511c47cf048"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210904.1.0",
+                    "release": "34.20210919.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "170ac81600d924624dba845c74edfd829813951fd8ab182728e4af1d652e7498",
-                                "uncompressed-sha256": "63c0e89c042460fa740d32bc5b4ff9ea346178c90c1a65f33e7ce01345903535"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "3dfe1da6d5549eb9c5aaceb1d42b3125f5cacbf320f8d9fb882fb8843fe51259",
+                                "uncompressed-sha256": "cb0f1027f66c31f71199fca6fd854d0661bf418a5ae9e22bd427d531ec6028a0"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210904.1.0",
+                    "release": "34.20210919.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "603a073a4ba9ed91360f264ec601518b69bf6c4435d10b7bec438cc9e9add6a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "0355cdf963800cbff0ade827635cacd41953c3e9c24044590461736bce8def4d"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210904.1.0",
+                    "release": "34.20210919.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210904.1.0/x86_64/fedora-coreos-34.20210904.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "0d796765b3fdb12cf1c7f40fc043ccfb5c7dce87a2cd9546508a4f296fad6982",
-                                "uncompressed-sha256": "ea0e03f4ffe25c5d49e857f46b70551f9f83e9d0b2da36ad55bd98e15a0a9462"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/34.20210919.1.0/x86_64/fedora-coreos-34.20210919.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "c40a53ab075127c15d6b659e02baa645a29971aa3b965ac01a7e12c9ebe9a5a0",
+                                "uncompressed-sha256": "6ea6aac897ec108e7a8df0aaeff49a15886182c8c388eaa67e287372a3eb20fc"
                             }
                         }
                     }
@@ -390,95 +390,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0717c5d6ce1703ae6"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-0a5ea15fd6e834075"
                         },
                         "ap-east-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0e6115d7e12781da4"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-026375defe751414f"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0f006dc854ba422e4"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-000f2323851d27cfa"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-01bf831583dc37981"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-016533d51555b9922"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0968f60f3f85fc5b0"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-0bd8b464bb566f737"
                         },
                         "ap-south-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0bf969124a2b708c9"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-0d25eac2e8c61780f"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0635a57a1cd2bc352"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-0934f699eccab5f5b"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0dcd77ef022b8b5ae"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-02b77c3989d072e72"
                         },
                         "ca-central-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-07925fcb7857f9308"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-09ff755b979675fd7"
                         },
                         "eu-central-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-01a3cd315ef4f0205"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-09031dbbdf8a19250"
                         },
                         "eu-north-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-09577c6ec04354543"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-005720cf1727c18fd"
                         },
                         "eu-south-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-035b7496b66aa4b7d"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-025de39feb4d91623"
                         },
                         "eu-west-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-078057e7ec9331b08"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-04cef339da4667fa9"
                         },
                         "eu-west-2": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-06557e5fc056913a7"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-0f97c42b79d34923c"
                         },
                         "eu-west-3": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0f3696f9a8bbe81ca"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-0432ca62f409765e5"
                         },
                         "me-south-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0e6ac16cd8c8844a5"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-00ac19a8ab5a2288b"
                         },
                         "sa-east-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-08ee086aa2a3fde9b"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-0055c262b03d6a8bf"
                         },
                         "us-east-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0f1543fc61b63a73f"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-00fd001715251b312"
                         },
                         "us-east-2": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-0914fd6f1372f8c73"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-0d159523cfdefa7b4"
                         },
                         "us-west-1": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-04aec091f41e3dedd"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-0606311ce5f39c58c"
                         },
                         "us-west-2": {
-                            "release": "34.20210904.1.0",
-                            "image": "ami-08c00a8171697e9de"
+                            "release": "34.20210919.1.0",
+                            "image": "ami-0908a13ff322a7c1a"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-34-20210904-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210919-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,92 +1,92 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2021-09-16T16:16:50Z",
-        "generator": "fedora-coreos-stream-generator v0.1.0-5-gb145af2"
+        "last-modified": "2021-09-21T14:15:05Z",
+        "generator": "fedora-coreos-stream-generator v0.1.0-6-ge7eb37e"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "34.20210821.3.0",
+                    "release": "34.20210904.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "c422dfde56c2029eb2df04561f6ef8857e946935fa0b82b3ba4fe4cb7b66e798",
-                                "uncompressed-sha256": "abe705aaa511fcbeff8f47085aae12fd60bd3e9db705a7a60502a43db17d0060"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/aarch64/fedora-coreos-34.20210904.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/aarch64/fedora-coreos-34.20210904.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "a5db096a709c4ae43782ff5d9bd6f08334f2f07731e2b3a3fadd42890f23f3fc",
+                                "uncompressed-sha256": "7e35b002e8cca981d84d251cabb4d6d86a98682ff2980e8ab26b297296deb028"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210821.3.0",
+                    "release": "34.20210904.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "34a3f4100b9341eecab12e182bc24e7bc42649b938a08cbfe5c21158287ea03f",
-                                "uncompressed-sha256": "2d0fee93290546663bcd83b3c528350faf36205ee319e675285e95657c0d9db8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/aarch64/fedora-coreos-34.20210904.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/aarch64/fedora-coreos-34.20210904.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "3e961ecbb0d04fc3adb35d9446faa5dfa826360ea848fea192fa330761ccd682",
+                                "uncompressed-sha256": "09cd06973b91524ee696235f24850a76034ede8398b9e6697520674d0e3a690a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-live.aarch64.iso.sig",
-                                "sha256": "12245ecb20d5342ddd2ca3c9ace87bd830559cc0fcf1695b8cb73d2a3f5434cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/aarch64/fedora-coreos-34.20210904.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/aarch64/fedora-coreos-34.20210904.3.0-live.aarch64.iso.sig",
+                                "sha256": "a5511d85e7938f004274a29aa475c08e779a6feacb9b0c4531fb7ace8bc305fb"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-live-kernel-aarch64.sig",
-                                "sha256": "0fc3fe26f04840fcadc0fd24b02abf04b365a09a96945b1d74e325c9f5e75411"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/aarch64/fedora-coreos-34.20210904.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/aarch64/fedora-coreos-34.20210904.3.0-live-kernel-aarch64.sig",
+                                "sha256": "fa96c183ae9df2605aca4832c4a245350be338205045750a8f200e3a7dfda51c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "1a0e4b20c1a2d6417835984b52645a4773ba46000cba68a9cd586e2bac06e404"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/aarch64/fedora-coreos-34.20210904.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/aarch64/fedora-coreos-34.20210904.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "ae3da1b3997f4b707f6a9d4942e0d8db1d67d506212ae609a5aadaf278159ff3"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "bf3583fd373636d8120d486dfd62ac85398bde057af8e566f688b978c613c16a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/aarch64/fedora-coreos-34.20210904.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/aarch64/fedora-coreos-34.20210904.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "724bc49aab6cf0e333326f99b866841a89f90daca7275fcd6c623c3d769f71cb"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "7b50a2a62b9df0003ba10ca59eeefa6c214aa99bf21edd0ec1e63167e487e6af",
-                                "uncompressed-sha256": "fdfe2a8a3c2634c55ff403a0da1fba72ad427561e6de83f1e66059398fa6b207"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/aarch64/fedora-coreos-34.20210904.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/aarch64/fedora-coreos-34.20210904.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "0d6cf05f20a7e59c45659b2c9de3b58e0678c318190f563dca69d1a9467a4878",
+                                "uncompressed-sha256": "4ee8331285a92971c42bb5bbe0bb97137cb7dfaa7a9d63bc8e8fb95f1bcfe677"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210821.3.0",
+                    "release": "34.20210904.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "c193f406f498e09ff7ff54391b42b9ac9481155e27425f0f4139e48b6122e511",
-                                "uncompressed-sha256": "2a11aa62550810f70ff132834f9a5f83e6921ef832b5e6d6d02296d648cfc4a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/aarch64/fedora-coreos-34.20210904.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/aarch64/fedora-coreos-34.20210904.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "9f64e2bf0050224d219b0a624e6871fa7e4c633c6bea215b76648211d9ebbc78",
+                                "uncompressed-sha256": "31d9a48973814029d17bdae3dab9f2b1f9b6d696b5b7f73d2b99e5bf1c9082db"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210821.3.0",
+                    "release": "34.20210904.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/aarch64/fedora-coreos-34.20210821.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "9de9e6d3b6f31b812034a72265bacf42e6ad9e0935630169d3485e3ef20d5dfb",
-                                "uncompressed-sha256": "c872169d1a1ee3038e78a269f8d604e78262090892fd8cb1376df56410bde2ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/aarch64/fedora-coreos-34.20210904.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/aarch64/fedora-coreos-34.20210904.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "9fb7294e4cd9e07a98fde0b2f736b29c139f9cf85bc95ee6d2f061b9fcfc0922",
+                                "uncompressed-sha256": "bafa61e92de1b6e9ac842f1653634b166686970806bc6aba3c8df1ca18989a90"
                             }
                         }
                     }
@@ -96,88 +96,88 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-0bde2bde601a1d640"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-02ef0b259facc92dc"
                         },
                         "ap-east-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-05d93271c94d74feb"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-0c93c7dcfb65d6a6d"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-0391339ec29cb3e42"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-064a41a34d3646e17"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-00f197de801ab41ba"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-08af48ebb7a67b146"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-08769df4bb2eba99e"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-02dfcf7af9a01c1c3"
                         },
                         "ap-south-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-003caaaef262fb5b4"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-08b5f89b842ac4ddf"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-0089fcac7a6ce9c82"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-0ff58e6aeb9648c00"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-07978e1a2f0280714"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-094fd3e73df26c1fc"
                         },
                         "ca-central-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-0b9c2d5294b889d44"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-012ac408e91277084"
                         },
                         "eu-central-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-032f6f6d340911309"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-032fe6ea5052e2967"
                         },
                         "eu-north-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-065df82b2b5d40103"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-0c0251fb4237fcb9c"
                         },
                         "eu-south-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-0f032302d14c66b72"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-0c7b002f06dba793b"
                         },
                         "eu-west-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-0211ffe4a0a5a352c"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-0c5fc362947cda993"
                         },
                         "eu-west-2": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-06de3c6b106427133"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-0398f3be8b5f2fa9e"
                         },
                         "eu-west-3": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-0160b50c808c22698"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-0f3063a4a8f73c445"
                         },
                         "me-south-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-0c83614fb7d6da392"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-0588b32482a16c30f"
                         },
                         "sa-east-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-015255dad1c628b54"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-009e9f4043a178ea0"
                         },
                         "us-east-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-0df737d22f586800c"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-05eac31e7164b39bd"
                         },
                         "us-east-2": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-07d9abc83405ce5b1"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-079b08c6a185a9bd6"
                         },
                         "us-west-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-02de2cc30fc97785f"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-027ba4eba6854809f"
                         },
                         "us-west-2": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-02760313f49df3a92"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-0b0f9e84289d300df"
                         }
                     }
                 }
@@ -186,201 +186,201 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210821.3.0",
+                    "release": "34.20210904.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "70189fbd4c4b96d3999d4a1b462a6211f11f5ff3196043105fc9d282bf934880",
-                                "uncompressed-sha256": "9ca84b52ea1182b72572153587099367e566f629d9e32c64cc6583c9b36e44bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "18396f97dfd09daeda4796ed744405261c5f805acd1c7c2c37663ccb6d560542",
+                                "uncompressed-sha256": "ed5e4574bb2dfa76f86e6e4151a72631a97dfb2264233703322210edca60e6de"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210821.3.0",
+                    "release": "34.20210904.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "3ad485fe94fd7f119f35a45176fc7702ee226bf4ef8f68053697d77c3ac4b409",
-                                "uncompressed-sha256": "fa095a9a87dcdcfe3bdf9bdce774490d794659113eb9dfdb7799f2379f150395"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "bd5c1a76dfbfe23de8bb2f8876e66c62b4cbe9e936432ac489223c4841a1f637",
+                                "uncompressed-sha256": "9ccd6db005c1734447ff9b50688565e99d16da61f57e194dc2c9ebf828a019f8"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210821.3.0",
+                    "release": "34.20210904.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "aaba2862ca997ee6cf58ecf8ed4cda6542e8f8631ba6aea461ef40e538b4aefc",
-                                "uncompressed-sha256": "4149f1c07a1988dcc25d8ede8c202ed64815e9b0f0386b19b2cea61855b31c14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "b048d7129cbd0c07a6643f0e78c322c701fe1750db0ff8d39cccf8f181e1deb1",
+                                "uncompressed-sha256": "e1b37d3373f70857ade1bd6d9d5751cdbe4084e4ac4d1e5f5a5148b31eed1fbc"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "34.20210821.3.0",
+                    "release": "34.20210904.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "06d9eb8cf04cc27cbd9f314bdb231fa7bc5665cd5996763f0b542afb7492c2b9",
-                                "uncompressed-sha256": "bb3b9b8c6943815e8386c88dfe07f2539f35aa8f57a822921ae3fa11bc5720f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "c629fce54f639067fccb35344c5bc28536fa5d13a7bb7e3daa4005bfb9c51a9f",
+                                "uncompressed-sha256": "6406103b68332fd792b7cdbd88bb423a2603d515c58e57b5da0e407c94ff889a"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210821.3.0",
+                    "release": "34.20210904.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "417c6ef412e208e97409419b9d2de07fc5d2bab7a48c0bad5ddb023ed7141849",
-                                "uncompressed-sha256": "25d09cad19b7acdd2681e23d2a423e2b79d26000d12a035ff9380e29ac6c9caf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "cb8cdf64f0b4d1eef301a6901ff5e067b995614819dae17e34f1703804ae52a6",
+                                "uncompressed-sha256": "74abe0ecd82c542709ac7018298a1b6571d35b3c9a41920afe4fef635167e85e"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210821.3.0",
+                    "release": "34.20210904.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "3529286e5f6eaff60142206e2e16892a28e555519149d9342d9da1a82b1a3012",
-                                "uncompressed-sha256": "281cf865fc7393b652672c638f228398976573f7aad9c2f6436a1cd2e7377c12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "813ccb8e625702288d0c3d16891566ea145b092079d468191fc8ec248a4341ea",
+                                "uncompressed-sha256": "82abda613bc86000e0814bd95a17f94fe694a69c7fba0c507aa30796611abb3c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210821.3.0",
+                    "release": "34.20210904.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "ff79db40a6c8dcf63e3a9060458d30d745b26977d71c57939afa2986cb1977fd",
-                                "uncompressed-sha256": "161066ab26bde78dcf0436ea61c57fa51aab5fdbd099829c3ed3f1dd1e0717ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "b8e8aea3b2214c340f00643adb5f2b53e57d515b95ced792eeaafec74d4c7e03",
+                                "uncompressed-sha256": "4de96b8a0a475841d3a3d195f0abe8a3eb37b527d08fb73c5bf7ad1cf7e594c9"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210821.3.0",
+                    "release": "34.20210904.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "1d31c6b621397bc569f000068f92e406909b89c193fe6d01c8e069d673bc7116",
-                                "uncompressed-sha256": "a7f2c04865250fedaa6a6301d262d17088a0433b82783e01d6cd574633a6337a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "0fd7434c5d509f9a31799f4e943e03a5331e8c9f10399077ab7df1785a2c4acb",
+                                "uncompressed-sha256": "3d66ddbbc2ce4ed72bb2a3d5fc5f377b69c71c4c08b82c9d7b7d9a7f43fbfafe"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210821.3.0",
+                    "release": "34.20210904.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "ba56601b10e7480ee4afa4e70d294f9b464f361b001c8feac7a81307cec46c11",
-                                "uncompressed-sha256": "e3d1be928efafa26e48a97b1d0a7d7f9380e75469922ccb34501cd4d25727256"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "f7d1c5cc2c1926b915c57b60ff00dac73a28f4c491ff594657c840370028548f",
+                                "uncompressed-sha256": "cd8df8a5fed37d67153bf7587d29dff104b12b0d6641e5224fc926d54245dfab"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-live.x86_64.iso.sig",
-                                "sha256": "49e5288595bbd49447cc77b3fba6798b8e4cb21c44c76312cdb8435346a2097b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-live.x86_64.iso.sig",
+                                "sha256": "a04c7d9f36c1ba02dde1269da73b01e68f8479c9f1f1c7aeb4b6bb3c154b8069"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-live-kernel-x86_64.sig",
-                                "sha256": "a100553f9aa2ebd5f134f807cac26b6ad4cb7ac1bb5aef850d847021bd7f07ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-live-kernel-x86_64.sig",
+                                "sha256": "1f62afb48c611eb246f7535a3ef3d23f5b0ae93041de5d37fb4618d52bc8c35a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "acc9c1fa372d33f9421836100495820b4b59f2cc52c0fcf2b44fec0f0e01cbee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "e07b073ba026ca16d00fd61ea0049b2f0e299c9c97d068b8c8a8b4ea4fa786f7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "1e7afbec2d1f7cc409e403fbfd4fbdccf076f4a98b8dc63d13360589e77d9a6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "ca89d415d8856c20a1613007340104965e542856082f3005e3aa5455663b4256"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "48068d17619c3496729ed296c7e488683a8a0e9e49881dc93f1369026284dc60",
-                                "uncompressed-sha256": "157ffe3aa5f99af71e5386045df51c8c743e5047949f30950c5004543c775909"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "0adba96aaca9893027270b680e6b41310b3e7789b62219368b1b477695a6376e",
+                                "uncompressed-sha256": "0fa2607c0382e26e753b0fb5197e89ea5068fd9f4b30404aa80073a07ea0b3d2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210821.3.0",
+                    "release": "34.20210904.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "92f2bca6524a304143307164a85a9c2122d2c3422f54079dd782fae20ab00b24",
-                                "uncompressed-sha256": "80a9b0f9a7f1fcac64a207ec802e158e2be7461b5b4213a74a4bd9a32a50a301"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "a3a0d6780ffd2ca6b1c50932a8d1560119d6ad7a370ddd0767ef95a824f35ca2",
+                                "uncompressed-sha256": "124dd1e47514b3c7d4c966af5e9f9aacddda8be0732c800e0f9cd8a1c1b7ad16"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210821.3.0",
+                    "release": "34.20210904.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "642fbdc27cef6efff8f7546efa53b20ef30f8ffc08ba977df7ffca1ec9a7ac8e",
-                                "uncompressed-sha256": "6323943c6c4ab1274431330faab3a359f1d958e67aad056aef4abc9df3363824"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "58e9e841a42944c616925deaa11849881c9cfc47e7d2116bc3c2c9985fea632a",
+                                "uncompressed-sha256": "0accb5cae1a1bf68ca0f63df55eb31beec518b64d239b121b0348447d124763b"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210821.3.0",
+                    "release": "34.20210904.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "f5f4ba31e7913920104ab4faccee392895a008a4c00d13c14a76d1ca26da751a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "b873c30de26007b91afefa2a0643ed283402816af453a6ad1bb647947bfb4839"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210821.3.0",
+                    "release": "34.20210904.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210821.3.0/x86_64/fedora-coreos-34.20210821.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "5f57fe5fda24fefa559125530c60e091c9a59766a872cc0e3765f1e255f77c8a",
-                                "uncompressed-sha256": "be6aeb1df0899a973110683ebbd91f92089b1deb7f280974302919cbc138c60b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210904.3.0/x86_64/fedora-coreos-34.20210904.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "129692fd749b5163e961e3ffcbc44dd2f31e8369e96de5302eb12ccf61e20481",
+                                "uncompressed-sha256": "cb6f759f41b5c71c48e9ea9ac13d3d52f3274e59fe89aa66b7c863977b8d59dc"
                             }
                         }
                     }
@@ -390,95 +390,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-0488288ef40242f4f"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-0b748e75910222d2c"
                         },
                         "ap-east-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-073dc97b1970a203a"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-076284674f886a387"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-0151aec678c93e680"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-05dff05740dee546a"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-0851775fb4dff19af"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-0a3b8e1a51b8dd0ba"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-067daa6f839d6f982"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-0bf2922ccbfd6aba5"
                         },
                         "ap-south-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-05a81df62665aeff4"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-0d208b223dfd615cc"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-05bcaed4343b6f31a"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-058483b94486e7bcd"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-02b32d52b9288e255"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-070beb6cb872ca125"
                         },
                         "ca-central-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-0df350f1651cd544b"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-04bf3ac40bcc0bcb8"
                         },
                         "eu-central-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-0608f6ebe8f1d7bfa"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-04520793404d11329"
                         },
                         "eu-north-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-037e60a41946a97cc"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-0313aa7a489c3f092"
                         },
                         "eu-south-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-07636b38676bea5aa"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-0258ea5c31d0243fb"
                         },
                         "eu-west-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-024b4d04fcd7bc451"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-0231d530c7816ceee"
                         },
                         "eu-west-2": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-07f187c879dcd24cd"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-018f227c99cab4a55"
                         },
                         "eu-west-3": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-0c18396959d497787"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-049b895302b6bc877"
                         },
                         "me-south-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-0fd9425d966eea869"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-0f6b55cd167ebf160"
                         },
                         "sa-east-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-0a1380cff6141d66f"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-0da8571381b98ff4a"
                         },
                         "us-east-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-00469a94375c094bb"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-09a8c278a7eec012d"
                         },
                         "us-east-2": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-0663f60fae16c2567"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-0d9fa07517a576552"
                         },
                         "us-west-1": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-0083451ac2358a03c"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-08c65639becf2dab6"
                         },
                         "us-west-2": {
-                            "release": "34.20210821.3.0",
-                            "image": "ami-0f8b956470d0f9de4"
+                            "release": "34.20210904.3.0",
+                            "image": "ami-0e0fe648f85a617fe"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-34-20210821-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210904-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2021-09-16T16:17:27Z",
-        "generator": "fedora-coreos-stream-generator v0.1.0-5-gb145af2"
+        "last-modified": "2021-09-21T14:16:25Z",
+        "generator": "fedora-coreos-stream-generator v0.1.0-6-ge7eb37e"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "34.20210904.2.0",
+                    "release": "34.20210919.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "8ecdab06717c10d8f4735932e27df71d17c05088c0013d9f8bbb6770d960b6bd",
-                                "uncompressed-sha256": "e5bdcb6301dc9bc6c251e243c446f16333ad5d0a97aa8de04826e505cdc04254"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/aarch64/fedora-coreos-34.20210919.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/aarch64/fedora-coreos-34.20210919.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "1c80eec5b88b3830d5456ebf5b5453247b05f23eaa6dd3abbd73283b72fd4c8c",
+                                "uncompressed-sha256": "e104884026b877b13edc3e9a04a8d3f22149661a204a8c1a358b2dea7c6e0b4e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210904.2.0",
+                    "release": "34.20210919.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "79e80af42199ad1d72daf689e29904f613e401365de869133d1a633745b4a52e",
-                                "uncompressed-sha256": "9967ae644a983a9b827bb74f175a21e3ee60860d53a2f49dc6057f0a6a6b8c39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/aarch64/fedora-coreos-34.20210919.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/aarch64/fedora-coreos-34.20210919.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "177557540adbd88ae3cca2ff4d576aaf4ab9b58851a4264d90c0cd8d98a726d4",
+                                "uncompressed-sha256": "68d8535c33f8206872ade264db8d293b7cf5425c830db357d6d13eab8a0ead3b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-live.aarch64.iso.sig",
-                                "sha256": "a2e18332999f49316f289bd66f1abbba54f775ad8084694e6116bd1d2c7e3a40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/aarch64/fedora-coreos-34.20210919.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/aarch64/fedora-coreos-34.20210919.2.0-live.aarch64.iso.sig",
+                                "sha256": "3a4e969e1156e38a2b886bcc73c4c230180011b76454bb4fd4d1069facc3dbf6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-live-kernel-aarch64.sig",
-                                "sha256": "fa96c183ae9df2605aca4832c4a245350be338205045750a8f200e3a7dfda51c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/aarch64/fedora-coreos-34.20210919.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/aarch64/fedora-coreos-34.20210919.2.0-live-kernel-aarch64.sig",
+                                "sha256": "91503b64280e195dbbb4ec5bd7c118c14eff482939c38b40ac9f27ef884e1dcb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "a5efcbf749a828281575779f5fc11bd3dbbd6d80378643e9a5854de40906bb9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/aarch64/fedora-coreos-34.20210919.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/aarch64/fedora-coreos-34.20210919.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "4d9b1b02f02e634845d2e79131ffa56e1916f740837c48e2941bd4cd5ee597c1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "cceaefe50e6f5b34edfd172b8b6327f3fa8f3c4bab8ccbce2735087857c7d14d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/aarch64/fedora-coreos-34.20210919.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/aarch64/fedora-coreos-34.20210919.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "46554f91bc8fc327d0dad3f2afb56cc1bc8424e45e67170434e76d36cc5961d1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "041d8bf3f227d7efb09a147bfe676ea1689a0491b776721ddb738f9246b279a1",
-                                "uncompressed-sha256": "d6446cd4790e529e6add1b137f4c568d132e89e05a71604fe012e0a2734061ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/aarch64/fedora-coreos-34.20210919.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/aarch64/fedora-coreos-34.20210919.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "c08b242d6d555728b1bb3bba1b5bdd3379ae4a838c77d0c543f87fb40831c2c0",
+                                "uncompressed-sha256": "bf2ee9d0d85a410a09ba19fc39d6927376e76bee910a556d9a3da2ca8230ab91"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210904.2.0",
+                    "release": "34.20210919.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "359f0dc05a2df49a4958feba1e020a58ce90742ba3ef0b8177dd578f54f7435c",
-                                "uncompressed-sha256": "d7cdadb1b4eadcb743217c288075efce0cf81d88cb680a2dbe877fa4ccd94993"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/aarch64/fedora-coreos-34.20210919.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/aarch64/fedora-coreos-34.20210919.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "db3ddf97bb95c5171d478c3c98fd0a4d4d345cb5ea1ea34f757c01f81caf3c74",
+                                "uncompressed-sha256": "a9cc5cdf0c8db09021c775c52f3214536033b2a4697d571d60b25939c3407036"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210904.2.0",
+                    "release": "34.20210919.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/aarch64/fedora-coreos-34.20210904.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "960b88bc626ba61320ed0e1fbb3f5ecadce386e2b5cebb9421bbf27a4650b292",
-                                "uncompressed-sha256": "83ef805c968419c8b6a2dbe5a9a440a2182cd8c96badee65a1b87e91615848f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/aarch64/fedora-coreos-34.20210919.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/aarch64/fedora-coreos-34.20210919.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "2884493f5630d43605841d9a1b507d960c393c43eab8500b1b5e4600ed72c42b",
+                                "uncompressed-sha256": "cd9c90357652a49b671b75f5c68f9892d4b52e5b155412276ea7fce7b5951ea1"
                             }
                         }
                     }
@@ -96,88 +96,88 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0d364915e149fc08c"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0da0fe59ea181d442"
                         },
                         "ap-east-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-05065bb42e7e5ebc1"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0345afef777212dcd"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0e67b3a9d5776105f"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0a031239f171e6863"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0b8b0ed835861fbea"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0a182b72615f00ed1"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0d36a8e0946d25b45"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-072647df0d0b2d5e8"
                         },
                         "ap-south-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-054e31bd65fb5bf00"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-00cbcba9edaac14db"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-02da3b7c6a6620e52"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-07911c405535a8397"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-084276ffc8b1d483f"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0a9478af651843860"
                         },
                         "ca-central-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-00428b92ccfe37a19"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0be31edc96687cd01"
                         },
                         "eu-central-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-01e2a8626f175ecf0"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-075f9336b6f062160"
                         },
                         "eu-north-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-055892bf301fe95f1"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0cb4503968154f502"
                         },
                         "eu-south-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-02b4987780972f465"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-07e7cb53479332bed"
                         },
                         "eu-west-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-01cd97a508e77d145"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-00c07a36683defd64"
                         },
                         "eu-west-2": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0bb3519a6ec49e1ef"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0d5fa36bf7b776508"
                         },
                         "eu-west-3": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0fdc320908ad946b7"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0d690967723725344"
                         },
                         "me-south-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-039ac475fd669ebb8"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0e5f16c642a1b0709"
                         },
                         "sa-east-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0a9c29db7e3d8a738"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0011d905b3c9de948"
                         },
                         "us-east-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-03c39b2c945cb44ea"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0687baee86bb5c0ee"
                         },
                         "us-east-2": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-07e1e820623770b08"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-05a9d427341c91375"
                         },
                         "us-west-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-037866acc1c5369d5"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0d5cba1ec2775227c"
                         },
                         "us-west-2": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0b082a3d0e6fe4315"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-07818dc107396b365"
                         }
                     }
                 }
@@ -186,201 +186,201 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210904.2.0",
+                    "release": "34.20210919.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "0cb14043bf5648502cd8264ac224703db1f7cb3ce927369d4be409ac398bd7b1",
-                                "uncompressed-sha256": "3d76c5e576d369408a6e2599b700c93da125c9bb0356344238e9db3b076f6a2b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "67127e6ca8245504d35a925a0ac1ad3ade26102e0820cd07768a5279ccd362b6",
+                                "uncompressed-sha256": "5ccac5519d8f1a28f6c09654d333978eb256ff82764c3bce35f91f228b3fae54"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210904.2.0",
+                    "release": "34.20210919.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "706f7be9d52f1d8a1b6c9d89fd40cd789532a46874a9e0805b0add0b0a3434ec",
-                                "uncompressed-sha256": "462611cb0db943006ef2c2357e46a014cd11517dc7b98aee18ffe31dbae0046c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "eec8ad9b0bd6f6a4084acd69b5a5175850bdcadeac6a2cb1c510d508c34437c9",
+                                "uncompressed-sha256": "381a5d03dbee84aea512bcef2988b4a0a8647db7dd2e5eeb4817c5c16aa1cdf8"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210904.2.0",
+                    "release": "34.20210919.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "af42c6dd95f6ef9b8c8aa4d318d6bafe458ecde2ef7d97623389bae27afad176",
-                                "uncompressed-sha256": "762331b083cc5b44d96c65910451155c986cb2061d0e1dad44383317bbb6d89e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "bb13c49945842756ab4c6c1c32899153b28fd338d210f72d08511b8704df3bc9",
+                                "uncompressed-sha256": "6fd97a0aeb463f8537373e3f5fff5e5870586a6fa5862872ec8c3afe4380b21e"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "34.20210904.2.0",
+                    "release": "34.20210919.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "7fb0034bd11c003a1879a1fd10e23fcc16692f4a98c35b635a74c2ac0aae6eae",
-                                "uncompressed-sha256": "12b3f7d5f0655bc9d2c0075eea9f01837d30379f2588c9001cf67b40d7169456"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "b99eb5549d23c21b061e3b13a09923d3b40f7f80fc71241c1e00accb96b74bfe",
+                                "uncompressed-sha256": "2b60bac3a8c4ee110f8dc93a621e6210b2e4db94ebcdc21fe0b5e05fef9f8aeb"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210904.2.0",
+                    "release": "34.20210919.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "9acfba508280caf6f15fe1576b485981f7ed94acf69280032c07b351404a7bbb",
-                                "uncompressed-sha256": "af836a381e99e8d1610d0c86d5b7fca037451553243405dab518292dbd709e5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "d78efc67d5cedb1ba01b29e79906dfced5babc6d880b03f3d9fcf07fa709f6d0",
+                                "uncompressed-sha256": "ac9daf10c75f4e1907eab2fff3ca0114ba12a9aa24e081541eae232294301a69"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210904.2.0",
+                    "release": "34.20210919.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "cbb71675814d15bb8109321e667f7ccd995f55afe03f7626f3b8dfc7f19d4168",
-                                "uncompressed-sha256": "9bfcc2c8269bda4a65805aaa373d72fc35e7210891791516c87f1dfc1908c30d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "69c6a98fea2c3b8b5dc713b4abdede5105b0f2e1c1b3a13d4121b3aba1c5c159",
+                                "uncompressed-sha256": "6b9dd368d57b538322817b1b6b1aa2601fb90d76e932a0ef1a32cc30d2f5c42a"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210904.2.0",
+                    "release": "34.20210919.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "be5fb7c84f41c9c56bb8dd7e2e225ec9e03171fd3e5c3839c8115925508d922a",
-                                "uncompressed-sha256": "0d16ea0e1e585b1cc9535e30c656f61076bc744d6231f96bf5771360d0c6c694"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f2dca84842e24b0804f8d516d780dddcaa194e4e4d48d65fa72a559e0c19c017",
+                                "uncompressed-sha256": "7f0b81a3f98cf233482d83486fa449c1996eafce3723f9fc5d07394eb4f710a7"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210904.2.0",
+                    "release": "34.20210919.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "5a17451e6b598b1be8df1cbf224046a2e27e222bb253f0f61c9881ae72d989fd",
-                                "uncompressed-sha256": "abe0c809952b9c3711955032d9e168f797c0d89dff634a3cae29b1acebcc831d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "c984046477222017229effc46b171eb6bb49cfe3995bbeea8563fc6742e1e030",
+                                "uncompressed-sha256": "e36fc5a4904d6b17732a3d249557d87abb888bf47e4e61e5fa30dab9e0c16ddb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210904.2.0",
+                    "release": "34.20210919.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "4549a9ea2f6246120ce8bd53189002c3490bab4c0d7f327fb547aa868a07558b",
-                                "uncompressed-sha256": "c6c44b58b178949b8c87c903b190ad19eda56c6226bccd14f6887162619a275b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "27ad022c5d5c78a7526d791d93ba5d1ce40f1f87bc326f439bc102f245db25fd",
+                                "uncompressed-sha256": "921420c687b0248ee5625aae19c37ef8eb575bbe06394b2690da2b034d1b12e4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-live.x86_64.iso.sig",
-                                "sha256": "4d4eb0f146934fbd4cb17580ff8048be6e3bec20967cd79ec281322e1e8856a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-live.x86_64.iso.sig",
+                                "sha256": "5eb13ebcc0b55def6c55e1415261f5a9e3c6444ac564344ed960610cd53bd4db"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-live-kernel-x86_64.sig",
-                                "sha256": "1f62afb48c611eb246f7535a3ef3d23f5b0ae93041de5d37fb4618d52bc8c35a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-live-kernel-x86_64.sig",
+                                "sha256": "04a2faa363a1bb4edf357c272b57d2d431cbd2afab160971bc2883ae9fefd5ae"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "af74b2cbd5cff86c5a17f137d7919534b2682e66290ed419222801699dbfb032"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "4a998025b93b5cb1bffdebae38a5f0b85cf823536c4d1f72c7f0f2afa7c0a395"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "f0b8106d59909efaeb2b0edf37eb193fd4eb7c371244e4adf60f65863bc552b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "4b5da717801d3ce4681070d66254e3ca00c3eefb121c1c8a42eb21f3adafeca8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "d9ca20619db0c9e5b6b3e8095235d8d3b0f9206a9643ac14b5344cc7469216bc",
-                                "uncompressed-sha256": "188d7a34e5ed3e71beae803335f861bafec987d59febf8b6e1cc36800b431593"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "95e5191b66d1b8e447f39acd46b9b48cc5a3fe2fc47bbc59089ba771066d0424",
+                                "uncompressed-sha256": "64fa20142f9bd8100c97fc6fdbbaa158b42e0cf076ccb306fe679769f66bb26e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210904.2.0",
+                    "release": "34.20210919.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "dfd19a678d0ef318b2d491fa156b3b9ef080fe509777d695fd1d7a55ff18cc45",
-                                "uncompressed-sha256": "b58491ebf8b6121ad15753185ad5dd00cd9fe75cc09f7a62efa9ce4226af8f2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "078353bb840f91e4660b4dfba51ce5ee66d4f38bab6d42416809c92ee55fdbf0",
+                                "uncompressed-sha256": "fede510965b8fb22a5c33fde31581d2f500f4b32bc2cf745a1877a8126b66e5d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210904.2.0",
+                    "release": "34.20210919.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "7a8b5822809f84605b88698728e73ca89dbccbedb87debeee4371e9400b9142f",
-                                "uncompressed-sha256": "7b3b2b06f0d5c1452e70ae77414270d516e58115350904e2f83c373698dabd55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "42f3a35397097ea1223f836313485b3efb88b5d523f05de95fdfe0affb8d8a04",
+                                "uncompressed-sha256": "b8c63de8f36ef360980f9ebc69a247bc03d8bba64b149d464635863139887624"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210904.2.0",
+                    "release": "34.20210919.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "fdff8a923d01b7e0070e650bda899fba79c22e3804ed38267253ce3d3e0739a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "355828f74d0970de4a914ac077949fd5f25d0f27891c47375b3919b2ad4bd703"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210904.2.0",
+                    "release": "34.20210919.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210904.2.0/x86_64/fedora-coreos-34.20210904.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "350ec1d3980bd18f21f1a7029f684e106fe7dbee9ace99303d8fb11c79967e32",
-                                "uncompressed-sha256": "5c36bc1b16a92bf9c9531d0de216a531aa0c75278e8145664bfefa52d66ef5fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210919.2.0/x86_64/fedora-coreos-34.20210919.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "bc09119d2173612f712ce5cbf9c28971a243626d88342672252f27369a9ba604",
+                                "uncompressed-sha256": "645ac362fc1bcdd66eac4844e769017890f522975193ffaa4e893660557f0e73"
                             }
                         }
                     }
@@ -390,95 +390,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0dd82c4d84a2e58c7"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0e9077f0d81266912"
                         },
                         "ap-east-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-016a56073b83b04e3"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-065ab84fea94e0c0f"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0795b233a41eda957"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-088a09582730acfa7"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-08caf09eb37612b95"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-087a76f55c80a616e"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-01892167333e57d82"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0b955e5e27da14f3e"
                         },
                         "ap-south-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-05ea5ee0622ee3fef"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0cb7e348a65161eeb"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-08d987494f5a28dcd"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-061d73f6c1f46c9b9"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0c75d5c1fceafd5cb"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-01d0083ddb69973f6"
                         },
                         "ca-central-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0296ec6419a1cb3aa"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-08e9dde4df1da0675"
                         },
                         "eu-central-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0fa5fa0929173bada"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-027f689233dd39aa0"
                         },
                         "eu-north-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-04be5853fd7c19297"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-039e39697b43170e5"
                         },
                         "eu-south-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0a5c5c26657eaaaae"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0aa0aa10faab5ea6d"
                         },
                         "eu-west-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0a7d419562195c0c5"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0a882cef324b43348"
                         },
                         "eu-west-2": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0281bf8ea3f8c9df3"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-001ad12038f3dcb2c"
                         },
                         "eu-west-3": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0000dbe118e307155"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0a437bde8c69acac7"
                         },
                         "me-south-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0fa7526f74366f395"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-04ffca13c78cd1e77"
                         },
                         "sa-east-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0b8ab6e96cdbf5c34"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0f3085de8ca7bdb1a"
                         },
                         "us-east-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-00ab51eb2af60e684"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0659e575637e71f39"
                         },
                         "us-east-2": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0107c4e7008d49354"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-08eda99e9e1482270"
                         },
                         "us-west-1": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0125e834d546f82a7"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0396c7333ce01bd81"
                         },
                         "us-west-2": {
-                            "release": "34.20210904.2.0",
-                            "image": "ami-0ea45f7e95a6cccc1"
+                            "release": "34.20210919.2.0",
+                            "image": "ami-0a735340bc7d3577f"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-34-20210904-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210919-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2021-09-07T04:22:36Z"
+    "last-modified": "2021-09-21T14:20:56Z"
   },
   "releases": [
     {
@@ -37,7 +37,7 @@
       }
     },
     {
-      "version": "34.20210821.1.1",
+      "version": "34.20210904.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -45,11 +45,11 @@
       }
     },
     {
-      "version": "34.20210904.1.0",
+      "version": "34.20210919.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1631026800,
+          "start_epoch": 1632236400,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2021-09-07T16:27:58Z"
+    "last-modified": "2021-09-21T14:19:40Z"
   },
   "releases": [
     {
@@ -45,7 +45,7 @@
       }
     },
     {
-      "version": "34.20210808.3.0",
+      "version": "34.20210821.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -53,11 +53,11 @@
       }
     },
     {
-      "version": "34.20210821.3.0",
+      "version": "34.20210904.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1631044800,
+          "start_epoch": 1632236400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2021-09-07T17:08:30Z"
+    "last-modified": "2021-09-21T14:20:33Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "34.20210821.2.0",
+      "version": "34.20210904.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "34.20210904.2.0",
+      "version": "34.20210919.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1631044800,
+          "start_epoch": 1632236400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
```
stable
    version: 34.20210904.3.0 (latest)
    start: 2021-09-21 15:00:00+00:00 UTC (in 0:38:12)
           2021-09-21 11:00:00-04:00 Raleigh/New York/Toronto
           2021-09-21 17:00:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)
next
    version: 34.20210919.1.0 (latest)
    start: 2021-09-21 15:00:00+00:00 UTC (in 0:38:12)
           2021-09-21 11:00:00-04:00 Raleigh/New York/Toronto
           2021-09-21 17:00:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)
testing
    version: 34.20210919.2.0 (latest)
    start: 2021-09-21 15:00:00+00:00 UTC (in 0:38:12)
           2021-09-21 11:00:00-04:00 Raleigh/New York/Toronto
           2021-09-21 17:00:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)
```