### PR TITLE
Roll back `testing` and `next` on AWS only; delete update edges

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,21 +1,21 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-01-05T21:48:34Z",
+        "last-modified": "2022-01-12T21:09:14Z",
         "generator": "fedora-coreos-stream-generator v0.2.1"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220103.1.0",
+                    "release": "35.20211215.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220103.1.0/aarch64/fedora-coreos-35.20220103.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220103.1.0/aarch64/fedora-coreos-35.20220103.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "afc2066b17e6528dbd09d5411f0c4481d19c9140ff4fae530efd16dbea532b2c",
-                                "uncompressed-sha256": "65a33e9912aa2f278718b533a972786fe74e3f940ba3c0018aa7ffaa31b88864"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211215.1.0/aarch64/fedora-coreos-35.20211215.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211215.1.0/aarch64/fedora-coreos-35.20211215.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "d23ea61b9bc55057f269fc85f921b0a93644c0fc3b49cec11e55c085d36a8a8c",
+                                "uncompressed-sha256": "f096e3075c4e8a595565d5ca3be3e18d89a55a0b173d74c0a2346342b032722d"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-08ded33be06b8e9e4"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-06932db05e48bdb6b"
                         },
                         "ap-east-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-00a64eac4da11af32"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-029e11c56d6257ec5"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-053b64dae22398ab3"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-0d0e16305ee14951c"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-027ea6355713aaeec"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-091742b951269a796"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-0e4349044f50d5400"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-00e7214109ab2776d"
                         },
                         "ap-south-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-0366cbc12f0b50f5a"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-0478c2dd722efdb00"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-0a6f249a8b622d5e7"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-0b66452eadcd4484c"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-07074dbddd02e2e8f"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-0085bc31111d1aa14"
                         },
                         "ap-southeast-3": {
                             "release": "35.20220103.1.0",
                             "image": "ami-0564cd63f7ecae28c"
                         },
                         "ca-central-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-0ba42789d90898add"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-0f572de2f4eceb4e9"
                         },
                         "eu-central-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-0e978d13c15a25d8d"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-0ed3035fe8125d556"
                         },
                         "eu-north-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-07e2cedbce5b1f206"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-058ba5f37143852e1"
                         },
                         "eu-south-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-0d0816dcfd643d354"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-0894e26a37bf8cc24"
                         },
                         "eu-west-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-05cc1077b22f20918"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-0b5faec771942c61d"
                         },
                         "eu-west-2": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-0fe886722abc79062"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-00b36b48f85b7d027"
                         },
                         "eu-west-3": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-0082885fa7956387a"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-0cd21ec718f513345"
                         },
                         "me-south-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-0aeaf81ea8fe2baa4"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-0b931446ac5908a4b"
                         },
                         "sa-east-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-039eb98f87364b01a"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-0c804163b5aeb987a"
                         },
                         "us-east-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-09f1cacd25740aeb2"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-06e2f9bc81a807ba6"
                         },
                         "us-east-2": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-035bf9fb222a6f5d0"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-0b521b73b309ebca4"
                         },
                         "us-west-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-0eb2e8bdd6d85f349"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-07f7eef47c119b506"
                         },
                         "us-west-2": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-02354ef05a05ac802"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-06f23ba7afcf9086f"
                         }
                     }
                 }
@@ -203,14 +203,14 @@
                     }
                 },
                 "aws": {
-                    "release": "35.20220103.1.0",
+                    "release": "35.20211215.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220103.1.0/x86_64/fedora-coreos-35.20220103.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220103.1.0/x86_64/fedora-coreos-35.20220103.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "66fb70f9a1c26e5ed97cfcf015895fc324d64549957fcbe3bd1fcf88746fe22d",
-                                "uncompressed-sha256": "0a261d4d47510d741730ae9d84cc6980fe99f7c32029216369e6e258380455fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211215.1.0/x86_64/fedora-coreos-35.20211215.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20211215.1.0/x86_64/fedora-coreos-35.20211215.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "01fde4b3c4bbbef9aebc07e15d4b10de3968e7b1e7c08203d106122551b5764f",
+                                "uncompressed-sha256": "50301dcbfe35db36d0de4d60d933a180f9ea2358cd54bd644229e4021c05864d"
                             }
                         }
                     }
@@ -407,92 +407,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-0730ea29409275ae7"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-0cb6c0d0bce1ec6d1"
                         },
                         "ap-east-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-02040997bd0f54ac1"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-0f0e64e135c8427f2"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-04f15a3a562472019"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-062ce4c06b49fffb9"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-00af5155d35d5e915"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-05e860952bd5b9965"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-06c83ca48765bacff"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-0909ab0d80ffca1f6"
                         },
                         "ap-south-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-092999b3c2fe7d804"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-0f2dc6115ea38f7a1"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-05e607c035edc58cc"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-0b13bf7f2c779be80"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-09ea431812e892f8a"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-01e3fd0df55b46103"
                         },
                         "ap-southeast-3": {
                             "release": "35.20220103.1.0",
                             "image": "ami-0986806574ac7a94d"
                         },
                         "ca-central-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-00f293c3fe94253b2"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-065aaa653c2018c4e"
                         },
                         "eu-central-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-02de97675429e2182"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-0e9c66b84ce2224ff"
                         },
                         "eu-north-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-0c865f2f6d5a0c598"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-07353aa8e508b189c"
                         },
                         "eu-south-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-057836775adb1afcf"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-0cb6dcf1cb5f58056"
                         },
                         "eu-west-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-03f4c147ce897b127"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-058d622700e1e403e"
                         },
                         "eu-west-2": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-08bd807908f76b0fd"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-09e66e34808eece6c"
                         },
                         "eu-west-3": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-002e95f7e7c72eb18"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-07809e17ace008f40"
                         },
                         "me-south-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-094b9af41fb742999"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-037a5f0a96a72f5d8"
                         },
                         "sa-east-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-040207ae5970c2fc0"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-04ffe78418b0e09d3"
                         },
                         "us-east-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-0d91a5f6340b7cc6f"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-028f0863970d230a3"
                         },
                         "us-east-2": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-05c19d404a981b4ce"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-057d4ad4af27d4a76"
                         },
                         "us-west-1": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-062f97d666ebabe1b"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-05af6eeef8b944a29"
                         },
                         "us-west-2": {
-                            "release": "35.20220103.1.0",
-                            "image": "ami-080b2b1b82cb88084"
+                            "release": "35.20211215.1.0",
+                            "image": "ami-006ce49a04a748b86"
                         }
                     }
                 },

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,21 +1,21 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-01-05T21:48:33Z",
+        "last-modified": "2022-01-12T21:09:14Z",
         "generator": "fedora-coreos-stream-generator v0.2.1"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220103.2.0",
+                    "release": "35.20211215.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220103.2.0/aarch64/fedora-coreos-35.20220103.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220103.2.0/aarch64/fedora-coreos-35.20220103.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "7ad2d31b70e365bddc52fe0b63b42e2357a428fa68117980015ea8545226f875",
-                                "uncompressed-sha256": "9acb3952d5778c86fada628f9057f10bcb809737b3765315c7b268b7d3644e55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211215.2.0/aarch64/fedora-coreos-35.20211215.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211215.2.0/aarch64/fedora-coreos-35.20211215.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "15374b0b9906fea7f2a0ec58333222b74d33899d26a334e722eb25681c733099",
+                                "uncompressed-sha256": "fd7a04be4cbc95e6b4592842453d59bbf33ba39b4c409922e9fb91991b3a8519"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-0bcf7621f76feb9d0"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0a9358794a0d5b8eb"
                         },
                         "ap-east-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-058cd21d7a899746c"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-06dc639e36d68d92f"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-098d6555d5acdde4d"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0c7f52fc39299f56f"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-04c0f11a951dd5de9"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-041ea1c866f42e04a"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-051a5487b57923c75"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0c66074bc9434d939"
                         },
                         "ap-south-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-097f7bdd85f3c76ac"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0eb520da80032c45f"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-01219f16e7a04c27d"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0a9d019b31b4252bd"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-08d4be7adf92d7412"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-02ac79b2eeb1e9bbf"
                         },
                         "ap-southeast-3": {
                             "release": "35.20220103.2.0",
                             "image": "ami-02fcc5890f536476d"
                         },
                         "ca-central-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-02a3a4d26143690b5"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0c1b5212c2cbf04dd"
                         },
                         "eu-central-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-00f2549e8209cc327"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0b06da8249b9a9f47"
                         },
                         "eu-north-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-0db784ab8c9d76445"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0d85c3de0844fed16"
                         },
                         "eu-south-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-0227caead20ceef88"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0cfe8c0ea343764d0"
                         },
                         "eu-west-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-029db7d5546b261f6"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-028853ebc8942152b"
                         },
                         "eu-west-2": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-0a4ab298e417e704b"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0b5d583ea3bad8aad"
                         },
                         "eu-west-3": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-09fd38424a3969e5a"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-092404f8a01061ca0"
                         },
                         "me-south-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-019fe453c23e2d4c0"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-07792a96b35ca0195"
                         },
                         "sa-east-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-0d554dfac894f6184"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-09dda11a9b20d01df"
                         },
                         "us-east-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-0859455924f7dd2d1"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-009a568cfed4be545"
                         },
                         "us-east-2": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-001abbb4fe1503f2a"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0c30c73ccb7fdf9e7"
                         },
                         "us-west-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-04dc2ae442f0f27a0"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-09fc8ee7038538127"
                         },
                         "us-west-2": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-057af35d2dc6038f1"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-01263d1857c7a2b84"
                         }
                     }
                 }
@@ -203,14 +203,14 @@
                     }
                 },
                 "aws": {
-                    "release": "35.20220103.2.0",
+                    "release": "35.20211215.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220103.2.0/x86_64/fedora-coreos-35.20220103.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220103.2.0/x86_64/fedora-coreos-35.20220103.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "e62f201c701fab81483892aaebc1a2417fa0055665883698226b8a4611c58376",
-                                "uncompressed-sha256": "6e6753d6c554e7e00f11f16c88e79a342d386fbe62f6153a2584b7e4d5f0c107"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211215.2.0/x86_64/fedora-coreos-35.20211215.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20211215.2.0/x86_64/fedora-coreos-35.20211215.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "74f416754cc72288b28c291eee08a33150d5eef1ae81394c2bf813f8da1971ce",
+                                "uncompressed-sha256": "ca6adfabddf5bdc46438d4a8b56a2f1bda642c2a6af30de6315560da965d7664"
                             }
                         }
                     }
@@ -407,92 +407,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-0686a6b6e59ef900b"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-06ef522a271249a80"
                         },
                         "ap-east-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-02f7510a726a9aa6b"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-01ab7f46c63b3a530"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-09fa49afd9c8de6d5"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0a06511293ad5981b"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-064fcaad6101abad4"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0137e42dbc6bd97b6"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-05f07422f3c56e9ec"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0e6337393619cf704"
                         },
                         "ap-south-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-0bef65019215dfe87"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-058682ce6c31ed292"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-0109129d0539a7ae8"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0c23407e6c48b3652"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-0dee7afc9cb7e8775"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-08b9dfc7f511da7de"
                         },
                         "ap-southeast-3": {
                             "release": "35.20220103.2.0",
                             "image": "ami-0ea5d907e5b97c166"
                         },
                         "ca-central-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-0946760f01276c569"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-020e703563ae98724"
                         },
                         "eu-central-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-0242c8a92e80c5cbb"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-029b4515ea1ed6a93"
                         },
                         "eu-north-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-06d14107a058d01c4"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0ab6626547c1ab149"
                         },
                         "eu-south-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-006129bcdd4ad41e8"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-01afdcdc67f241cad"
                         },
                         "eu-west-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-08edafe64418e429a"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0c9d0d7ce312b9c83"
                         },
                         "eu-west-2": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-0cdd5ee75ed4e102c"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-057e0e282b0481a62"
                         },
                         "eu-west-3": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-053e2818146a53c29"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-00213b7b41c4fb691"
                         },
                         "me-south-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-0f725578d5be52e82"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-069f0b120acf5b88b"
                         },
                         "sa-east-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-0513292f040c8c67c"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0d2afadd0d961fda0"
                         },
                         "us-east-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-0b50205d463aa46d9"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0b4801e32acc763ed"
                         },
                         "us-east-2": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-06a67cc62cb3f15b6"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-01eabe2528cf0fc21"
                         },
                         "us-west-1": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-02fb010ee671c467d"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0d50b82c84ae37090"
                         },
                         "us-west-2": {
-                            "release": "35.20220103.2.0",
-                            "image": "ami-0a88f1314fece4ff8"
+                            "release": "35.20211215.2.0",
+                            "image": "ami-0d41bf8aec8a3dd62"
                         }
                     }
                 },

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-01-05T21:48:35Z"
+    "last-modified": "2022-01-12T21:09:14Z"
   },
   "releases": [
     {
@@ -49,16 +49,6 @@
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
-        }
-      }
-    },
-    {
-      "version": "35.20220103.1.0",
-      "metadata": {
-        "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1641423600,
-          "start_percentage": 0.0
         }
       }
     }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-01-05T21:48:34Z"
+    "last-modified": "2022-01-12T21:09:14Z"
   },
   "releases": [
     {
@@ -73,16 +73,6 @@
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
-        }
-      }
-    },
-    {
-      "version": "35.20220103.2.0",
-      "metadata": {
-        "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1641423600,
-          "start_percentage": 0.0
         }
       }
     }


### PR DESCRIPTION
Mitigate AWS Xen boot failures from https://github.com/coreos/fedora-coreos-tracker/issues/1066 until we can roll out a fix.  We can continue allowing new launches of the affected versions on non-AWS platforms, but update edges aren't platform-specific so drop those for everyone.

Don't roll back `ap-southeast-3`, since there's no previous image to roll back to.  There's no point in breaking that region completely.