### PR TITLE
templates: add task for updating fedora-coreos-stream-generator

### DIFF
--- a/ISSUE_TEMPLATE/next.md
+++ b/ISSUE_TEMPLATE/next.md
@@ -60,10 +60,10 @@ From a checkout of this repo:
 fedora-coreos-stream-generator -releases=https://fcos-builds.s3.amazonaws.com/prod/streams/next/releases.json  -output-file=streams/next.json -pretty-print
 ```
 
-- [ ] Add a rollout.  For a 48-hour rollout starting at 10 AM ET, run:
+- [ ] Add a rollout.  For example, for a 48-hour rollout starting at 10 AM ET the same day, run:
 
 ```
-./rollout.py add next <version> "10 am ET" 48
+./rollout.py add next <version> "10 am ET today" 48
 ```
 
 - [ ] Commit the changes and open a PR against the repo.  Paste the output of `make print-rollouts` into the PR description.

--- a/ISSUE_TEMPLATE/next.md
+++ b/ISSUE_TEMPLATE/next.md
@@ -49,6 +49,8 @@ At this point, Cincinnati will see the new release on its next refresh and creat
 
 ## Refresh metadata (stream and updates)
 
+- [ ] Make sure your `fedora-coreos-stream-generator` binary is up-to-date.
+
 From a checkout of this repo:
 
 - [ ] Update stream metadata, by running:

--- a/ISSUE_TEMPLATE/stable.md
+++ b/ISSUE_TEMPLATE/stable.md
@@ -60,10 +60,10 @@ From a checkout of this repo:
 fedora-coreos-stream-generator -releases=https://fcos-builds.s3.amazonaws.com/prod/streams/stable/releases.json  -output-file=streams/stable.json -pretty-print
 ```
 
-- [ ] Add a rollout.  For a 48-hour rollout starting at 10 AM ET, run:
+- [ ] Add a rollout.  For example, for a 48-hour rollout starting at 10 AM ET the same day, run:
 
 ```
-./rollout.py add stable <version> "10 am ET" 48
+./rollout.py add stable <version> "10 am ET today" 48
 ```
 
 - [ ] Commit the changes and open a PR against the repo.  Paste the output of `make print-rollouts` into the PR description.

--- a/ISSUE_TEMPLATE/stable.md
+++ b/ISSUE_TEMPLATE/stable.md
@@ -49,6 +49,8 @@ At this point, Cincinnati will see the new release on its next refresh and creat
 
 ## Refresh metadata (stream and updates)
 
+- [ ] Make sure your `fedora-coreos-stream-generator` binary is up-to-date.
+
 From a checkout of this repo:
 
 - [ ] Update stream metadata, by running:

--- a/ISSUE_TEMPLATE/testing.md
+++ b/ISSUE_TEMPLATE/testing.md
@@ -60,10 +60,10 @@ From a checkout of this repo:
 fedora-coreos-stream-generator -releases=https://fcos-builds.s3.amazonaws.com/prod/streams/testing/releases.json  -output-file=streams/testing.json -pretty-print
 ```
 
-- [ ] Add a rollout.  For a 48-hour rollout starting at 10 AM ET, run:
+- [ ] Add a rollout.  For example, for a 48-hour rollout starting at 10 AM ET the same day, run:
 
 ```
-./rollout.py add testing <version> "10 am ET" 48
+./rollout.py add testing <version> "10 am ET today" 48
 ```
 
 - [ ] Commit the changes and open a PR against the repo.  Paste the output of `make print-rollouts` into the PR description.

--- a/ISSUE_TEMPLATE/testing.md
+++ b/ISSUE_TEMPLATE/testing.md
@@ -49,6 +49,8 @@ At this point, Cincinnati will see the new release on its next refresh and creat
 
 ## Refresh metadata (stream and updates)
 
+- [ ] Make sure your `fedora-coreos-stream-generator` binary is up-to-date.
+
 From a checkout of this repo:
 
 - [ ] Update stream metadata, by running:


### PR DESCRIPTION
It's mentioned in the prereqs that it should be updated, but that's not
as strong as actually having it be a task.