### PR TITLE
workflows: add job to check stream metadata for unexpected changes

### DIFF
--- a/.github/workflows/stream-diff.yml
+++ b/.github/workflows/stream-diff.yml
@@ -1,0 +1,38 @@
+---
+name: Check stream diffs
+on:
+  pull_request:
+    branches: [main]
+    paths: ["streams/*.json"]
+permissions:
+  contents: read
+
+jobs:
+  stream-diff:
+    name: Check stream diffs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Genericize new metadata
+        run: |
+          mkdir -p new/streams
+          for stream in streams/*.json; do
+              echo "${stream}"
+              ci/genericize-stream.py "${stream}" > "new/${stream}"
+          done
+      - name: Genericize old metadata
+        run: |
+          git checkout "${GITHUB_BASE_REF}"
+          mkdir -p old/streams
+          for stream in streams/*.json; do
+              echo "${stream}"
+              ci/genericize-stream.py "${stream}" > "old/${stream}"
+          done
+      - name: Compare genericized metadata
+        uses: coreos/check-diff@main
+        with:
+          basedir: old
+          patchdir: new

--- a/ci/genericize-stream.py
+++ b/ci/genericize-stream.py
@@ -1,0 +1,84 @@
+#!/usr/bin/python3
+
+import json
+import sys
+
+def walk(item, cb_obj=None, cb_list=None, cb_str=None):
+    '''Recursively descend a JSON dict, calling callbacks for each type.
+    cb_str() must return the replacement string.'''
+    if isinstance(item, dict):
+        ret = {}
+        for k, v in item.items():
+            ret[k] = walk(v, cb_obj, cb_list, cb_str)
+        if cb_obj:
+            cb_obj(ret)
+        return ret
+    elif isinstance(item, list):
+        ret = []
+        for v in item:
+            ret.append(walk(v, cb_obj, cb_list, cb_str))
+        if cb_list:
+            cb_list(ret)
+        return ret
+    elif isinstance(item, str):
+        if cb_str:
+            item = cb_str(item)
+        return item
+    else:
+        return item
+
+
+def replace_string(tree, old, new):
+    '''Replace substring old with new throughout tree.'''
+    return walk(tree, cb_str=lambda s: s.replace(old, new))
+
+
+def replace_key(tree, key, new):
+    '''Replace the value of key with new throughout tree.'''
+    def cb_obj(o):
+        if key in o:
+            o[key] = new
+    return walk(tree, cb_obj=cb_obj)
+
+
+def get_releases(stream):
+    '''Get all releases mentioned in the stream metadata.'''
+    releases = set()
+    def cb_obj(obj):
+        release = obj.get('release', None)
+        if release:
+            releases.add(release)
+    walk(stream, cb_obj=cb_obj)
+    return releases
+
+
+def genericize_stream(path):
+    '''Load the stream metadata at path and remove all version-specific
+    references.'''
+    with open(path) as f:
+        input = f.read()
+
+    stream = json.loads(input)
+    stream['metadata']['last-modified'] = 'LAST-MODIFIED'
+    stream = replace_key(stream, 'sha256', 'HASH')
+    stream = replace_key(stream, 'uncompressed-sha256', 'HASH')
+    for release in get_releases(stream):
+        stream = replace_string(stream, release, 'RELEASE')
+        # for GCP image name
+        stream = replace_string(stream, release.replace('.', '-'), 'RELEASE')
+    # replace AMI IDs
+    for arch in stream['architectures'].values():
+        aws = arch.get('images', {}).get('aws', {})
+        aws['regions'] = replace_key(aws.get('regions', {}), 'image', 'AMI')
+    output = json.dumps(stream, indent=4)
+
+    if len(input.splitlines()) != len(output.splitlines()):
+        # This could make the interdiff annotations appear on the wrong lines,
+        # and shouldn't happen provided that the input data is
+        # pretty-printed, so fail.
+        raise Exception('Genericizing stream metadata changed the line count')
+    return output
+
+
+if __name__ == '__main__':
+    print(genericize_stream(sys.argv[1]))


### PR DESCRIPTION
Stream metadata updates are large diffs containing mostly routine changes, with a small chance of serious breakage.  Reviewing them is tedious and reviewers have overlooked problems in the past.  To aid PR reviews, add a CI job that "genericizes" stream metadata from both the base branch and the PR (by replacing strings that routinely change) and then compares the two.  If there are any remaining differences, fail the job (which will not block merge) and add annotation boxes to the GitHub diff view that mark the unexpected differences:

![image](https://user-images.githubusercontent.com/361374/154257875-cc781593-79ac-4636-8c3e-122d34eb0d1d.png)

Proposed by @jlebon.