### PR TITLE
Roll out stable 35.20220131.3.0, testing 35.20220213.2.0, next 35.20220213.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-02-02T14:39:04Z",
+        "last-modified": "2022-02-15T18:08:30Z",
         "generator": "fedora-coreos-stream-generator v0.2.2"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220131.1.0",
+                    "release": "35.20220213.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "b6bdaff644c88f7c178ecef99faa08a06e1fd7dab55c008e1c365e58c16b4cad",
-                                "uncompressed-sha256": "356adb5eea39acdef63dbae51ef08384bfdd953b053a151a30dbf243a60dc94f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "d38158d244dc859153b80b043cf93abbf27a96aae55e6353db7c558e2929ffab",
+                                "uncompressed-sha256": "da2f7bfb9b5f600ffa3ca791724c3ef007103717a4ddbc74c8286158d5f180b5"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220131.1.0",
+                    "release": "35.20220213.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "7b64052a5b70f6d30a2456683a5dbd3dcca6249e075378c5b74f65db5d78ebbf",
-                                "uncompressed-sha256": "cf7e9ec2c1e5f1faeb9a75ddd219a536fc153f070a214a07d727f37f0eba3996"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "7a8cf0db845f491f520d1ccd8c1dc00ffcdf6a8c7419367ec0d6610cf4d13751",
+                                "uncompressed-sha256": "0ea3dd918e0ff2b6d00704e3d1b89b2a164bbdad69c79695c770aaebbda27df7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-live.aarch64.iso.sig",
-                                "sha256": "2768a4ba849acf8ec60253f28d13b82edebb00ea993944a88deddc0de6e4ebfd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-live.aarch64.iso.sig",
+                                "sha256": "b56ebde4fd150a76b9e1d47c931a1b357007b4d33d5559e5d701414ac56d1c56"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-live-kernel-aarch64.sig",
-                                "sha256": "8541d9979e98aa85ebc134fd3200eae52e2020333e723c255890323a49436177"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-live-kernel-aarch64.sig",
+                                "sha256": "497b13809b045f99031cdd1ba12d53014cd28a6798b7e504bb8b50d40e8c9f17"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "b56fc77c116f9bd2e909fc0e29f2a8a0188f3a837d9917ce7972bcbdef1b2d28"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "af230a27abe321d122959a483c4d9b952a00efefd04550a2afde61ca4aa4ff2b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "80642fee8ca972fd71cb88abdf856fefe09090c60edc2492cd66c64aa83733a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "1801951c0ba2bbe17a50d37227094635167f15813facdf6abd0214e178269eeb"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "fc9c092ad17a61729827782f92b3a02d4d8085d056f812b9e28cd64abc017f8d",
-                                "uncompressed-sha256": "7205b2d659c3915c8e4b3ed176e0006020e90d7c81b62129ba603f6ab8998703"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "0a046f9f28562117c7453561c63b40401816b4b6fdd822a3bc7962c38c1f8fa7",
+                                "uncompressed-sha256": "6d7afaf254a96fe6dcaadc7cc20dd965ec6669c317f8d49bdf8804b0aa6abd39"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220131.1.0",
+                    "release": "35.20220213.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "2aa14f30b52bfa7a2f579016d744a9e846efc2e715de4fe125b458f66585d509",
-                                "uncompressed-sha256": "9ba128e9b9c7a6856024a209b6e09b67c0fd1bac35dfa3e9b145cb419abe76a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "250558cf1b73c6d0527dc16347f45c9c4989d0fd356be3b9109619da0b17fe64",
+                                "uncompressed-sha256": "33fa7b2ba16ef52a8efdb016e1ff7715eac7d3f15bd02156d26efaf1055df74a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220131.1.0",
+                    "release": "35.20220213.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/aarch64/fedora-coreos-35.20220131.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "85b15d44338c9752c82ff71c11e5ae885386f803af1b8ac7131ce6cc0cbfdd9a",
-                                "uncompressed-sha256": "b973ced3d2306a2e983c2fb432d363b630b1c79ce371bdaf3ce66f748681d59a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "8f5bf3956a59b3cba1e290fc869b829b5f80184e4ac95615c4e24a0b909d0128",
+                                "uncompressed-sha256": "78f75c86515efbfd349853e7326613e2aeba06ce803574ae0c7d15be61278385"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0beb5154e88023de0"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0e204b8d9e2ec8b1b"
                         },
                         "ap-east-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-079809b5a50c2dd68"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-022458ed1932cbcbf"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0620e66614453e16b"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0a3aeae77f086d99e"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0475ba80486857995"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-01622fd4b169524d0"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0742dd62cfc294bae"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0536e53eaee08ec41"
                         },
                         "ap-south-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-036480caf49062463"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0ee315b5390f8149c"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0104e66a990b33b1b"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-09cca851b3d24ec34"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-02861877c9520b796"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-094e204312b097277"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0e618ad8dd5505bc2"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-076feca5ed4716f6e"
                         },
                         "ca-central-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-02056efe282bb05e4"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-048cb2f9cdd528e3d"
                         },
                         "eu-central-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0a7e33698b1387f1d"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0db6ac6cb338b48ed"
                         },
                         "eu-north-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0432d2ad9239be750"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0fe4c8df8bd61c10d"
                         },
                         "eu-south-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-045f274e64d8dd06c"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0d7c98342917c85ff"
                         },
                         "eu-west-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-07ce3506a6f95eb80"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0beac7ab989617999"
                         },
                         "eu-west-2": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0a91a71618e1f8470"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0caf9a290d03fe902"
                         },
                         "eu-west-3": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-01e84825e7ee53ef5"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0fd4080b283d2f72c"
                         },
                         "me-south-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0a248ba00823f7e89"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0d85bec59ff000b18"
                         },
                         "sa-east-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-09317b930f0cf7e1c"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-09637b1ada88e163b"
                         },
                         "us-east-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-031e41b1f247ff14f"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-007d6c41686e273c6"
                         },
                         "us-east-2": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0ad922e01cd70ecd8"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-03ff4d94e13fb4a51"
                         },
                         "us-west-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0934add52f9cf76d6"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-007f00e1b26617ec9"
                         },
                         "us-west-2": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-074104b99c89483a2"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-031aea7c8353360b6"
                         }
                     }
                 }
@@ -190,214 +190,214 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20220131.1.0",
+                    "release": "35.20220213.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "7740202ef58a634f91517f488d0fed5f03c795de4b8ca4bed66ab67546d24bd9",
-                                "uncompressed-sha256": "83f494ac43d89f632db5726a04b233f5ddc90245d2f1eeab5fd9cc63aed0ea96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "b38fc2b2e4a0eb5b1b3ee0099f9a612383d46461152bffb11cd16aaa77717933",
+                                "uncompressed-sha256": "4bbd5964c6ed142af6949234c47d264fa0080e92a5048c26cc66e0f309d7a922"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20220131.1.0",
+                    "release": "35.20220213.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "69602248b204f18320dbc5b9ac2701f5e80d38dfb18caf9d53eef1e475aa9300",
-                                "uncompressed-sha256": "f51a261736fa5aa4ea823b850e3fc39d2ee43f720c092e60370719782078e270"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "75b8560dcf243eeaa3ab5a5c644712e820e3f67e7c568063977b7e7fcd376ed4",
+                                "uncompressed-sha256": "24b30320810675b34fd725fc63178d5dda9cc7472279ddf9ca3c6938617e0b12"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20220131.1.0",
+                    "release": "35.20220213.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "b002f60664a152e1fafbe27b1a7f653b929561342e8d4d83755691ac33a78f91",
-                                "uncompressed-sha256": "71cd7ac7df4fe6e97633e0d9ac1204e4b3cf6499b363410cd185ef3b411c28b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "7cf62ef31c0c03b1f6de82c3051d6f5ef70e04c29b1e193822857ca022ce4c02",
+                                "uncompressed-sha256": "cf5ac78be20ced26a5dc47854719a7c4cad9f5e91da85e73018b2825f48d5753"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20220131.1.0",
+                    "release": "35.20220213.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "15afdc9ee9b5c16d2a85e6c986ef3b41823fb07c55b8c00dbedb1d85af938523",
-                                "uncompressed-sha256": "b40c3cfa1483028d8f8a10f871929c04965ec9e60a0f309c763dd7ae749db212"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "940282d0ce5eac81cfbef3e036a571531f5b25c96eed9e7363d4bd26fd1ab79e",
+                                "uncompressed-sha256": "c1f7a009b475c8e81554d703c004eda7939e00865e8db7ef3311f20d9251320f"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20220131.1.0",
+                    "release": "35.20220213.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "b70b14bf6f2931680c46de4cd51e72f36c1ec973f5f91b5cd90a9244b5598095",
-                                "uncompressed-sha256": "0158f4b0306f5cb1ebe31a0da7021117b19988bf55d5363e7a0e86fc924ef393"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "d428a325474912d33790918bb9ab52ad593cca767f1c92dca5f9806540481a3f",
+                                "uncompressed-sha256": "48bc68abd51f29cb9e4b019ef81a73cc794cb19003e858fd875c3ff7d3bffe5f"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20220131.1.0",
+                    "release": "35.20220213.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "53c44a4285f8f418d9f100b033c721cb0c5828c80c7f296d22f09e47c6771337",
-                                "uncompressed-sha256": "70e9a2c6b19f6121526b43ca98000a0b260a895c252a9229624641a4e47de335"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "4e42b24cf17ddd3ae73f19ca66155d5c50f26b0216c555d278ccbb52f9568dd5",
+                                "uncompressed-sha256": "ea83d06d87921a72c7d8cd082ad9acf453b306bb749d57443738508c1af6736d"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220131.1.0",
+                    "release": "35.20220213.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "39ec8d9f7a809b5c4a0d2a26ce6ac1c6358f3ca038ea66a29c57890f137eca8e",
-                                "uncompressed-sha256": "87c1e1d9018117461e123aedce8617ef0482501a13d741c1846fad96f00aedde"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "64dc1644ce67a5f8d45815f146b754f1432ee98c08ecc2861d3c8ad59621b6f8",
+                                "uncompressed-sha256": "a8abed20861b0185e8f46ac0dba7d0729fa2d175e5e2742ecff22d6516eb41c3"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20220131.1.0",
+                    "release": "35.20220213.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "345835be5dc605da26f0d757e946b60f0c380e2f1f53fc06c1f8cbbb89670d91",
-                                "uncompressed-sha256": "292c81edb76752384cea95535fa00500bef10ac146976ec2f4dc2cd638916842"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "3fdb913aa8fc7efa64c27bd00bbbdbe665ea3533f1d9bf0bb2829b5dbf072a3c",
+                                "uncompressed-sha256": "76f254f18f7535994cf65b8f1c64f63e459cbcb163b658d9a647da587fb57b14"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220131.1.0",
+                    "release": "35.20220213.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "4067e90e6a141df6d72f6c66ebc8987dabe46164744b20de2c0d05e4a707f43b",
-                                "uncompressed-sha256": "790d5808256ad2b930b8b0d2824ec6c9e0a18151c2ad0dd01619ddf2d0853fe3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "90fe7510d193898db948389bd8cbb203ce102c3abe18e00289f4a955c0330395",
+                                "uncompressed-sha256": "434c696b76c1a8f66bd50d40fc4519a7b7a90b13a616deeac4afc647cd1146de"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-live.x86_64.iso.sig",
-                                "sha256": "df08f6f089b5752a31ab3a7f74db465bead6619df2bea28542790c967f57bd98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-live.x86_64.iso.sig",
+                                "sha256": "058f495d396ecac763e1f0f2c308ce44b514665fc15f8b21e9dc0dbdbc3532db"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-live-kernel-x86_64.sig",
-                                "sha256": "246720fce1961aa468d02804f2d71f56b6579d68ed60c2c7836dc497dc062fe5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-live-kernel-x86_64.sig",
+                                "sha256": "819fda78ef91bbb41809433c36e2047c5fcf4324b7d14b3a4a13b77d47565a3d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "2904324658f7c3ce3ee1c7d196c203097e1f8aabf1f8a1e13e43ab3b297c5610"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "1b34e447041667bd9a800afef8f76a250a51f2e162c1be26c66c8c3f6c31edf7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "6e5d12f37a6857f4dbdc8f9e6428c5be2ffcd38a4333645ba6703df739d8ac3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "5b0d5a1985cf979cfdb56cc05d0cfd66de7773e4fef18d36e5a7b0fedcccae89"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "1193ad32d3327eece92de53d8cb80f07d3223cec7c2a8f67685ed331c0085d1f",
-                                "uncompressed-sha256": "d98e12c3f5345c371f5ea716b87a4e5da428068b8ff88d746880948f236e90c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "3993914962f7174e89e98a870e1a640d41e183ed8218b96c768c92e8488772b9",
+                                "uncompressed-sha256": "d8756570d3014709836cbe0acf3cb2d1c1cbda371f8abd91c5529e8b5e640ef7"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "35.20220131.1.0",
+                    "release": "35.20220213.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "d5581eaf98251f871f090888e9eb77a5a72d8757075e70831723e124f4079d0d",
-                                "uncompressed-sha256": "5572699e59ef0f23c9e1794e880e7b14f41db1381c2d1f7c105332dd8c987ae6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "5e7d12a5489db3159737154f16933bf1327336fc2cbdcc6e29b4f542ca9c8152",
+                                "uncompressed-sha256": "5be8c72308249e20fbc20bbe2a8ae26256270c5386b1733a5dd85b98f3a454ce"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220131.1.0",
+                    "release": "35.20220213.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "00062cf37010db6435bfee563defaf6c607bc2d0ab6598104070034f9d7864af",
-                                "uncompressed-sha256": "1b15a835ca1008b1b1ca432537ba00fc6357292217650212c43507211995d359"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "8497d89942ea2fdda96957454bf95ea5600e3b34d4c373883c02a05d86bc910c",
+                                "uncompressed-sha256": "a19bf2d7196cb9c337d33ea4d75efb5ed3d9a06b2f1cbf2b43e4eed9c65aefe0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220131.1.0",
+                    "release": "35.20220213.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e9dda3ac196bb498fcafe5fd3630070f02148c44361d9e5a85e4e2a046e64e90",
-                                "uncompressed-sha256": "619cfeb61943dc86e644f106a523f46af658d01b166d0f09103ca0d13a107637"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "5c2b864678142edd097041b95c13d69c589e06b62d424a1f57ba596499b16640",
+                                "uncompressed-sha256": "4c00d6363148645c0c281ccb8a769558807560aa9d9f639cd3244944d9e8f342"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20220131.1.0",
+                    "release": "35.20220213.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "160896ce5832840609cd0bc3b4ff17568b9dec31ed1f976edc29a7bdd6452018"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "f2ba9c8083a07fd63c20b8baf5de736f65c6177b9595dbd485680799d06b6fe4"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20220131.1.0",
+                    "release": "35.20220213.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220131.1.0/x86_64/fedora-coreos-35.20220131.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "2c9715b317533fee98c9aecd052a52976728a34144e16eb5f8b8c84515ffe7e7",
-                                "uncompressed-sha256": "e41c3ec27e4a0ca5e3a0172491172c34b6250a42ef134b627c6d626628bb58fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "92a69afd574fe6bebb609beabf3b419eb8adbb93c5b057a54db94f3d90edd0f3",
+                                "uncompressed-sha256": "dd6fd085f1a9a833d45cf2a9991fda9a4d61a932b8d713f28ded7dff313f4076"
                             }
                         }
                     }
@@ -407,100 +407,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-031b3319dff40c54c"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0a0cd0e8f1ef6d253"
                         },
                         "ap-east-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0cd88b89da0b82ac3"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0ab96a0ec91e6d9b7"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-045e904c7808fc441"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0d049636d3cab17e1"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-040cb2f7f96b8363f"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-02bfe75599ed6f42f"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0f5cbea5d20dfdfd7"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-08dc81bde802307ba"
                         },
                         "ap-south-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-01531a8f829b626dd"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0b0e3b9d40acc40c6"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0440556b427d40e7d"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-075109509d62c8f1b"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-05a62b3098d8d2299"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0327938a7ba5de17f"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-07bef5d07038ac914"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-09e8deaed10ff322a"
                         },
                         "ca-central-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0143eb540ecd5fa79"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-022227f42eb5881b3"
                         },
                         "eu-central-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-040f052a460926762"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-00888e60839bd3c96"
                         },
                         "eu-north-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-077be138d871e79b2"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-04f6426df26065696"
                         },
                         "eu-south-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-06b7b91a62ef9dfcb"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0f494d85c23fdfd33"
                         },
                         "eu-west-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0351cfb6602407672"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0aa27e5fa778c6edc"
                         },
                         "eu-west-2": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-06fadd084b0dd9fcb"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-02791e1e7a29162a1"
                         },
                         "eu-west-3": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0d04243cbc5fca50e"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-08f0c1a39c428119e"
                         },
                         "me-south-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-020ef94c29b13f567"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-093bcb7d63330191f"
                         },
                         "sa-east-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0846c2ce779bb84f0"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-03b917db8a33b2aa3"
                         },
                         "us-east-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-008db52691656f8b1"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0c20867691710ea7d"
                         },
                         "us-east-2": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0c9b96788432a9fff"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0e8d3faf8e0a9a94d"
                         },
                         "us-west-1": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-07e35e6a9d2705fa7"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-0807bf8681ed714bd"
                         },
                         "us-west-2": {
-                            "release": "35.20220131.1.0",
-                            "image": "ami-0ab03ba458ebe9960"
+                            "release": "35.20220213.1.0",
+                            "image": "ami-02fa7536ce7598a07"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220131.1.0",
+                    "release": "35.20220213.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-35-20220131-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-35-20220213-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,92 +1,92 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-02-02T14:38:59Z",
+        "last-modified": "2022-02-15T18:08:28Z",
         "generator": "fedora-coreos-stream-generator v0.2.2"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220116.3.0",
+                    "release": "35.20220131.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "c5bd63ac3d8a4e6ec48c6776888889e916963a4dcb9ea8489a456825abbc6026",
-                                "uncompressed-sha256": "730afad50f160622dc7c596846adddb5fb148b605098a077b318c7c2e5d4d0c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "fb74d87ab7a28c1dcfc7b0c4a265e73f4c73efdd56e9079bd73eea34523b09dc",
+                                "uncompressed-sha256": "287ef3a8ae62f005add5cb456bcb7a89edfe22a697079e1c4fef9991d88da9db"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220116.3.0",
+                    "release": "35.20220131.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "a7b71e5d8e7492f06952ea08592d4d436c1cf680b784e84a52523de50fc193d0",
-                                "uncompressed-sha256": "cf702e840f70d2e81ca92612f6773ac9a3a3686a4d541fbcbd22eccf6d61ff09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "0da0bf8f6fb53e0acd48b1cbd10a1fcd2dee574d13d0623da9d2326ae6bfe911",
+                                "uncompressed-sha256": "4001dcbbbcc917852653a9ae28355c6b39d68057fdd9db38874d22237dc898bc"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-live.aarch64.iso.sig",
-                                "sha256": "3cf3dca295d6db69eb4b9d84237eb3a86266f05b8bfa3d56f82b1e44f17c523d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-live.aarch64.iso.sig",
+                                "sha256": "a98b11e76b8409007a0fad4281e578a9325ba998d39faf2a8508e52bce752e51"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-live-kernel-aarch64.sig",
                                 "sha256": "8541d9979e98aa85ebc134fd3200eae52e2020333e723c255890323a49436177"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "91d5e9cfeb1dcd3f74f996fd432311814eadd91cbd1b205ddd1fb340b469f387"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "dadb080a0f78b2fa86479d01e6062e0a9779f629e3c17b53c722bb7294538952"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "110ddcc50626dd5387380de4502f8d253313a78522534b280108ac15a4326399"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "cf360b571ff9cee470cd20a5d12c13f4b05128557e95158ecc8bdfdeb2f33eda"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "425d5941dce3a255c374289010636ea4e3a0a7907248d53c2d93510c03a1b62d",
-                                "uncompressed-sha256": "09920ff23d5d2c66c9c78c6d3c2dd7f9c3f923bf950f2de5c0ae3e99994112b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "1c78f48abc849b2fc1620bef032c87a634ab7c129ee8279ab388b772936b02a9",
+                                "uncompressed-sha256": "83c38f6460cb343d258bc6724526b220c30bb242bef27e839ec1915d1a8b5b27"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220116.3.0",
+                    "release": "35.20220131.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "f20c3fff9f69467c624eba0c7b90540bdc1ac7539a3327e65b0b0002659a9eeb",
-                                "uncompressed-sha256": "58dc5c2781206c4ee365ab78e14ad4bd27afc19a437df616ece72cc37caa53e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "3c2d55cf183e98f2d3e71eddc8f3b79ff828908a12c1d5e267d00048a4ad7c32",
+                                "uncompressed-sha256": "6ae93855fb8a152d164afaa85472e7f012a829e36a4c0c6bb98e6c3e0701e23e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220116.3.0",
+                    "release": "35.20220131.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/aarch64/fedora-coreos-35.20220116.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "6705d5d990fc5dc8921e2abf1c8569cdc1e2b3f06df20cd868130a1ecf3c830c",
-                                "uncompressed-sha256": "cd6f49d112b11000c98b6272e38debbecf0f9014ef210f4ddbdd67495a9aad3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "02de579dc9d9a5f1c1a1870aba16600f53a304b759743d74168ff2520313a9ce",
+                                "uncompressed-sha256": "4e4e28af20265f0ed5d604c822d5bdc1e27a9ae1079e70a831bdf756aabeae32"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-005ad708af7e6e135"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-029aa950f45645aea"
                         },
                         "ap-east-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-091fce459ddac74ed"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0b3beac9e03d4d6ee"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-0546af5f446cf276f"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-07ef12021cbdf21cd"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-09c20376dc0367918"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-075a2b531dc10f0cd"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-0d552bfeb3e508f26"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0d8703a94d9031501"
                         },
                         "ap-south-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-008e9951222796636"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-03cd4db6241702f7d"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-02c0a5d18c87e1be7"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-02b7cc5d7e20ba996"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-060d83aa3ccc7e1a2"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0559ee7fdaa3f4dd1"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-033c67d3facd54f4d"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-021c764b883861b7b"
                         },
                         "ca-central-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-018885050abf53478"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-08206e0252a5f4aed"
                         },
                         "eu-central-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-0f79ab7f3248307a0"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0e33a11c4f3adae4f"
                         },
                         "eu-north-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-02d23f89c191939fe"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-08311960ca892c8f6"
                         },
                         "eu-south-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-03e731ece2da2d3dc"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-057f285f19a0a5345"
                         },
                         "eu-west-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-0eec9689d4f265114"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-037511ea5de170037"
                         },
                         "eu-west-2": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-0ddb529baca7bc4ec"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-05eea0c1b87222961"
                         },
                         "eu-west-3": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-0cf2bcdf48d74ced8"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0ec5d030ea498d31d"
                         },
                         "me-south-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-085cc2bf9242b2277"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0ccc4d6d6f5c24bc5"
                         },
                         "sa-east-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-05e1e855ca6e1c697"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-02d727b82bf32b151"
                         },
                         "us-east-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-0d603cec9507c6d1a"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0a1caf7189177752e"
                         },
                         "us-east-2": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-05755d4e1afd6e9da"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-064bf257437cc589b"
                         },
                         "us-west-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-05e9f5a4c7bf4d1a7"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-011b73f3e0a2abe91"
                         },
                         "us-west-2": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-01cf27ac729a40c17"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-067b4da020522661a"
                         }
                     }
                 }
@@ -190,214 +190,214 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20220116.3.0",
+                    "release": "35.20220131.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "a2e7a79f9171ce001225832561650ef410e94e81042e174a06d18d7397a82d2e",
-                                "uncompressed-sha256": "39ed3c857ea366fa61546efa4e39a63601aed14962c5bdff5a958d40efa53c8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "e369e93206d1f43783bbf6eccc8e67a62aca0f407d1352c997dd065e71e43f61",
+                                "uncompressed-sha256": "3cd14f3327ffcb3e5d7892e30a4027ecfc4493df77f94b57ae6b8868ba8ded4f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20220116.3.0",
+                    "release": "35.20220131.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "7cf5018556c8694912ea1cad099cafb1f984fefd00baf321d0d92dc1ddd90471",
-                                "uncompressed-sha256": "4f74b77ba3683bd5a80f3dd59d76ae691efccc05175c56aee7bb899ac020cbd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "ebfdaea9965568c9286322e8144711488392837f6916f95ca9f761564ac84e0e",
+                                "uncompressed-sha256": "4ec51bfbdb567b93add340eb04ae41cdd6f8793eccad801d1f660c05bb00bf01"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20220116.3.0",
+                    "release": "35.20220131.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "2b4ef982c0e196edb2df2620039783704a6acf15f8497a567e4611513233f583",
-                                "uncompressed-sha256": "141161cf85a85b00363301c6c3c5ddc7cbe4df349b273cf3bf23b75b8cd3b32d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "8000383d7af7a6d000f21cc52bd94d136cbbac4ad1ff350a548d40da0e50bd81",
+                                "uncompressed-sha256": "00c59e5cbaf207b765a41ace96a136cf53c1a2a7051dd0202c726f7cfde62fbb"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20220116.3.0",
+                    "release": "35.20220131.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "b8f4d0da17d535f31efa7515bd38ff16bde0f4392286c7cb5101d661a583571e",
-                                "uncompressed-sha256": "3324b7662b6a4d656ace9b305c1b3e427b680bdf88a7fdae27bda90af908b28b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "8d1ca5dfb799c954bd4b4c96a696d9ef37eaa4da95f0a4ffd5ec1b90480de0bb",
+                                "uncompressed-sha256": "5eec12983670b1e4d332ec02454fa0ed5318fc74168a6c3190917dad36a28826"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20220116.3.0",
+                    "release": "35.20220131.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "56a58b0f3ba43f98463665899bff612c12156ad4b16316b806b23287e9d5db6b",
-                                "uncompressed-sha256": "d5a0ed0c6b67f08d2c7dbdf1b476e4b5d03b9599176c3ca88197431342cc6836"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "42140d1e97b6f871bcbcdcf5691d5415987b842ccd411f351e0ccec5f2f12325",
+                                "uncompressed-sha256": "4e80604ea81c8591bb94f51814412d5932c947adda2977d89eb3f480c2e28bac"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20220116.3.0",
+                    "release": "35.20220131.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "93fec116ed40dc938f2f8cd2394c70770a5c04b9ef507fdf10cb3fc414c06014",
-                                "uncompressed-sha256": "38784352e9ffbdf3206331b12d84520af86cd2156c0b9d79e43c58c8343a419d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "7c5ba0b75304fd4998e00f827e8c00b425185e965c148ff425eb1f63d53ce3bb",
+                                "uncompressed-sha256": "e07415f3bf8411a68e25bdc94c6cbdf643324b44d3114db9e216073693f7cb59"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220116.3.0",
+                    "release": "35.20220131.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "6dfc1a20a306b75f955b3d77121ecfbb728944b8e654cbd21ad340c5118c6691",
-                                "uncompressed-sha256": "48f8b87670eb0c4c5edfbba1c2bd2f798721c9818ca41ec66ff09ce0d79786e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "d1e5bafb13ec662db190922ffd23ddbfdb9902e63fbdcc0a29ff8b8decda914c",
+                                "uncompressed-sha256": "7b274e8f8b6ed290a15c6fa1fd070cc8a4ba6219e903a5a585d2fdf197dbc452"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20220116.3.0",
+                    "release": "35.20220131.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "43a97a3fd94548620e4f69d5a04c78167b72dfa466acae949a3620a37d78fad3",
-                                "uncompressed-sha256": "4c632c377e7999f43789dbb0cf88dce23c0e6695d1bcb78f591c4949f91e915b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "0e8dcef140ac4c88fe18102307eca2e86bb00380587e4dfd49e01095bb0fb586",
+                                "uncompressed-sha256": "1292f66643c64c4eec180a52ba9507d98a19eaf9e198a5a3a1fb944f08d42ebd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220116.3.0",
+                    "release": "35.20220131.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "ef98e9afb2116c8a1d3eac54abb86c42247cd2756157c07957784a683cf19b8e",
-                                "uncompressed-sha256": "cfe6bd6f8d50db96f0fcf2099994c5dd80cabe37e07785f63b6752af7c3ed34e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "54b88ac0f74bdeb1ba75ae77e3f4608c4726f22f38704abb1b2b88fda4951073",
+                                "uncompressed-sha256": "58489436c469325dcadead6962f4548218e7d046317aab7e1a413e676619f923"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-live.x86_64.iso.sig",
-                                "sha256": "d491d100645786eb95d53a2411d07349a95c0167426fbee73a988b92afbdf58a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-live.x86_64.iso.sig",
+                                "sha256": "3557d9426fa94f2a04c9f2ed55b9b93e42b6c3bdf9ba82e6c9b4c7b4f313a8a9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-live-kernel-x86_64.sig",
                                 "sha256": "246720fce1961aa468d02804f2d71f56b6579d68ed60c2c7836dc497dc062fe5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "8b06eb6979103b33eb5378ef5923cf868444564a387a9f842df17bb9cd87a7fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "6d8666863dcd29813aa527a04ca82b8830c4e99eff990bdd52e599aad8de4337"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "5ea5c03edba1996b4371d7499fbfbb91083c39ca4520f669e9284ea2c0ed2090"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "2684951ccc7f5d82f3e03599c6f103ee4febaaa80c7cb6491951b48c68421229"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "6f7b873f8d1086c3c2255ca4eb71b9c5ee860b1e3c1e0573e8f64ee2dab90b2a",
-                                "uncompressed-sha256": "71e03d5cee9a2cca50685855e37de148d4616232242e377c89eb6ed0a4e7de0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "8bdeb822562edb8afe324550bf2e3947e830fc906fa671d6f4eb6f3150cab853",
+                                "uncompressed-sha256": "4393bfa8eb28618af35f2323837218d7f4cea1f6792160d2ee187f69a30f5d99"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "35.20220116.3.0",
+                    "release": "35.20220131.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "d885fc019269ba4e315c2903dc96f53b9617c19d550e81e8c6cd7a665583b0b8",
-                                "uncompressed-sha256": "a34510d0239366e5464d4ec6faa4697e1f7853a868a389df678c7217edba3184"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "9978c515237e91d9dccac3423be4e3c2e9946fd2eb506c89307fcb828fcbe676",
+                                "uncompressed-sha256": "f64f3ab465f67a145d50deedb7f431a012017df11700de373bad88cfa747f1f9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220116.3.0",
+                    "release": "35.20220131.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "17b89fc6bb490940ede4e41de11389f867c4802c0f3c24f4ad475cb3c8f750ed",
-                                "uncompressed-sha256": "c44479ba9f4bb219e924839f04fdc30149137e23bfd5c63429b8e52cb7b90d04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "bc4cc3243e2418631971e3b26c737f70109cb8d76324c8dd455e3339a7b76993",
+                                "uncompressed-sha256": "975515bd415a9359ac870a1f6836933a54ab60db619f8c5c14db9706a63b6061"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220116.3.0",
+                    "release": "35.20220131.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "42fe6f0784da5c7127b6d1da7156ff540a842cf21d5a078681c063c6f2897d12",
-                                "uncompressed-sha256": "df589709416910f96449ef132669c081af0bced140f40ca61079dc741b45e395"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "7342de6bbe9537e2e71415425706b1173704f5746aeeebfccff01435cccf0179",
+                                "uncompressed-sha256": "662f56a01367337925c1f9e4879db5a687b22e673bbe95036505122f02883ae1"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20220116.3.0",
+                    "release": "35.20220131.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "d690f86993f5ecae729dc6327205b49930b7326c931149063ed9b246aaac2f4d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "a2658cc6289160cd50f157983e5727af98d976bba85879dc3c2392b650632c54"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20220116.3.0",
+                    "release": "35.20220131.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220116.3.0/x86_64/fedora-coreos-35.20220116.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "311fd88c039d2f3c8f4b73f68321a70c39b253df340560fb42ccae44c8e1bd83",
-                                "uncompressed-sha256": "c82d1234ab484e9798607a93c3b1ca6e4f110108a33131c55723260ab789ee08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "996be3e6b6621630f05c4d8e090f2dff71fbb7dca4ec70e926f98140eb048ac9",
+                                "uncompressed-sha256": "c8a098a5b867d29988b43f268bdcdde6fcbdbb9d9f145f16084351dbe64b328a"
                             }
                         }
                     }
@@ -407,100 +407,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-01dccf98168d25614"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0d7dffee79bc75cb9"
                         },
                         "ap-east-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-0442f79e4ceead79b"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0cf828d0d8d60efd8"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-03ab3373c4cdaad10"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0d5338124f8acdafe"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-08c44077438b106e1"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-058e724b2743d89b4"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-07774c91604c2c606"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0958a026e4feb267e"
                         },
                         "ap-south-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-022a283ef9f5e0229"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0a9b0a29f001aab78"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-07aca7a236baee995"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0ad5f7dec4de4bfc1"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-021e870e65e904303"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-04ca148c5cffba2e0"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-0404ff550e58d0b02"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-032c546157088c446"
                         },
                         "ca-central-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-00f1e813bf6df159f"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0cfa10fbc35d1a8ff"
                         },
                         "eu-central-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-01cd01b45986e15ad"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0dbddf4bd613898e9"
                         },
                         "eu-north-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-0a9ca8ef4d489b125"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-01ffc5c9756d4986a"
                         },
                         "eu-south-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-0d967c8ae3b6c54df"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0eace9fbb3ec117d6"
                         },
                         "eu-west-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-0063b41519559e356"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0b12902a541809f70"
                         },
                         "eu-west-2": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-03e198424491c4188"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0bfb62a1ace3df24e"
                         },
                         "eu-west-3": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-03f1d420b7a1cc878"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0f84940a129d40262"
                         },
                         "me-south-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-0482e6b87eb9aca83"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0361ebf1c2d0ab77c"
                         },
                         "sa-east-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-0b999bf4680d02710"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-04bc8bdabf1a6f313"
                         },
                         "us-east-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-02893d32330a6332a"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-04fc9c162cb5bf796"
                         },
                         "us-east-2": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-02bcc8e6a2c68fd73"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0f8912c7897cd9b9a"
                         },
                         "us-west-1": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-0045db79b1ea9e003"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0affd003fe89bd2cc"
                         },
                         "us-west-2": {
-                            "release": "35.20220116.3.0",
-                            "image": "ami-08ffbf521d0a950ee"
+                            "release": "35.20220131.3.0",
+                            "image": "ami-0356cac95b1e86503"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220116.3.0",
+                    "release": "35.20220131.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-35-20220116-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-35-20220131-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-02-02T14:39:00Z",
+        "last-modified": "2022-02-15T18:08:29Z",
         "generator": "fedora-coreos-stream-generator v0.2.2"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220131.2.0",
+                    "release": "35.20220213.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "d79c2cdc66abda0291a3a0aaba3da47785793d36d76ec588de562a67cdb136a4",
-                                "uncompressed-sha256": "59d346f2a7ed3d2329b8d673664323ec0b484d86ef56d3c09094454abfbd82f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "bc6448bb54cd64eeb0313cd814a5d3d9b530edb6bdc34d032dfd8bb3308d07f8",
+                                "uncompressed-sha256": "9567a633d18b52767976cdcb20500bc7b3b0911b88f7f7e57d5d0aa79c149235"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220131.2.0",
+                    "release": "35.20220213.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "f9cc565479b3955a570ad75846d7f80b7c4de20e83fabe3336382779598dec1c",
-                                "uncompressed-sha256": "98dfbde9d4ba4953653d00f1830a7e48cc16db67ec241a7e04934947d0b9d8ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "cd892802b7904ee7e0fe9453504a6216be461761537b4b91d141a5aef6f2f857",
+                                "uncompressed-sha256": "ace6508f15426e9e1f36868cf96807e4c696e91d4a768bdb427695a982409be5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-live.aarch64.iso.sig",
-                                "sha256": "dded315ce6040c51e6e3940d088c845b446fff108192b58b463ac35b80cb164e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-live.aarch64.iso.sig",
+                                "sha256": "60c4c3dd83fcc11e1a9982026aa089afba2378463ef968b20ae8e8eeabdbcd65"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-live-kernel-aarch64.sig",
-                                "sha256": "8541d9979e98aa85ebc134fd3200eae52e2020333e723c255890323a49436177"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-live-kernel-aarch64.sig",
+                                "sha256": "497b13809b045f99031cdd1ba12d53014cd28a6798b7e504bb8b50d40e8c9f17"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "85acab7c1cfddefdce183d9d0be58ba315b1281c44c1578387a3f812ee9e968e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "6b4c2b2bb3632fdf9f0e02b8e843f97a80ebb8e500edbbc82d992a937fa6ce07"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "f99dbfb9b878f78e4dff8d038cf94db7a163115a925f5526c49901220c225ff6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "d1ce4e358e6630d54455bfe2dfc6d3f6cf3a885cc6f498f667b5976ccee1dea1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "218d637cb4c6837e6b85c5bcbca52772bb517dcfad79c33203d27d96c1ccaa74",
-                                "uncompressed-sha256": "763853ccf62f94b6d7d6abf8800799b42103528469467973a4f02d0e2f18035e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "cefb77e587c8f86404eb284f238ff11632e4915969b14852a812589d39a633eb",
+                                "uncompressed-sha256": "a5f72bea5f9d7cd2225f39266ee48fd6df864d97d844edbf96627ac045813ba7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220131.2.0",
+                    "release": "35.20220213.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "61d64e4b39cb87f90053e157df5356cfd968faf1bb8401882225a507c2e379d6",
-                                "uncompressed-sha256": "b6550661a798afc6a651db0d8518f565a02b9bb3608c5d3dd1184644d5957efa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "3d222337acbbe16e83d06092fe274096f92667af445aefde976845ce0e3d1aa0",
+                                "uncompressed-sha256": "0c797c11cbe32f0a4cbf2227aaa474107c40d96c05c29ce342b23f7f43e07be9"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220131.2.0",
+                    "release": "35.20220213.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/aarch64/fedora-coreos-35.20220131.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "0db5707717b1fea0115a6dd5454158252f15642e6b5c13add9297ef534b3aa68",
-                                "uncompressed-sha256": "f76166203975a6e65bf37ad29022ced75b128bc05e63e6fb06b319b75d7fc500"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "6d06f223ef5fafc146fc36210d49738d657ab844f9a3d153d410c0075dc9bdab",
+                                "uncompressed-sha256": "9bdb5d6ca3befe572a8c0fa6ea6ad0c5feee41c98a5afd62ecd88506aeb37a8b"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0bf408bdb5b7ebb27"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-08cf3e8c5217c2be5"
                         },
                         "ap-east-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0737e828bf85817fa"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-038f0b2127534d256"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-01276a7dfe84149fa"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0ba4eb3de14203fd7"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-03f247ec6134fa44a"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-02e5b39c92ee95103"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-009bdf352fc4b5202"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0a5057e9df28013aa"
                         },
                         "ap-south-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0cb3446850eb606c1"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0569adc043b323f64"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-023b1a1d09c546eee"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-091d7efb9112ed0c3"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0369980f83e16b6f8"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-008606103e380b946"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0f4d94de45cece940"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0d0ffd5131711eb12"
                         },
                         "ca-central-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0f1448c1948102b8b"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0ea99514aaba61ec1"
                         },
                         "eu-central-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-03983754e9ee37587"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0e6d85b90d8b66963"
                         },
                         "eu-north-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-049099c04e87d0798"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-008f0bbf338ec122b"
                         },
                         "eu-south-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0f9b4277ee02583c2"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-041b70b28f41995fb"
                         },
                         "eu-west-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0585cdf51ce17aa52"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0e2923ca864fe42f6"
                         },
                         "eu-west-2": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0a3640011ff085676"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-08a8644ced3c26663"
                         },
                         "eu-west-3": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0c258c67f569c52dd"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0050f73008b491ed2"
                         },
                         "me-south-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-054a399066aeece84"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0700090e6a05e0f02"
                         },
                         "sa-east-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0a74e4f92365541f2"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-06424fb4797fa0533"
                         },
                         "us-east-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0cc35b566168e17f8"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0f3e407df13c1cb59"
                         },
                         "us-east-2": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0818921db05d5b8f2"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0c1d5b876e5d2af38"
                         },
                         "us-west-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-09586ddbd029b9090"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-04ee925c6a2c52da6"
                         },
                         "us-west-2": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0264fe80ab649b137"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-011589fc2b7b54c3f"
                         }
                     }
                 }
@@ -190,214 +190,214 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20220131.2.0",
+                    "release": "35.20220213.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "406196a31a6f852b477ef241c84a33a8693225d2dfd147c94cfc12c1c59fdc20",
-                                "uncompressed-sha256": "e93bae8fa142e6389768154e23b376030472f8adc17c742d17c291dad35419d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8f86c20198aca6684e77b0d3b292bf21c885aca96b5ca0c77d6f71695bcd2e2c",
+                                "uncompressed-sha256": "eaac77ee1de5ad9cbf3ed0ceb73b175b454a796780b59b3a31cd6bee1a9cb80e"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20220131.2.0",
+                    "release": "35.20220213.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "690e75e05c123554373b44eba455ce0cdb16bd4536ae6eeb8086ba2e434a6049",
-                                "uncompressed-sha256": "33855fb24cf5359ebb3a8051b8a33b7794dca046e8e369ac597d2c6ce02ab28d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "aa980b66ab92bc477bebae6e911faa7f4466031e037b288509c9db51351260db",
+                                "uncompressed-sha256": "a721ae528fa0acd03711b2e8c645c5bc79341640f11ccee83ca3e70433150e0f"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20220131.2.0",
+                    "release": "35.20220213.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "37de2e964d15cbcdabcf4bfc68f27faab944bf23e3f96823769139520b1436b1",
-                                "uncompressed-sha256": "9e4d82c83effffbc8fda361165aaa1dde8c1c534cd7b87e61e631e4d6d63dbaa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "54ac81b55bea695447bb6f87b8a0775772df58a67a7099d2d06ea8a2825503dd",
+                                "uncompressed-sha256": "b0edd3e2f83565cf191c230a8db3bea48bfa78a75e109aaf4e8a6aa51c79b825"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20220131.2.0",
+                    "release": "35.20220213.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "db009c1a1ca1b08b45b9efcfde3c014f737c865ff598f9ada491729a48625095",
-                                "uncompressed-sha256": "a67fa89cb27f6b0079a4641e94654899e2640648d3963540927dbaac3e44c50d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "a570d8d4d48ffec57e0b7b6f496d25624c634ccefd35fcd8edd175212a240c5f",
+                                "uncompressed-sha256": "ee2e02348dbef29c7b659578ef577e9def11375b63b26651c7348b71657c786d"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20220131.2.0",
+                    "release": "35.20220213.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "85ff05defc8ed01f4c2c18a33389dca8ffa4e6bf9bee5352d71e5a4a09e98fb8",
-                                "uncompressed-sha256": "9892e62f49f51718afac6a61ff5805e95ea0578f3a5523beb2eeddf2417e6b50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "40d94104161d4a0ae66b971586fdf21b9e0a7b55eefb8b4fa16386fe76208471",
+                                "uncompressed-sha256": "0a90c9b448f7283f48f1db571e24a309f9b52b9083d6597a3d29000738d33662"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20220131.2.0",
+                    "release": "35.20220213.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "e01242ae36114a0313f4f6c5c947524972c1f2194bb744c2050e0bc1b39d6025",
-                                "uncompressed-sha256": "230a31a1820f4b9de80f627fd43f57879b5ef810b37dd69aa6074ce17055f6a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "00b05e0405fc7ff7478df1def165f673415e67895b713e0656b89a50e0c367eb",
+                                "uncompressed-sha256": "1f4521c1ae4e0d0fd6ca7cfd8455a80ff78ad740decbeaa4beb1198cfd279306"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220131.2.0",
+                    "release": "35.20220213.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "fcfa1db83d950f6855ef533a718ff5339123aa8f0b262cf09641a3df9cb1110b",
-                                "uncompressed-sha256": "5791238fb6b8878264d1fcd2b69ee0ea71468052d5775700d2c6bdd8fc8a4a5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "d13a0738811ae1fe538d03971c91afc524662f050f94789e1c24d4195e47fdca",
+                                "uncompressed-sha256": "4ad0151a61c5ee3f427cdead8202ab543791670266fd5c32e571c11866a691ff"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20220131.2.0",
+                    "release": "35.20220213.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "192901c7afe7874761a5e66df5d0d54683d0c050735bed8bc0fdbd5c7558d87d",
-                                "uncompressed-sha256": "4032f4e17229e363d45f70d047d715f11ec24238ef34d9395bb936b703cb34bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "e2c0b5cf60d68d2db01edb7c914cc3bd8663b4a02d4087b7df31f4536f229172",
+                                "uncompressed-sha256": "839e774691d2387b746379330439b14dc3ea82d53f6f120f7868b4d0a043b466"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220131.2.0",
+                    "release": "35.20220213.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "1c71146b553e19fd84df667a567abeeb0bb59254c53d6c25ebac15c2164d7e5a",
-                                "uncompressed-sha256": "f5beb153fc510b4e0a7df02f642a658f0a9175494ab238d97a0ab471228be5ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "4a3f5b7d2bed29f5759447b8b58a33fc26dabaf5f7eebf73c664761f737b0f80",
+                                "uncompressed-sha256": "3f54d4b9ac126a287f19ad3719a0566a1ad25c53dd4befb9b9ede7616269e75b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-live.x86_64.iso.sig",
-                                "sha256": "803158350a99876bf32c343cd571681c9c775ac96ebf5e9c5d6694bc8b93438a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-live.x86_64.iso.sig",
+                                "sha256": "232e3a6d078d0e126769007b365ad1670d4ac1497fdc14fc76abd71ae0dd7dc8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-live-kernel-x86_64.sig",
-                                "sha256": "246720fce1961aa468d02804f2d71f56b6579d68ed60c2c7836dc497dc062fe5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-live-kernel-x86_64.sig",
+                                "sha256": "819fda78ef91bbb41809433c36e2047c5fcf4324b7d14b3a4a13b77d47565a3d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "e36477cdc73a2c09bf6f78ab4a240e5e076dbe7c15a496a3a78e18cd228f402b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "d6e79a8bf8f72a844a918ea582e3c5c0fd5f62c55cd083eda5fed50fc8793c3f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "57dac362a06949a3ad706d31e7f1bb312b636c1eb8ee346b05f8faa2e2daceb3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "7c016258351f2962e87e572beede1158f9269c67c2e2257aa7b11e6a90e12c61"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f78af437b14f70bf78e27d039dbca32048e7cc39f255bc5900d90273b681c220",
-                                "uncompressed-sha256": "f1cc35adadf57bad77d4e3a8cce66ceeb3b4418e26559d897e35a34addbc8a90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "e20f4570892bf8296689cf9b46cf04793333132f988caa1c36639ba4b262da46",
+                                "uncompressed-sha256": "a7059eca35ac237336955232b47353d01b7e212d99f2a5aab7f15ccd6bc275d7"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "35.20220131.2.0",
+                    "release": "35.20220213.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "0389f124cce2e4c30dcd09ea2ca313db6279543e615f5d9c8944c8fd6e5f89aa",
-                                "uncompressed-sha256": "8e3f333ea76ccfd928823bf182fd936dd57960261c9698a247307d7067f62878"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "854327e12870309a7646d26ba4dee83d78ab94ae3e102a591828a2b057715076",
+                                "uncompressed-sha256": "f708500d100a922277b4af4495be7dabb65e3b00617520f5ad70e459802a93fd"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220131.2.0",
+                    "release": "35.20220213.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "9643a33d56d2ebba059d6b1401797012cda0c0ae563989fee3290da55290330b",
-                                "uncompressed-sha256": "71c73e412734f7562e1fedc016836817118c16c419c9d1581c4769948c5d85df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "dba22301f21df82c836a719c5cf56ffe48536b3d96bd4865a4f5ba3b11391f0f",
+                                "uncompressed-sha256": "a4f1547178f819211b6a5440add930a639669edc40fd9b416245d1047328ab9a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220131.2.0",
+                    "release": "35.20220213.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "8eddbdbe2ef2e2f9b6eec9c90b55380110e56b5912ec8723f3b07981071b07c9",
-                                "uncompressed-sha256": "1c34a76f41e2eba924f4331067e815878460705da92805a71c70df7bb5b0372e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "cc2d07fb9eee125dcc4a946bf3f266b34c94a41a943adf3a99f02f26601c8ec8",
+                                "uncompressed-sha256": "376af02865b9f614de45b83d5d6086afdc260c0602a57038b6d73c383d034931"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20220131.2.0",
+                    "release": "35.20220213.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "3f2be1680eed9e5bd9313605c604967099424fa69999e1960aa23f839c107332"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "4d8ef869310f55738f13ba99bb4cbc88599bd4a9bcfffd50f4d42bde7805049b"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20220131.2.0",
+                    "release": "35.20220213.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220131.2.0/x86_64/fedora-coreos-35.20220131.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "84de61ab6ecfb467ba11d6d890f1607a1f3bfe71815e80ebd5b3f2317e4f2067",
-                                "uncompressed-sha256": "76d64f23bc96df975ea25e4a1f5271b53d1732479812d8e3a20db9702bc17e84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "e73a6abec6fb44ece014d07d535da4fd30d9d9af7587befb4e93a4a0fab935eb",
+                                "uncompressed-sha256": "ff7cebb706a4913c828217cdcc34850fde382ab506eb72aad6d5e2a42ff07ca0"
                             }
                         }
                     }
@@ -407,100 +407,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0eb5e307cf5f3bd4b"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0319bf7189ac85ff0"
                         },
                         "ap-east-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0ff8342c0ae78868e"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-07531a214944b285c"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0984dd3904711fa02"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0a716b96a405f111d"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-019ca028b24612462"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0a17ea0ebd906cd45"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0ab1b9a3c16986b70"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0047329a12948572d"
                         },
                         "ap-south-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0c9752f47359435c2"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0dceaa797d978c066"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0a121158b2674b7d7"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-041563cf894c64166"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0b39b9e374849bd4a"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0bccd304cdba08c13"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0ca19445d0133d23f"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-033c4c60be5669fe2"
                         },
                         "ca-central-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0b631a7be8aa6efdc"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0c6b10d52f2eff30b"
                         },
                         "eu-central-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0eff44d62eb7d69bb"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0eec56090150a673e"
                         },
                         "eu-north-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-05b99634db22c1976"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0164e0edbd2b75333"
                         },
                         "eu-south-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-00d487a5ae0b0083f"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-00bd91801f8f65cff"
                         },
                         "eu-west-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-07c3c455f3d820cba"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0bcc8c603220e20b6"
                         },
                         "eu-west-2": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0f0fae3645f38838e"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-064526f874517ef46"
                         },
                         "eu-west-3": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0fdea4c39b2f8a44d"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0fd6f29b2f0117131"
                         },
                         "me-south-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-006eef4530acd4b3d"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-06f75871363b73828"
                         },
                         "sa-east-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0a1bff7cf92f10cea"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-076b1cf25f26db223"
                         },
                         "us-east-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-00f6fef9aec04b4b6"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0297b11c78bad6a9e"
                         },
                         "us-east-2": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-053a395c8b174c3d5"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-026f38fb14511653a"
                         },
                         "us-west-1": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0ee514606c11b6da3"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0d0819237c34b411f"
                         },
                         "us-west-2": {
-                            "release": "35.20220131.2.0",
-                            "image": "ami-0dddd708136ad4d5e"
+                            "release": "35.20220213.2.0",
+                            "image": "ami-0763622c9b4f43a8a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220131.2.0",
+                    "release": "35.20220213.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-35-20220131-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-35-20220213-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-02-02T14:39:05Z"
+    "last-modified": "2022-02-15T18:08:30Z"
   },
   "releases": [
     {
@@ -45,7 +45,7 @@
       }
     },
     {
-      "version": "35.20220116.1.1",
+      "version": "35.20220131.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -53,11 +53,11 @@
       }
     },
     {
-      "version": "35.20220131.1.0",
+      "version": "35.20220213.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1643817600,
+          "start_epoch": 1644955200,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-02-02T14:39:00Z"
+    "last-modified": "2022-02-15T18:08:29Z"
   },
   "releases": [
     {
@@ -53,7 +53,7 @@
       }
     },
     {
-      "version": "35.20220103.3.0",
+      "version": "35.20220116.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -61,11 +61,11 @@
       }
     },
     {
-      "version": "35.20220116.3.0",
+      "version": "35.20220131.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1643817600,
+          "start_epoch": 1644955200,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-02-02T14:39:01Z"
+    "last-modified": "2022-02-15T18:08:30Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "35.20220116.2.1",
+      "version": "35.20220131.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "35.20220131.2.0",
+      "version": "35.20220213.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1643817600,
+          "start_epoch": 1644955200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @saqibali-2k via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).