### PR TITLE
templates: note that the x86_64 pipeline automatically starts multi-arch

### DIFF
--- a/ISSUE_TEMPLATE/next.md
+++ b/ISSUE_TEMPLATE/next.md
@@ -12,7 +12,7 @@ Name this issue `next: new release on YYYY-MM-DD` with today's date. Once the pi
 
 ## Build
 
-- [ ] Start a [pipeline build](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/fedora-coreos/job/fedora-coreos-fedora-coreos-pipeline/build?delay=0sec) (select `next`, leave all other defaults)
+- [ ] Start a [pipeline build](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/fedora-coreos/job/fedora-coreos-fedora-coreos-pipeline/build?delay=0sec) (select `next`, leave all other defaults). This will automatically run multi-arch builds.
 - Post a link to the jobs as a comment to this issue
     - [ ] x86_64
     - [ ] aarch64 ([multi-arch pipeline](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/multi-arch-pipeline/))

--- a/ISSUE_TEMPLATE/next.md
+++ b/ISSUE_TEMPLATE/next.md
@@ -13,10 +13,10 @@ Name this issue `next: new release on YYYY-MM-DD` with today's date. Once the pi
 ## Build
 
 - [ ] Start a [pipeline build](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/fedora-coreos/job/fedora-coreos-fedora-coreos-pipeline/build?delay=0sec) (select `next`, leave all other defaults). This will automatically run multi-arch builds.
-- Post a link to the jobs as a comment to this issue
+- Post links to the jobs as a comment to this issue
     - [ ] x86_64
     - [ ] aarch64 ([multi-arch pipeline](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/multi-arch-pipeline/))
-- Wait for the job to finish and succeed
+- Wait for the jobs to finish and succeed
     - [ ] x86_64
     - [ ] aarch64
 

--- a/ISSUE_TEMPLATE/stable.md
+++ b/ISSUE_TEMPLATE/stable.md
@@ -12,7 +12,7 @@ Name this issue `stable: new release on YYYY-MM-DD` with today's date. Once the 
 
 ## Build
 
-- [ ] Start a [pipeline build](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/fedora-coreos/job/fedora-coreos-fedora-coreos-pipeline/build?delay=0sec) (select `stable`, leave all other defaults)
+- [ ] Start a [pipeline build](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/fedora-coreos/job/fedora-coreos-fedora-coreos-pipeline/build?delay=0sec) (select `stable`, leave all other defaults). This will automatically run multi-arch builds.
 - Post a link to the job as a comment to this issue
     - [ ] x86_64
     - [ ] aarch64 ([multi-arch pipeline](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/multi-arch-pipeline/))

--- a/ISSUE_TEMPLATE/stable.md
+++ b/ISSUE_TEMPLATE/stable.md
@@ -13,10 +13,10 @@ Name this issue `stable: new release on YYYY-MM-DD` with today's date. Once the 
 ## Build
 
 - [ ] Start a [pipeline build](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/fedora-coreos/job/fedora-coreos-fedora-coreos-pipeline/build?delay=0sec) (select `stable`, leave all other defaults). This will automatically run multi-arch builds.
-- Post a link to the job as a comment to this issue
+- Post links to the jobs as a comment to this issue
     - [ ] x86_64
     - [ ] aarch64 ([multi-arch pipeline](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/multi-arch-pipeline/))
-- Wait for the job to finish and succeed
+- Wait for the jobs to finish and succeed
     - [ ] x86_64
     - [ ] aarch64
 

--- a/ISSUE_TEMPLATE/testing.md
+++ b/ISSUE_TEMPLATE/testing.md
@@ -12,7 +12,7 @@ Name this issue `testing: new release on YYYY-MM-DD` with today's date. Once the
 
 ## Build
 
-- [ ] Start a [pipeline build](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/fedora-coreos/job/fedora-coreos-fedora-coreos-pipeline/build?delay=0sec) (select `testing`, leave all other defaults)
+- [ ] Start a [pipeline build](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/fedora-coreos/job/fedora-coreos-fedora-coreos-pipeline/build?delay=0sec) (select `testing`, leave all other defaults). This will automatically run multi-arch builds.
 - Post a link to the jobs as a comment to this issue
     - [ ] x86_64
     - [ ] aarch64 ([multi-arch pipeline](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/multi-arch-pipeline/))

--- a/ISSUE_TEMPLATE/testing.md
+++ b/ISSUE_TEMPLATE/testing.md
@@ -13,10 +13,10 @@ Name this issue `testing: new release on YYYY-MM-DD` with today's date. Once the
 ## Build
 
 - [ ] Start a [pipeline build](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/fedora-coreos/job/fedora-coreos-fedora-coreos-pipeline/build?delay=0sec) (select `testing`, leave all other defaults). This will automatically run multi-arch builds.
-- Post a link to the jobs as a comment to this issue
+- Post links to the jobs as a comment to this issue
     - [ ] x86_64
     - [ ] aarch64 ([multi-arch pipeline](https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/multi-arch-pipeline/))
-- Wait for the job to finish and succeed
+- Wait for the jobs to finish and succeed
     - [ ] x86_64
     - [ ] aarch64
 


### PR DESCRIPTION
The next step asks for a link to the aarch64 job, but the instructions didn't make it clear that the job is started automatically.

Requested in https://github.com/coreos/fedora-coreos-streams/pull/407#issuecomment-958055372.