### PR TITLE
testing: rollout 35.20211029.2.0

### DIFF
--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2021-11-02T15:06:03Z",
-        "generator": "fedora-coreos-stream-generator v0.1.0-7-gfe56f7b"
+        "last-modified": "2021-11-09T21:50:02Z",
+        "generator": "fedora-coreos-stream-generator v0.2.0"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "34.20211031.2.0",
+                    "release": "35.20211029.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/aarch64/fedora-coreos-34.20211031.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/aarch64/fedora-coreos-34.20211031.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "b3d825fc787e04611eabdbc2e6c4d755b341f9cb368175fbb7b76d5f2f6dd57e",
-                                "uncompressed-sha256": "fd0ab39990cb9b69a3a4e7b8163be5d678a870ff0934d90bc9c9569de5d8a8db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/aarch64/fedora-coreos-35.20211029.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/aarch64/fedora-coreos-35.20211029.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "89e08ce57777aac10ef90ea22cf18909472aee45f572f5bacd22923fc0398384",
+                                "uncompressed-sha256": "634f6ea241acf93052ba91147acfca27e5394472b2af96f9e0d5d60696517310"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20211031.2.0",
+                    "release": "35.20211029.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/aarch64/fedora-coreos-34.20211031.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/aarch64/fedora-coreos-34.20211031.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "7b472b977a000c5b1dc4ffd1ce571d905dd6a353bd63bde20af595710a6b304c",
-                                "uncompressed-sha256": "5abe6b34bfaf5f988adefe13a8a4e058b5e2766a824555cd732fb24b1d3a9fe5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/aarch64/fedora-coreos-35.20211029.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/aarch64/fedora-coreos-35.20211029.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "c119e7441e25a9d4d68854b9db8066e080e8342a4eeb533a2b0eef11a97bea96",
+                                "uncompressed-sha256": "a146f51b2eb3115dbb63bb461c6d4c4eed4e1b829b7c69e31eb81ba1755bec51"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/aarch64/fedora-coreos-34.20211031.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/aarch64/fedora-coreos-34.20211031.2.0-live.aarch64.iso.sig",
-                                "sha256": "1cd657a00ec1ae6609ba7eb87aa71bc5b99efa93e3a2a1a0039961e43eb453a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/aarch64/fedora-coreos-35.20211029.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/aarch64/fedora-coreos-35.20211029.2.0-live.aarch64.iso.sig",
+                                "sha256": "61b6c722147d6f7dbaf0074030b7a26199088698b225e03e3d90fb7c49309e23"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/aarch64/fedora-coreos-34.20211031.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/aarch64/fedora-coreos-34.20211031.2.0-live-kernel-aarch64.sig",
-                                "sha256": "7c5b5f6a2907a031a3997e019e6860603dcd3fd4343726eefd43d86f039cb65f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/aarch64/fedora-coreos-35.20211029.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/aarch64/fedora-coreos-35.20211029.2.0-live-kernel-aarch64.sig",
+                                "sha256": "dfc34166f7919478c99b400def2eeb83b89922f7eaa2302150cdb7fae1b0a682"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/aarch64/fedora-coreos-34.20211031.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/aarch64/fedora-coreos-34.20211031.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "53eed97178a72bda40c62aef436e15fecf8eb6630bbbc0b928ad9e2ab5760037"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/aarch64/fedora-coreos-35.20211029.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/aarch64/fedora-coreos-35.20211029.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "921449bdaa4ba3f5def736772dd8bfe4df701d0ca95373a30494fcfd5b3d1e8d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/aarch64/fedora-coreos-34.20211031.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/aarch64/fedora-coreos-34.20211031.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "e2dec64a97bf1a040f6be55f826f23c78b1bd192258494de3af11872f64da088"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/aarch64/fedora-coreos-35.20211029.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/aarch64/fedora-coreos-35.20211029.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "5ef5489f4d03a3209689ca0daad2e2e83e7ce933cc3828028e7b9bd083d3774a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/aarch64/fedora-coreos-34.20211031.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/aarch64/fedora-coreos-34.20211031.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "4423abf9eefc226278dd31b1fb7d828461995553af8b37eea412bed0bd712542",
-                                "uncompressed-sha256": "42b1d004360dc12b98c6a728d5b21b5d066023e20b206015ad680362d68a7ba3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/aarch64/fedora-coreos-35.20211029.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/aarch64/fedora-coreos-35.20211029.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "797af5633199bec0efd71ce55a1069b27643595bf4184e5ec94c046fe313716c",
+                                "uncompressed-sha256": "e49ddd1e39dece57cbb2ac27d093ba5c7584988d68c804a3cd6c2f26c97427b7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20211031.2.0",
+                    "release": "35.20211029.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/aarch64/fedora-coreos-34.20211031.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/aarch64/fedora-coreos-34.20211031.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "065b5394d2a46741d9592ecb09146ee2aa1a23a72eaaa6a11206744ac2fe5b16",
-                                "uncompressed-sha256": "4565b4aed3c3ae8d1438b4cbbc98c0e5ae44ac7167995d1d761df8570e4b0f5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/aarch64/fedora-coreos-35.20211029.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/aarch64/fedora-coreos-35.20211029.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c6838d5e6d73b46850739e899db05b2bfb5bd670eb0039bf86bd82cf5fa932d1",
+                                "uncompressed-sha256": "05ae0cedb1aa96db1962642ce5b5884f796c05dc8cf74ece0b50564838db8ff7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20211031.2.0",
+                    "release": "35.20211029.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/aarch64/fedora-coreos-34.20211031.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/aarch64/fedora-coreos-34.20211031.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "c4fa3f600d439eddc221fd96faf3e309a0043480879971d21e8ef7af0e585f6f",
-                                "uncompressed-sha256": "7656d61f7be303519de8484fe43d50625cb46ac47a43eff87c83c6fa3599b5ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/aarch64/fedora-coreos-35.20211029.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/aarch64/fedora-coreos-35.20211029.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "8cae4cd6b3d617d1ef5505952433354dabd9e742655e6dbcf86bec3f9e4204f0",
+                                "uncompressed-sha256": "7f977f6754097acc37432cc87ad140a944179b22ede0252ce3e6905f0204eead"
                             }
                         }
                     }
@@ -96,88 +96,88 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-019200e53b55aaede"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0b6740e61326985f6"
                         },
                         "ap-east-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-0243fed777796c37c"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-044720a5ad7ac336c"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-02db535504924a7bc"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-04f47c031bb1d18ac"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-044d1164c09b754dc"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-01a4d16f7939a56ae"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-0e4f875a6979afc70"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0caa989fad1b9a235"
                         },
                         "ap-south-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-07a2968a6c7d7f0e4"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-04dc102699aec7c5d"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-0e40324393a946348"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0e7c29ab943e00ada"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-03eb21f5242aa83f5"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0668e9c7aec8d5048"
                         },
                         "ca-central-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-057fbf8480ade3bc1"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-044957787c3d374da"
                         },
                         "eu-central-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-09006dba8a1a56efc"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-00357294c530d3d3e"
                         },
                         "eu-north-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-05891b438aee1edae"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0ef46d93756dba977"
                         },
                         "eu-south-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-0a21c4228bd42a010"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-017e7435cb731b08c"
                         },
                         "eu-west-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-0a8b84389d5e3d676"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-06430cf6c06a7d84f"
                         },
                         "eu-west-2": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-0d1de292235aa6da6"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0538d3bdb6258b17c"
                         },
                         "eu-west-3": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-055c28e1827c51aa0"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0e1b7343837516af4"
                         },
                         "me-south-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-05b8c5c84fd6eceed"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-016422c244b2bacca"
                         },
                         "sa-east-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-0638813de6aa0e85d"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0ff19670352e60cd5"
                         },
                         "us-east-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-06de25803bd1f2e2b"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0aac0ed13bc7bf382"
                         },
                         "us-east-2": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-0e687a193772442ed"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-015879747a5f42705"
                         },
                         "us-west-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-0cbdade9d358f8774"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0e056950f5687d05f"
                         },
                         "us-west-2": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-02a09d1cb4d886b32"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-07e65886ad44dacaa"
                         }
                     }
                 }
@@ -186,201 +186,201 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20211031.2.0",
+                    "release": "35.20211029.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "c6a70bb8baa2cf48cabe3d1789e0d9e0647c71fd91fe251c66a91f509393d713",
-                                "uncompressed-sha256": "44b82656d3c6a8f0ced706b165033e136aea4b89b84b966932a1ec427a1ebe52"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "e2c91bb7d9e8980677d6ba690918272da6ec89c5016747cc493734471f84030e",
+                                "uncompressed-sha256": "f4d3aba543a555edd170a678ab5441887aedefd0bf759ea11e85c38c97817ae5"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20211031.2.0",
+                    "release": "35.20211029.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "96d77c477cd294909b6bea8a5f1799dfd7bcb1b0f59bb8bfed126d3c121cb777",
-                                "uncompressed-sha256": "526cdd73a9e43d859c488cde8200376e2e355691962cdb936baaad5f6d7454be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "a533d17de287cd7018586baca72496c2f0403e724ef50ab5949496b832bffffa",
+                                "uncompressed-sha256": "d6855c7475bc9b0333a8d9c23e59f835b32f2212e4653fd11d6ec430ba8a4276"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20211031.2.0",
+                    "release": "35.20211029.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "bc4ae8936bd01482d336e075d66a7bc08ac325d36aa01b583cc2b2e0300144e2",
-                                "uncompressed-sha256": "6f2b44f1125dbce69dd95a4b47fd7b16551c1140dd5343defdff2b7e63fa4d9d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "f7b36c3616e0767aa870a504ae38e3c7751d4bfd1bb2d9c34e75a2240cc20a0d",
+                                "uncompressed-sha256": "8c3ce2d410934118e2f04134d70d1623988e56f210df83c60819f31df8130a7d"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "34.20211031.2.0",
+                    "release": "35.20211029.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "a29be8c4296def9f301e143f2367616faaf8d243098a2dc30ec55cc486d0558f",
-                                "uncompressed-sha256": "a186d69236ebde4532eae172e3f25c5203e4396575d5f0d6d4292e28194df9ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "625cadc2b43d3bd56379a7fa3f706254092d1315ba5e6c135b085b1caaed2957",
+                                "uncompressed-sha256": "8df9e8cd0e0fbaba60b49ed399db3194352aac87b780591bc33cfb6497a37096"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20211031.2.0",
+                    "release": "35.20211029.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "691aeeac4f09fb9e469dc357ee4c72f1c09dca1a4e237fafce41c0d0205d162b",
-                                "uncompressed-sha256": "a07f13a48c0eff196a3cbb3b792cc15067aea4469f48f8c10f714a866a5c421c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "430f11c0bfcd2bba662d901b4155de237eb329bf6e5770ad4d3375814fc79176",
+                                "uncompressed-sha256": "f834a44f43cab8f58571e89a235503f0c941577e8190ff9963537cf8272c443b"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20211031.2.0",
+                    "release": "35.20211029.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "5b1186d65e30808e2d3358859fbe5c142f193285ec833397ffa6aeaf160b6508",
-                                "uncompressed-sha256": "16d0e04b680ce9782cd8b0a1c57c66baccef36e71b6cfd91d2be5eb7a78f7e5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "22a82925cb2112cdd16ae7cf2dd4a160284a2edb570eac71f9ed8d4ba98f4bc7",
+                                "uncompressed-sha256": "7605e3a08c28bf6ab0d8a71bfc459c15c9dbc38473fe937f0a922440e403b9bb"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20211031.2.0",
+                    "release": "35.20211029.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "96571fcb476668d1c333eb9ff68b382173aa47131d55522dba6ae72ea5c9c3e1",
-                                "uncompressed-sha256": "f628d22e424efb3a38f5c53eb5e7b1f595319be26a4fc56580f3fd0b6cabb438"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "be3482893bfca0fbb199c5a5cf9e282ebaf38b58e1058dcbe527ca31f45372bb",
+                                "uncompressed-sha256": "e9357d47f5911d0da3a8ac25fe48b56ecbaaee3377d8f4b8f2a6b7181a1e7b82"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20211031.2.0",
+                    "release": "35.20211029.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "659300cc9eb854cf349a4232c7493e3b7f4c776f619aa480ee85a63720a92f07",
-                                "uncompressed-sha256": "54fd5fd1c937e861050e09b6ee4acda2c56c093b5322b3ae3d235a193253b5ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "6c3fc7743e2f7a146f0f3e805466193cf89f85ba24d493663acf601932e1a5a4",
+                                "uncompressed-sha256": "24f712a715d00840eb41b728fab8dc95d056bff977164cf2335e2dc15c273c6c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20211031.2.0",
+                    "release": "35.20211029.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "c2199e7d2632dcde97389341dbe2565ac86c717f7b17fcb5ae0c25960214761d",
-                                "uncompressed-sha256": "4b32d1b0a0de07d9bdf33a9ff5c6af8215cf00910b2d57abd5bc0343df3bb848"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "2ef9fbbbc699e06c0064e6b671091428f49e0d1db85afbb0821505a21ab4428c",
+                                "uncompressed-sha256": "61e6b1d44827e0b9a3f961d2888769bb240575b5be43e857c7f5ac94374c188f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-live.x86_64.iso.sig",
-                                "sha256": "c2e064a475aeb2c6c78385059898f051336be5a30a4c79212e9b415b2917b30a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-live.x86_64.iso.sig",
+                                "sha256": "c2574687a02a0cabcb8d629a6e8248676d0c405a17e4eea9a894e274c4fbb559"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-live-kernel-x86_64.sig",
-                                "sha256": "7a4d35d0209f6550b77da33d876c3325c92d27838be8107a5295a2d1b97811d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-live-kernel-x86_64.sig",
+                                "sha256": "a1c4ee19119ff2d2116211be2a3652981e49073bc7a8540d7552cc8077a44b0a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "adda16a5351986fdc32fc46585781d6487cd48cd51335aaebd3dc3593df21b0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "c56429ac7368ab60994fd5926ee6abb9b8da9af3c2b0155b6fc0c5976cec6a1e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "48d05d2371457f4ed42b33546d968723d4a7da9d92528b19b85e2f0db9f755d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "3c0649147b712e0f6b4604bb89ead8c243f6f164068879bfd08ebac771ba01a0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "13ea4bcc8571a69e57e05aac6bf29c18186d3a30dcf1389858519c21ded6fdcb",
-                                "uncompressed-sha256": "d2d54ad655edbdfcc635bf2f0cded865b438415a4207b0ae4c9e1627822524dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "5e7afa9aae27aaae094d6475ea54866bda58561ad0cec851db54b9fdd8af3d61",
+                                "uncompressed-sha256": "6d8447004810baab920a274071d91a358da1d719e4ae3bafc51e6821af545d78"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20211031.2.0",
+                    "release": "35.20211029.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "262089e970c15ce917be4e6887c4d931e0c7e2325195fa00393c9fdd93b8b600",
-                                "uncompressed-sha256": "0fcad0f97e9aa10308357633e36cfb1c22a516182d29b7faef74084e0fa48197"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "3f5d9e915406bd9a3c293452ff9281bf5fef764a64b1331517b30b0d9f74f204",
+                                "uncompressed-sha256": "02229d401e0bd2c2a3802ddf8111bfa499b32dfa3a115c15df7bbc1cba747d7c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20211031.2.0",
+                    "release": "35.20211029.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "0ca12a9a57fc7d5712d46cc1f5a8d4008c611aa53c5f1d832975375839267f84",
-                                "uncompressed-sha256": "09dd59afc24509fbfe48adb5606b191c6b3e6f84748719864adc64609ebeeb69"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "83f8a92a2c05081238f6f4d8b8caf63634d27dec74a7e411409ff32599ef1a3d",
+                                "uncompressed-sha256": "716246293a6efdd5e992033856e6f03caf61f50dd9c6edd89fd1d74dd46a6429"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20211031.2.0",
+                    "release": "35.20211029.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "5e0de16f09a4486ed6e149df5978364b0b8e345d103d496994fb7798ad62275f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "75116cf5f63459df10a01ecf307218c01b71d8db2fe8d588d505d41468d0e130"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20211031.2.0",
+                    "release": "35.20211029.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20211031.2.0/x86_64/fedora-coreos-34.20211031.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "c96b9415439e62071d52899cef64694593842d076e4f48c70b0334484926cddc",
-                                "uncompressed-sha256": "2400b513e18138ad910822a954313376b187beef56616368d1eca33a9af7f287"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211029.2.0/x86_64/fedora-coreos-35.20211029.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "2109bbc84c5b64c4c1f20b164398e3d04b737bf60b271011a1f4f8b5bef2cad2",
+                                "uncompressed-sha256": "166d1a9246b553c24b79b211a23c8ffebf53f089289dfaa09f909f371d16ae30"
                             }
                         }
                     }
@@ -390,95 +390,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-006d04535bec49461"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-040cf10603d993463"
                         },
                         "ap-east-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-0269ff6d412681c63"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-00b1e8df60d9bd263"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-0ab0e6c41c4fa1b6f"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0d8cf4489bbb617aa"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-0805b36d95d504aa5"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0ee498f7f0a1cb2c1"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-0f3e2bca2a4c53078"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0066c960626ed325d"
                         },
                         "ap-south-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-0b24fd42af41e3d80"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0a1c7340694d0711a"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-01b01fc3ce4708ff4"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-04adc3faefc58b801"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-088731dc7abe2ddfc"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0e9b85b0c229145ba"
                         },
                         "ca-central-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-07100ab3ac3a33ad1"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0a1a6de30c9e9b68c"
                         },
                         "eu-central-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-0fee012e5f755b8c8"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-04a5220f9b1791e7e"
                         },
                         "eu-north-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-043e8a3948feb87e9"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0854676d1d0797203"
                         },
                         "eu-south-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-0bd8912b7ef83e105"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-049193f618702aecc"
                         },
                         "eu-west-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-089c9f10e1f243159"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0ccdd5698b3b1c884"
                         },
                         "eu-west-2": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-0406fb5b42a5572a3"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-03079d183f52bef6b"
                         },
                         "eu-west-3": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-09bb137a647aa9e60"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0889bcbe46f116248"
                         },
                         "me-south-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-039203dceb490d230"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-069790a2d79061657"
                         },
                         "sa-east-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-0141d139bf1caa270"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0343527c7edadf655"
                         },
                         "us-east-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-091ebfd8bae393817"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0fb9805f3cfccb66a"
                         },
                         "us-east-2": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-07593b73d7e3aef11"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-0e28a363d5dd03270"
                         },
                         "us-west-1": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-0907bcf322ebe5b3e"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-038f6008987a3510e"
                         },
                         "us-west-2": {
-                            "release": "34.20211031.2.0",
-                            "image": "ami-07d6531122f8b5f7d"
+                            "release": "35.20211029.2.0",
+                            "image": "ami-08e1fb5766b6751e3"
                         }
                     }
                 },
                 "gcp": {
+                    "release": "35.20211029.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-34-20211031-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-35-20211029-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2021-11-02T15:06:03Z"
+    "last-modified": "2021-11-09T21:50:33Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "34.20211016.2.1",
+      "version": "34.20211031.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,12 +69,15 @@
       }
     },
     {
-      "version": "34.20211031.2.0",
+      "version": "35.20211029.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1635868800,
+          "duration_minutes": 4320,
+          "start_epoch": 1636552800,
           "start_percentage": 0.0
+        },
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     }


### PR DESCRIPTION
```
testing
    version: 35.20211029.2.0 (latest)
    start: 2021-11-10 14:00:00+00:00 UTC (in 16:47:58)
           2021-11-10 09:00:00-05:00 Raleigh/New York/Toronto
           2021-11-10 15:00:00+01:00 Berlin/France/Poland
    duration: 4320m (72.0h)

```