### PR TITLE
Roll out stable 35.20220213.3.0, testing 35.20220227.2.0, next 35.20220227.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-02-15T18:08:30Z",
+        "last-modified": "2022-03-01T18:21:44Z",
         "generator": "fedora-coreos-stream-generator v0.2.2"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220213.1.0",
+                    "release": "35.20220227.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "d38158d244dc859153b80b043cf93abbf27a96aae55e6353db7c558e2929ffab",
-                                "uncompressed-sha256": "da2f7bfb9b5f600ffa3ca791724c3ef007103717a4ddbc74c8286158d5f180b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "89bbcacc5b7e0177b2afb7f3d7341f35cef7d7430c31c06fc06c0ecf3a7aace5",
+                                "uncompressed-sha256": "abea5e8e159ac6ee5c515a03d72f7926355bade58addcfda2474c611201cf9e2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220213.1.0",
+                    "release": "35.20220227.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "7a8cf0db845f491f520d1ccd8c1dc00ffcdf6a8c7419367ec0d6610cf4d13751",
-                                "uncompressed-sha256": "0ea3dd918e0ff2b6d00704e3d1b89b2a164bbdad69c79695c770aaebbda27df7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "11b2bd455004e1747a9e77d0f32b0877d8b8d2f04e5602b42c1c1a5466a90a3d",
+                                "uncompressed-sha256": "ef1c9a1dc3d6971d59d57df2e8629fdc55df61e99099c120c79f43bad110e989"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-live.aarch64.iso.sig",
-                                "sha256": "b56ebde4fd150a76b9e1d47c931a1b357007b4d33d5559e5d701414ac56d1c56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-live.aarch64.iso.sig",
+                                "sha256": "99381c5308cf0835d22f6d83a787c23f982099b71d4c6c56d639558505f4f016"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-live-kernel-aarch64.sig",
                                 "sha256": "497b13809b045f99031cdd1ba12d53014cd28a6798b7e504bb8b50d40e8c9f17"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "af230a27abe321d122959a483c4d9b952a00efefd04550a2afde61ca4aa4ff2b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "254d6a26ef732d28a577f5a5875b928b88712b2a9cd4a74e643b9b0e4d5e925b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "1801951c0ba2bbe17a50d37227094635167f15813facdf6abd0214e178269eeb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "d3d32e096bd184de47a094763d12b2eeb39be75279b72dc91495ba52290d585d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "0a046f9f28562117c7453561c63b40401816b4b6fdd822a3bc7962c38c1f8fa7",
-                                "uncompressed-sha256": "6d7afaf254a96fe6dcaadc7cc20dd965ec6669c317f8d49bdf8804b0aa6abd39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "0d50ff9cadfaf366a9bffa370e41ab07d922d48c309f539bb049b3b06eea106a",
+                                "uncompressed-sha256": "4bdd4bcecaccd3c33a22dd9e3db876bee571f5e5e6e3575530378c2ec4234e23"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220213.1.0",
+                    "release": "35.20220227.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "250558cf1b73c6d0527dc16347f45c9c4989d0fd356be3b9109619da0b17fe64",
-                                "uncompressed-sha256": "33fa7b2ba16ef52a8efdb016e1ff7715eac7d3f15bd02156d26efaf1055df74a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "d1e15fb0c97d7345f95762f1484a9d1cc9235c8e7b67789d9d16b2f7c0348aa2",
+                                "uncompressed-sha256": "c9633736d38287cedd33dbf6cf382d69e80bdcced121bfa63230c77bd05e70e6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220213.1.0",
+                    "release": "35.20220227.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/aarch64/fedora-coreos-35.20220213.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "8f5bf3956a59b3cba1e290fc869b829b5f80184e4ac95615c4e24a0b909d0128",
-                                "uncompressed-sha256": "78f75c86515efbfd349853e7326613e2aeba06ce803574ae0c7d15be61278385"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "5cbe2771d65758eb2855d2d48b5d7fdf074011ea682b075c52e51e371c71d852",
+                                "uncompressed-sha256": "8a148d5a853ea6089e76a7e3b5a3f3e29db050f77ed203137c8fd443aaa66d49"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0e204b8d9e2ec8b1b"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-0a09aa1f42ce275fa"
                         },
                         "ap-east-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-022458ed1932cbcbf"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-01413f73b42f1b720"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0a3aeae77f086d99e"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-0dc1c5f65cf2443eb"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-01622fd4b169524d0"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-08e6238758ae2ebfc"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0536e53eaee08ec41"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-0b584b332e5d06e27"
                         },
                         "ap-south-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0ee315b5390f8149c"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-00b9a9c76299c9635"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-09cca851b3d24ec34"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-070b4f16d19bb4f40"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-094e204312b097277"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-040dcbe40cacee6d7"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-076feca5ed4716f6e"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-0ac7a59672837c6bd"
                         },
                         "ca-central-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-048cb2f9cdd528e3d"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-0789894c3a6a1a935"
                         },
                         "eu-central-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0db6ac6cb338b48ed"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-0f26467e7bdf63968"
                         },
                         "eu-north-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0fe4c8df8bd61c10d"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-031e5a2a234770089"
                         },
                         "eu-south-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0d7c98342917c85ff"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-09072357c3e6b2128"
                         },
                         "eu-west-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0beac7ab989617999"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-00f9d689d4b06d251"
                         },
                         "eu-west-2": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0caf9a290d03fe902"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-07276e1c733453598"
                         },
                         "eu-west-3": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0fd4080b283d2f72c"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-0c964064fe2189d9f"
                         },
                         "me-south-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0d85bec59ff000b18"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-00fb30b72547bb5d9"
                         },
                         "sa-east-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-09637b1ada88e163b"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-01aa47cdae92bbc8d"
                         },
                         "us-east-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-007d6c41686e273c6"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-09fa743ae0edd0613"
                         },
                         "us-east-2": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-03ff4d94e13fb4a51"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-03faf8212e7d18e33"
                         },
                         "us-west-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-007f00e1b26617ec9"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-07f0a5baada496ef1"
                         },
                         "us-west-2": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-031aea7c8353360b6"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-033a224513fb2d3dd"
                         }
                     }
                 }
@@ -190,214 +190,214 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20220213.1.0",
+                    "release": "35.20220227.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "b38fc2b2e4a0eb5b1b3ee0099f9a612383d46461152bffb11cd16aaa77717933",
-                                "uncompressed-sha256": "4bbd5964c6ed142af6949234c47d264fa0080e92a5048c26cc66e0f309d7a922"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8c53ad4c2a8deb310a318ee90a64d19121d186f78e619a78708cc88c9aeced7a",
+                                "uncompressed-sha256": "0586fc61262eeefc2a98b7030df453885866475405968a413ecfbd3d4830c8b1"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20220213.1.0",
+                    "release": "35.20220227.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "75b8560dcf243eeaa3ab5a5c644712e820e3f67e7c568063977b7e7fcd376ed4",
-                                "uncompressed-sha256": "24b30320810675b34fd725fc63178d5dda9cc7472279ddf9ca3c6938617e0b12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "8c16ee38ba4d7b52cb0f093fd640cb4570bead6eaac16f8b10bdea185cfa6759",
+                                "uncompressed-sha256": "b710f37a235465f33a1e876923314a5e2fb2c86b568fff26888ffa335b8ce881"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20220213.1.0",
+                    "release": "35.20220227.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7cf62ef31c0c03b1f6de82c3051d6f5ef70e04c29b1e193822857ca022ce4c02",
-                                "uncompressed-sha256": "cf5ac78be20ced26a5dc47854719a7c4cad9f5e91da85e73018b2825f48d5753"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "c03f5a9af57873018ac4d47a57f1b1f30f5469d44dd17cbe8d1c7ca2dcc90f81",
+                                "uncompressed-sha256": "692136e3cd71f52ec87da517da05b146dc01ed727cdc3af57facd3df0b519b30"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20220213.1.0",
+                    "release": "35.20220227.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "940282d0ce5eac81cfbef3e036a571531f5b25c96eed9e7363d4bd26fd1ab79e",
-                                "uncompressed-sha256": "c1f7a009b475c8e81554d703c004eda7939e00865e8db7ef3311f20d9251320f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "2948dde71645f20424b0f577b8c899b73b90f8922850577179e58efcf5b414ef",
+                                "uncompressed-sha256": "158440632c310765a99e77abfe1cece5d6383d56126c16b35e757245827ff8e4"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20220213.1.0",
+                    "release": "35.20220227.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "d428a325474912d33790918bb9ab52ad593cca767f1c92dca5f9806540481a3f",
-                                "uncompressed-sha256": "48bc68abd51f29cb9e4b019ef81a73cc794cb19003e858fd875c3ff7d3bffe5f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "847620105c31eccd3dfc6f1b8f8014fd8c3633a1fcb7301fa983ac8fdbca55bd",
+                                "uncompressed-sha256": "ab3da367eaf1f9a157304a2faf383d2efd6196c4df8acc1ce0ccdcf726bbf163"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20220213.1.0",
+                    "release": "35.20220227.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "4e42b24cf17ddd3ae73f19ca66155d5c50f26b0216c555d278ccbb52f9568dd5",
-                                "uncompressed-sha256": "ea83d06d87921a72c7d8cd082ad9acf453b306bb749d57443738508c1af6736d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "36a28ee2f40bcff9d4d742dbd73f9f1121ea0ae36b6636a839fa0903c1759a69",
+                                "uncompressed-sha256": "952f228fdc7f7a169dc67271c06ade7cc7a6b66744231792efdcea3527c7f978"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220213.1.0",
+                    "release": "35.20220227.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "64dc1644ce67a5f8d45815f146b754f1432ee98c08ecc2861d3c8ad59621b6f8",
-                                "uncompressed-sha256": "a8abed20861b0185e8f46ac0dba7d0729fa2d175e5e2742ecff22d6516eb41c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "6b15f7a71a4100bdf7db1c29d5f9dcf218b84e9409ca188639e7463dc18deba5",
+                                "uncompressed-sha256": "b6065bb9e4e31df6eb5cfeac478944fb40797c62fb759faa42189116e4ac7c45"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20220213.1.0",
+                    "release": "35.20220227.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "3fdb913aa8fc7efa64c27bd00bbbdbe665ea3533f1d9bf0bb2829b5dbf072a3c",
-                                "uncompressed-sha256": "76f254f18f7535994cf65b8f1c64f63e459cbcb163b658d9a647da587fb57b14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "b871206c102d0c1b02ab419c1415a51dd936d107239bf21404d27d9a23ec54a4",
+                                "uncompressed-sha256": "cfba48d9db6c65cb0e09f2022130780df071e0b9c8ce80b1b73460521add83ff"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220213.1.0",
+                    "release": "35.20220227.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "90fe7510d193898db948389bd8cbb203ce102c3abe18e00289f4a955c0330395",
-                                "uncompressed-sha256": "434c696b76c1a8f66bd50d40fc4519a7b7a90b13a616deeac4afc647cd1146de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "442c97a56887e56f07320835f66b155e6935462b536fd69a156e7f2311733dea",
+                                "uncompressed-sha256": "27b5b35cd9ee15e035386a0a854b8e6a2430749628a17a69e05d8dc58da23dc0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-live.x86_64.iso.sig",
-                                "sha256": "058f495d396ecac763e1f0f2c308ce44b514665fc15f8b21e9dc0dbdbc3532db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-live.x86_64.iso.sig",
+                                "sha256": "66436a54e052227f137c789f5cc7b2f8493416ff7ffbfa06f67041bb60fcfa48"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-live-kernel-x86_64.sig",
                                 "sha256": "819fda78ef91bbb41809433c36e2047c5fcf4324b7d14b3a4a13b77d47565a3d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "1b34e447041667bd9a800afef8f76a250a51f2e162c1be26c66c8c3f6c31edf7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "9cb254ffa98c130767e440353cf9c555d6b0f6ccc570baf68f9b78532d5c5eb8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "5b0d5a1985cf979cfdb56cc05d0cfd66de7773e4fef18d36e5a7b0fedcccae89"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "3754cf31a23b10de78773c82111994c48168d89cbb9cc39bff4a2b5adf08c9d4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "3993914962f7174e89e98a870e1a640d41e183ed8218b96c768c92e8488772b9",
-                                "uncompressed-sha256": "d8756570d3014709836cbe0acf3cb2d1c1cbda371f8abd91c5529e8b5e640ef7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "6dd9a81c514283dc82567bb3fcb48147f568ddfbf79a3fb13992f350874145a7",
+                                "uncompressed-sha256": "9639bafc5e3dc8ef5a82509fb6de9ccab112beaa30f5d01c5948b2fc45ae3819"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "35.20220213.1.0",
+                    "release": "35.20220227.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "5e7d12a5489db3159737154f16933bf1327336fc2cbdcc6e29b4f542ca9c8152",
-                                "uncompressed-sha256": "5be8c72308249e20fbc20bbe2a8ae26256270c5386b1733a5dd85b98f3a454ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "61fb77ecc0a61fe97ca322f10ab902287fa3d3726c5a88d452a689e6aafb31a2",
+                                "uncompressed-sha256": "3026d8c2bb9ade26e66d1fa0081c5ee53ddd59ba6a9328ea1e370645779e222d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220213.1.0",
+                    "release": "35.20220227.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "8497d89942ea2fdda96957454bf95ea5600e3b34d4c373883c02a05d86bc910c",
-                                "uncompressed-sha256": "a19bf2d7196cb9c337d33ea4d75efb5ed3d9a06b2f1cbf2b43e4eed9c65aefe0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "846c75855bd38ced0ece4b97e0f66d1cbc3ad3a519ca36e825229dbf68486764",
+                                "uncompressed-sha256": "8b591badfde75c6411edf1e7046fa738c0bd9b2a6cb5738ebf08292bc4199f08"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220213.1.0",
+                    "release": "35.20220227.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "5c2b864678142edd097041b95c13d69c589e06b62d424a1f57ba596499b16640",
-                                "uncompressed-sha256": "4c00d6363148645c0c281ccb8a769558807560aa9d9f639cd3244944d9e8f342"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "a22bf32055042bb21f3e707fb4b32d8e83a7731af29e1ff998dcbcc6bb74e157",
+                                "uncompressed-sha256": "ad1e09a7ca466f512dc2aa3d390638012653f4fa3e0abde4df59638b6324d64a"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20220213.1.0",
+                    "release": "35.20220227.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "f2ba9c8083a07fd63c20b8baf5de736f65c6177b9595dbd485680799d06b6fe4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "4547c0ef9dacdfbcb11b486a2f425e448beddf079d81acd7acd3ea730d116f08"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20220213.1.0",
+                    "release": "35.20220227.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220213.1.0/x86_64/fedora-coreos-35.20220213.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "92a69afd574fe6bebb609beabf3b419eb8adbb93c5b057a54db94f3d90edd0f3",
-                                "uncompressed-sha256": "dd6fd085f1a9a833d45cf2a9991fda9a4d61a932b8d713f28ded7dff313f4076"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "8300df44256e25ed8956cba9df67272ceee71727fcd15e279b48c86b4d933991",
+                                "uncompressed-sha256": "b2e6c0a663a9bec431192bcf3f2117987095f8babbadeb237ddbe8a9a6083ed6"
                             }
                         }
                     }
@@ -407,100 +407,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0a0cd0e8f1ef6d253"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-0e34154475d9c0d4b"
                         },
                         "ap-east-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0ab96a0ec91e6d9b7"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-0bcbc67435a7fa556"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0d049636d3cab17e1"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-0e263f59bbbd63fca"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-02bfe75599ed6f42f"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-0ec0fea156cf2fc0e"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-08dc81bde802307ba"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-0419ab56488bbadde"
                         },
                         "ap-south-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0b0e3b9d40acc40c6"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-0021ea94822727b1f"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-075109509d62c8f1b"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-0d73e9efe22a33414"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0327938a7ba5de17f"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-02f215e1abd688565"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-09e8deaed10ff322a"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-075c164d681f99526"
                         },
                         "ca-central-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-022227f42eb5881b3"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-0d9292a29800a4f50"
                         },
                         "eu-central-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-00888e60839bd3c96"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-02953ff6e3c237b03"
                         },
                         "eu-north-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-04f6426df26065696"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-06970397d028ac52f"
                         },
                         "eu-south-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0f494d85c23fdfd33"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-007be425d61314441"
                         },
                         "eu-west-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0aa27e5fa778c6edc"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-0d85cd328f4ee10bf"
                         },
                         "eu-west-2": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-02791e1e7a29162a1"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-0a752b2f899eda43e"
                         },
                         "eu-west-3": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-08f0c1a39c428119e"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-008c44a52cef73830"
                         },
                         "me-south-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-093bcb7d63330191f"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-06e210c977b8dedc3"
                         },
                         "sa-east-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-03b917db8a33b2aa3"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-03007b5966771950d"
                         },
                         "us-east-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0c20867691710ea7d"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-0274c95a639845095"
                         },
                         "us-east-2": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0e8d3faf8e0a9a94d"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-06c983e752d0c51ce"
                         },
                         "us-west-1": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-0807bf8681ed714bd"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-0d778844dde4a5650"
                         },
                         "us-west-2": {
-                            "release": "35.20220213.1.0",
-                            "image": "ami-02fa7536ce7598a07"
+                            "release": "35.20220227.1.0",
+                            "image": "ami-0936c265a97568a81"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220213.1.0",
+                    "release": "35.20220227.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-35-20220213-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-35-20220227-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,92 +1,92 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-02-15T18:08:28Z",
+        "last-modified": "2022-03-01T18:21:42Z",
         "generator": "fedora-coreos-stream-generator v0.2.2"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220131.3.0",
+                    "release": "35.20220213.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "fb74d87ab7a28c1dcfc7b0c4a265e73f4c73efdd56e9079bd73eea34523b09dc",
-                                "uncompressed-sha256": "287ef3a8ae62f005add5cb456bcb7a89edfe22a697079e1c4fef9991d88da9db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "263c5f46efa8b6cc4b4c64f003187f6d37e05df8e8d063e4aa8f4be415dcd3b9",
+                                "uncompressed-sha256": "6fb3c700c8ff26968691771ae02be49cbf031bc826fef52a68f1986574b8f208"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220131.3.0",
+                    "release": "35.20220213.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "0da0bf8f6fb53e0acd48b1cbd10a1fcd2dee574d13d0623da9d2326ae6bfe911",
-                                "uncompressed-sha256": "4001dcbbbcc917852653a9ae28355c6b39d68057fdd9db38874d22237dc898bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "229886dbed8cdd85427931a2665df8cc78583a3b25b6c125d3d6448f2f1e6042",
+                                "uncompressed-sha256": "e7b98657dda48913a1f4d1a5fdf70dc5d453ea95eab20b64c142255aab7230ba"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-live.aarch64.iso.sig",
-                                "sha256": "a98b11e76b8409007a0fad4281e578a9325ba998d39faf2a8508e52bce752e51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-live.aarch64.iso.sig",
+                                "sha256": "7d26bb3a9fc73c56693cd1025f52de29587e0df268c711edb9f2cb97bab486f4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-live-kernel-aarch64.sig",
-                                "sha256": "8541d9979e98aa85ebc134fd3200eae52e2020333e723c255890323a49436177"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-live-kernel-aarch64.sig",
+                                "sha256": "497b13809b045f99031cdd1ba12d53014cd28a6798b7e504bb8b50d40e8c9f17"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "dadb080a0f78b2fa86479d01e6062e0a9779f629e3c17b53c722bb7294538952"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "59b7b842123e87611ce8f26994ae0b43e92bcc7dcb85eae7a04a2581883e6c4b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "cf360b571ff9cee470cd20a5d12c13f4b05128557e95158ecc8bdfdeb2f33eda"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "7925e994a7567fc204446cd1d3e53bd6f14c26557ebb8ccbe2bf537018e53504"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "1c78f48abc849b2fc1620bef032c87a634ab7c129ee8279ab388b772936b02a9",
-                                "uncompressed-sha256": "83c38f6460cb343d258bc6724526b220c30bb242bef27e839ec1915d1a8b5b27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "71af6a7d9e4247f0c2035bdeb4d21b4c61d5a773f83dc74f99547b7ba3330441",
+                                "uncompressed-sha256": "be0551da01d54519aae20caf21d9a5ae6a36e076137bc91db1801a292f68fe6a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220131.3.0",
+                    "release": "35.20220213.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "3c2d55cf183e98f2d3e71eddc8f3b79ff828908a12c1d5e267d00048a4ad7c32",
-                                "uncompressed-sha256": "6ae93855fb8a152d164afaa85472e7f012a829e36a4c0c6bb98e6c3e0701e23e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "9fe3e878fe145b261ed615e39e5c9b103f3d7ae0625de413d71159dbf2d0bdfd",
+                                "uncompressed-sha256": "99e07dcf9882bf69ee08b6714f92953eeb0401337a474b8dba7e158be1111726"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220131.3.0",
+                    "release": "35.20220213.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/aarch64/fedora-coreos-35.20220131.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "02de579dc9d9a5f1c1a1870aba16600f53a304b759743d74168ff2520313a9ce",
-                                "uncompressed-sha256": "4e4e28af20265f0ed5d604c822d5bdc1e27a9ae1079e70a831bdf756aabeae32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "72a22f6fae15a8d1331e7a8d3037d8de3870b773b69d98bd8a1ff158c3c8731f",
+                                "uncompressed-sha256": "e60b33ecc99e5e9b0d742359440cb11d8d6d99c51177a8aa5d332dadffb98f9f"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-029aa950f45645aea"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0a2f7df8d86ad3331"
                         },
                         "ap-east-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0b3beac9e03d4d6ee"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-03b8aaae7b797b6b5"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-07ef12021cbdf21cd"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0438cdcb95093b8fd"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-075a2b531dc10f0cd"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-00dce453e1a510ecd"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0d8703a94d9031501"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0dde96280e829cb4d"
                         },
                         "ap-south-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-03cd4db6241702f7d"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-05de9ee0c730ff0f5"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-02b7cc5d7e20ba996"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-05bd4afd1b4979666"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0559ee7fdaa3f4dd1"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-014828542cfe3451e"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-021c764b883861b7b"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-07e849871c9089078"
                         },
                         "ca-central-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-08206e0252a5f4aed"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0c31c0731184fc345"
                         },
                         "eu-central-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0e33a11c4f3adae4f"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0bc126eca6515b6d9"
                         },
                         "eu-north-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-08311960ca892c8f6"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-00a3e5a47b32118b1"
                         },
                         "eu-south-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-057f285f19a0a5345"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0e6f88b10f972fbb6"
                         },
                         "eu-west-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-037511ea5de170037"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0291741226a8558f8"
                         },
                         "eu-west-2": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-05eea0c1b87222961"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-03f1b759de3ba3e15"
                         },
                         "eu-west-3": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0ec5d030ea498d31d"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0ffdfef19643ac7f5"
                         },
                         "me-south-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0ccc4d6d6f5c24bc5"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-01b200b88d399e6ee"
                         },
                         "sa-east-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-02d727b82bf32b151"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-02a09f1ddbd9660c4"
                         },
                         "us-east-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0a1caf7189177752e"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0096b1f15ad6a702a"
                         },
                         "us-east-2": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-064bf257437cc589b"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0da3d12ea4bb2e9b6"
                         },
                         "us-west-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-011b73f3e0a2abe91"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-00fc16fb7b264ffc6"
                         },
                         "us-west-2": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-067b4da020522661a"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-058fa5813155ee333"
                         }
                     }
                 }
@@ -190,214 +190,214 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20220131.3.0",
+                    "release": "35.20220213.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "e369e93206d1f43783bbf6eccc8e67a62aca0f407d1352c997dd065e71e43f61",
-                                "uncompressed-sha256": "3cd14f3327ffcb3e5d7892e30a4027ecfc4493df77f94b57ae6b8868ba8ded4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "5330a055352e620228b325b2cc678b46645f0cb8e2fa4059b36552a19e217699",
+                                "uncompressed-sha256": "9bce952457af527166aa3d740fb7d326fdaf0f129986a05fa3977ddafe05e62e"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20220131.3.0",
+                    "release": "35.20220213.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "ebfdaea9965568c9286322e8144711488392837f6916f95ca9f761564ac84e0e",
-                                "uncompressed-sha256": "4ec51bfbdb567b93add340eb04ae41cdd6f8793eccad801d1f660c05bb00bf01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "87560f75bee41c6d1cd663d2276d99f5f61a6301ab957e38acb604c05a46150b",
+                                "uncompressed-sha256": "3563ad3106a3a640007dce649c27b774a26f39caf574aeebd210d83aabe3c861"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20220131.3.0",
+                    "release": "35.20220213.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "8000383d7af7a6d000f21cc52bd94d136cbbac4ad1ff350a548d40da0e50bd81",
-                                "uncompressed-sha256": "00c59e5cbaf207b765a41ace96a136cf53c1a2a7051dd0202c726f7cfde62fbb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "f48e47777f7d6087a2c94efa3c09178bb52bb5fcec1b861577e485468f2acf3a",
+                                "uncompressed-sha256": "b609f6f9029109cc8aa18828fd509de1a3fc000b1046747de266b055e4f8a557"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20220131.3.0",
+                    "release": "35.20220213.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "8d1ca5dfb799c954bd4b4c96a696d9ef37eaa4da95f0a4ffd5ec1b90480de0bb",
-                                "uncompressed-sha256": "5eec12983670b1e4d332ec02454fa0ed5318fc74168a6c3190917dad36a28826"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "6b1ec4024a460fe8926afd4f293f029badfe4bbca66b6a0c6b8d928027d1179e",
+                                "uncompressed-sha256": "481c1d00b9df7391523e8a3a67706131f5f310476c61044e8122967fcc1a60c8"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20220131.3.0",
+                    "release": "35.20220213.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "42140d1e97b6f871bcbcdcf5691d5415987b842ccd411f351e0ccec5f2f12325",
-                                "uncompressed-sha256": "4e80604ea81c8591bb94f51814412d5932c947adda2977d89eb3f480c2e28bac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "ed9a27fe264ae9d02c9592f824c0c562545444e4022a2299590c13f7bc872eb8",
+                                "uncompressed-sha256": "f85a67236fdf199e1068e47e33a528db8741d151fa1d50df0536b6a688bf78b3"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20220131.3.0",
+                    "release": "35.20220213.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "7c5ba0b75304fd4998e00f827e8c00b425185e965c148ff425eb1f63d53ce3bb",
-                                "uncompressed-sha256": "e07415f3bf8411a68e25bdc94c6cbdf643324b44d3114db9e216073693f7cb59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "d5df14adab71e18d2029ee2a0ded33e7c97f3aeed658152e87131abaea5684e2",
+                                "uncompressed-sha256": "31b971cb0c28a16b8db77bdc7dade325e8064c2a078c051204f9ddafe77296da"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220131.3.0",
+                    "release": "35.20220213.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "d1e5bafb13ec662db190922ffd23ddbfdb9902e63fbdcc0a29ff8b8decda914c",
-                                "uncompressed-sha256": "7b274e8f8b6ed290a15c6fa1fd070cc8a4ba6219e903a5a585d2fdf197dbc452"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "7508462fc0372c8021a00a1e113e7ee60526bd63304a5c62ce02bf600295562d",
+                                "uncompressed-sha256": "cd1b9eabc97d9fe782a446f31acbd4347c51024ef683415903e1d551d8efc5bf"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20220131.3.0",
+                    "release": "35.20220213.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "0e8dcef140ac4c88fe18102307eca2e86bb00380587e4dfd49e01095bb0fb586",
-                                "uncompressed-sha256": "1292f66643c64c4eec180a52ba9507d98a19eaf9e198a5a3a1fb944f08d42ebd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "9560ea678703879ae8bbdf1ac785bc5a5e0b10d5da05e4b848f7a6832fd9015d",
+                                "uncompressed-sha256": "39e30797b7ef03e8d47addf2605e43d232e246026e515cd8513b500c49840502"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220131.3.0",
+                    "release": "35.20220213.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "54b88ac0f74bdeb1ba75ae77e3f4608c4726f22f38704abb1b2b88fda4951073",
-                                "uncompressed-sha256": "58489436c469325dcadead6962f4548218e7d046317aab7e1a413e676619f923"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "b3900038e2466935c12038692dbab5636d87614ba6e47525d88803c3592e1d77",
+                                "uncompressed-sha256": "df195a70a21025253e103c3c72300a01ec508754d54770e8b63e39e5e38dcbe5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-live.x86_64.iso.sig",
-                                "sha256": "3557d9426fa94f2a04c9f2ed55b9b93e42b6c3bdf9ba82e6c9b4c7b4f313a8a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-live.x86_64.iso.sig",
+                                "sha256": "889a35225dbed2f3d398e42e2508707d04f44fd7797f9fe6cfb0c1ce577c2121"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-live-kernel-x86_64.sig",
-                                "sha256": "246720fce1961aa468d02804f2d71f56b6579d68ed60c2c7836dc497dc062fe5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-live-kernel-x86_64.sig",
+                                "sha256": "819fda78ef91bbb41809433c36e2047c5fcf4324b7d14b3a4a13b77d47565a3d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "6d8666863dcd29813aa527a04ca82b8830c4e99eff990bdd52e599aad8de4337"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "4e7a91b3125467d99f37f450160a74a597afd4713968ee1777c0011560a37933"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "2684951ccc7f5d82f3e03599c6f103ee4febaaa80c7cb6491951b48c68421229"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "8dd30f01c078cc24704fcd62ab36756be784a4aef1c0d40f8da08ddb262b0b5c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "8bdeb822562edb8afe324550bf2e3947e830fc906fa671d6f4eb6f3150cab853",
-                                "uncompressed-sha256": "4393bfa8eb28618af35f2323837218d7f4cea1f6792160d2ee187f69a30f5d99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "cd6f33c028dc3ca668efa5299cd14ec24d5b20623ad62dc2282edacd932a51f8",
+                                "uncompressed-sha256": "75986d58d4b81802306d99bd8763feca89060d73d59de0582191104f1e4af4ad"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "35.20220131.3.0",
+                    "release": "35.20220213.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "9978c515237e91d9dccac3423be4e3c2e9946fd2eb506c89307fcb828fcbe676",
-                                "uncompressed-sha256": "f64f3ab465f67a145d50deedb7f431a012017df11700de373bad88cfa747f1f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "f207c7e73fb10acfd545f83a0625c4544625580da85a818cf0b5909e5160a9f1",
+                                "uncompressed-sha256": "903ba17b04dcfa9682bdd3645bce610ada33ba9b40b4a14f8ee06e7b7af5cd7d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220131.3.0",
+                    "release": "35.20220213.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "bc4cc3243e2418631971e3b26c737f70109cb8d76324c8dd455e3339a7b76993",
-                                "uncompressed-sha256": "975515bd415a9359ac870a1f6836933a54ab60db619f8c5c14db9706a63b6061"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "ae7eeb7829645043dd4d82de04423062d7dab7b08d2e55386b0597e855c65312",
+                                "uncompressed-sha256": "f7700a50455a2549f9b7c7608398d2d1968079dd7e5b5cf4cd885c6028677a76"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220131.3.0",
+                    "release": "35.20220213.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "7342de6bbe9537e2e71415425706b1173704f5746aeeebfccff01435cccf0179",
-                                "uncompressed-sha256": "662f56a01367337925c1f9e4879db5a687b22e673bbe95036505122f02883ae1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "625429e1b15f3c4dd15def29a1876cf578046f2d63f8db972f1082c131896be7",
+                                "uncompressed-sha256": "2f5285290fe580d176b0daea8603010085818e5499747a2d7e9f3ecd445cdf28"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20220131.3.0",
+                    "release": "35.20220213.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "a2658cc6289160cd50f157983e5727af98d976bba85879dc3c2392b650632c54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "1afead99d281b036487575f59854f9a746a56793ac05e654ac6180fbaa5206dd"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20220131.3.0",
+                    "release": "35.20220213.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220131.3.0/x86_64/fedora-coreos-35.20220131.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "996be3e6b6621630f05c4d8e090f2dff71fbb7dca4ec70e926f98140eb048ac9",
-                                "uncompressed-sha256": "c8a098a5b867d29988b43f268bdcdde6fcbdbb9d9f145f16084351dbe64b328a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "2973d22d64de353a86fe721f7bf8ac4a9691954cdb21d84a46abbd8deb30e6ac",
+                                "uncompressed-sha256": "f4db02f38e3ebd681d65b663e1a9071f5554220c24b0b89461c0ed5b5609f66e"
                             }
                         }
                     }
@@ -407,100 +407,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0d7dffee79bc75cb9"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0bdbaa3b71e5533ff"
                         },
                         "ap-east-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0cf828d0d8d60efd8"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-01f95e3ef562facc1"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0d5338124f8acdafe"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-062f02717f3281d54"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-058e724b2743d89b4"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-03258e226d3085a98"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0958a026e4feb267e"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-028b6e9c968dc521d"
                         },
                         "ap-south-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0a9b0a29f001aab78"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-09275ca26766ba225"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0ad5f7dec4de4bfc1"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0dcdb18a273b945fd"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-04ca148c5cffba2e0"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0831e1e583aa2fc7b"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-032c546157088c446"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0923893ce69c79233"
                         },
                         "ca-central-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0cfa10fbc35d1a8ff"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-050c6f96c6e3864ff"
                         },
                         "eu-central-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0dbddf4bd613898e9"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0a58701048da1fad3"
                         },
                         "eu-north-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-01ffc5c9756d4986a"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-044a450f9c57819b5"
                         },
                         "eu-south-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0eace9fbb3ec117d6"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-01c2ae669a24f802a"
                         },
                         "eu-west-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0b12902a541809f70"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0ff530e464d386737"
                         },
                         "eu-west-2": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0bfb62a1ace3df24e"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0ab3c0791eff8b354"
                         },
                         "eu-west-3": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0f84940a129d40262"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-00a105840e2f197df"
                         },
                         "me-south-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0361ebf1c2d0ab77c"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-070edc94e465906f0"
                         },
                         "sa-east-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-04bc8bdabf1a6f313"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0d866ec67524a52da"
                         },
                         "us-east-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-04fc9c162cb5bf796"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-06eec2310d4a15743"
                         },
                         "us-east-2": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0f8912c7897cd9b9a"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0a4385dd87fd58ca7"
                         },
                         "us-west-1": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0affd003fe89bd2cc"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0bbb617b1e32ad528"
                         },
                         "us-west-2": {
-                            "release": "35.20220131.3.0",
-                            "image": "ami-0356cac95b1e86503"
+                            "release": "35.20220213.3.0",
+                            "image": "ami-0429826b67e324e93"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220131.3.0",
+                    "release": "35.20220213.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-35-20220131-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-35-20220213-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-02-15T18:08:29Z",
+        "last-modified": "2022-03-01T18:21:43Z",
         "generator": "fedora-coreos-stream-generator v0.2.2"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220213.2.0",
+                    "release": "35.20220227.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "bc6448bb54cd64eeb0313cd814a5d3d9b530edb6bdc34d032dfd8bb3308d07f8",
-                                "uncompressed-sha256": "9567a633d18b52767976cdcb20500bc7b3b0911b88f7f7e57d5d0aa79c149235"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "d77ce52b9fdf92739757e9f78d752392f9cb865a2fb7783f19413d797ea486bb",
+                                "uncompressed-sha256": "0eee86f35ba58096028235c8123e7b935194332005b778ab91a2fd5e386552e5"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220213.2.0",
+                    "release": "35.20220227.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "cd892802b7904ee7e0fe9453504a6216be461761537b4b91d141a5aef6f2f857",
-                                "uncompressed-sha256": "ace6508f15426e9e1f36868cf96807e4c696e91d4a768bdb427695a982409be5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a350e5c28d238cc0bd6b82f601f83d7018b5363a421bac175c9878d4694495b9",
+                                "uncompressed-sha256": "e52d5507611488fffed5295a7a5955eaf9ea0ebcf4ae1b1f724f230961fd6d60"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-live.aarch64.iso.sig",
-                                "sha256": "60c4c3dd83fcc11e1a9982026aa089afba2378463ef968b20ae8e8eeabdbcd65"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-live.aarch64.iso.sig",
+                                "sha256": "3ae81e03c5202bbdbc241d7edd25a81f339a04b57920450ed2877ed8a7da2b5b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-live-kernel-aarch64.sig",
                                 "sha256": "497b13809b045f99031cdd1ba12d53014cd28a6798b7e504bb8b50d40e8c9f17"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "6b4c2b2bb3632fdf9f0e02b8e843f97a80ebb8e500edbbc82d992a937fa6ce07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "ecab03f3a795fd5cea31cbf0561ff4076f73a580b1c8d6f6d3a08f22652b762c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "d1ce4e358e6630d54455bfe2dfc6d3f6cf3a885cc6f498f667b5976ccee1dea1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "5e06ca991d92a7e9538aa74c5f7b9a7f2d8e1f009b0d71be03cd997d494a7f96"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "cefb77e587c8f86404eb284f238ff11632e4915969b14852a812589d39a633eb",
-                                "uncompressed-sha256": "a5f72bea5f9d7cd2225f39266ee48fd6df864d97d844edbf96627ac045813ba7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "0bbf7f4ea9edc73d91b4b51da78ffd330f21277ead172486d5e93265f224aa21",
+                                "uncompressed-sha256": "8b27690426feb139246df7df58e034aad1eef26fb48b17266deddbda5839c5dd"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220213.2.0",
+                    "release": "35.20220227.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "3d222337acbbe16e83d06092fe274096f92667af445aefde976845ce0e3d1aa0",
-                                "uncompressed-sha256": "0c797c11cbe32f0a4cbf2227aaa474107c40d96c05c29ce342b23f7f43e07be9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "01e1c1725e59c8211c93ec19706de24b22a8a9b7cefbedcd10b43ae1f4651aa1",
+                                "uncompressed-sha256": "ca261e3ee04ad0a93d21140f30b5b9d12220db20d05e0149a12d4d9e1e1b6c8a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220213.2.0",
+                    "release": "35.20220227.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/aarch64/fedora-coreos-35.20220213.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "6d06f223ef5fafc146fc36210d49738d657ab844f9a3d153d410c0075dc9bdab",
-                                "uncompressed-sha256": "9bdb5d6ca3befe572a8c0fa6ea6ad0c5feee41c98a5afd62ecd88506aeb37a8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "ab4e60172b8c953eca614b4f517bf86c21d7f04d00b323aa4e920faa1b9d259d",
+                                "uncompressed-sha256": "c3bf77c3cdcb8d3ea346f12d44b39b3486ba5c33364df22fc6d111949486b57f"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-08cf3e8c5217c2be5"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0c739984d3507d7da"
                         },
                         "ap-east-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-038f0b2127534d256"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0d3108153c9b154c3"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0ba4eb3de14203fd7"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-05b3aaf7b83db7e0a"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-02e5b39c92ee95103"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0bdea33e5a2b9b2d6"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0a5057e9df28013aa"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0ddbc8585ed42fd9f"
                         },
                         "ap-south-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0569adc043b323f64"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0f31bf9f3e6a88b38"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-091d7efb9112ed0c3"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-009ea3db10666e63d"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-008606103e380b946"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0d80360e9b01ce839"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0d0ffd5131711eb12"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0b3fa9c3b7f1ed61c"
                         },
                         "ca-central-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0ea99514aaba61ec1"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-07ac14f5ff6e0e3fb"
                         },
                         "eu-central-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0e6d85b90d8b66963"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0b44f9b5c3e773260"
                         },
                         "eu-north-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-008f0bbf338ec122b"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0e762e35204bd4b94"
                         },
                         "eu-south-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-041b70b28f41995fb"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-014ba1d865d2db1ba"
                         },
                         "eu-west-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0e2923ca864fe42f6"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-07d751f8cd7a31061"
                         },
                         "eu-west-2": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-08a8644ced3c26663"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-02639a34599a64b39"
                         },
                         "eu-west-3": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0050f73008b491ed2"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0702d047077b7942f"
                         },
                         "me-south-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0700090e6a05e0f02"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-02d83400fc3f0f6ae"
                         },
                         "sa-east-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-06424fb4797fa0533"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0e479f7ceb420b4b6"
                         },
                         "us-east-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0f3e407df13c1cb59"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0862763d88c89bf7e"
                         },
                         "us-east-2": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0c1d5b876e5d2af38"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-05e0bc4f349f8e12a"
                         },
                         "us-west-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-04ee925c6a2c52da6"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-00a301cd77f1594c9"
                         },
                         "us-west-2": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-011589fc2b7b54c3f"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0594d10d8345da763"
                         }
                     }
                 }
@@ -190,214 +190,214 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20220213.2.0",
+                    "release": "35.20220227.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "8f86c20198aca6684e77b0d3b292bf21c885aca96b5ca0c77d6f71695bcd2e2c",
-                                "uncompressed-sha256": "eaac77ee1de5ad9cbf3ed0ceb73b175b454a796780b59b3a31cd6bee1a9cb80e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "cfd66af4abf002cf04d1051f6847bd5e52ebf6bc30388f2a9c84e119b90fc68b",
+                                "uncompressed-sha256": "1b880403bb8f31776d3a613e772853aaab8dfdef719a56bdf59680e5ccd0a67a"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20220213.2.0",
+                    "release": "35.20220227.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "aa980b66ab92bc477bebae6e911faa7f4466031e037b288509c9db51351260db",
-                                "uncompressed-sha256": "a721ae528fa0acd03711b2e8c645c5bc79341640f11ccee83ca3e70433150e0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "ff5ba2f75cecae0b9889efe47a06ba15c7eaf552f099194b5006d1aa857a9d1f",
+                                "uncompressed-sha256": "4966d6364eea2ad1acda037008537a5630579b893b9d860f04a47b2e465ece35"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20220213.2.0",
+                    "release": "35.20220227.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "54ac81b55bea695447bb6f87b8a0775772df58a67a7099d2d06ea8a2825503dd",
-                                "uncompressed-sha256": "b0edd3e2f83565cf191c230a8db3bea48bfa78a75e109aaf4e8a6aa51c79b825"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "fa3c1bd44ee1d8ac1d19a279220446f56224b651d608644d8a9e5bb819814bc7",
+                                "uncompressed-sha256": "33097caa51c0eeab2207ba48c6a21a9de195386172d5768830008621e1fa6ef4"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20220213.2.0",
+                    "release": "35.20220227.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "a570d8d4d48ffec57e0b7b6f496d25624c634ccefd35fcd8edd175212a240c5f",
-                                "uncompressed-sha256": "ee2e02348dbef29c7b659578ef577e9def11375b63b26651c7348b71657c786d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "3ace066f7f0b389aac6b806521a5a9e8cfa909dd7282e8880d650f32e220506f",
+                                "uncompressed-sha256": "2dc705dd1de682679d7dbe087809a1e99f1d9ea5a354420a35f5c53391e5df0e"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20220213.2.0",
+                    "release": "35.20220227.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "40d94104161d4a0ae66b971586fdf21b9e0a7b55eefb8b4fa16386fe76208471",
-                                "uncompressed-sha256": "0a90c9b448f7283f48f1db571e24a309f9b52b9083d6597a3d29000738d33662"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "6b4e6014fcb12b6b3a3d3bc5a7ddf161488bc137fcfdd26baf33c6a10d73af37",
+                                "uncompressed-sha256": "fdca6f8001f1e2f1062fb5023e549d93b894a6d44c3959b0d3299a905bc2bc58"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20220213.2.0",
+                    "release": "35.20220227.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "00b05e0405fc7ff7478df1def165f673415e67895b713e0656b89a50e0c367eb",
-                                "uncompressed-sha256": "1f4521c1ae4e0d0fd6ca7cfd8455a80ff78ad740decbeaa4beb1198cfd279306"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "962749314ed1666270862e759a21dc08cf20e5d72fdbbb1899714ca229eb3295",
+                                "uncompressed-sha256": "ad77f0cca60625b2267ccad5d744b4f9755e29fe5b7c9db5aceecd6d8c27ec68"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220213.2.0",
+                    "release": "35.20220227.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "d13a0738811ae1fe538d03971c91afc524662f050f94789e1c24d4195e47fdca",
-                                "uncompressed-sha256": "4ad0151a61c5ee3f427cdead8202ab543791670266fd5c32e571c11866a691ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "7f80b22ae44b9514259550664e1723b50867a55b261d3d8defe658af87b5bfba",
+                                "uncompressed-sha256": "fc48b62a62b9f5e08b7990b81f95c8654d61919b81174dfa4b5e15b927a699ea"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20220213.2.0",
+                    "release": "35.20220227.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "e2c0b5cf60d68d2db01edb7c914cc3bd8663b4a02d4087b7df31f4536f229172",
-                                "uncompressed-sha256": "839e774691d2387b746379330439b14dc3ea82d53f6f120f7868b4d0a043b466"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "702baf88eff56083df4c3752fc197507d349fdbe8e56cac36bc991d844f003f9",
+                                "uncompressed-sha256": "56082cb72e6422a7b741925704590a07c6fa20bba75f1ecca318af5c6461a011"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220213.2.0",
+                    "release": "35.20220227.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "4a3f5b7d2bed29f5759447b8b58a33fc26dabaf5f7eebf73c664761f737b0f80",
-                                "uncompressed-sha256": "3f54d4b9ac126a287f19ad3719a0566a1ad25c53dd4befb9b9ede7616269e75b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "2dee93ab0019062c1bcd1bac81ac4df158a4aaf52cc336753400bced496170d4",
+                                "uncompressed-sha256": "bb09e2a304f0710eeb0c7117cd1da99f80e3eefbe33b1efc1874bab460fb9ca1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-live.x86_64.iso.sig",
-                                "sha256": "232e3a6d078d0e126769007b365ad1670d4ac1497fdc14fc76abd71ae0dd7dc8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-live.x86_64.iso.sig",
+                                "sha256": "fb0c5fe1f0dc54ea94833bd6afb509fe154939480d4c468ca9794a9afad9e19e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-live-kernel-x86_64.sig",
                                 "sha256": "819fda78ef91bbb41809433c36e2047c5fcf4324b7d14b3a4a13b77d47565a3d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "d6e79a8bf8f72a844a918ea582e3c5c0fd5f62c55cd083eda5fed50fc8793c3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "ee29eab5bcb168559d506978d2eda660f7e2de9d4044b2a3cdaf7847d8a17f5c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "7c016258351f2962e87e572beede1158f9269c67c2e2257aa7b11e6a90e12c61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "9ec6ecf0cf69c3b6927fe94bb14fa0d4b5c9c4e0fccf464d8d7ac15157472f39"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "e20f4570892bf8296689cf9b46cf04793333132f988caa1c36639ba4b262da46",
-                                "uncompressed-sha256": "a7059eca35ac237336955232b47353d01b7e212d99f2a5aab7f15ccd6bc275d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "2765ec4948b399d2b1b36a17ae4f5a1c9e8b57f4b30ceaa33fc48fcd1921d113",
+                                "uncompressed-sha256": "df834a18658a391cad4e764dc073f1885e420f457e593432f36e515d5f1e0567"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "35.20220213.2.0",
+                    "release": "35.20220227.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "854327e12870309a7646d26ba4dee83d78ab94ae3e102a591828a2b057715076",
-                                "uncompressed-sha256": "f708500d100a922277b4af4495be7dabb65e3b00617520f5ad70e459802a93fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "a8dab9c45646475c6cbd67b38f39e7cb62ee8665b2e16d15cd878773d067ff5c",
+                                "uncompressed-sha256": "89a1ff3ef25ce05b4af6d15c8273a324f3090905727ded5edc7eb97511a3319b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220213.2.0",
+                    "release": "35.20220227.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "dba22301f21df82c836a719c5cf56ffe48536b3d96bd4865a4f5ba3b11391f0f",
-                                "uncompressed-sha256": "a4f1547178f819211b6a5440add930a639669edc40fd9b416245d1047328ab9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "301b94b5aacece1c7340f1869d6b911f962701ead16a6154b1d0874f0f0916bd",
+                                "uncompressed-sha256": "e67223f94b7efd3774d8d6dca13bab3c9fdc00da2f4679546cce8c0991c08334"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220213.2.0",
+                    "release": "35.20220227.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "cc2d07fb9eee125dcc4a946bf3f266b34c94a41a943adf3a99f02f26601c8ec8",
-                                "uncompressed-sha256": "376af02865b9f614de45b83d5d6086afdc260c0602a57038b6d73c383d034931"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "c86d9a55ef3cb34ff11091eb8ae59507cf15db5295b4f8135ac1767ee1d56079",
+                                "uncompressed-sha256": "cfbf92403681ffb30e7fbee3a24413171b6fd000045f879ea18248b2736a6c65"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20220213.2.0",
+                    "release": "35.20220227.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "4d8ef869310f55738f13ba99bb4cbc88599bd4a9bcfffd50f4d42bde7805049b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "e858f4538649301c23ec72a56f516d5cf16accaa43606fd3d70669548e904134"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20220213.2.0",
+                    "release": "35.20220227.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220213.2.0/x86_64/fedora-coreos-35.20220213.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "e73a6abec6fb44ece014d07d535da4fd30d9d9af7587befb4e93a4a0fab935eb",
-                                "uncompressed-sha256": "ff7cebb706a4913c828217cdcc34850fde382ab506eb72aad6d5e2a42ff07ca0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "975e1f249d609254a25a01385c2878ed88b16fc64978bdca57e6941dec76597c",
+                                "uncompressed-sha256": "b0d7dec63a4076162e25b2d02c1aaf7006575c586ac759d13ca9e2bf31147044"
                             }
                         }
                     }
@@ -407,100 +407,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0319bf7189ac85ff0"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-05ee326c89b6bae8a"
                         },
                         "ap-east-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-07531a214944b285c"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0313e78cdb8c1bdd4"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0a716b96a405f111d"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-03d4e3966f1695d75"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0a17ea0ebd906cd45"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-09b7b6d724cfb97e2"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0047329a12948572d"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0893f89fc65e26ca4"
                         },
                         "ap-south-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0dceaa797d978c066"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0ae8d47e7687c018c"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-041563cf894c64166"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-08527cd789def68aa"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0bccd304cdba08c13"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0208a17c49c6de1af"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-033c4c60be5669fe2"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0cfacbf3b0d80c560"
                         },
                         "ca-central-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0c6b10d52f2eff30b"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0717c610f13192456"
                         },
                         "eu-central-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0eec56090150a673e"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0845998e65d78b93e"
                         },
                         "eu-north-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0164e0edbd2b75333"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-049c3560796ef880a"
                         },
                         "eu-south-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-00bd91801f8f65cff"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-059947512130a4446"
                         },
                         "eu-west-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0bcc8c603220e20b6"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0ce59a6a1a7dfe560"
                         },
                         "eu-west-2": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-064526f874517ef46"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-08ff894b65f456e36"
                         },
                         "eu-west-3": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0fd6f29b2f0117131"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0b8c9513741b260b7"
                         },
                         "me-south-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-06f75871363b73828"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0d6948ab87710fa23"
                         },
                         "sa-east-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-076b1cf25f26db223"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0f163c8623b78e616"
                         },
                         "us-east-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0297b11c78bad6a9e"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0fe28656b71691ab9"
                         },
                         "us-east-2": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-026f38fb14511653a"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-003d9a4bba01c47bd"
                         },
                         "us-west-1": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0d0819237c34b411f"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-0b9a818b7116a51d7"
                         },
                         "us-west-2": {
-                            "release": "35.20220213.2.0",
-                            "image": "ami-0763622c9b4f43a8a"
+                            "release": "35.20220227.2.0",
+                            "image": "ami-088e6151725796cf6"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220213.2.0",
+                    "release": "35.20220227.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-35-20220213-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-35-20220227-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-02-15T18:08:30Z"
+    "last-modified": "2022-03-01T18:21:45Z"
   },
   "releases": [
     {
@@ -45,7 +45,7 @@
       }
     },
     {
-      "version": "35.20220131.1.0",
+      "version": "35.20220213.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -53,11 +53,11 @@
       }
     },
     {
-      "version": "35.20220213.1.0",
+      "version": "35.20220227.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1644955200,
+          "start_epoch": 1646168400,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-02-15T18:08:29Z"
+    "last-modified": "2022-03-01T18:21:43Z"
   },
   "releases": [
     {
@@ -53,7 +53,7 @@
       }
     },
     {
-      "version": "35.20220116.3.0",
+      "version": "35.20220131.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -61,11 +61,11 @@
       }
     },
     {
-      "version": "35.20220131.3.0",
+      "version": "35.20220213.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1644955200,
+          "start_epoch": 1646168400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-02-15T18:08:30Z"
+    "last-modified": "2022-03-01T18:21:44Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "35.20220131.2.0",
+      "version": "35.20220213.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "35.20220213.2.0",
+      "version": "35.20220227.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1644955200,
+          "start_epoch": 1646168400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @gursewak1997 via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).