### PR TITLE
next: rollout 35.20211025.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2021-10-20T19:42:23Z",
+        "last-modified": "2021-10-26T21:18:21Z",
         "generator": "fedora-coreos-stream-generator v0.1.0-7-gfe56f7b"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20211017.1.0",
+                    "release": "35.20211025.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/aarch64/fedora-coreos-35.20211017.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/aarch64/fedora-coreos-35.20211017.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "a95194b36e60c06d4af372bc45d5c03dc281e303f39262fa2dc4528fc6aea6c8",
-                                "uncompressed-sha256": "76fd1217c40f525b3237249252486459aaa7f4f6a394a20cc1ebf0a0d9322b6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/aarch64/fedora-coreos-35.20211025.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/aarch64/fedora-coreos-35.20211025.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "df0d9e77a8bffd5f1e7bd5364fc85632b1f37960da4b25ef025b814b31831a95",
+                                "uncompressed-sha256": "e416bf866ffef4c419f0b90f15208bc47327a786a7318715fa3b95db5ff18018"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20211017.1.0",
+                    "release": "35.20211025.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/aarch64/fedora-coreos-35.20211017.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/aarch64/fedora-coreos-35.20211017.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "49e2ed3e9a339ba8421d075a8fac0bc0dd3048bf24bb39bad826fcf9fe79da96",
-                                "uncompressed-sha256": "40e1ed04c40c9ab309bd81fb40ff8e8bac198e4919c5947a2b5566c5ec294933"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/aarch64/fedora-coreos-35.20211025.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/aarch64/fedora-coreos-35.20211025.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "fd418310d8d086e4c3402109bb160556f3678245ac72ff4f4b86fb55c50b4ad6",
+                                "uncompressed-sha256": "14648014dd6012577e2191af68aa0548014311b67c6ddc54ec2cb98e37ad2a32"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/aarch64/fedora-coreos-35.20211017.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/aarch64/fedora-coreos-35.20211017.1.0-live.aarch64.iso.sig",
-                                "sha256": "3df6325802c290decf34dfa92c1bf5c375a69c5a7e6ceba75e63a34b477eae17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/aarch64/fedora-coreos-35.20211025.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/aarch64/fedora-coreos-35.20211025.1.0-live.aarch64.iso.sig",
+                                "sha256": "f9a142cf25b497c862e4d0a42c7f62023bfb0cef595b15a6ed1d544b40007421"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/aarch64/fedora-coreos-35.20211017.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/aarch64/fedora-coreos-35.20211017.1.0-live-kernel-aarch64.sig",
-                                "sha256": "d3131a5dafbb60406dc8e959b25fe6cb8a0998637d9ac8f37aab1ab5a875d066"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/aarch64/fedora-coreos-35.20211025.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/aarch64/fedora-coreos-35.20211025.1.0-live-kernel-aarch64.sig",
+                                "sha256": "8460a2114bc78b93469e15cbecf8b22c623debed50138a95a2b3ddf395f8d533"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/aarch64/fedora-coreos-35.20211017.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/aarch64/fedora-coreos-35.20211017.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "889f76cbd83ec0531bb976a9875878da5be8eae824bcfe523d525ea613819fe5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/aarch64/fedora-coreos-35.20211025.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/aarch64/fedora-coreos-35.20211025.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "217b7c3bf14860ecd730ebeeb65e802879fd2974e58e9ce369e2d9cf208169ec"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/aarch64/fedora-coreos-35.20211017.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/aarch64/fedora-coreos-35.20211017.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "25f388ba6e7efbb4cc75910ad00359aa024e948aa6b046b0c997026eeb62ff3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/aarch64/fedora-coreos-35.20211025.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/aarch64/fedora-coreos-35.20211025.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "9c89eb96ab3d2b2bfc75e3cf51124dcdaa353187ee19a1af9b8f66a591f2206f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/aarch64/fedora-coreos-35.20211017.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/aarch64/fedora-coreos-35.20211017.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "c97a4511ccb513ee8499e66cbb64e277c3ab78359fd9a422abbf7ce405132b19",
-                                "uncompressed-sha256": "a960d4ad6a4cafe63bb69ca650586e36d5ca9ee94727a913c9b487d0ac3e8166"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/aarch64/fedora-coreos-35.20211025.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/aarch64/fedora-coreos-35.20211025.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "b12f61eb6ef0d853b6868c57447f7b8f1444832f1e98592babed64853ac0e583",
+                                "uncompressed-sha256": "3f9b7f9bf7b4e94dbcb9f5606804218a2f49c90247f1cd4b5b99ac65ae358636"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20211017.1.0",
+                    "release": "35.20211025.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/aarch64/fedora-coreos-35.20211017.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/aarch64/fedora-coreos-35.20211017.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "0c287c74ffda14ebe8de6cdd05604643548c8c6b84bb9c969d1c45f520b7274c",
-                                "uncompressed-sha256": "772cc184d6161fd8a3322b6a772616e7ea34d4481c1413c4afebd7c1b353a5ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/aarch64/fedora-coreos-35.20211025.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/aarch64/fedora-coreos-35.20211025.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "5e24053a72a95a3e69263c5aaf38b6fbc9516e05e2f2e1b8ad97e8652c4ee7b7",
+                                "uncompressed-sha256": "9d572716e1763b59830f920f156c3be8986ebc4256e528648d7a4c97bb6f6863"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20211017.1.0",
+                    "release": "35.20211025.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/aarch64/fedora-coreos-35.20211017.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/aarch64/fedora-coreos-35.20211017.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "faa3981a34239e734df4dbaae27ae7da3b02e185d6d98b19138f9d305d470a87",
-                                "uncompressed-sha256": "65783cad9699076f8cf2f5f96e9394f758e99f678d9130050622b3295f9865cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/aarch64/fedora-coreos-35.20211025.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/aarch64/fedora-coreos-35.20211025.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "725165aae5ecf972efced8947ff56772394b3223dd061aa78c0af5f3064ae47a",
+                                "uncompressed-sha256": "94a39df46ecdfa89f4de785a5cbc5f37a2b45157f2384922b158c92d94e474e7"
                             }
                         }
                     }
@@ -96,88 +96,88 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-01881d404beb21e51"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-01dcadf3f1a1950c7"
                         },
                         "ap-east-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-0cc9bdc929a419cfb"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-00ed132fdba62e02d"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-0f0600b57f9b9d735"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-04de1a179e5e810b4"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-09673508154e9efda"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-01a133e7b31f332fe"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-070b0292d6af657d2"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-086dd296f58c8aa27"
                         },
                         "ap-south-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-00db81695bf025852"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-06b0068f3920d55c8"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-015b3944fabcd3aff"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-08a7f3c47a9a10016"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-014b9316ee45a58a6"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-044aa911af570c665"
                         },
                         "ca-central-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-0c5ece86a2e6a0cb8"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-0b503ea65aaa6ca42"
                         },
                         "eu-central-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-0bef4b420a7fb640a"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-060474b1f5ea227b6"
                         },
                         "eu-north-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-018c5c9bc2dae3da4"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-0931b7c9e97cc7b92"
                         },
                         "eu-south-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-0ea424b970fec56e5"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-01f99e462a721763c"
                         },
                         "eu-west-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-0fa3ba331f7051625"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-08dea86c6b4aeb18f"
                         },
                         "eu-west-2": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-09138fc144fb74d76"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-040e50b0a8da8d13d"
                         },
                         "eu-west-3": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-01ef0786eee530c69"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-031b32a7e6594cc89"
                         },
                         "me-south-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-038a327e082a8f6a9"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-0d0b0ff14fa44651a"
                         },
                         "sa-east-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-06d11a1b1617217a1"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-06084f19ef1d21b0e"
                         },
                         "us-east-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-0d931dcf937916b39"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-0d720e89d5ae6f12b"
                         },
                         "us-east-2": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-0d2cb28a0833cf9cf"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-0c98ac82cff75f55e"
                         },
                         "us-west-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-03b5bc21b213c6c1d"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-0b47101fd58dae1c4"
                         },
                         "us-west-2": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-0c3e9db64c0bde0e4"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-0a0396e9adae9b223"
                         }
                     }
                 }
@@ -186,201 +186,201 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20211017.1.0",
+                    "release": "35.20211025.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "5fa38dba623d2e9e748d7ce1453ef4954f6cc43c0cc0dac7efb504417e6302ea",
-                                "uncompressed-sha256": "b91bb12a07553825f2b72c8f8d7a8a339fdac205520f518a14ea17ef028f9f67"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "b7318c411ff76aaddeb7c6b5de1cf0104a12c5445c0e27d42aa20e2a92388e1f",
+                                "uncompressed-sha256": "3dd555d8e277933881e0349338231997c0949b8dcfe942365a03376a2d38aeb9"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20211017.1.0",
+                    "release": "35.20211025.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "b9298b0bff295a46fdbffef578b1b5c8ce7e849d1e9f6c94630ddfc8f3f31051",
-                                "uncompressed-sha256": "99866b6c6f074bc6bd5b7dfe12f7824cfa14a68c4f2910015ac30a8d6cae942e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "9f9b998e68c98090a12fd75b69e4cc1fb861073e2945c945440df4d9dc69f2dc",
+                                "uncompressed-sha256": "6d350509e3459ca0cd950cea23b66a7a1a5fc495d8863d23ae9acc0e3ea552be"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20211017.1.0",
+                    "release": "35.20211025.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "cb452f2e5ccad7cc5132c3ffba037b3bbea18190a9e5190298d5a5ad99a5348a",
-                                "uncompressed-sha256": "b94011d9d35805e390369336f0d339272ad7c1dd53dea078ef451a1e8a2889b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "a44d334169c8b97a0dd71a43a06a1b6af9e7863773dd1b449eca1e9bdf4cf48c",
+                                "uncompressed-sha256": "79f84b2cbf8d050699eb5334ff3c6e36e7706c18b813f4553f6af6b957841229"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20211017.1.0",
+                    "release": "35.20211025.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "6dcb0c42d2d89248152f88db2912bbb6e1b2e84351ab5667ae2ddeac639b0117",
-                                "uncompressed-sha256": "6ac36b4e4b3ae8e3a6c8ceba26d846609990f932a8985f025adb8c78d09d8749"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "5b9fa0b62091e1dde56dc5a6075f9f287a9522d3bf33612c5b645e62d0a3e7b6",
+                                "uncompressed-sha256": "839e6063ce271770098e48710da548437076a939911d064ea9a991ad110e9aaa"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20211017.1.0",
+                    "release": "35.20211025.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "84a05b3044e47f55b5e75b48d0dfc5fdc6be9d713ec3fd373e883555d2b1d2b0",
-                                "uncompressed-sha256": "c343930888daeff87b1745642459264b6c2d8317ba55e933d62a61f84bd0511e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "73ef0ac85a28dc5ac14127244d0e419986235faca682b6449aea458f6ac9d702",
+                                "uncompressed-sha256": "63abdd3841c83533db427f3d9b51051bae6b1747b089bac1a6f2287103f09458"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20211017.1.0",
+                    "release": "35.20211025.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "cf232bc8462a116ea7f7ff72508688fd6b63fde730fd07f5e7d61a924c8be536",
-                                "uncompressed-sha256": "0894207271f846041a765c0587e63febe45016b8ed573c54ed398c6c2d2ad722"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "08229f912aa03dfdbc267f84cd507545e25e6e0bd43dbde5f9372d7306e8b9b4",
+                                "uncompressed-sha256": "9c4a4840a9bca08a90ab631c5ee72c7ad03a02a44cee65c21a5f9c273481f898"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20211017.1.0",
+                    "release": "35.20211025.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "96e3b9f7bd838109824f3ab6ea8cbe3050ea8c0cb3fb15e834ee94f338bada53",
-                                "uncompressed-sha256": "a386a4b1144ce150ee05e5d8a72c2a987e4b1459381056f0df31d2cf9eaf4d08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "bdf8e730158574fd596dc84127ed30bb1352ec7ca0c0df6f40cc016981425dd4",
+                                "uncompressed-sha256": "34fd7448bdc041e87a7a94b1739efbf2d4d7ad129d122363f7f845d79a3ec604"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20211017.1.0",
+                    "release": "35.20211025.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "6caa0d24c204ea16402aa2e7c1b4af8fad18dc2dde985f917d887534682ee49c",
-                                "uncompressed-sha256": "6a76d02fcd0ffc857b6111c3a5a9754d3f6951fd7190b03b5239ea4f80241d7f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "ed7ea50784c54724026eee6102fa7a473e6e1a47f4d5252e0c53918913f5aa10",
+                                "uncompressed-sha256": "ecacc4571b5b7f503df603bab438b6d3af20cbdefa1f05ea6f051513342950ae"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20211017.1.0",
+                    "release": "35.20211025.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "7441167de47db3e206aeb21e065b95fdd1bb107d0183da840a5cc6399037a360",
-                                "uncompressed-sha256": "17c57ca44694babbaeb2559dcf4b0dc111b372bbe37f9bb20a6db1a56bd6b31f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "29212c6765ddabc964331dc3fe3fabfa60beab7e26b33122f39ce612ca73cd45",
+                                "uncompressed-sha256": "3b88492c9d744b680030653b5338f005735beb360f0ec12ffbe4d67d5249afdf"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-live.x86_64.iso.sig",
-                                "sha256": "19ab1c348c282225acb972a73e986688c9b85975b1cad49eeba6b57a2b70ab2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-live.x86_64.iso.sig",
+                                "sha256": "3e656f286d7d1bde13c455cd6487ca5b6036b1b2ede105389eee3b80fd7dcf27"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-live-kernel-x86_64.sig",
-                                "sha256": "946c8d226d7c12e823957e7d10ecbdf57522317274108393f82a61c661bc1831"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-live-kernel-x86_64.sig",
+                                "sha256": "d03a2fb80391196feab4d71069806d6974759fc7a5e041ca41827182e4114f09"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "b370d26fe6ad8c6f09d43ba7786027144bd365fb43afa12fd1c5ee42bb81741c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "d43830980066664066eb1917282cfc80b506853ff421e504f4f1ecc44f9f022b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "242b3718fe68bcce37bdf0cf06bffb2970a06002406dcd136f2931791470ef75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "827e9af72969bbf8775660c47324ea25189b380f067ad4adc943c7df1fe489e3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "35392b8e98477940f87df9a63cdfdd34539a4459afefee9a5ab03aa95b4c6266",
-                                "uncompressed-sha256": "f0f78f51d061cf110e3e2053f05d77c7de8f7f584d4be000cbe1092e1e7957d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "acfa337fc4a5f05f1abd2e4ef229b936be416f37d7a115a3dca32cd915527f83",
+                                "uncompressed-sha256": "4ca706928e122ef3747c7b2f29268820552ce18d2f8d980f99537966fa25bab5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20211017.1.0",
+                    "release": "35.20211025.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "9dcbe376f210199b099a5826397970e43e75103854e8c4fd2418558d5c09cc5e",
-                                "uncompressed-sha256": "cf3d4d4ab632c46c8e84ac0cd55fea4ae817ed50bd014a2faac5c1363f7b6917"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "0d6bfe41c8acd70fa365259d175cc780e1308c19a1b900358ff7e2cffac12fda",
+                                "uncompressed-sha256": "b0453d83e38762e64f2a7294739ce6adc5a0b734d6e67538d1cce1a6549b046f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20211017.1.0",
+                    "release": "35.20211025.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "a660f6352c1be6eb92db4a0cce3ad77e822c9544116c847455f598cb18389fcb",
-                                "uncompressed-sha256": "08651d0633037e8b9bde105cc0bd9cfdd28fce4c4a9a82c5b9b415fe5d02f81b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "49ac793b544fb6e2a3ab049f3d500e90b03d62db5da22e568a2bf9bb1892cc6d",
+                                "uncompressed-sha256": "f2c1b3eebf91898827c9d75ea4934349a9c216fe0a6c454b3258b52a90a3b5b8"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20211017.1.0",
+                    "release": "35.20211025.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "f13697af3a8b2d547f6c9fb4f2fdc0fc88b38c56276e31148de03d51d48c113a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "f8d32652ad3c7bd33f08cb6e8ec87259954b7c835cde64b0bc3df51be57c06ec"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20211017.1.0",
+                    "release": "35.20211025.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211017.1.0/x86_64/fedora-coreos-35.20211017.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "5cf91263b1e91c7c24734ddbb059f392c4271623d774f422ae8a711afa82bcc7",
-                                "uncompressed-sha256": "5006b5fcc1b813a9d723493b7d6d800e250196d171c8bff4f663dd7af9fdca49"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211025.1.0/x86_64/fedora-coreos-35.20211025.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "bf181ad6f0efa93679fcb01492c9d13424076d3d8ca51fa5fa99a33e77e47ec2",
+                                "uncompressed-sha256": "111fce4cc37b3ba4691f4396a267b403845c78b75794de0470e2d104144faff5"
                             }
                         }
                     }
@@ -390,95 +390,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-0de9dd8d4177a63ef"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-0d48ff1bbad3aef7a"
                         },
                         "ap-east-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-0405cb15a7f73fdc6"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-0a4db1bfc4d0554de"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-072960dfff79694c4"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-01a385a16ea91c300"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-08d750dc96a559215"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-043825f5e53462cf0"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-05206614a2ad3e61d"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-04b984130f1558799"
                         },
                         "ap-south-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-02b11f906fb8a9bf6"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-00bc918fa5928cfe6"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-0f0f1d999fdcd69b6"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-0d5650a7346028ed1"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-002c868513ae83bf3"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-00ac0c2a1fc0bda01"
                         },
                         "ca-central-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-05a655f97f00e6d21"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-05ebb349d9c1ec36a"
                         },
                         "eu-central-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-02dd21f0703c9c496"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-0c435e007fd2faeda"
                         },
                         "eu-north-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-0d713a5766578ab87"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-038f117f8428859f0"
                         },
                         "eu-south-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-0815cae7e4c8dd4a2"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-08ad52013794774d0"
                         },
                         "eu-west-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-0d2a26f872f6f9531"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-0bd6ba0015c88b9ee"
                         },
                         "eu-west-2": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-032b59de86455f655"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-068862f002e6ac39c"
                         },
                         "eu-west-3": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-011eeb8f23893b0d7"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-0abe06026cc0c05c7"
                         },
                         "me-south-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-0e87e7f7d7b16c271"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-043224cfce503978f"
                         },
                         "sa-east-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-0bec0df78ac37f1ed"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-0ccbb8fedf285d83c"
                         },
                         "us-east-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-0307915022f8c2377"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-01375747a669e5dd6"
                         },
                         "us-east-2": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-0a5a60c5327f52380"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-06fc0220cb4b44858"
                         },
                         "us-west-1": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-022dc1eee62afa42d"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-0b4e73e777d553864"
                         },
                         "us-west-2": {
-                            "release": "35.20211017.1.0",
-                            "image": "ami-02f8b71d61ef96e62"
+                            "release": "35.20211025.1.0",
+                            "image": "ami-01ef4d5144c7f5aaa"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-35-20211017-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-35-20211025-1-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2021-10-20T19:42:47Z"
+    "last-modified": "2021-10-26T21:24:18Z"
   },
   "releases": [
     {
@@ -45,7 +45,7 @@
       }
     },
     {
-      "version": "35.20211010.1.0",
+      "version": "35.20211017.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -53,11 +53,11 @@
       }
     },
     {
-      "version": "35.20211017.1.0",
+      "version": "35.20211025.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1634760000,
+          "start_epoch": 1635285600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
```
next
    version: 35.20211025.1.0 (latest)
    start: 2021-10-27 00:00:00+00:00 UTC (in 3:27:46)
           2021-10-26 20:00:00-04:00 Raleigh/New York/Toronto
           2021-10-27 02:00:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)
```
https://github.com/coreos/fedora-coreos-streams/issues/396 