### PR TITLE
workflows/rollout: fix pushing to coreosbot-releng fork

### DIFF
--- a/.github/workflows/rollout.yml
+++ b/.github/workflows/rollout.yml
@@ -47,6 +47,9 @@ jobs:
         with:
           # save token for use when pushing
           token: ${{ secrets.COREOSBOT_RELENG_TOKEN }}
+          # We need an unbroken commit chain when pushing to the fork.  Don't
+          # make assumptions about which commits are already available there.
+          fetch-depth: 0
       - name: Check out fedora-coreos-stream-generator
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
If we make a shallow clone of this repo, and the downstream fork doesn't contain all of its parent commits, GitHub rejects our push with `shallow update not allowed`.  To avoid making assumptions about the state of the fork, make a full clone of this repo.