### PR TITLE
release-prereqs.md: drop requirements no longer needed

### DIFF
--- a/release-prereqs.md
+++ b/release-prereqs.md
@@ -1,7 +1,5 @@
 # Prerequisites for performing a release
 
-- access to the official CentOS CI fedora-coreos namespace
-- [`fedora-coreos-stream-generator`](https://github.com/coreos/fedora-coreos-stream-generator/)
-- a checkout and GitHub fork of [`this repo`](https://github.com/coreos/fedora-coreos-streams)
-- a checkout and GitHub fork of [`fedora-coreos-config`](https://github.com/coreos/fedora-coreos-config)
-- a checkout of [`fedora-coreos-releng-automation`](https://github.com/coreos/fedora-coreos-releng-automation)
+- access to the official [CentOS CI fedora-coreos namespace](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/)
+- an up to date and newly compiled [`fedora-coreos-stream-generator`](https://github.com/coreos/fedora-coreos-stream-generator/)
+- a checkout and GitHub fork of [`fedora-coreos-streams`](https://github.com/coreos/fedora-coreos-streams)


### PR DESCRIPTION
Over time we have automated some things so that we don't require as
many local git repos etc.. Let's update to the current requirements and
also update the current requirements to be a little more verbose/obvious.