### PR TITLE
templates: several updates

### DIFF
--- a/ISSUE_TEMPLATE/next.md
+++ b/ISSUE_TEMPLATE/next.md
@@ -49,6 +49,7 @@ At this point, Cincinnati will see the new release on its next refresh and creat
 
 ## Refresh metadata (stream and updates)
 
+- [ ] Wait for all releases that will be released simultaneously to reach this step in the process
 - [ ] Go to the [rollout workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml), click "Run workflow", and fill out the form
 
 <details>

--- a/ISSUE_TEMPLATE/next.md
+++ b/ISSUE_TEMPLATE/next.md
@@ -76,7 +76,7 @@ fedora-coreos-stream-generator -releases=https://fcos-builds.s3.amazonaws.com/pr
 
 - [ ] Verify that the PR contains the expected OS versions
 - [ ] Post a link to the resulting PR as a comment to this issue
-- [ ] Wait for someone else to approve the PR.
+- [ ] Review and approve the PR, then wait for someone else to approve it also
 - [ ] Once approved, merge it and verify that the [`sync-stream-metadata` job](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/sync-stream-metadata/) syncs the contents to S3
 - [ ] Verify the new version shows up on [the download page](https://getfedora.org/en/coreos/download?stream=next)
 - Verify the incoming edges are showing up in the update graph.

--- a/ISSUE_TEMPLATE/next.md
+++ b/ISSUE_TEMPLATE/next.md
@@ -79,7 +79,7 @@ fedora-coreos-stream-generator -releases=https://fcos-builds.s3.amazonaws.com/pr
 - [ ] Wait for someone else to approve the PR.
 - [ ] Once approved, merge it and verify that the [`sync-stream-metadata` job](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/sync-stream-metadata/) syncs the contents to S3
 - [ ] Verify the new version shows up on [the download page](https://getfedora.org/en/coreos/download?stream=next)
-- [ ] Verify the incoming edges are showing up in the update graph.
+- Verify the incoming edges are showing up in the update graph.
     - [ ] [x86_64](https://builds.coreos.fedoraproject.org/graph?stream=next&basearch=x86_64)
     - [ ] [aarch64](https://builds.coreos.fedoraproject.org/graph?stream=next&basearch=aarch64)
 

--- a/ISSUE_TEMPLATE/stable.md
+++ b/ISSUE_TEMPLATE/stable.md
@@ -49,6 +49,7 @@ At this point, Cincinnati will see the new release on its next refresh and creat
 
 ## Refresh metadata (stream and updates)
 
+- [ ] Wait for all releases that will be released simultaneously to reach this step in the process
 - [ ] Go to the [rollout workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml), click "Run workflow", and fill out the form
 
 <details>

--- a/ISSUE_TEMPLATE/stable.md
+++ b/ISSUE_TEMPLATE/stable.md
@@ -76,7 +76,7 @@ fedora-coreos-stream-generator -releases=https://fcos-builds.s3.amazonaws.com/pr
 
 - [ ] Verify that the PR contains the expected OS versions
 - [ ] Post a link to the resulting PR as a comment to this issue
-- [ ] Wait for someone else to approve the PR.
+- [ ] Review and approve the PR, then wait for someone else to approve it also
 - [ ] Once approved, merge it and verify that the [`sync-stream-metadata` job](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/sync-stream-metadata/) syncs the contents to S3
 - [ ] Verify the new version shows up on [the download page](https://getfedora.org/en/coreos/download?stream=stable)
 - Verify the incoming edges are showing up in the update graph.

--- a/ISSUE_TEMPLATE/stable.md
+++ b/ISSUE_TEMPLATE/stable.md
@@ -71,7 +71,7 @@ fedora-coreos-stream-generator -releases=https://fcos-builds.s3.amazonaws.com/pr
 ./rollout.py add stable <version> "10 am ET today" 48
 ```
 
-- [ ] Commit the changes and open a PR against the repo
+- Commit the changes and open a PR against the repo
 </details>
 
 - [ ] Verify that the PR contains the expected OS versions

--- a/ISSUE_TEMPLATE/stable.md
+++ b/ISSUE_TEMPLATE/stable.md
@@ -79,7 +79,7 @@ fedora-coreos-stream-generator -releases=https://fcos-builds.s3.amazonaws.com/pr
 - [ ] Wait for someone else to approve the PR.
 - [ ] Once approved, merge it and verify that the [`sync-stream-metadata` job](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/sync-stream-metadata/) syncs the contents to S3
 - [ ] Verify the new version shows up on [the download page](https://getfedora.org/en/coreos/download?stream=stable)
-- [ ] Verify the incoming edges are showing up in the update graph.
+- Verify the incoming edges are showing up in the update graph.
     - [ ] [x86_64](https://builds.coreos.fedoraproject.org/graph?stream=stable&basearch=x86_64)
     - [ ] [aarch64](https://builds.coreos.fedoraproject.org/graph?stream=stable&basearch=aarch64)
 

--- a/ISSUE_TEMPLATE/testing.md
+++ b/ISSUE_TEMPLATE/testing.md
@@ -49,6 +49,7 @@ At this point, Cincinnati will see the new release on its next refresh and creat
 
 ## Refresh metadata (stream and updates)
 
+- [ ] Wait for all releases that will be released simultaneously to reach this step in the process
 - [ ] Go to the [rollout workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml), click "Run workflow", and fill out the form
 
 <details>

--- a/ISSUE_TEMPLATE/testing.md
+++ b/ISSUE_TEMPLATE/testing.md
@@ -79,7 +79,7 @@ fedora-coreos-stream-generator -releases=https://fcos-builds.s3.amazonaws.com/pr
 - [ ] Wait for someone else to approve the PR.
 - [ ] Once approved, merge it and verify that the [`sync-stream-metadata` job](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/sync-stream-metadata/) syncs the contents to S3
 - [ ] Verify the new version shows up on [the download page](https://getfedora.org/en/coreos/download?stream=testing)
-- [ ] Verify the incoming edges are showing up in the update graph.
+- Verify the incoming edges are showing up in the update graph.
     - [ ] [x86_64](https://builds.coreos.fedoraproject.org/graph?stream=testing&basearch=x86_64)
     - [ ] [aarch64](https://builds.coreos.fedoraproject.org/graph?stream=testing&basearch=aarch64)
 

--- a/ISSUE_TEMPLATE/testing.md
+++ b/ISSUE_TEMPLATE/testing.md
@@ -76,7 +76,7 @@ fedora-coreos-stream-generator -releases=https://fcos-builds.s3.amazonaws.com/pr
 
 - [ ] Verify that the PR contains the expected OS versions
 - [ ] Post a link to the resulting PR as a comment to this issue
-- [ ] Wait for someone else to approve the PR.
+- [ ] Review and approve the PR, then wait for someone else to approve it also
 - [ ] Once approved, merge it and verify that the [`sync-stream-metadata` job](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/sync-stream-metadata/) syncs the contents to S3
 - [ ] Verify the new version shows up on [the download page](https://getfedora.org/en/coreos/download?stream=testing)
 - Verify the incoming edges are showing up in the update graph.

--- a/ISSUE_TEMPLATE/testing.md
+++ b/ISSUE_TEMPLATE/testing.md
@@ -71,7 +71,7 @@ fedora-coreos-stream-generator -releases=https://fcos-builds.s3.amazonaws.com/pr
 ./rollout.py add testing <version> "10 am ET today" 48
 ```
 
-- [ ] Commit the changes and open a PR against the repo
+- Commit the changes and open a PR against the repo
 </details>
 
 - [ ] Verify that the PR contains the expected OS versions


### PR DESCRIPTION
For convenience, we'd like all streams to be updated in the same PR.  (Also, there will be merge conflicts if a second PR is created before the first one merges.)  Add a sync step to make this explicit.