### PR TITLE
RELEASE: move lucab to standby release executor

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -52,7 +52,6 @@ release executors are (in alphabetical order, see below for the rotation):
 
 - Clement Verna
 - Gursewak Singh
-- Luca Bruno
 - Renata Ravanelli
 - Saqib Ali
 
@@ -67,6 +66,7 @@ schedule. The current set of standby executors are (in alphabetical order,
 see below for the rotation):
 
 - Benjamin Gilbert
+- Luca Bruno
 - Sohan Kunkerkar
 - Timothée Ravier
 


### PR DESCRIPTION
Per https://github.com/coreos/fedora-coreos-streams/pull/403#issuecomment-957173597.  Four seems like a good number of regular executors.

cc @lucab 