### PR TITLE
rollout: validate duration when adding new rollout

### DIFF
--- a/rollout.py
+++ b/rollout.py
@@ -66,6 +66,10 @@ def add(info, version, start, duration, barrier=None, deadend=None,
     if start_time is None:
         raise Exception(f"Couldn't parse '{start}'")
 
+    # Validate duration
+    if duration <= 0:
+        raise Exception(f'Duration must be positive; found {duration}')
+
     # Validate version
     if info['stream'] not in VERSION_STREAM_CODES:
         raise Exception(f"Unknown stream '{info['stream']}'")


### PR DESCRIPTION
We basically never want a zero-hour rollout; it's not safe.  If for some reason we did need that, it seems fine to require hand-editing the JSON.