### PR TITLE
next: rollout 35.20211003.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2021-09-28T16:12:11Z",
-        "generator": "fedora-coreos-stream-generator v0.1.0-6-ge7eb37e"
+        "last-modified": "2021-10-06T18:42:22Z",
+        "generator": "fedora-coreos-stream-generator v0.1.0-7-gfe56f7b"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20210924.1.0",
+                    "release": "35.20211003.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/aarch64/fedora-coreos-35.20210924.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/aarch64/fedora-coreos-35.20210924.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "a5a5dd89bf6b1fb3aab5a56ddb5530576a12ddde89345d4a7bd4e7e4fbd64414",
-                                "uncompressed-sha256": "29e0ee97abd87af5a681ffeabd0f56d726b01035b0265c8fd6196267c8a07378"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "4591708afa43e45b13866b2a3dc097ff218b657eb4a074de743d9493d76ab1e7",
+                                "uncompressed-sha256": "bb946c52f5f410c2c84963dab8efa66a49980b807cb330fd3ca00ef1bfbf7dd3"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20210924.1.0",
+                    "release": "35.20211003.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/aarch64/fedora-coreos-35.20210924.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/aarch64/fedora-coreos-35.20210924.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "4906e4f035111109e122c5d870f2cde3e5696a70e4641878ac9585e7fee72b58",
-                                "uncompressed-sha256": "f86d82e3b6e154a5840e061768a8ec5039fdb911b1b33d5c0360bd6fdcccc23e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a16b59e9fdc2744f9b2bf2346a03399ad7cd4c59dc7f017de2cd7ac08907fe26",
+                                "uncompressed-sha256": "467160ad8a49d1d83365cfb58e40ca407fb1a3ddfc8c3baaf0364b003ff7d80d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/aarch64/fedora-coreos-35.20210924.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/aarch64/fedora-coreos-35.20210924.1.0-live.aarch64.iso.sig",
-                                "sha256": "c8b8cb6ef51a899486d1f061641fd701ccae6ef4f0b0a63864953e1548001c24"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-live.aarch64.iso.sig",
+                                "sha256": "3f8411baebba3549f5c73e9f2c1f6424226433ccf6cb561e6eaf5d19a89163bc"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/aarch64/fedora-coreos-35.20210924.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/aarch64/fedora-coreos-35.20210924.1.0-live-kernel-aarch64.sig",
-                                "sha256": "db0e8dbe7e705ee3c01ad033436d9bc243d7795d539b566112c54d78fb0d41fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-live-kernel-aarch64.sig",
+                                "sha256": "7cd682d5f5f8efca47ff93ca698a9ee11f6d834c63708f0b2ecd55fa9c612f6d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/aarch64/fedora-coreos-35.20210924.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/aarch64/fedora-coreos-35.20210924.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "274f0fed6f68afdcca184d95a1e964feae4cb9451cb3d5ac07ddf7f2d6934788"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "c4c7eabced775e121e39cb6ed81f50570e89aa8ad8daceac7fd185950134cd8c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/aarch64/fedora-coreos-35.20210924.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/aarch64/fedora-coreos-35.20210924.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "c463565b62532eb0283423d74139371410c1bb34419d390f229ab8c758795aae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "12116304a303c949e30e7d1c21af5f30667f0c772d707cbeeb874edbaff71761"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/aarch64/fedora-coreos-35.20210924.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/aarch64/fedora-coreos-35.20210924.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "06933c8b6a26ea478ed8d6d9fc5ebc9456ccac2dbac361cebeef03559010c6da",
-                                "uncompressed-sha256": "d8d5131dc49ccb8e47eca60cc72b6613928d9c160e16898de14f0ec1e2d0317b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "df650407059ea8fb705cfee78b63565b7893eb3e2866e4fc2a836daf2f3654d9",
+                                "uncompressed-sha256": "6a0dcd6bc54403118b3f27b98abc4621f1543f5688f874526f7d195d4be32892"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20210924.1.0",
+                    "release": "35.20211003.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/aarch64/fedora-coreos-35.20210924.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/aarch64/fedora-coreos-35.20210924.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "e0cce055d2fe37352380b2039bacb4d10fa920e63df5fb8071faf1538103a32b",
-                                "uncompressed-sha256": "0c04d82461b0f2483b5844c6f7bb3c7c34d3c065d2c6387dbd192c3764c3ebd7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "64db9438c3badfca041c3724dabe5cdf64f137092889165180afc7736184f2a3",
+                                "uncompressed-sha256": "9478ed7a9c6834f3a0e7290bf582be93949d8c422adf2aa8c93df93f09a5e347"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20210924.1.0",
+                    "release": "35.20211003.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/aarch64/fedora-coreos-35.20210924.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/aarch64/fedora-coreos-35.20210924.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "a53a1b45f3af3d889158fccb85532e6f9bae23c07967a1d02bc6f99aff700de7",
-                                "uncompressed-sha256": "212fc9b81743a25b54c420b73aea77913755c7c5de5fc8c0d90587a1dad59777"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "143968d7e96a4e13339d38d2ba9c76f73b4e47b67b726f626ab1f86518044742",
+                                "uncompressed-sha256": "7c7725ccf8c1c59834d644dc3ea43c4be5c6cbaa11ebf2133dcd284b0d3429e1"
                             }
                         }
                     }
@@ -96,88 +96,88 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-06d42a30e99afd2e8"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0b4692ae0677ccd59"
                         },
                         "ap-east-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0382f102307ab3adb"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-08d5b19ecfc804827"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-00cbc0e23de46da46"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0f1b3f76564a39e70"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-00cbc3387e4975099"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0c69b93960058b1ac"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0ab21536fa5fa69f8"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0f103173225fd666a"
                         },
                         "ap-south-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0ca24896c13ef2dd6"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0bdc35070464825a8"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0a7f8f5739bbd7106"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-06bad002e95c15b1a"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-071853c082a6d1ebd"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-03a49ae2d2db0e44b"
                         },
                         "ca-central-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-01d44de4f6c1bbabd"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0bd07083dc72cf6f2"
                         },
                         "eu-central-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0611bd595e14d0172"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0a7e5362addddb497"
                         },
                         "eu-north-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0c7d6484c704b43ee"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0179b18ae0f1e1021"
                         },
                         "eu-south-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0e26fa72168bae95e"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-07a5ba1ab3b25e65c"
                         },
                         "eu-west-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-00ebe0f8ef6e6aa82"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-06ecb75e1320a135b"
                         },
                         "eu-west-2": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-065b23be93689b5ff"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0b852cdd6f143faa9"
                         },
                         "eu-west-3": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0b8039d05c31d3ef4"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-032f86eb0a27667e9"
                         },
                         "me-south-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-081e6b580230299a9"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0f865c8da42026df3"
                         },
                         "sa-east-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0e0a88094bce94b30"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0e4dc80f08d626346"
                         },
                         "us-east-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-05b60c3e2c35b687a"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0c889eb7b9dc6585a"
                         },
                         "us-east-2": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0f029cba8d822e4bf"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-01c98f4042ebdc465"
                         },
                         "us-west-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0e2d72ee3d1f6ac8a"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-03854f2ac9cd7910e"
                         },
                         "us-west-2": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-067780c7330a8cb8f"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0385c71613d75ef41"
                         }
                     }
                 }
@@ -186,201 +186,201 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20210924.1.0",
+                    "release": "35.20211003.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "7b8f7a932779a6369cac196766d27f10cddde7e0d0f09ff5684b2f8dac35e204",
-                                "uncompressed-sha256": "54a6cc2f8d33e6b966d64155abb6a916e5bf36b6aece025c04e9cbae49a0d0f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "bc4f5a4a5019523c06556bf121bc588c6a2d9ef4b8934c30ecb68c89c6a4ec52",
+                                "uncompressed-sha256": "890defa339c9d00fe97d27b52da8340938babd3f438d14dacf965169b624224c"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20210924.1.0",
+                    "release": "35.20211003.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "183ab0c6a201f9c58ba6e8173edb3ae15e9dd67c8a1e7ff401d4404a2e872c69",
-                                "uncompressed-sha256": "fd9d505c65e4611ad88f6d6488a2e9a4f2933748bfa36596d319264428a75fc1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "b6bd5e9dd557144fd1592688b90974814c35a47bb09b6aeb94c09943dc28baf4",
+                                "uncompressed-sha256": "1f10789665208ae14ad3416b785362609a0c361ec0cd6898fbbefb8535aeb9c2"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20210924.1.0",
+                    "release": "35.20211003.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "26d7deb7e366b0be9df68b6546bfd6d063310e68f0d2b9cb48efe8d7bb04133d",
-                                "uncompressed-sha256": "ce60ea330bd90ac0ef552320bd3eec2bba26e041243fc19e59a9a8449838c1d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "86d5002bc7ee63ec4d436ef984233463e41cda073bf01c388e5e4aeee859e9e9",
+                                "uncompressed-sha256": "768a8a74e04cac1426bff47d58e9466cbf3bd304903b7768bc3d29e491c4014c"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20210924.1.0",
+                    "release": "35.20211003.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "af4158176dca7efb05d8b573b47dc5d2fe381fc953fb6124a6235c24bf5b1dfc",
-                                "uncompressed-sha256": "46967d5496b81822dc0d88b1f1d263b5ccece36c55a12f416e5a32a3cee0a0a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "bdc873b1b23c81c676268ab3d58d9fe82b5093d4f694de34390b4b7638f9cb8a",
+                                "uncompressed-sha256": "0b71662108ae5c8458d70d01c73c488bc1801dbd790543a21abaa2e07c0c9fdd"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20210924.1.0",
+                    "release": "35.20211003.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "eace494862be9a7feb55093fecfa68691b7c465568729a3023865df69f768cf9",
-                                "uncompressed-sha256": "dae5388b82afc0f75a39f208c1cb6eb798403dfe09fef38bf28214c4fca128f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "58fb026fa4cee4c882f1d9f0f62dc78797c51b5632b6247fa9e05b5481a541be",
+                                "uncompressed-sha256": "0f47fb1d9a42f7db16053bbd2cec42460f247a619c6256dbbcd3a8dbb5c166e2"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20210924.1.0",
+                    "release": "35.20211003.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "2c6e6c0f733a78ffc24977acb054e5d54f5a79120804773afb989fbb95480332",
-                                "uncompressed-sha256": "8caeec702af22e67256fb3d363faf4da12f3874fb527ef4b0801811c9da7a701"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "1f161a283fc89f92bc4a54c59654c38e803daeeffe74cdb168681f4cf6aaf269",
+                                "uncompressed-sha256": "c57da45d2978bd3cc4b05fcbd6327e95d1aa8ab8b7d739fab254daf26728f2e9"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20210924.1.0",
+                    "release": "35.20211003.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "038b52ba6be44206d665c74ac945c57f03999b7af577684b44c5786207599f6b",
-                                "uncompressed-sha256": "18b937e2bf132d7bee52c63a4c04c3a49755ff0550ad990293e3e621437eeb82"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "54149e84e982ccf29bd3a3d7147f05e8deb6dfefa1c9c74e216bbd391e6e2bc4",
+                                "uncompressed-sha256": "b2a688f83ac40d56d475a302e2e2589a60d359e669e31f1cf02addb567cccbae"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20210924.1.0",
+                    "release": "35.20211003.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "922d820821d17ed5c94605e760e392465a960107a3c0f3960d459319a85a9dc9",
-                                "uncompressed-sha256": "301a0d7f675acfdacf3e8a110811d5e054b5c89cb9159d211770862c19668489"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "fe86a047bf2657700e4561b34ff5231bb8fd349247da3732ac1151c42632df4d",
+                                "uncompressed-sha256": "15c0f5f9d127f0d273a45b7b23e20fd73c56ded520a3725353ea9be85f143408"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20210924.1.0",
+                    "release": "35.20211003.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "81e813822e872bc13972f2bc1c8f09a6c1e09d3acc5862638b98942cd7cfe2fe",
-                                "uncompressed-sha256": "248688268153e0df0767cffa4684f43e7569f0b88ecf1fc80d8abfd3f1d597c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "6706ee77919dcfddf5b924a8c4366963a6c730aabc0bf40bb5985ea1e9d904e2",
+                                "uncompressed-sha256": "723c4323c4c834e8d3b01f59e8d180563b68f12343e1ae92bc60f3b1075f8f04"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-live.x86_64.iso.sig",
-                                "sha256": "0a728a1133e7d3f4ae183cbf3fdd059fe394888d41bb89c56ed7c5f5d4bed2a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-live.x86_64.iso.sig",
+                                "sha256": "9922dd666adaef36be3b2c82d001b027c25d7e07647ae82b544d604e23fc279b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-live-kernel-x86_64.sig",
-                                "sha256": "b08eef9c57efbc571e82f4af618f1c14ddd7cabae95c371b81e37c5395d3f394"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-live-kernel-x86_64.sig",
+                                "sha256": "7c37113fa574ecc7cfb4b8dac2fe1905a4ffa20cd646c63bb1050d72b6ba9a7e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "84c435a9cc298bb1c20ddb909b8fa45be8f41e6f2199df223edb3d4fcdab30bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "8ce6457fd15a3ba8e74df3da6f3d105799436940f6c4eaf4d8574d22cdc14d5f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "40033be1f04ab0a2ca5f946df158585e108390b86894dbf9f9a3cee894728e1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "6558aa8a996eb1894228ce4fd747d22966b2c15e3f2d708fd9feb43d7c0d3163"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "1570084e8a57789fa17a046ea6d51c130ad7566c58e675bfae7cf858b2c06766",
-                                "uncompressed-sha256": "3367f51cdb73106c61d87dc3b1e203d5c158f41aaa5ef4cab8c30d3aabab73f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "04ceaf2178a96341fbfdfa3e33df262cef08ea646ea2c926a97639a275f849b1",
+                                "uncompressed-sha256": "f4201f5e3dbd7de297b2a8583ee153bf418e536ba96fa5133b08aeb11201047a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20210924.1.0",
+                    "release": "35.20211003.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "0bea405011a5209b949ac4082a6672622c1ad446caee0ab27b5f68c567afefe5",
-                                "uncompressed-sha256": "75ee7ad7165bb3356ddb6466f4574a23134ca69f0ba2d51a38dc234400f16979"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "db60877ad7179452357062f05038bac628dc27987299434b6215eb19f5269293",
+                                "uncompressed-sha256": "1f83be2ea084f99a99da924c0e7c127baade9b97f62e5cacfb15a62fb202b08e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20210924.1.0",
+                    "release": "35.20211003.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e8d8f5b7a89f4ab97a7130a01d865678d9c50b6d53eb09d9e063c79416d5d1aa",
-                                "uncompressed-sha256": "b64bfe885307b230944f4d07c3974c308a5a66f32dec410f1f0034ae3fea380d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "8b71a254847b3188ccd39f581eeb14d7200897bc1b63f8eaca771dab5aea2010",
+                                "uncompressed-sha256": "af8c235c3262be0a0d47451b5aa480878b9ebb4fa95243e7e418f023afe40f1c"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20210924.1.0",
+                    "release": "35.20211003.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "5e385d57496e59faa9dea1c538e0e6947ef7f7739d69b4212060e047dcb7d067"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "881b8ca86379d4cbbe34f5e8b7b732b8bff3ddbb0a06f25fac27f95e99843279"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20210924.1.0",
+                    "release": "35.20211003.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20210924.1.0/x86_64/fedora-coreos-35.20210924.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "68fe597fd8ceae334eea8a6579fc022e4fa1179a020c3e605b56f10642b2cb65",
-                                "uncompressed-sha256": "d7b07061f001317f8487aead4f9977fe5ccc36afddb198fee11e51c22843aa54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "0b6aa7e9144089c07afe3215fd26a73f9782557adf3eb6dc86759160c1ae6e89",
+                                "uncompressed-sha256": "e11de14a29c956db30312fa386ea159c61dfbae06d4311f933ced45ceee95af1"
                             }
                         }
                     }
@@ -390,95 +390,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0199ac42155241cdc"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0c79617a2e6bf6390"
                         },
                         "ap-east-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0e87bcffa861edf46"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-00176b5647ad98f95"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0c9e1e6c5b0015ce9"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-09e8222770d5d957d"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0c8c85125d87b817d"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-07c72b81bd2998993"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0e315650977f2d69f"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0e34a23c4fd01b9b7"
                         },
                         "ap-south-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0426095b3e4e70514"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-06b0f68be4cbe174e"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0570cc7fd61b2c99d"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0deb982139ef106fd"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0f484e165c548bf85"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0c8982d5453a2796f"
                         },
                         "ca-central-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0b3998de1bbc95d27"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-08b87e9908ffb9078"
                         },
                         "eu-central-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0532cc81679fffa4b"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-03a76a7ac5b93a1bb"
                         },
                         "eu-north-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-01ec413df57ac7f43"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0f98e2ed4e122a191"
                         },
                         "eu-south-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0ef3c54020fd3109e"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0f9e6415dc3871172"
                         },
                         "eu-west-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0dee42635dcd5108a"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-02b629f447eaba836"
                         },
                         "eu-west-2": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0653b35ecba7d6708"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-08e4e484dfc7b3748"
                         },
                         "eu-west-3": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-01f5908e25fd01292"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0a75b03fd14491f2a"
                         },
                         "me-south-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0801dc983255ade62"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0d271881b940782a1"
                         },
                         "sa-east-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0402f8bc77eeb4c5d"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0a0f584c20c8f7073"
                         },
                         "us-east-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0db8e8b6e69878a6b"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-08a2a4f6f7a90e59f"
                         },
                         "us-east-2": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-03e0e407518c2b35c"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-02788553e7ebca195"
                         },
                         "us-west-1": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-0275f856bf432582d"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-0dc4d30fc1cbeb4c6"
                         },
                         "us-west-2": {
-                            "release": "35.20210924.1.0",
-                            "image": "ami-01882f4ee81d36603"
+                            "release": "35.20211003.1.0",
+                            "image": "ami-028d8003721553b1f"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-35-20210924-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-35-20211003-1-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2021-09-28T15:59:28Z"
+    "last-modified": "2021-10-06T20:06:13Z"
   },
   "releases": [
     {
@@ -37,23 +37,23 @@
       }
     },
     {
-      "version": "34.20210919.1.0",
+      "version": "35.20210924.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        },
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     },
     {
-      "version": "35.20210924.1.0",
+      "version": "35.20211003.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 4320,
-          "start_epoch": 1632848400,
+          "duration_minutes": 2880,
+          "start_epoch": 1633554000,
           "start_percentage": 0.0
-        },
-        "barrier": {
-          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     }


### PR DESCRIPTION
```
$ make print-rollouts
stable
    version: 34.20210904.3.0 (*** NOT LATEST ***)
    start: 2021-09-21 15:00:00+00:00 UTC (15 days, 5:08:26 ago)
           2021-09-21 11:00:00-04:00 Raleigh/New York/Toronto
           2021-09-21 17:00:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)
testing
    version: 34.20210919.2.0 (*** NOT LATEST ***)
    start: 2021-09-21 15:00:00+00:00 UTC (15 days, 5:08:26 ago)
           2021-09-21 11:00:00-04:00 Raleigh/New York/Toronto
           2021-09-21 17:00:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)
next
    version: 35.20211003.1.0 (latest)
    start: 2021-10-06 21:00:00+00:00 UTC (in 0:51:32)
           2021-10-06 17:00:00-04:00 Raleigh/New York/Toronto
           2021-10-06 23:00:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)

```