### PR TITLE
Roll out stable 35.20220116.3.0, testing 35.20220131.2.0, next 35.20220131.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-01-28T03:11:32Z",
+        "last-modified": "2022-02-02T14:39:04Z",
         "generator": "fedora-coreos-stream-generator v0.2.2"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220116.1.1",
+                    "release": "35.20220131.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/aarch64/fedora-coreos-35.20220116.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/aarch64/fedora-coreos-35.20220116.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "5a7b95750368e3634606a0b597c4f4257066932c3ec31868732e452ed652d7a1",
-                                "uncompressed-sha256": "4ea0a2ce099b1158a708b700a7946d75f40a66f53d7f2b0974db47eec40672a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "b6bdaff644c88f7c178ecef99faa08a06e1fd7dab55c008e1c365e58c16b4cad",
+                                "uncompressed-sha256": "356adb5eea39acdef63dbae51ef08384bfdd953b053a151a30dbf243a60dc94f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220116.1.1",
+                    "release": "35.20220131.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/aarch64/fedora-coreos-35.20220116.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/aarch64/fedora-coreos-35.20220116.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "5a6d464cd792ce3e88e88da8bd96f6582b6a3727deadaaad7731104ec3b85bf4",
-                                "uncompressed-sha256": "b30eff60a5847e99ec71edada85f8f6e429e425236fb6e0cc6481d1272c4c173"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "7b64052a5b70f6d30a2456683a5dbd3dcca6249e075378c5b74f65db5d78ebbf",
+                                "uncompressed-sha256": "cf7e9ec2c1e5f1faeb9a75ddd219a536fc153f070a214a07d727f37f0eba3996"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/aarch64/fedora-coreos-35.20220116.1.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/aarch64/fedora-coreos-35.20220116.1.1-live.aarch64.iso.sig",
-                                "sha256": "7723c13b97ecd9c6503650ae0538a754a307a9e5e60a0bb887a7683294f61056"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-live.aarch64.iso.sig",
+                                "sha256": "2768a4ba849acf8ec60253f28d13b82edebb00ea993944a88deddc0de6e4ebfd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/aarch64/fedora-coreos-35.20220116.1.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/aarch64/fedora-coreos-35.20220116.1.1-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-live-kernel-aarch64.sig",
                                 "sha256": "8541d9979e98aa85ebc134fd3200eae52e2020333e723c255890323a49436177"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/aarch64/fedora-coreos-35.20220116.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/aarch64/fedora-coreos-35.20220116.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "9e09827236dd13238576564b20853b737853a8dd2cbc90333dd3dc3d1d28e2cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "b56fc77c116f9bd2e909fc0e29f2a8a0188f3a837d9917ce7972bcbdef1b2d28"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/aarch64/fedora-coreos-35.20220116.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/aarch64/fedora-coreos-35.20220116.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "18efc6ae8321d91f4a7771d6e2cd9ffd329e79fe751e6734bfc18c6fc691a0e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "80642fee8ca972fd71cb88abdf856fefe09090c60edc2492cd66c64aa83733a4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/aarch64/fedora-coreos-35.20220116.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/aarch64/fedora-coreos-35.20220116.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "e2eb6442bb4b91b065c6a06a56e5e52d91ead50f6913cd461150a28b3fba2692",
-                                "uncompressed-sha256": "946f706ff34d09d41b9157b139c81d3b5ec7719d5c18c9f566f1d6f7387e6a02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "fc9c092ad17a61729827782f92b3a02d4d8085d056f812b9e28cd64abc017f8d",
+                                "uncompressed-sha256": "7205b2d659c3915c8e4b3ed176e0006020e90d7c81b62129ba603f6ab8998703"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220116.1.1",
+                    "release": "35.20220131.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/aarch64/fedora-coreos-35.20220116.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/aarch64/fedora-coreos-35.20220116.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "c31f178191a3f5b4e42b519c214e0abe7b4a691d14e4ba297f691a18e7ad1573",
-                                "uncompressed-sha256": "24297e8221d4dc2f223235dfc47460715caecae7f96be14e2fd34e7f12fcba21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "2aa14f30b52bfa7a2f579016d744a9e846efc2e715de4fe125b458f66585d509",
+                                "uncompressed-sha256": "9ba128e9b9c7a6856024a209b6e09b67c0fd1bac35dfa3e9b145cb419abe76a1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220116.1.1",
+                    "release": "35.20220131.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/aarch64/fedora-coreos-35.20220116.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/aarch64/fedora-coreos-35.20220116.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "a36724679a0d67d09972e6fcb6151c86f50df0a89cb2f275c69d6e5f00c8de7e",
-                                "uncompressed-sha256": "e5511ddcf4bf5bd39e87eec7e49215616a0e4021680adf5681f25eaa445df68c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "85b15d44338c9752c82ff71c11e5ae885386f803af1b8ac7131ce6cc0cbfdd9a",
+                                "uncompressed-sha256": "b973ced3d2306a2e983c2fb432d363b630b1c79ce371bdaf3ce66f748681d59a"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0d051211115bac7d6"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0beb5154e88023de0"
                         },
                         "ap-east-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0b0613d2a00661123"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-079809b5a50c2dd68"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0560af44b14ff3727"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0620e66614453e16b"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0be30f81cfdec916e"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0475ba80486857995"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-02dd2fe190cd6a8fa"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0742dd62cfc294bae"
                         },
                         "ap-south-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-03316ef982870c0f1"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-036480caf49062463"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-06c22e3d13590b5b9"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0104e66a990b33b1b"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-05a5de435f3fae998"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-02861877c9520b796"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0e08b76a3dabadb4d"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0e618ad8dd5505bc2"
                         },
                         "ca-central-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0a74c8c72aeba86e6"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-02056efe282bb05e4"
                         },
                         "eu-central-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-061d40ccbe9642f97"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0a7e33698b1387f1d"
                         },
                         "eu-north-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0fc0db6b55f8d2922"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0432d2ad9239be750"
                         },
                         "eu-south-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-054523111279b5972"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-045f274e64d8dd06c"
                         },
                         "eu-west-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0e78dd202e1ae297b"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-07ce3506a6f95eb80"
                         },
                         "eu-west-2": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-055ac92d6795fdd3e"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0a91a71618e1f8470"
                         },
                         "eu-west-3": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-04b739e1ba1b4ad9d"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-01e84825e7ee53ef5"
                         },
                         "me-south-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0da6a202f88b563c5"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0a248ba00823f7e89"
                         },
                         "sa-east-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0a8ae63bcd7d99536"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-09317b930f0cf7e1c"
                         },
                         "us-east-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-027411afd7ec31e5d"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-031e41b1f247ff14f"
                         },
                         "us-east-2": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-00e9b9ba721e4aa7c"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0ad922e01cd70ecd8"
                         },
                         "us-west-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0b143f5acc88a44b0"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0934add52f9cf76d6"
                         },
                         "us-west-2": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0220b430ecde837ea"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-074104b99c89483a2"
                         }
                     }
                 }
@@ -190,214 +190,214 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20220116.1.1",
+                    "release": "35.20220131.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "1fcfa803814ef132c53d4fe4cc23ca22b08fddf727daddae06ae1c5b576f23c3",
-                                "uncompressed-sha256": "8fe92333df0f03b4613b5d6d2d0564e3bd3ee31ec76caa740cb52afc2c59d8b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "7740202ef58a634f91517f488d0fed5f03c795de4b8ca4bed66ab67546d24bd9",
+                                "uncompressed-sha256": "83f494ac43d89f632db5726a04b233f5ddc90245d2f1eeab5fd9cc63aed0ea96"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20220116.1.1",
+                    "release": "35.20220131.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "64c4e96468865ac5f64e8e94b9f81644e77eaae58f17147a69c1f4ac20457f12",
-                                "uncompressed-sha256": "f19b297887c40e53a0caa43bc223635ae8cc074b6e07e57e2e4f16d81e2125cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "69602248b204f18320dbc5b9ac2701f5e80d38dfb18caf9d53eef1e475aa9300",
+                                "uncompressed-sha256": "f51a261736fa5aa4ea823b850e3fc39d2ee43f720c092e60370719782078e270"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20220116.1.1",
+                    "release": "35.20220131.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "95dfc47dd3b5072c0e4c95bf7adc74a8b7b0b87cf0a09beddc6f86b3938257d9",
-                                "uncompressed-sha256": "fc997386b475e6e1a7bd9f5085a8b49332ba8763b0963ba258a62cbcd2228216"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "b002f60664a152e1fafbe27b1a7f653b929561342e8d4d83755691ac33a78f91",
+                                "uncompressed-sha256": "71cd7ac7df4fe6e97633e0d9ac1204e4b3cf6499b363410cd185ef3b411c28b8"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20220116.1.1",
+                    "release": "35.20220131.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "450d98253acaf212a13f24cd472106a1e96be998e4869285ba987b1c33e439e3",
-                                "uncompressed-sha256": "1a91b6dda755927109dec27781285e23f8328596ca140144331504c23f29af32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "15afdc9ee9b5c16d2a85e6c986ef3b41823fb07c55b8c00dbedb1d85af938523",
+                                "uncompressed-sha256": "b40c3cfa1483028d8f8a10f871929c04965ec9e60a0f309c763dd7ae749db212"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20220116.1.1",
+                    "release": "35.20220131.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "97c3a68b567212bc12b099cb37ffbebf01fadc67bdd18fe0761bb35df3553976",
-                                "uncompressed-sha256": "1244cf4c1b2dab3df4a978dab539b19da3e3fe4403a43974d74fb97cad2ce87d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "b70b14bf6f2931680c46de4cd51e72f36c1ec973f5f91b5cd90a9244b5598095",
+                                "uncompressed-sha256": "0158f4b0306f5cb1ebe31a0da7021117b19988bf55d5363e7a0e86fc924ef393"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20220116.1.1",
+                    "release": "35.20220131.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "f9da5261a54598bcbacadf0d2362310943e31d14c89c66e2336b4ffc6de1a455",
-                                "uncompressed-sha256": "c350b91c6d4b4bd1ff20eddfd8c5feb305e24fcb177e327ccc7d2e32cd2f718d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "53c44a4285f8f418d9f100b033c721cb0c5828c80c7f296d22f09e47c6771337",
+                                "uncompressed-sha256": "70e9a2c6b19f6121526b43ca98000a0b260a895c252a9229624641a4e47de335"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220116.1.1",
+                    "release": "35.20220131.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "b625ad6eb32b7fd35c8e7b17f0dd26f43d8c2d5bf796b298f9c3c7b3c43be5cc",
-                                "uncompressed-sha256": "0c95896278aaa1aa112098a77f378862635e008689c98dd5cbf724f590056859"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "39ec8d9f7a809b5c4a0d2a26ce6ac1c6358f3ca038ea66a29c57890f137eca8e",
+                                "uncompressed-sha256": "87c1e1d9018117461e123aedce8617ef0482501a13d741c1846fad96f00aedde"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20220116.1.1",
+                    "release": "35.20220131.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "5d79444f206a841fd77cffcdb005a7124a1543609d777d41dfd7d3eada93cc66",
-                                "uncompressed-sha256": "a8b708098a2e618fa0b0b71b34ab6b57a7d7f48751c8d1041e2e755bba411152"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "345835be5dc605da26f0d757e946b60f0c380e2f1f53fc06c1f8cbbb89670d91",
+                                "uncompressed-sha256": "292c81edb76752384cea95535fa00500bef10ac146976ec2f4dc2cd638916842"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220116.1.1",
+                    "release": "35.20220131.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "50a8801a7013cca36d4bf59fde203a08f48c322d427a4549708dd5f3ff5728a7",
-                                "uncompressed-sha256": "aa3c139590ca9a80704d0b97a4c2b25b8a89799f8ecc57b2c8d4df2b808935af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "4067e90e6a141df6d72f6c66ebc8987dabe46164744b20de2c0d05e4a707f43b",
+                                "uncompressed-sha256": "790d5808256ad2b930b8b0d2824ec6c9e0a18151c2ad0dd01619ddf2d0853fe3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-live.x86_64.iso.sig",
-                                "sha256": "3c21311e3856234e80f10700cfd58c8f8834f2d1e666bb4a64a2171820910ab3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-live.x86_64.iso.sig",
+                                "sha256": "df08f6f089b5752a31ab3a7f74db465bead6619df2bea28542790c967f57bd98"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-live-kernel-x86_64.sig",
                                 "sha256": "246720fce1961aa468d02804f2d71f56b6579d68ed60c2c7836dc497dc062fe5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "5c38adc51db145454a45098aeb152a9c924f3dfddd6230b9ea7715a7d49dcc24"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "2904324658f7c3ce3ee1c7d196c203097e1f8aabf1f8a1e13e43ab3b297c5610"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "aa8e8c26522234e6d159fee84c8ca64524a44d37b673351842e286b52c94106b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "6e5d12f37a6857f4dbdc8f9e6428c5be2ffcd38a4333645ba6703df739d8ac3b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "003e1fe52bcd27e6f7c25b0ecd82b265d3ab8aa3e454f1abfe2cc9ac6c900c3a",
-                                "uncompressed-sha256": "717a8b7fb75504bdcc25e1b555dd0a8a8251c803e4cb1d132c495b32e58fb2e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "1193ad32d3327eece92de53d8cb80f07d3223cec7c2a8f67685ed331c0085d1f",
+                                "uncompressed-sha256": "d98e12c3f5345c371f5ea716b87a4e5da428068b8ff88d746880948f236e90c3"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "35.20220116.1.1",
+                    "release": "35.20220131.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "3625278bcd9c2c7fac2e1e91ce42502861eb48e57ff3399559294ae899dede1d",
-                                "uncompressed-sha256": "98af3df1d69f99564b774dd30aa0b0f6088ae14fdab4247ad7f66c804fca823f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "d5581eaf98251f871f090888e9eb77a5a72d8757075e70831723e124f4079d0d",
+                                "uncompressed-sha256": "5572699e59ef0f23c9e1794e880e7b14f41db1381c2d1f7c105332dd8c987ae6"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220116.1.1",
+                    "release": "35.20220131.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "dae7b9161f948f2cb386c756abf4ec15585092f84a27fd64ae1e9f4f60241085",
-                                "uncompressed-sha256": "54798ae4b24d51ed2487ffb8abd215123deabdc9e88170e3f59b8b85eebf9989"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "00062cf37010db6435bfee563defaf6c607bc2d0ab6598104070034f9d7864af",
+                                "uncompressed-sha256": "1b15a835ca1008b1b1ca432537ba00fc6357292217650212c43507211995d359"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220116.1.1",
+                    "release": "35.20220131.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "099c51ccc56b5bd92ee9593b60a9d2df9b33ef9103a2cea806855dd5cfda7951",
-                                "uncompressed-sha256": "ef03d4ffb5a7f15acefa032fea1e9e704f5bb5a62dca16d7103338bd17226b64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e9dda3ac196bb498fcafe5fd3630070f02148c44361d9e5a85e4e2a046e64e90",
+                                "uncompressed-sha256": "619cfeb61943dc86e644f106a523f46af658d01b166d0f09103ca0d13a107637"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20220116.1.1",
+                    "release": "35.20220131.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "6076773dc63912f02b79a75545aa1778617614f2705fd72030e92e3a4d7c82b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "160896ce5832840609cd0bc3b4ff17568b9dec31ed1f976edc29a7bdd6452018"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20220116.1.1",
+                    "release": "35.20220131.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220116.1.1/x86_64/fedora-coreos-35.20220116.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "c57fb996bb68124213eae1e045e0d3731c3bb16004b95f140f558331ab5d0b9a",
-                                "uncompressed-sha256": "8ebbd2d807d9de013433dcb405e069c4156fa39cb4339c81c5725f5d9f965a4e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "2c9715b317533fee98c9aecd052a52976728a34144e16eb5f8b8c84515ffe7e7",
+                                "uncompressed-sha256": "e41c3ec27e4a0ca5e3a0172491172c34b6250a42ef134b627c6d626628bb58fa"
                             }
                         }
                     }
@@ -407,100 +407,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-05ab7a6fa5724c3bb"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-031b3319dff40c54c"
                         },
                         "ap-east-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0fbff66ca76af9601"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0cd88b89da0b82ac3"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-05205ff98dad1cfa9"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-045e904c7808fc441"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-088f90c5fbccc9374"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-040cb2f7f96b8363f"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0b057f7b44449c19d"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0f5cbea5d20dfdfd7"
                         },
                         "ap-south-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-00798b510ed364fef"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-01531a8f829b626dd"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-01cfcabb098b49412"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0440556b427d40e7d"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-08a155347174a2f1a"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-05a62b3098d8d2299"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-06bdfc4d806a46b40"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-07bef5d07038ac914"
                         },
                         "ca-central-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0f05b8a87cbac20b6"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0143eb540ecd5fa79"
                         },
                         "eu-central-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0b0aa6d5279ae5822"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-040f052a460926762"
                         },
                         "eu-north-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0c3f14e94206c71ea"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-077be138d871e79b2"
                         },
                         "eu-south-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0c064d83785dd0d45"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-06b7b91a62ef9dfcb"
                         },
                         "eu-west-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-00ff8a166fa965a54"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0351cfb6602407672"
                         },
                         "eu-west-2": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-017fa5bf2c982645c"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-06fadd084b0dd9fcb"
                         },
                         "eu-west-3": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-01c4c57b8eb789980"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0d04243cbc5fca50e"
                         },
                         "me-south-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0e229c215138b9e30"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-020ef94c29b13f567"
                         },
                         "sa-east-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-08d5f965e7fcf4490"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0846c2ce779bb84f0"
                         },
                         "us-east-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-09fa9db76008e8e98"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-008db52691656f8b1"
                         },
                         "us-east-2": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0aefd03abe96e4daa"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0c9b96788432a9fff"
                         },
                         "us-west-1": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0c4bcfcdf68c44106"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-07e35e6a9d2705fa7"
                         },
                         "us-west-2": {
-                            "release": "35.20220116.1.1",
-                            "image": "ami-0200d152737da82af"
+                            "release": "35.20220131.1.0",
+                            "image": "ami-0ab03ba458ebe9960"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220116.1.1",
+                    "release": "35.20220131.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-35-20220116-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-35-20220131-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,92 +1,92 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-01-18T15:49:43Z",
-        "generator": "fedora-coreos-stream-generator v0.2.1"
+        "last-modified": "2022-02-02T14:38:59Z",
+        "generator": "fedora-coreos-stream-generator v0.2.2"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220103.3.0",
+                    "release": "35.20220116.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "4f401a15fd0e684ff63ca41d90952a290dd23ec90ba2263db901c9fb7ff8bcc5",
-                                "uncompressed-sha256": "70c0f27e650204f81a643ff8cb4d0ef285e499f8702e28498a1f0b505020a17f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "c5bd63ac3d8a4e6ec48c6776888889e916963a4dcb9ea8489a456825abbc6026",
+                                "uncompressed-sha256": "730afad50f160622dc7c596846adddb5fb148b605098a077b318c7c2e5d4d0c6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220103.3.0",
+                    "release": "35.20220116.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "db3d1087459b9962ddd0a7d67de94a3dbbe4ff880f49d6fcf56ba76f7ef6c3b7",
-                                "uncompressed-sha256": "8bbbe03b41f9541b43611e620e7c96b40f8d14589ba3196a75e5086d39dbf1bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a7b71e5d8e7492f06952ea08592d4d436c1cf680b784e84a52523de50fc193d0",
+                                "uncompressed-sha256": "cf702e840f70d2e81ca92612f6773ac9a3a3686a4d541fbcbd22eccf6d61ff09"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-live.aarch64.iso.sig",
-                                "sha256": "d38563dcc081aff88614643ed91d1bbe278b4fa57b0f47c2b96bf4151540aed9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-live.aarch64.iso.sig",
+                                "sha256": "3cf3dca295d6db69eb4b9d84237eb3a86266f05b8bfa3d56f82b1e44f17c523d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-live-kernel-aarch64.sig",
-                                "sha256": "f80a7636b7948e095aa22f1306c8e33da0f75a599b819c222ff5fd30278333aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-live-kernel-aarch64.sig",
+                                "sha256": "8541d9979e98aa85ebc134fd3200eae52e2020333e723c255890323a49436177"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "270290466531ac9ef6e9a0acbc7195c43fb126eb1aa09c01bb9f53674ef17793"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "91d5e9cfeb1dcd3f74f996fd432311814eadd91cbd1b205ddd1fb340b469f387"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "f0cc83023eb682f85fff937ba992743fafa7209757aed06dd44c859685a9f6bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "110ddcc50626dd5387380de4502f8d253313a78522534b280108ac15a4326399"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "2bd038aaefacd7147d8c795ecd0b824270e214b67794e56bf2d6268959addb2f",
-                                "uncompressed-sha256": "3bc46755fcf2196ce6d71ad11d62b0b8749182f7600757ebaa04b066f83932ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "425d5941dce3a255c374289010636ea4e3a0a7907248d53c2d93510c03a1b62d",
+                                "uncompressed-sha256": "09920ff23d5d2c66c9c78c6d3c2dd7f9c3f923bf950f2de5c0ae3e99994112b9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220103.3.0",
+                    "release": "35.20220116.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "bf6b4d3ed75d25f4d2573ceb867410ab46dcaa67d02f8f0074e8e5be5de0685a",
-                                "uncompressed-sha256": "6b7d7f08265e1b11f355e574dcc7ef6479141b753e8b1e14fcbe9f5713252ce0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "f20c3fff9f69467c624eba0c7b90540bdc1ac7539a3327e65b0b0002659a9eeb",
+                                "uncompressed-sha256": "58dc5c2781206c4ee365ab78e14ad4bd27afc19a437df616ece72cc37caa53e5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220103.3.0",
+                    "release": "35.20220116.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "f40ba05afae55307ef15683befd821340d001f3199f0fade09eed5cb427f10ef",
-                                "uncompressed-sha256": "01715fbc7f37991644e1fc62ceb6a2b00fcd7d23d7c75b16838d9575737f7e25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "6705d5d990fc5dc8921e2abf1c8569cdc1e2b3f06df20cd868130a1ecf3c830c",
+                                "uncompressed-sha256": "cd6f49d112b11000c98b6272e38debbecf0f9014ef210f4ddbdd67495a9aad3a"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-04243218e79da129d"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-005ad708af7e6e135"
                         },
                         "ap-east-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0ad0141a546b99321"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-091fce459ddac74ed"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-00109204da2d01f3c"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-0546af5f446cf276f"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0d1ae2cd9c11d1db3"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-09c20376dc0367918"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-058197e0ff424188e"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-0d552bfeb3e508f26"
                         },
                         "ap-south-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0f02f129c1b36beb6"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-008e9951222796636"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-011d3d77386057e2d"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-02c0a5d18c87e1be7"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-08d54bd8bc4e2ee7b"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-060d83aa3ccc7e1a2"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0a77531b991bd9d6e"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-033c67d3facd54f4d"
                         },
                         "ca-central-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-09478ae75cc5932e5"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-018885050abf53478"
                         },
                         "eu-central-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-06964f107dcc3c04a"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-0f79ab7f3248307a0"
                         },
                         "eu-north-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0ac89e700f22dd585"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-02d23f89c191939fe"
                         },
                         "eu-south-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0cf6dfda91b26a173"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-03e731ece2da2d3dc"
                         },
                         "eu-west-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-035674d4522607850"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-0eec9689d4f265114"
                         },
                         "eu-west-2": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0976e1d2b2ddee812"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-0ddb529baca7bc4ec"
                         },
                         "eu-west-3": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-07eb4f10d0d2cdc33"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-0cf2bcdf48d74ced8"
                         },
                         "me-south-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-01ec562ae7e771083"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-085cc2bf9242b2277"
                         },
                         "sa-east-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0d628de6de4d7d01f"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-05e1e855ca6e1c697"
                         },
                         "us-east-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0cf0f6f506cfcfa37"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-0d603cec9507c6d1a"
                         },
                         "us-east-2": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0edfbb24f21230a6c"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-05755d4e1afd6e9da"
                         },
                         "us-west-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-051972548d6957854"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-05e9f5a4c7bf4d1a7"
                         },
                         "us-west-2": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-070c441120ca3686e"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-01cf27ac729a40c17"
                         }
                     }
                 }
@@ -190,214 +190,214 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20220103.3.0",
+                    "release": "35.20220116.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "4198d09e125e5d3adac797d8e9c1cb307bd92fe02904b8761f118370796637db",
-                                "uncompressed-sha256": "2e66524b956e4bfe2f7147c222385deb547a4201491b387c6ce724300823d576"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "a2e7a79f9171ce001225832561650ef410e94e81042e174a06d18d7397a82d2e",
+                                "uncompressed-sha256": "39ed3c857ea366fa61546efa4e39a63601aed14962c5bdff5a958d40efa53c8c"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20220103.3.0",
+                    "release": "35.20220116.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "ecdd97d28cf60dbaec6a0911a925d5887e929ca5137f8e68bd3361726c3e1d10",
-                                "uncompressed-sha256": "bfd6151f71e542fb5d7efe1aec6c371762845479ec702db106b68dd62034fbe3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "7cf5018556c8694912ea1cad099cafb1f984fefd00baf321d0d92dc1ddd90471",
+                                "uncompressed-sha256": "4f74b77ba3683bd5a80f3dd59d76ae691efccc05175c56aee7bb899ac020cbd0"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20220103.3.0",
+                    "release": "35.20220116.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "14744c4a6216074064ccf8b546b399cbb962073b76580dfa545d28e2168ac3e9",
-                                "uncompressed-sha256": "be9dba121e013ad2e13593d66a036c9b753a408acca179464e09187273f538b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "2b4ef982c0e196edb2df2620039783704a6acf15f8497a567e4611513233f583",
+                                "uncompressed-sha256": "141161cf85a85b00363301c6c3c5ddc7cbe4df349b273cf3bf23b75b8cd3b32d"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20220103.3.0",
+                    "release": "35.20220116.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "61894ac6470364668f3d2c938bcaa4e284fd79d53604b7557b63e693d69533e7",
-                                "uncompressed-sha256": "9d1e5010c3d39c6cb5242c60fc64596c82bf9e2105886f7615131e2b13e48728"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "b8f4d0da17d535f31efa7515bd38ff16bde0f4392286c7cb5101d661a583571e",
+                                "uncompressed-sha256": "3324b7662b6a4d656ace9b305c1b3e427b680bdf88a7fdae27bda90af908b28b"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20220103.3.0",
+                    "release": "35.20220116.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "ef520bb8883e66ee17459794d66e29ad621f079999cfc1bab04272cc85309d1f",
-                                "uncompressed-sha256": "74ec195a0b66b7a34429f2a2c341fea06e553a24a09e5e2d79ef88c8d5bd9722"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "56a58b0f3ba43f98463665899bff612c12156ad4b16316b806b23287e9d5db6b",
+                                "uncompressed-sha256": "d5a0ed0c6b67f08d2c7dbdf1b476e4b5d03b9599176c3ca88197431342cc6836"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20220103.3.0",
+                    "release": "35.20220116.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "3053f7deaf0cc9fbd1f03cf957c185df9b1a90977b1d6259b3bfd5c80e6bab88",
-                                "uncompressed-sha256": "be9d39af0c4a88a600ebd3e10f89e1b8adf0d33a54291bd45f4a68b9ece3ccf0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "93fec116ed40dc938f2f8cd2394c70770a5c04b9ef507fdf10cb3fc414c06014",
+                                "uncompressed-sha256": "38784352e9ffbdf3206331b12d84520af86cd2156c0b9d79e43c58c8343a419d"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220103.3.0",
+                    "release": "35.20220116.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "faaf20563e6ca8be6b8b4911604614a2dc06332fd9cb2a26b240a44da387276d",
-                                "uncompressed-sha256": "2472b74d38bfa0ceec22dee76f66c41af5b9ece2af86b818431f511babbc853a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "6dfc1a20a306b75f955b3d77121ecfbb728944b8e654cbd21ad340c5118c6691",
+                                "uncompressed-sha256": "48f8b87670eb0c4c5edfbba1c2bd2f798721c9818ca41ec66ff09ce0d79786e7"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20220103.3.0",
+                    "release": "35.20220116.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "ee499cce41134d0e2ecb36437d9a946adf6c0646306263af1ab6d24ed0f2053b",
-                                "uncompressed-sha256": "c44820f864705ead2e85aa1fa189d9d5b01bf256ab718c32e2690ee01987ad0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "43a97a3fd94548620e4f69d5a04c78167b72dfa466acae949a3620a37d78fad3",
+                                "uncompressed-sha256": "4c632c377e7999f43789dbb0cf88dce23c0e6695d1bcb78f591c4949f91e915b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220103.3.0",
+                    "release": "35.20220116.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "19c9c304700855439d3549fb4ca98dd63ab61f65a1223e6c4835eed276ce2781",
-                                "uncompressed-sha256": "937df2bc5457d4806649bc391e825dd0e1e888a87cb41e9f1ce3786984a7b413"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "ef98e9afb2116c8a1d3eac54abb86c42247cd2756157c07957784a683cf19b8e",
+                                "uncompressed-sha256": "cfe6bd6f8d50db96f0fcf2099994c5dd80cabe37e07785f63b6752af7c3ed34e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-live.x86_64.iso.sig",
-                                "sha256": "0dc9642daacb234499afca3cc291f5420c2cf7f832a9ce01cd1b08a3364e2891"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-live.x86_64.iso.sig",
+                                "sha256": "d491d100645786eb95d53a2411d07349a95c0167426fbee73a988b92afbdf58a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-live-kernel-x86_64.sig",
-                                "sha256": "805823399fd1c4b50a677834971b4e516f3dd6456b128225e36da933142274a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-live-kernel-x86_64.sig",
+                                "sha256": "246720fce1961aa468d02804f2d71f56b6579d68ed60c2c7836dc497dc062fe5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "605a4f8e0ae567ec0b0f3308ecc57eeb38d59a1be813abb544d73e9666a66838"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "8b06eb6979103b33eb5378ef5923cf868444564a387a9f842df17bb9cd87a7fd"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "b610e413da5fa34e0500226b678f01ec64bb3e6983629d1b328c7824476e31ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "5ea5c03edba1996b4371d7499fbfbb91083c39ca4520f669e9284ea2c0ed2090"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "01aead3d16f5df75fe1dda1d3834e3cd91f6d6b9cd7622fece2db5a9461b298b",
-                                "uncompressed-sha256": "6850e8313efe6981658e9ed31517d5167c8eba7cd4a31b42f9e8bc0a8f62316b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "6f7b873f8d1086c3c2255ca4eb71b9c5ee860b1e3c1e0573e8f64ee2dab90b2a",
+                                "uncompressed-sha256": "71e03d5cee9a2cca50685855e37de148d4616232242e377c89eb6ed0a4e7de0d"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "35.20220103.3.0",
+                    "release": "35.20220116.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "145dd3042c6ec92796c5d1b28ebcb37596a01dda4f169a4e4f97d9ba2d25b23b",
-                                "uncompressed-sha256": "fbd6ce49e0b4974828eb6dfbe70dd4664767c6b7acfa2820d696ff86dd589624"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "d885fc019269ba4e315c2903dc96f53b9617c19d550e81e8c6cd7a665583b0b8",
+                                "uncompressed-sha256": "a34510d0239366e5464d4ec6faa4697e1f7853a868a389df678c7217edba3184"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220103.3.0",
+                    "release": "35.20220116.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "3109807db69846049f7c4db85563fe596f2043493e3ded8cd7e9488afb94a9e5",
-                                "uncompressed-sha256": "9b7ea63b918b6f924a701b63bdb625dd7b6877dff319a5515f012e4a07c0d82b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "17b89fc6bb490940ede4e41de11389f867c4802c0f3c24f4ad475cb3c8f750ed",
+                                "uncompressed-sha256": "c44479ba9f4bb219e924839f04fdc30149137e23bfd5c63429b8e52cb7b90d04"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220103.3.0",
+                    "release": "35.20220116.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "866c4bdc15fd5d23f71a263776cb8f45f21d994615618cc0ac21404a5e01c1fe",
-                                "uncompressed-sha256": "f60587c8a294dcd96b0e57fe87184f3216de457dfc785d0d37e09be069b94a7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "42fe6f0784da5c7127b6d1da7156ff540a842cf21d5a078681c063c6f2897d12",
+                                "uncompressed-sha256": "df589709416910f96449ef132669c081af0bced140f40ca61079dc741b45e395"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20220103.3.0",
+                    "release": "35.20220116.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "9587e3981683efabc87cd6765c61568189ee98be38cf7125e629c79c20bec16d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "d690f86993f5ecae729dc6327205b49930b7326c931149063ed9b246aaac2f4d"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20220103.3.0",
+                    "release": "35.20220116.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "628e20f938ffc5d3d1ee9c13d3a37d10de99909d998a580e8e914d7e8b70bdc8",
-                                "uncompressed-sha256": "ac50f453e847f9044e9fcb18474b57c840d5123eee71a6c2c9a03524740b75e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "311fd88c039d2f3c8f4b73f68321a70c39b253df340560fb42ccae44c8e1bd83",
+                                "uncompressed-sha256": "c82d1234ab484e9798607a93c3b1ca6e4f110108a33131c55723260ab789ee08"
                             }
                         }
                     }
@@ -407,100 +407,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0551aba89c6f35ee8"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-01dccf98168d25614"
                         },
                         "ap-east-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-01b34f29609005ee1"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-0442f79e4ceead79b"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0ad6f525cb99bc9c7"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-03ab3373c4cdaad10"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0f395be9a1732fd4d"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-08c44077438b106e1"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0a7867838bfabbdca"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-07774c91604c2c606"
                         },
                         "ap-south-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0aa3d17142e57341a"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-022a283ef9f5e0229"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-039555a00fdf9d03a"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-07aca7a236baee995"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-035559685aabd03f3"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-021e870e65e904303"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-02e8300eabf9ec7d7"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-0404ff550e58d0b02"
                         },
                         "ca-central-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-04af29347a428a0fa"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-00f1e813bf6df159f"
                         },
                         "eu-central-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0bdf128fbf0be498f"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-01cd01b45986e15ad"
                         },
                         "eu-north-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0059c5f9a478d4b8b"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-0a9ca8ef4d489b125"
                         },
                         "eu-south-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0812767014dbcc469"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-0d967c8ae3b6c54df"
                         },
                         "eu-west-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-05080098689b11896"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-0063b41519559e356"
                         },
                         "eu-west-2": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-072785d61ba0815a9"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-03e198424491c4188"
                         },
                         "eu-west-3": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-094aca76d4740b9f1"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-03f1d420b7a1cc878"
                         },
                         "me-south-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0d2133ae5f5dc390f"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-0482e6b87eb9aca83"
                         },
                         "sa-east-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-010bb43073fef0d85"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-0b999bf4680d02710"
                         },
                         "us-east-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0ebf4b94cc66b73f2"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-02893d32330a6332a"
                         },
                         "us-east-2": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-093c9728036d3fba5"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-02bcc8e6a2c68fd73"
                         },
                         "us-west-1": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0c2f00f048b52c9bf"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-0045db79b1ea9e003"
                         },
                         "us-west-2": {
-                            "release": "35.20220103.3.0",
-                            "image": "ami-0dc238fdeeb83b541"
+                            "release": "35.20220116.3.0",
+                            "image": "ami-08ffbf521d0a950ee"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220103.3.0",
+                    "release": "35.20220116.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-35-20220103-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-35-20220116-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-01-28T03:11:30Z",
+        "last-modified": "2022-02-02T14:39:00Z",
         "generator": "fedora-coreos-stream-generator v0.2.2"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220116.2.1",
+                    "release": "35.20220131.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/aarch64/fedora-coreos-35.20220116.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/aarch64/fedora-coreos-35.20220116.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "f9ad7663d0dfffa404d27f14f8bf53d9dd55e6b6ffa37986af4157a8b08db544",
-                                "uncompressed-sha256": "5d7947df11324c7146f02dc7c2c27e5f61978c35f61e598ed795315506081777"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "d79c2cdc66abda0291a3a0aaba3da47785793d36d76ec588de562a67cdb136a4",
+                                "uncompressed-sha256": "59d346f2a7ed3d2329b8d673664323ec0b484d86ef56d3c09094454abfbd82f3"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220116.2.1",
+                    "release": "35.20220131.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/aarch64/fedora-coreos-35.20220116.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/aarch64/fedora-coreos-35.20220116.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "513b264aafaee5bf777537fef4646b20f3acdd8139e6c527ae962669586a0e47",
-                                "uncompressed-sha256": "8b65c116bd989fff05d8b62078f141a07c6ae64dce83aaa9a2a748f7b738e476"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "f9cc565479b3955a570ad75846d7f80b7c4de20e83fabe3336382779598dec1c",
+                                "uncompressed-sha256": "98dfbde9d4ba4953653d00f1830a7e48cc16db67ec241a7e04934947d0b9d8ae"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/aarch64/fedora-coreos-35.20220116.2.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/aarch64/fedora-coreos-35.20220116.2.1-live.aarch64.iso.sig",
-                                "sha256": "174ad594aa16a60bfbf6dcb0fcc726c16b1c5b61b3e261aa6b4e2a0fc5b26dec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-live.aarch64.iso.sig",
+                                "sha256": "dded315ce6040c51e6e3940d088c845b446fff108192b58b463ac35b80cb164e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/aarch64/fedora-coreos-35.20220116.2.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/aarch64/fedora-coreos-35.20220116.2.1-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-live-kernel-aarch64.sig",
                                 "sha256": "8541d9979e98aa85ebc134fd3200eae52e2020333e723c255890323a49436177"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/aarch64/fedora-coreos-35.20220116.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/aarch64/fedora-coreos-35.20220116.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "880e9f70cd888d890925903a79b0ea419ebad8346e98bc7c9bfd259fcc977fcc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "85acab7c1cfddefdce183d9d0be58ba315b1281c44c1578387a3f812ee9e968e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/aarch64/fedora-coreos-35.20220116.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/aarch64/fedora-coreos-35.20220116.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "f3f3a797c0d48702d599ac50a2fcb0a7b8f15d53867e579213b071df68f1cbba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "f99dbfb9b878f78e4dff8d038cf94db7a163115a925f5526c49901220c225ff6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/aarch64/fedora-coreos-35.20220116.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/aarch64/fedora-coreos-35.20220116.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "9301266d8aad99215f301a05f0cbee17160edcd116b638994ac8742b9da29712",
-                                "uncompressed-sha256": "52a0db438b1895ae0ab844d6ec4bf87dcc19e7261cb0d61eac21dfe8b291d755"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "218d637cb4c6837e6b85c5bcbca52772bb517dcfad79c33203d27d96c1ccaa74",
+                                "uncompressed-sha256": "763853ccf62f94b6d7d6abf8800799b42103528469467973a4f02d0e2f18035e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220116.2.1",
+                    "release": "35.20220131.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/aarch64/fedora-coreos-35.20220116.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/aarch64/fedora-coreos-35.20220116.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "e75f8a97f021e080f41f27f0ec512a33219eed38a0030ab01f0119a04ae4b129",
-                                "uncompressed-sha256": "d596818b169a0ec414cf19050bd24fc49a41c9733ec3f55057dc7406231a9414"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "61d64e4b39cb87f90053e157df5356cfd968faf1bb8401882225a507c2e379d6",
+                                "uncompressed-sha256": "b6550661a798afc6a651db0d8518f565a02b9bb3608c5d3dd1184644d5957efa"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220116.2.1",
+                    "release": "35.20220131.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/aarch64/fedora-coreos-35.20220116.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/aarch64/fedora-coreos-35.20220116.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "cdd307f09a82cd4efb7d9a62ab5e50e74fa8941c7960344fe2767ca7b0cf928c",
-                                "uncompressed-sha256": "96461c0d6523a5cbb67ea914b5caa2fced2386866e10a41e1f54e8408ec21456"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "0db5707717b1fea0115a6dd5454158252f15642e6b5c13add9297ef534b3aa68",
+                                "uncompressed-sha256": "f76166203975a6e65bf37ad29022ced75b128bc05e63e6fb06b319b75d7fc500"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0cb7b7fc57faa9ca1"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0bf408bdb5b7ebb27"
                         },
                         "ap-east-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0eb5c1758676168ff"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0737e828bf85817fa"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0d4f30cc77b3a6c6b"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-01276a7dfe84149fa"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0017323ff12e8c3c9"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-03f247ec6134fa44a"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0c0e3ad893eedb606"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-009bdf352fc4b5202"
                         },
                         "ap-south-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0d33850637bf3de58"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0cb3446850eb606c1"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-031b8823946a2ae5f"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-023b1a1d09c546eee"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0f627726625080d43"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0369980f83e16b6f8"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-085fe753eeb647968"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0f4d94de45cece940"
                         },
                         "ca-central-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-01612a42b8d94d263"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0f1448c1948102b8b"
                         },
                         "eu-central-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0b7bbbdb4483d960a"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-03983754e9ee37587"
                         },
                         "eu-north-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0decc7ff1b6073358"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-049099c04e87d0798"
                         },
                         "eu-south-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0c18890bf20072b48"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0f9b4277ee02583c2"
                         },
                         "eu-west-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0df9d8f98f638ed61"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0585cdf51ce17aa52"
                         },
                         "eu-west-2": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0d4646f1ade382e6c"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0a3640011ff085676"
                         },
                         "eu-west-3": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-04cc5f65c946c4437"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0c258c67f569c52dd"
                         },
                         "me-south-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-064a7f4e768f1f9b8"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-054a399066aeece84"
                         },
                         "sa-east-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0efbae678a64d1314"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0a74e4f92365541f2"
                         },
                         "us-east-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-03065eb714c96296d"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0cc35b566168e17f8"
                         },
                         "us-east-2": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0a49a605ee7e94ae0"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0818921db05d5b8f2"
                         },
                         "us-west-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0c1226197b8c3b768"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-09586ddbd029b9090"
                         },
                         "us-west-2": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-080180035c859dd79"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0264fe80ab649b137"
                         }
                     }
                 }
@@ -190,214 +190,214 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20220116.2.1",
+                    "release": "35.20220131.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "3fb895d2e95f320480d9735bbbf697bde4edd1699325911525b9a9c78e1d0c02",
-                                "uncompressed-sha256": "68b4ff92e73688a8bfefb85b8fa1b620888e17cdcdbf9b010ea4bcdfecaad49e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "406196a31a6f852b477ef241c84a33a8693225d2dfd147c94cfc12c1c59fdc20",
+                                "uncompressed-sha256": "e93bae8fa142e6389768154e23b376030472f8adc17c742d17c291dad35419d7"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20220116.2.1",
+                    "release": "35.20220131.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "bf4099301587af0f8c19964c4f2d2c38a84a7fefe61b5644f1dadc782dab572c",
-                                "uncompressed-sha256": "b6c3b67a70e0efaf9b357bcb402c559dc200b22a3db9b686b640f69fba999a13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "690e75e05c123554373b44eba455ce0cdb16bd4536ae6eeb8086ba2e434a6049",
+                                "uncompressed-sha256": "33855fb24cf5359ebb3a8051b8a33b7794dca046e8e369ac597d2c6ce02ab28d"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20220116.2.1",
+                    "release": "35.20220131.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "15e4f65aa681be603670356d73e802cdd5e17eaac141dea007d22f3853b55512",
-                                "uncompressed-sha256": "4e8cc451f9635eccfe7b518e2f27778d22430d7fdeccccf6b0ecbaf9bd7f6b70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "37de2e964d15cbcdabcf4bfc68f27faab944bf23e3f96823769139520b1436b1",
+                                "uncompressed-sha256": "9e4d82c83effffbc8fda361165aaa1dde8c1c534cd7b87e61e631e4d6d63dbaa"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20220116.2.1",
+                    "release": "35.20220131.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "1757201c847be5b49ce6b2419d639dc819c91059ed36395a44ac6017ff5b8285",
-                                "uncompressed-sha256": "5bef0149be9867d1b397fb20672d0e920ac0c5764e08d54f2d02d6e0c1a12942"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "db009c1a1ca1b08b45b9efcfde3c014f737c865ff598f9ada491729a48625095",
+                                "uncompressed-sha256": "a67fa89cb27f6b0079a4641e94654899e2640648d3963540927dbaac3e44c50d"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20220116.2.1",
+                    "release": "35.20220131.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "4e0a39ba792d773c6f26c86518b9681cd81248b5405943fcf26285a20066710e",
-                                "uncompressed-sha256": "fa60fa51a31205630e4b596d474af89257cad45304128ecef71a38afa4ea7037"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "85ff05defc8ed01f4c2c18a33389dca8ffa4e6bf9bee5352d71e5a4a09e98fb8",
+                                "uncompressed-sha256": "9892e62f49f51718afac6a61ff5805e95ea0578f3a5523beb2eeddf2417e6b50"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20220116.2.1",
+                    "release": "35.20220131.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "525d5d23653f6cfcad02f434a3d18119bd9847ddddc3a891f1f3edf7e6f487d0",
-                                "uncompressed-sha256": "8447b1643409e0ec5446e612e62b19ae42c8cfabcf30160ac65c51cb13a23e8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e01242ae36114a0313f4f6c5c947524972c1f2194bb744c2050e0bc1b39d6025",
+                                "uncompressed-sha256": "230a31a1820f4b9de80f627fd43f57879b5ef810b37dd69aa6074ce17055f6a4"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220116.2.1",
+                    "release": "35.20220131.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "8445fefdfb3a669a4231824438b52ac301559f1be003655aa66e755b4142b2ea",
-                                "uncompressed-sha256": "18d4c4ed9a6c53a605630323c3a2ff3582808690fe70c23fdc5de79e8b869a36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "fcfa1db83d950f6855ef533a718ff5339123aa8f0b262cf09641a3df9cb1110b",
+                                "uncompressed-sha256": "5791238fb6b8878264d1fcd2b69ee0ea71468052d5775700d2c6bdd8fc8a4a5d"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20220116.2.1",
+                    "release": "35.20220131.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "aa8f1d62e80f456f84610a6b3dd00a1b9839b18b89df376892a510a585b78979",
-                                "uncompressed-sha256": "fc68f21b048ba40ce0e0bd7511cbf5a34a64e0a9629602705ee30a34acd2f8f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "192901c7afe7874761a5e66df5d0d54683d0c050735bed8bc0fdbd5c7558d87d",
+                                "uncompressed-sha256": "4032f4e17229e363d45f70d047d715f11ec24238ef34d9395bb936b703cb34bc"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220116.2.1",
+                    "release": "35.20220131.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "764d3fc010fde04608aefdea929733f23ffa8f60a329f80a311d9e96e5fab529",
-                                "uncompressed-sha256": "7ad557adbe3ea34663c26f4d9729b763a1693527ed82cdc18cf85eb1b4e645a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "1c71146b553e19fd84df667a567abeeb0bb59254c53d6c25ebac15c2164d7e5a",
+                                "uncompressed-sha256": "f5beb153fc510b4e0a7df02f642a658f0a9175494ab238d97a0ab471228be5ee"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-live.x86_64.iso.sig",
-                                "sha256": "dbfc79e182446a2c67095cc768035c66a96dc8f132173c07c1336f6924a858ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-live.x86_64.iso.sig",
+                                "sha256": "803158350a99876bf32c343cd571681c9c775ac96ebf5e9c5d6694bc8b93438a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-live-kernel-x86_64.sig",
                                 "sha256": "246720fce1961aa468d02804f2d71f56b6579d68ed60c2c7836dc497dc062fe5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "21c3f74327a54c8fdb6d64aa85a763b875e4e89dbb61995d314e831d40abac07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "e36477cdc73a2c09bf6f78ab4a240e5e076dbe7c15a496a3a78e18cd228f402b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "22fa13af03000455525dfe58cb19b54e0a7f4b6115482a6e9d4c37f2c40626a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "57dac362a06949a3ad706d31e7f1bb312b636c1eb8ee346b05f8faa2e2daceb3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "832cc8c64a834628359efdaaa82ff6d62d9bfea46b56a4bc9d8fc2728dc27f93",
-                                "uncompressed-sha256": "1c91dff241ca711947145df26167906366521d94c95b4314042207870541f5c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "f78af437b14f70bf78e27d039dbca32048e7cc39f255bc5900d90273b681c220",
+                                "uncompressed-sha256": "f1cc35adadf57bad77d4e3a8cce66ceeb3b4418e26559d897e35a34addbc8a90"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "35.20220116.2.1",
+                    "release": "35.20220131.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "9676690571621c5027e0dd0e1011035faf5ba861a694165fe38de7b7ffc4941b",
-                                "uncompressed-sha256": "2f0d1849e9b7903def44e86a58985a3c923f36a62b8bf9619d3574cec819e45e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "0389f124cce2e4c30dcd09ea2ca313db6279543e615f5d9c8944c8fd6e5f89aa",
+                                "uncompressed-sha256": "8e3f333ea76ccfd928823bf182fd936dd57960261c9698a247307d7067f62878"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220116.2.1",
+                    "release": "35.20220131.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "eac3a72b5be88198fa710be4e3f0a53d6440e76bab4557203f02b1c6406c7b0d",
-                                "uncompressed-sha256": "28242a0491b623fc6b58d17db1095b244b216f5b39e4cc362bb38bb8fa13b35c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "9643a33d56d2ebba059d6b1401797012cda0c0ae563989fee3290da55290330b",
+                                "uncompressed-sha256": "71c73e412734f7562e1fedc016836817118c16c419c9d1581c4769948c5d85df"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220116.2.1",
+                    "release": "35.20220131.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "fd637e8448b069790df9ff7fb44caca828de9126cf3dd84b2b12d9c8ebc3bb78",
-                                "uncompressed-sha256": "6d38d8469d75486176ec090bdd81293a07e9feffeb5b2176b8af31cd44029b47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "8eddbdbe2ef2e2f9b6eec9c90b55380110e56b5912ec8723f3b07981071b07c9",
+                                "uncompressed-sha256": "1c34a76f41e2eba924f4331067e815878460705da92805a71c70df7bb5b0372e"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20220116.2.1",
+                    "release": "35.20220131.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "5d8517d371427feddc0c403b55c54286d91828a657a100f1a18c5591de359e42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "3f2be1680eed9e5bd9313605c604967099424fa69999e1960aa23f839c107332"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20220116.2.1",
+                    "release": "35.20220131.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.1/x86_64/fedora-coreos-35.20220116.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "f5534f0a4414cde0bfc9d1f9756403acfad1a335de0bc2c7dd733adcabad7892",
-                                "uncompressed-sha256": "4a034fe3099b7d8f6448cf3220301c75441cbefede38b90e006a7a67fa4c0b79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "84de61ab6ecfb467ba11d6d890f1607a1f3bfe71815e80ebd5b3f2317e4f2067",
+                                "uncompressed-sha256": "76d64f23bc96df975ea25e4a1f5271b53d1732479812d8e3a20db9702bc17e84"
                             }
                         }
                     }
@@ -407,100 +407,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-042b240cb736c1d83"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0eb5e307cf5f3bd4b"
                         },
                         "ap-east-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0cfa2b186b162dbe5"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0ff8342c0ae78868e"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0e5e7462845f7eb41"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0984dd3904711fa02"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-01416e6f457e44c78"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-019ca028b24612462"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-064866e8b01995fa2"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0ab1b9a3c16986b70"
                         },
                         "ap-south-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0ea5d67e00b7b43ae"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0c9752f47359435c2"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-06a87c249eceb8f3b"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0a121158b2674b7d7"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0837c84072a92a1b8"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0b39b9e374849bd4a"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-06ab6524e14f790f4"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0ca19445d0133d23f"
                         },
                         "ca-central-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0d613ddb1ba184a78"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0b631a7be8aa6efdc"
                         },
                         "eu-central-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-05b2d56b6c8cd5c21"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0eff44d62eb7d69bb"
                         },
                         "eu-north-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0ef0222a4be3d618f"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-05b99634db22c1976"
                         },
                         "eu-south-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0a2b7af4025f63587"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-00d487a5ae0b0083f"
                         },
                         "eu-west-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0b050ef6c2edc092e"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-07c3c455f3d820cba"
                         },
                         "eu-west-2": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0846630b33a3893b8"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0f0fae3645f38838e"
                         },
                         "eu-west-3": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-06c90a0509376744e"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0fdea4c39b2f8a44d"
                         },
                         "me-south-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-01fd5b58b31bd9f3d"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-006eef4530acd4b3d"
                         },
                         "sa-east-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-02fe1984c652fa88c"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0a1bff7cf92f10cea"
                         },
                         "us-east-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-04a5e5c76ec518d2f"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-00f6fef9aec04b4b6"
                         },
                         "us-east-2": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-0b06fe0e13057ad09"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-053a395c8b174c3d5"
                         },
                         "us-west-1": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-05a815c782092d505"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0ee514606c11b6da3"
                         },
                         "us-west-2": {
-                            "release": "35.20220116.2.1",
-                            "image": "ami-06eb4f935332bcb44"
+                            "release": "35.20220131.2.0",
+                            "image": "ami-0dddd708136ad4d5e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220116.2.1",
+                    "release": "35.20220131.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-35-20220116-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-35-20220131-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-01-28T03:11:33Z"
+    "last-modified": "2022-02-02T14:39:05Z"
   },
   "releases": [
     {
@@ -45,7 +45,7 @@
       }
     },
     {
-      "version": "35.20220116.1.0",
+      "version": "35.20220116.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -53,11 +53,11 @@
       }
     },
     {
-      "version": "35.20220116.1.1",
+      "version": "35.20220131.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1643340600,
+          "duration_minutes": 2880,
+          "start_epoch": 1643817600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-01-18T15:49:44Z"
+    "last-modified": "2022-02-02T14:39:00Z"
   },
   "releases": [
     {
@@ -53,7 +53,7 @@
       }
     },
     {
-      "version": "35.20211215.3.0",
+      "version": "35.20220103.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -61,11 +61,11 @@
       }
     },
     {
-      "version": "35.20220103.3.0",
+      "version": "35.20220116.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1642532400,
+          "start_epoch": 1643817600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-01-28T03:11:31Z"
+    "last-modified": "2022-02-02T14:39:01Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "35.20220116.2.0",
+      "version": "35.20220116.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "35.20220116.2.1",
+      "version": "35.20220131.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1643340600,
+          "duration_minutes": 2880,
+          "start_epoch": 1643817600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @ravanelli via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).