### PR TITLE
next: rollout 35.20211010.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2021-10-06T18:42:22Z",
+        "last-modified": "2021-10-13T13:08:41Z",
         "generator": "fedora-coreos-stream-generator v0.1.0-7-gfe56f7b"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20211003.1.0",
+                    "release": "35.20211010.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "4591708afa43e45b13866b2a3dc097ff218b657eb4a074de743d9493d76ab1e7",
-                                "uncompressed-sha256": "bb946c52f5f410c2c84963dab8efa66a49980b807cb330fd3ca00ef1bfbf7dd3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/aarch64/fedora-coreos-35.20211010.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/aarch64/fedora-coreos-35.20211010.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "432a8b5e667279b2e8b360a5343217686ee140ad1603b67957eca6049c695373",
+                                "uncompressed-sha256": "b395312a4ac5d42404748e0a1dff624f12026c2dd0bb0c3a485fdb142d1c1218"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20211003.1.0",
+                    "release": "35.20211010.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "a16b59e9fdc2744f9b2bf2346a03399ad7cd4c59dc7f017de2cd7ac08907fe26",
-                                "uncompressed-sha256": "467160ad8a49d1d83365cfb58e40ca407fb1a3ddfc8c3baaf0364b003ff7d80d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/aarch64/fedora-coreos-35.20211010.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/aarch64/fedora-coreos-35.20211010.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "3fcfd033c8eb9e1f2a7d18a1952620a73dd44b5bd4d23c0fed847a906d9d35f1",
+                                "uncompressed-sha256": "12ce1ec9a08bdb6a4c113f13844fd19d570287bf2f1e9686adabc1f75739b2bc"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-live.aarch64.iso.sig",
-                                "sha256": "3f8411baebba3549f5c73e9f2c1f6424226433ccf6cb561e6eaf5d19a89163bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/aarch64/fedora-coreos-35.20211010.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/aarch64/fedora-coreos-35.20211010.1.0-live.aarch64.iso.sig",
+                                "sha256": "235415fcb79b37ffc03ccfdd3dc160c315503609d63d7efdb96a3c3480c905e7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-live-kernel-aarch64.sig",
-                                "sha256": "7cd682d5f5f8efca47ff93ca698a9ee11f6d834c63708f0b2ecd55fa9c612f6d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/aarch64/fedora-coreos-35.20211010.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/aarch64/fedora-coreos-35.20211010.1.0-live-kernel-aarch64.sig",
+                                "sha256": "e08ecd745fe0f70564df04c4913ae248fd99fc23466abf3d1f7007fb61774bfd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "c4c7eabced775e121e39cb6ed81f50570e89aa8ad8daceac7fd185950134cd8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/aarch64/fedora-coreos-35.20211010.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/aarch64/fedora-coreos-35.20211010.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "c39ee6698e8dbbaee0a38410cf786a66f4c5f0ecbef7a385ef399f06134373e4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "12116304a303c949e30e7d1c21af5f30667f0c772d707cbeeb874edbaff71761"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/aarch64/fedora-coreos-35.20211010.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/aarch64/fedora-coreos-35.20211010.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "8e891b3fa868cc5696c9b381b067f04d380ae957ce4fa47d1ac62ffbd43bd2e9"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "df650407059ea8fb705cfee78b63565b7893eb3e2866e4fc2a836daf2f3654d9",
-                                "uncompressed-sha256": "6a0dcd6bc54403118b3f27b98abc4621f1543f5688f874526f7d195d4be32892"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/aarch64/fedora-coreos-35.20211010.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/aarch64/fedora-coreos-35.20211010.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "1a0a25085df3d21af1029a1bd0e43a2220b9aa031d8991dd64c8bac6b7806633",
+                                "uncompressed-sha256": "7392d6b044679158db66427b56a45d6ce5efd8f9049383d9b7711ce0be7edac4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20211003.1.0",
+                    "release": "35.20211010.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "64db9438c3badfca041c3724dabe5cdf64f137092889165180afc7736184f2a3",
-                                "uncompressed-sha256": "9478ed7a9c6834f3a0e7290bf582be93949d8c422adf2aa8c93df93f09a5e347"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/aarch64/fedora-coreos-35.20211010.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/aarch64/fedora-coreos-35.20211010.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "0c9475dec74bc39e555b39be433dc19c3e5386b2fd4936da6aae28f875778e92",
+                                "uncompressed-sha256": "3db43b6cf92b6a810b1b3e382bd41a5479813af68c43a082530f2cbb6f9920a6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20211003.1.0",
+                    "release": "35.20211010.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/aarch64/fedora-coreos-35.20211003.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "143968d7e96a4e13339d38d2ba9c76f73b4e47b67b726f626ab1f86518044742",
-                                "uncompressed-sha256": "7c7725ccf8c1c59834d644dc3ea43c4be5c6cbaa11ebf2133dcd284b0d3429e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/aarch64/fedora-coreos-35.20211010.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/aarch64/fedora-coreos-35.20211010.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "407076e288e074d1e9709f6510176338d65897e780838abca011bfc459f644c7",
+                                "uncompressed-sha256": "f78994a8dc57e176601f9b6aae645a017c051eb03669cae406203f3052a30ce8"
                             }
                         }
                     }
@@ -96,88 +96,88 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0b4692ae0677ccd59"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-0505301bca802fcf4"
                         },
                         "ap-east-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-08d5b19ecfc804827"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-0a43203a6166810ea"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0f1b3f76564a39e70"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-098711f1c2f5f2e11"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0c69b93960058b1ac"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-0ce5edf14d0f0057a"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0f103173225fd666a"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-02a6851e6ebd93916"
                         },
                         "ap-south-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0bdc35070464825a8"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-088d5e7d1a032676b"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-06bad002e95c15b1a"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-043483e383dd82cbb"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-03a49ae2d2db0e44b"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-01fc90d0e778feb18"
                         },
                         "ca-central-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0bd07083dc72cf6f2"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-046a44414ca1f2b8e"
                         },
                         "eu-central-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0a7e5362addddb497"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-06f80b7d3efbb1557"
                         },
                         "eu-north-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0179b18ae0f1e1021"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-0f1f439893d46c5c2"
                         },
                         "eu-south-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-07a5ba1ab3b25e65c"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-0b4d2460e9086b805"
                         },
                         "eu-west-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-06ecb75e1320a135b"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-05d7f51489f2cfe65"
                         },
                         "eu-west-2": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0b852cdd6f143faa9"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-083c64c9e0feb75bc"
                         },
                         "eu-west-3": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-032f86eb0a27667e9"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-0c58ea9cf29a808b2"
                         },
                         "me-south-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0f865c8da42026df3"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-08c6b17a4bd2a9c13"
                         },
                         "sa-east-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0e4dc80f08d626346"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-03d23be94cc438807"
                         },
                         "us-east-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0c889eb7b9dc6585a"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-0d2bb248a7d228080"
                         },
                         "us-east-2": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-01c98f4042ebdc465"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-004fabe74cd0a0e6f"
                         },
                         "us-west-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-03854f2ac9cd7910e"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-0cf48b84e8b7b2d27"
                         },
                         "us-west-2": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0385c71613d75ef41"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-02c1261f043748b65"
                         }
                     }
                 }
@@ -186,201 +186,201 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20211003.1.0",
+                    "release": "35.20211010.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "bc4f5a4a5019523c06556bf121bc588c6a2d9ef4b8934c30ecb68c89c6a4ec52",
-                                "uncompressed-sha256": "890defa339c9d00fe97d27b52da8340938babd3f438d14dacf965169b624224c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "09bc9fbae0885fec0bb9e46f4022b16e0b2f3f9b8a9a66cc955156a23a118b81",
+                                "uncompressed-sha256": "8158981a38392f2e256bcd22e4320c66da7167b9f0fd9d8fa72e1b65858f92cf"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20211003.1.0",
+                    "release": "35.20211010.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "b6bd5e9dd557144fd1592688b90974814c35a47bb09b6aeb94c09943dc28baf4",
-                                "uncompressed-sha256": "1f10789665208ae14ad3416b785362609a0c361ec0cd6898fbbefb8535aeb9c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "e9c0ffcfbd4420a0fcb2d65ddae95003c2e24203a769c401f8889bce339085f5",
+                                "uncompressed-sha256": "1bacf0c5ae17303168f88882549c6c93f2a05c0fcd89ada20c2782f2e32ff7c9"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20211003.1.0",
+                    "release": "35.20211010.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "86d5002bc7ee63ec4d436ef984233463e41cda073bf01c388e5e4aeee859e9e9",
-                                "uncompressed-sha256": "768a8a74e04cac1426bff47d58e9466cbf3bd304903b7768bc3d29e491c4014c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "9f0738920f6339715b6c941ec194194c60b6b9206c3f701a5dd5e8863aac3291",
+                                "uncompressed-sha256": "98bfe2af71c664d0428b2f0e696bd1d94fbbeb679c45f36c4d6881f49585921e"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20211003.1.0",
+                    "release": "35.20211010.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "bdc873b1b23c81c676268ab3d58d9fe82b5093d4f694de34390b4b7638f9cb8a",
-                                "uncompressed-sha256": "0b71662108ae5c8458d70d01c73c488bc1801dbd790543a21abaa2e07c0c9fdd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "50baba85f88ac38a3606c80a4d72f1115b2c783df9adae8ba4f140e4dbb0f36d",
+                                "uncompressed-sha256": "a33c52f41e7ed7d36392ecbdc10aa359e7d1ff4a67f5e8685cb7ed745e379a2f"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20211003.1.0",
+                    "release": "35.20211010.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "58fb026fa4cee4c882f1d9f0f62dc78797c51b5632b6247fa9e05b5481a541be",
-                                "uncompressed-sha256": "0f47fb1d9a42f7db16053bbd2cec42460f247a619c6256dbbcd3a8dbb5c166e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "bb1d48c1b5b71fb0ce2d8475f2f6923af72ec543b4b4dff6422be5c5b65f966f",
+                                "uncompressed-sha256": "7b0156bc06775c1a7d4451a62aa3bd2f282b1953837967c81c265dad06a64597"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20211003.1.0",
+                    "release": "35.20211010.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "1f161a283fc89f92bc4a54c59654c38e803daeeffe74cdb168681f4cf6aaf269",
-                                "uncompressed-sha256": "c57da45d2978bd3cc4b05fcbd6327e95d1aa8ab8b7d739fab254daf26728f2e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "36d384522c2c47de196d13f5f9f3f8af0e4f43cd5b81fe72d2333f82d01484f3",
+                                "uncompressed-sha256": "a074f8dbcef457634899d656e21ccee8da34fef404725068756b1f3877a453c5"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20211003.1.0",
+                    "release": "35.20211010.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "54149e84e982ccf29bd3a3d7147f05e8deb6dfefa1c9c74e216bbd391e6e2bc4",
-                                "uncompressed-sha256": "b2a688f83ac40d56d475a302e2e2589a60d359e669e31f1cf02addb567cccbae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "d7bdaed9dead6d16a53d4cc9c04ce3dd9d4eeb0e401bb2d83e3cabc807f6323c",
+                                "uncompressed-sha256": "f6b7293246eeda5a36c01ae627204eeb6664800aac18e92c72df36f18f16b7be"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20211003.1.0",
+                    "release": "35.20211010.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "fe86a047bf2657700e4561b34ff5231bb8fd349247da3732ac1151c42632df4d",
-                                "uncompressed-sha256": "15c0f5f9d127f0d273a45b7b23e20fd73c56ded520a3725353ea9be85f143408"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "b04463a03cff06912334c10dacf8b3e42b6e7898cd2da0e61d45b12e409afce2",
+                                "uncompressed-sha256": "e78015e977b55e6fcc065755c68579946bb8b5f3be3b2b2a324378b80b91416a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20211003.1.0",
+                    "release": "35.20211010.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "6706ee77919dcfddf5b924a8c4366963a6c730aabc0bf40bb5985ea1e9d904e2",
-                                "uncompressed-sha256": "723c4323c4c834e8d3b01f59e8d180563b68f12343e1ae92bc60f3b1075f8f04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "1709fb6c9e8dfe96eff0fb3359a9043280cef6bd1d9902371b22106c08310d3d",
+                                "uncompressed-sha256": "8c0eb7a6d1a7331151fdf990639724b99439b24c805fcc15ad863b1cd139a7cf"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-live.x86_64.iso.sig",
-                                "sha256": "9922dd666adaef36be3b2c82d001b027c25d7e07647ae82b544d604e23fc279b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-live.x86_64.iso.sig",
+                                "sha256": "8e33cd80e00096fd1f361bf78867062459deacd1e5f90810ab72dd506e963d69"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-live-kernel-x86_64.sig",
-                                "sha256": "7c37113fa574ecc7cfb4b8dac2fe1905a4ffa20cd646c63bb1050d72b6ba9a7e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-live-kernel-x86_64.sig",
+                                "sha256": "24c5cc6b1f541527f4cd2dc6d1672608fa1c8b16c37a9a427d989240712316b4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "8ce6457fd15a3ba8e74df3da6f3d105799436940f6c4eaf4d8574d22cdc14d5f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "482945271c41e3a54bebdf8d401db781a5b6e15eef8260ffcae4064618514781"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "6558aa8a996eb1894228ce4fd747d22966b2c15e3f2d708fd9feb43d7c0d3163"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "16d9e144793260bdc9544b173fa4745fb77bea231cb9a6b7348719fd67510dd3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "04ceaf2178a96341fbfdfa3e33df262cef08ea646ea2c926a97639a275f849b1",
-                                "uncompressed-sha256": "f4201f5e3dbd7de297b2a8583ee153bf418e536ba96fa5133b08aeb11201047a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "6f4b53a15ca28dd1557f43d1575e00e7b1796406d1e09ae7f6f17890e80f80ef",
+                                "uncompressed-sha256": "a8c52cfd899d3c1098bf02affa43483da763bf022d7f8479ed3063c17a6865fc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20211003.1.0",
+                    "release": "35.20211010.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "db60877ad7179452357062f05038bac628dc27987299434b6215eb19f5269293",
-                                "uncompressed-sha256": "1f83be2ea084f99a99da924c0e7c127baade9b97f62e5cacfb15a62fb202b08e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "b0f993065dce1db0bda04b058113b27834c5749ca8ec219205c6713b8c1acbb2",
+                                "uncompressed-sha256": "2d1c9f8f09d3ece58c41a51069f5e43e1278e98ab60629f75d6f2b978ca3ecb1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20211003.1.0",
+                    "release": "35.20211010.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "8b71a254847b3188ccd39f581eeb14d7200897bc1b63f8eaca771dab5aea2010",
-                                "uncompressed-sha256": "af8c235c3262be0a0d47451b5aa480878b9ebb4fa95243e7e418f023afe40f1c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "0d40685e6a0459bebdd357f25550f8795b1b55e54b1e086c888a744dea6cacc9",
+                                "uncompressed-sha256": "8ea96feeb2ca91a9fa7710ff27b3b2468cca4ab3d3657b656095e5584e8191f1"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20211003.1.0",
+                    "release": "35.20211010.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "881b8ca86379d4cbbe34f5e8b7b732b8bff3ddbb0a06f25fac27f95e99843279"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "f93d67b906d61f97210afb192cec0c19ad49cc8f14ad21210093d9c951f8c071"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20211003.1.0",
+                    "release": "35.20211010.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211003.1.0/x86_64/fedora-coreos-35.20211003.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "0b6aa7e9144089c07afe3215fd26a73f9782557adf3eb6dc86759160c1ae6e89",
-                                "uncompressed-sha256": "e11de14a29c956db30312fa386ea159c61dfbae06d4311f933ced45ceee95af1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211010.1.0/x86_64/fedora-coreos-35.20211010.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "8fc9384111b2f5335920eb9a7e0ad89ff68dd3652ebc580121b8a26c2cd5dc73",
+                                "uncompressed-sha256": "62bf2814664b184855cda232a5d621ed8887f51ca3064d35891b9db5558b0da6"
                             }
                         }
                     }
@@ -390,95 +390,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0c79617a2e6bf6390"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-05b1780f3f51084b0"
                         },
                         "ap-east-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-00176b5647ad98f95"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-06c7759cdf4542536"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-09e8222770d5d957d"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-0a46584a37dc38e90"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-07c72b81bd2998993"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-0de46dbd9bd9b8e63"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0e34a23c4fd01b9b7"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-0c84613bf64c65c6c"
                         },
                         "ap-south-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-06b0f68be4cbe174e"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-0e85603ba41e427e3"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0deb982139ef106fd"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-0fa07a79988f01685"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0c8982d5453a2796f"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-05d53bf25e58e084a"
                         },
                         "ca-central-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-08b87e9908ffb9078"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-029f690f8133ec188"
                         },
                         "eu-central-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-03a76a7ac5b93a1bb"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-0d9fa0f6d830d6108"
                         },
                         "eu-north-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0f98e2ed4e122a191"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-072f16b0b7abb0e41"
                         },
                         "eu-south-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0f9e6415dc3871172"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-00071dd5b9b950aaa"
                         },
                         "eu-west-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-02b629f447eaba836"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-087c9cfe22353cb65"
                         },
                         "eu-west-2": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-08e4e484dfc7b3748"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-0f589036123efe34c"
                         },
                         "eu-west-3": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0a75b03fd14491f2a"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-008ee572c2be998e2"
                         },
                         "me-south-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0d271881b940782a1"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-05bb4da8df37ab66c"
                         },
                         "sa-east-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0a0f584c20c8f7073"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-0355c9acda5955aac"
                         },
                         "us-east-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-08a2a4f6f7a90e59f"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-0f374d0d2c93f6a46"
                         },
                         "us-east-2": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-02788553e7ebca195"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-025ac28e0c7364dbb"
                         },
                         "us-west-1": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-0dc4d30fc1cbeb4c6"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-02b52a818369ce69e"
                         },
                         "us-west-2": {
-                            "release": "35.20211003.1.0",
-                            "image": "ami-028d8003721553b1f"
+                            "release": "35.20211010.1.0",
+                            "image": "ami-0df0d7e7584ee4c43"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-35-20211003-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-35-20211010-1-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2021-10-06T20:06:13Z"
+    "last-modified": "2021-10-13T13:14:45Z"
   },
   "releases": [
     {
@@ -39,9 +39,6 @@
     {
       "version": "35.20210924.1.0",
       "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        },
         "barrier": {
           "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
@@ -51,8 +48,16 @@
       "version": "35.20211003.1.0",
       "metadata": {
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "35.20211010.1.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1633554000,
+          "start_epoch": 1634133600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
```
next
    version: 35.20211010.1.0 (latest)
    start: 2021-10-13 14:00:00+00:00 UTC (in 0:45:00)
           2021-10-13 10:00:00-04:00 Raleigh/New York/Toronto
           2021-10-13 16:00:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)
```

https://github.com/coreos/fedora-coreos-streams/issues/386