### PR TITLE
RELEASE: create release checklists with template issue title

### DIFF
--- a/ISSUE_TEMPLATE/next.md
+++ b/ISSUE_TEMPLATE/next.md
@@ -1,6 +1,6 @@
 First, verify that you meet all the [prerequisites](https://github.com/coreos/fedora-coreos-streams/blob/main/RELEASE.md#prerequisites)
 
-Name this issue `next: new release on YYYY-MM-DD` with today's date. Once the pipeline spits out the new version ID, you can append it to the title e.g. `(31.20191117.2.0)`.
+Edit the issue title to include today's date. Once the pipeline spits out the new version ID, you can append it to the title e.g. `(31.20191117.2.0)`.
 
 # Pre-release
 

--- a/ISSUE_TEMPLATE/stable.md
+++ b/ISSUE_TEMPLATE/stable.md
@@ -1,6 +1,6 @@
 First, verify that you meet all the [prerequisites](https://github.com/coreos/fedora-coreos-streams/blob/main/RELEASE.md#prerequisites)
 
-Name this issue `stable: new release on YYYY-MM-DD` with today's date. Once the pipeline spits out the new version ID, you can append it to the title e.g. `(31.20191117.3.0)`.
+Edit the issue title to include today's date. Once the pipeline spits out the new version ID, you can append it to the title e.g. `(31.20191117.3.0)`.
 
 # Pre-release
 

--- a/ISSUE_TEMPLATE/testing.md
+++ b/ISSUE_TEMPLATE/testing.md
@@ -1,6 +1,6 @@
 First, verify that you meet all the [prerequisites](https://github.com/coreos/fedora-coreos-streams/blob/main/RELEASE.md#prerequisites)
 
-Name this issue `testing: new release on YYYY-MM-DD` with today's date. Once the pipeline spits out the new version ID, you can append it to the title e.g. `(31.20191117.2.0)`.
+Edit the issue title to include today's date. Once the pipeline spits out the new version ID, you can append it to the title e.g. `(31.20191117.2.0)`.
 
 # Pre-release
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,9 +13,9 @@ repository. An overview of the process can be seen in
 
 Those issues are generally created at the end of the previous release but if
 you need to manually create one, you can use the following links:
-- [stable](https://github.com/coreos/fedora-coreos-streams/issues/new?labels=kind/release,jira&template=stable.md)
-- [testing](https://github.com/coreos/fedora-coreos-streams/issues/new?labels=kind/release,jira&template=testing.md)
-- [next](https://github.com/coreos/fedora-coreos-streams/issues/new?labels=kind/release,jira&template=next.md)
+- [stable](https://github.com/coreos/fedora-coreos-streams/issues/new?labels=kind/release,jira&title=stable:%20new%20release%20on%20YYYY-MM-DD&template=stable.md)
+- [testing](https://github.com/coreos/fedora-coreos-streams/issues/new?labels=kind/release,jira&title=testing:%20new%20release%20on%20YYYY-MM-DD&template=testing.md)
+- [next](https://github.com/coreos/fedora-coreos-streams/issues/new?labels=kind/release,jira&title=next:%20new%20release%20on%20YYYY-MM-DD&template=next.md)
 
 ## Pipeline failures & recovery
 


### PR DESCRIPTION
Automatically fill in a template issue title, rather than requiring the release executor to copy it from the issue body.