### PR TITLE
Roll out testing 35.20220227.2.1, next 35.20220227.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-03-01T18:21:44Z",
+        "last-modified": "2022-03-09T17:52:58Z",
         "generator": "fedora-coreos-stream-generator v0.2.2"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220227.1.0",
+                    "release": "35.20220227.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "89bbcacc5b7e0177b2afb7f3d7341f35cef7d7430c31c06fc06c0ecf3a7aace5",
-                                "uncompressed-sha256": "abea5e8e159ac6ee5c515a03d72f7926355bade58addcfda2474c611201cf9e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "943dc9ecba7f19e7a8ef54170f84f980f98929ff4dd68d9f16cacf5144a402fd",
+                                "uncompressed-sha256": "686353aeccb10ef5fbb483f1e85d8b0ef6b615c9f651f090c4245e7fab00a69d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220227.1.0",
+                    "release": "35.20220227.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "11b2bd455004e1747a9e77d0f32b0877d8b8d2f04e5602b42c1c1a5466a90a3d",
-                                "uncompressed-sha256": "ef1c9a1dc3d6971d59d57df2e8629fdc55df61e99099c120c79f43bad110e989"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "88a9ddd56fc57667c4a0e239086192d6cd0e0c4bc6f42d5a936bceee8d822ca4",
+                                "uncompressed-sha256": "2075c9a4c21763399c7d10dda24dd1f3628b4d44091770e1a65acafe1b0e4741"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-live.aarch64.iso.sig",
-                                "sha256": "99381c5308cf0835d22f6d83a787c23f982099b71d4c6c56d639558505f4f016"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-live.aarch64.iso.sig",
+                                "sha256": "9f7c7df8216356d144200100d702d3b04f736345b95a528e26cdc635aa719d96"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-live-kernel-aarch64.sig",
-                                "sha256": "497b13809b045f99031cdd1ba12d53014cd28a6798b7e504bb8b50d40e8c9f17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-live-kernel-aarch64.sig",
+                                "sha256": "162048a19a21d6302f2c00706a2fd48b13044120598e79db1cbe435bd20a5fc5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "254d6a26ef732d28a577f5a5875b928b88712b2a9cd4a74e643b9b0e4d5e925b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "d4d4509a3c5464bf5b4622460c46405a67b21a784d2a506e0e7167409df93a7b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "d3d32e096bd184de47a094763d12b2eeb39be75279b72dc91495ba52290d585d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "7fbb864f15fa0308a871412a3f8dc1dfc41d2c35c4a4dfda2fc1d77eaf6b60e1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "0d50ff9cadfaf366a9bffa370e41ab07d922d48c309f539bb049b3b06eea106a",
-                                "uncompressed-sha256": "4bdd4bcecaccd3c33a22dd9e3db876bee571f5e5e6e3575530378c2ec4234e23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "5e171e24bff19f96fe4207a546b2f77d45e46ad2100613bbf5068508aab1fa07",
+                                "uncompressed-sha256": "9c2ae9455eefe04d157ed2d54784011dfdccb5303ad8a874abd6dba597f761d0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220227.1.0",
+                    "release": "35.20220227.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "d1e15fb0c97d7345f95762f1484a9d1cc9235c8e7b67789d9d16b2f7c0348aa2",
-                                "uncompressed-sha256": "c9633736d38287cedd33dbf6cf382d69e80bdcced121bfa63230c77bd05e70e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "2bbabb48c2455a5cc2c56b69ede7441587568d3b145938a235918f1a2eb355c1",
+                                "uncompressed-sha256": "7d05ece2a054993597eb9f575624a9e43aaa8a0d956db68b929b36274a222062"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220227.1.0",
+                    "release": "35.20220227.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/aarch64/fedora-coreos-35.20220227.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "5cbe2771d65758eb2855d2d48b5d7fdf074011ea682b075c52e51e371c71d852",
-                                "uncompressed-sha256": "8a148d5a853ea6089e76a7e3b5a3f3e29db050f77ed203137c8fd443aaa66d49"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "e4ae82ef49d545ddaa7502adf8b454a8495bb3e5c3db37ec5162fb29e934a442",
+                                "uncompressed-sha256": "37af35eb310f14fd9d0d1335bb6bbeba7296811ff4a889bf4cd79d79b1a8a88e"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-0a09aa1f42ce275fa"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0c0f83c68669b5638"
                         },
                         "ap-east-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-01413f73b42f1b720"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0bc59427705fd0dd1"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-0dc1c5f65cf2443eb"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0552f8efaa0df0e85"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-08e6238758ae2ebfc"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-03c09a92eef788efa"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-0b584b332e5d06e27"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-09b63d974b767e9dd"
                         },
                         "ap-south-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-00b9a9c76299c9635"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0265bd936b2005fee"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-070b4f16d19bb4f40"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0a85ebd0871534d93"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-040dcbe40cacee6d7"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0da09cfd3a9de3e76"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-0ac7a59672837c6bd"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0a00b5189588bfaf0"
                         },
                         "ca-central-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-0789894c3a6a1a935"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0e92945778d5e4012"
                         },
                         "eu-central-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-0f26467e7bdf63968"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-007a006bdc48e4c29"
                         },
                         "eu-north-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-031e5a2a234770089"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-07829af8bdfdec8d8"
                         },
                         "eu-south-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-09072357c3e6b2128"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0cf92ec59b3e3d9e6"
                         },
                         "eu-west-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-00f9d689d4b06d251"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-09740f17b56565aff"
                         },
                         "eu-west-2": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-07276e1c733453598"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0c631fc57ada5d138"
                         },
                         "eu-west-3": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-0c964064fe2189d9f"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-06be8c7901e94bdb0"
                         },
                         "me-south-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-00fb30b72547bb5d9"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0f69aa3d1e5b55ef2"
                         },
                         "sa-east-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-01aa47cdae92bbc8d"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0b462a3f8d30d64eb"
                         },
                         "us-east-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-09fa743ae0edd0613"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-02412801cb40c39a2"
                         },
                         "us-east-2": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-03faf8212e7d18e33"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0d68341bdfe5559dd"
                         },
                         "us-west-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-07f0a5baada496ef1"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0258e2dfc7a3ae8d8"
                         },
                         "us-west-2": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-033a224513fb2d3dd"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-02c5fc6d4fe2c321a"
                         }
                     }
                 }
@@ -190,214 +190,214 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20220227.1.0",
+                    "release": "35.20220227.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "8c53ad4c2a8deb310a318ee90a64d19121d186f78e619a78708cc88c9aeced7a",
-                                "uncompressed-sha256": "0586fc61262eeefc2a98b7030df453885866475405968a413ecfbd3d4830c8b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d71636ace25d999b31e92c3a0ed65a65521d16e4eab190128c52b31e930a4fad",
+                                "uncompressed-sha256": "d59956d1e17d870c2b85c59687ee09550ca8302d16934b4877a91ee538edfef6"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20220227.1.0",
+                    "release": "35.20220227.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "8c16ee38ba4d7b52cb0f093fd640cb4570bead6eaac16f8b10bdea185cfa6759",
-                                "uncompressed-sha256": "b710f37a235465f33a1e876923314a5e2fb2c86b568fff26888ffa335b8ce881"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "a8f4f2b3655aa136eea39f5bbf874e17602258fcccc579cb742b2481e903a6cc",
+                                "uncompressed-sha256": "6787b1cd54c044b867ed5242a20d82efe85ca4e66ab077e29ab1b1e2ce0f1009"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20220227.1.0",
+                    "release": "35.20220227.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "c03f5a9af57873018ac4d47a57f1b1f30f5469d44dd17cbe8d1c7ca2dcc90f81",
-                                "uncompressed-sha256": "692136e3cd71f52ec87da517da05b146dc01ed727cdc3af57facd3df0b519b30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "35c435ad14bcb6ef294ba5776af11303163c2496cfd9c480ddb0148757c249b8",
+                                "uncompressed-sha256": "6c7892a6c2eb261b50c05d1e2e9727acc16d35155280bdde840f18120f3754a5"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20220227.1.0",
+                    "release": "35.20220227.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "2948dde71645f20424b0f577b8c899b73b90f8922850577179e58efcf5b414ef",
-                                "uncompressed-sha256": "158440632c310765a99e77abfe1cece5d6383d56126c16b35e757245827ff8e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "07d8439f1f7fba292d003d3b6d3cd6b4c495d863bfc4ed5923729c58370f26b2",
+                                "uncompressed-sha256": "09e8084864b4af6387191cfa68bde016854dc332c484e9deedc89832dca10249"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20220227.1.0",
+                    "release": "35.20220227.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "847620105c31eccd3dfc6f1b8f8014fd8c3633a1fcb7301fa983ac8fdbca55bd",
-                                "uncompressed-sha256": "ab3da367eaf1f9a157304a2faf383d2efd6196c4df8acc1ce0ccdcf726bbf163"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "8d1a2890bbbc6e0b587cad176baa6e5f2f87f29da294974231037739f2b45a96",
+                                "uncompressed-sha256": "166794bad7e564c2715e04da5d2cf21fb593c835075ce9f7261c23c026808ba2"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20220227.1.0",
+                    "release": "35.20220227.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "36a28ee2f40bcff9d4d742dbd73f9f1121ea0ae36b6636a839fa0903c1759a69",
-                                "uncompressed-sha256": "952f228fdc7f7a169dc67271c06ade7cc7a6b66744231792efdcea3527c7f978"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "7d37c441460cdc3aea190bd43e945ed2e5f26a70ac60319c12f6d70a7453e960",
+                                "uncompressed-sha256": "3303e3c041afba5e0bf63773c6aa903d64b2e9ab2cd96b2fe41cce04756ece75"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220227.1.0",
+                    "release": "35.20220227.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "6b15f7a71a4100bdf7db1c29d5f9dcf218b84e9409ca188639e7463dc18deba5",
-                                "uncompressed-sha256": "b6065bb9e4e31df6eb5cfeac478944fb40797c62fb759faa42189116e4ac7c45"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "9df6734d52b3debd3216389388f1438d1f5243fd1f8f8752348c8778357dfa9f",
+                                "uncompressed-sha256": "bf7c6cb54ce0023a258bf2831d019c0f34a3dc09c3a9c6e2881a79e1ac27153e"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20220227.1.0",
+                    "release": "35.20220227.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "b871206c102d0c1b02ab419c1415a51dd936d107239bf21404d27d9a23ec54a4",
-                                "uncompressed-sha256": "cfba48d9db6c65cb0e09f2022130780df071e0b9c8ce80b1b73460521add83ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "5c98e1c7ca9ea89087c912dd3bef64d47b4edd880364c58efedcd2407a9cdaac",
+                                "uncompressed-sha256": "0a346b66d6f4771ba16e1d61ee9d05eeecfecffb1c9df7ff68eec6b269f169fe"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220227.1.0",
+                    "release": "35.20220227.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "442c97a56887e56f07320835f66b155e6935462b536fd69a156e7f2311733dea",
-                                "uncompressed-sha256": "27b5b35cd9ee15e035386a0a854b8e6a2430749628a17a69e05d8dc58da23dc0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "b16ea6ba61758a0edd009a7a821477375cb752f60a813f9dcb9b77b508b19212",
+                                "uncompressed-sha256": "036765bad47fe4a6678ef2aeb73bfbb75f75a0f5557d9cc1c6cb68dccdc85560"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-live.x86_64.iso.sig",
-                                "sha256": "66436a54e052227f137c789f5cc7b2f8493416ff7ffbfa06f67041bb60fcfa48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-live.x86_64.iso.sig",
+                                "sha256": "a14821e79ecd6e105fcc90fd76798bcc4e479e0890cef082484d8a6d6f09a6a9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-live-kernel-x86_64.sig",
-                                "sha256": "819fda78ef91bbb41809433c36e2047c5fcf4324b7d14b3a4a13b77d47565a3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-live-kernel-x86_64.sig",
+                                "sha256": "f8e91b01ece4d3b0aaebbe0f97d1ad3c639418cae8bf96b4e2b0d50f90f8a75d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "9cb254ffa98c130767e440353cf9c555d6b0f6ccc570baf68f9b78532d5c5eb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "d58fe6d4e0b473a0856775f0ee5a06dc8c6bcba47ae9c337be060da233bef2d7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "3754cf31a23b10de78773c82111994c48168d89cbb9cc39bff4a2b5adf08c9d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "0050d38a38af783b9be1afca776d27fed91cfad6dfdd68bc862d207fb3eeaf16"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "6dd9a81c514283dc82567bb3fcb48147f568ddfbf79a3fb13992f350874145a7",
-                                "uncompressed-sha256": "9639bafc5e3dc8ef5a82509fb6de9ccab112beaa30f5d01c5948b2fc45ae3819"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "a7433887a074869710da4fb6466b501f9cb261455702cd4a34dff5c6a1c0cf4b",
+                                "uncompressed-sha256": "bfed03f33e8569a80d8ac9781fa55edec634937ae10e1b09a7aa6d3a007e8cc0"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "35.20220227.1.0",
+                    "release": "35.20220227.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "61fb77ecc0a61fe97ca322f10ab902287fa3d3726c5a88d452a689e6aafb31a2",
-                                "uncompressed-sha256": "3026d8c2bb9ade26e66d1fa0081c5ee53ddd59ba6a9328ea1e370645779e222d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "4adafcd31bc113579ffb3db1792a9535150eb7dcf4a194f2988ecd3059f1074a",
+                                "uncompressed-sha256": "96fa52189052993f823e5b237eb3ad7de3fba0e2797ccbc772cc4ec338733b38"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220227.1.0",
+                    "release": "35.20220227.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "846c75855bd38ced0ece4b97e0f66d1cbc3ad3a519ca36e825229dbf68486764",
-                                "uncompressed-sha256": "8b591badfde75c6411edf1e7046fa738c0bd9b2a6cb5738ebf08292bc4199f08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "6ab115b938f56653797a3a7c42e9291c7cda3230356c8f80437036b07fa7972c",
+                                "uncompressed-sha256": "eac5064e29b01347aaa18cda2c49f25ab60a820b5cad1dc55480ec333dfc2304"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220227.1.0",
+                    "release": "35.20220227.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "a22bf32055042bb21f3e707fb4b32d8e83a7731af29e1ff998dcbcc6bb74e157",
-                                "uncompressed-sha256": "ad1e09a7ca466f512dc2aa3d390638012653f4fa3e0abde4df59638b6324d64a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "90a61177c3ef18c30c76d82a106758738b33fc80183541cebabdb9ff257a3d30",
+                                "uncompressed-sha256": "1cbfbd5f06d647a7df4647bb28f9c1a93638fffdff0b8bfa31fbde6921865824"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20220227.1.0",
+                    "release": "35.20220227.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "4547c0ef9dacdfbcb11b486a2f425e448beddf079d81acd7acd3ea730d116f08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "73017988a4b99b10f14e24a0ebc3429fdabd5ba3e4c168dc33349696b784193c"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20220227.1.0",
+                    "release": "35.20220227.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.0/x86_64/fedora-coreos-35.20220227.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "8300df44256e25ed8956cba9df67272ceee71727fcd15e279b48c86b4d933991",
-                                "uncompressed-sha256": "b2e6c0a663a9bec431192bcf3f2117987095f8babbadeb237ddbe8a9a6083ed6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "20688bf6543de2a2d33ca7432d57febc83266427705e103f35d97a8d9fcc1158",
+                                "uncompressed-sha256": "05d3157d0bac87756d034b1e244a965c35d34bca249ca9277d758f528349caa8"
                             }
                         }
                     }
@@ -407,100 +407,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-0e34154475d9c0d4b"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0c67fa68a227a3324"
                         },
                         "ap-east-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-0bcbc67435a7fa556"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0fcb214cc92f36943"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-0e263f59bbbd63fca"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0b08fe4781c0f2818"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-0ec0fea156cf2fc0e"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0abb897d72138ce72"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-0419ab56488bbadde"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0da1b17722c6cef1f"
                         },
                         "ap-south-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-0021ea94822727b1f"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-06ddedaa0890ac4a4"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-0d73e9efe22a33414"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0f9114937ff03596f"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-02f215e1abd688565"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0d9764f6639b31225"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-075c164d681f99526"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0f4f4d54c8dd0a389"
                         },
                         "ca-central-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-0d9292a29800a4f50"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-006a0ac1765b60872"
                         },
                         "eu-central-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-02953ff6e3c237b03"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0eb6e992f9d7e9473"
                         },
                         "eu-north-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-06970397d028ac52f"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-023a4145e73ac6738"
                         },
                         "eu-south-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-007be425d61314441"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0f2bdea5781fe6431"
                         },
                         "eu-west-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-0d85cd328f4ee10bf"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0d26f5722e73d7b12"
                         },
                         "eu-west-2": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-0a752b2f899eda43e"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0e0bcdb8b085a1375"
                         },
                         "eu-west-3": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-008c44a52cef73830"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-07eb4ecff35b4f471"
                         },
                         "me-south-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-06e210c977b8dedc3"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0cda070ae367f3fdb"
                         },
                         "sa-east-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-03007b5966771950d"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-03be1049afa16a05e"
                         },
                         "us-east-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-0274c95a639845095"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0c72f4646d855a439"
                         },
                         "us-east-2": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-06c983e752d0c51ce"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0c17c6f27a1d90aca"
                         },
                         "us-west-1": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-0d778844dde4a5650"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-0171b6d1e69d2073f"
                         },
                         "us-west-2": {
-                            "release": "35.20220227.1.0",
-                            "image": "ami-0936c265a97568a81"
+                            "release": "35.20220227.1.1",
+                            "image": "ami-031d77c4bad3bd77b"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220227.1.0",
+                    "release": "35.20220227.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-35-20220227-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-35-20220227-1-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-03-01T18:21:43Z",
+        "last-modified": "2022-03-09T17:52:57Z",
         "generator": "fedora-coreos-stream-generator v0.2.2"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220227.2.0",
+                    "release": "35.20220227.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "d77ce52b9fdf92739757e9f78d752392f9cb865a2fb7783f19413d797ea486bb",
-                                "uncompressed-sha256": "0eee86f35ba58096028235c8123e7b935194332005b778ab91a2fd5e386552e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "1c2d713e7a196fc222632653b5a3e88053aad8bffb7828ab36c6415bd2c7b91b",
+                                "uncompressed-sha256": "961da5cde8975907dc4bc3e7c80aff6d976acfce6ab6b5d358a5fec684735043"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220227.2.0",
+                    "release": "35.20220227.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "a350e5c28d238cc0bd6b82f601f83d7018b5363a421bac175c9878d4694495b9",
-                                "uncompressed-sha256": "e52d5507611488fffed5295a7a5955eaf9ea0ebcf4ae1b1f724f230961fd6d60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "b82a00fbd7a618d7ebf3a3e3aa358fdca3b8960903859d7a672fa087f42b9036",
+                                "uncompressed-sha256": "49d2b9dd75f9ef8c310546154816ac78bf485b5dc4314efe6b586be729ec91e9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-live.aarch64.iso.sig",
-                                "sha256": "3ae81e03c5202bbdbc241d7edd25a81f339a04b57920450ed2877ed8a7da2b5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-live.aarch64.iso.sig",
+                                "sha256": "6b0b34c5b1a79227056dcaa463f97bd983dfd47854d1022d05a1fd28597c11fd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-live-kernel-aarch64.sig",
-                                "sha256": "497b13809b045f99031cdd1ba12d53014cd28a6798b7e504bb8b50d40e8c9f17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-live-kernel-aarch64.sig",
+                                "sha256": "162048a19a21d6302f2c00706a2fd48b13044120598e79db1cbe435bd20a5fc5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "ecab03f3a795fd5cea31cbf0561ff4076f73a580b1c8d6f6d3a08f22652b762c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "70fd70a6d8051d2a9ab6b276d662a3272f2f343b8c25ac4df2c23e079bf3344e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "5e06ca991d92a7e9538aa74c5f7b9a7f2d8e1f009b0d71be03cd997d494a7f96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "a0e48ec34f5d08fd1a0c1f5521e2c88449be6a5a0062ec80819facc8b383e689"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "0bbf7f4ea9edc73d91b4b51da78ffd330f21277ead172486d5e93265f224aa21",
-                                "uncompressed-sha256": "8b27690426feb139246df7df58e034aad1eef26fb48b17266deddbda5839c5dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "09fc7d2f863b1fae9ebc044df54701886a780b09fb129aa62e9b8af6f2ade514",
+                                "uncompressed-sha256": "c71d31fdcd967d0cc7019db68da3706bcf769ba5625123c8ec293ac6a6cc5901"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220227.2.0",
+                    "release": "35.20220227.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "01e1c1725e59c8211c93ec19706de24b22a8a9b7cefbedcd10b43ae1f4651aa1",
-                                "uncompressed-sha256": "ca261e3ee04ad0a93d21140f30b5b9d12220db20d05e0149a12d4d9e1e1b6c8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "2924ce82b5cbb16b15e7cbb575ac27fd10236125aa0d29e598872cd3f216bf5a",
+                                "uncompressed-sha256": "ddcf05ffe0753508127ba11a646eb8ef5b56d32db9e587dfd0b3e1ff47301307"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220227.2.0",
+                    "release": "35.20220227.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/aarch64/fedora-coreos-35.20220227.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "ab4e60172b8c953eca614b4f517bf86c21d7f04d00b323aa4e920faa1b9d259d",
-                                "uncompressed-sha256": "c3bf77c3cdcb8d3ea346f12d44b39b3486ba5c33364df22fc6d111949486b57f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "1abc4af523e513c36712c25824c33d2342d5debf0bae7d80810843c0122c8657",
+                                "uncompressed-sha256": "3e70b8c72cd7f319b4b91a6ad53ff60126c3e9951a8894f9647333a3f2d3aaeb"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0c739984d3507d7da"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-07b351fa954fc01d7"
                         },
                         "ap-east-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0d3108153c9b154c3"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-01d41ba1854e8a71c"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-05b3aaf7b83db7e0a"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-0223212fcec5558a9"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0bdea33e5a2b9b2d6"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-07baff9aa18687ec3"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0ddbc8585ed42fd9f"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-0dae6926d53d9761f"
                         },
                         "ap-south-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0f31bf9f3e6a88b38"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-0066ce47c90838f7c"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-009ea3db10666e63d"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-0f2bc74fc3b042f29"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0d80360e9b01ce839"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-0056120ca73cb1ca0"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0b3fa9c3b7f1ed61c"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-00bbbc2bb1b86440e"
                         },
                         "ca-central-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-07ac14f5ff6e0e3fb"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-0785253714595aaf0"
                         },
                         "eu-central-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0b44f9b5c3e773260"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-04a9d7f81d2cfadda"
                         },
                         "eu-north-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0e762e35204bd4b94"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-08082843943a9e2f1"
                         },
                         "eu-south-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-014ba1d865d2db1ba"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-01bcbe48c57d5e685"
                         },
                         "eu-west-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-07d751f8cd7a31061"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-04bfb593a27dc0e89"
                         },
                         "eu-west-2": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-02639a34599a64b39"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-0a9b6bd35d019240b"
                         },
                         "eu-west-3": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0702d047077b7942f"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-0f90ad6416da1f52b"
                         },
                         "me-south-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-02d83400fc3f0f6ae"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-0fa468916b50e0df1"
                         },
                         "sa-east-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0e479f7ceb420b4b6"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-03e429db4042590ef"
                         },
                         "us-east-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0862763d88c89bf7e"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-049478f4119881fd2"
                         },
                         "us-east-2": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-05e0bc4f349f8e12a"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-068e85162deecb72c"
                         },
                         "us-west-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-00a301cd77f1594c9"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-06cd73532a1a31be9"
                         },
                         "us-west-2": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0594d10d8345da763"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-0da8796da996deed1"
                         }
                     }
                 }
@@ -190,214 +190,214 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20220227.2.0",
+                    "release": "35.20220227.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "cfd66af4abf002cf04d1051f6847bd5e52ebf6bc30388f2a9c84e119b90fc68b",
-                                "uncompressed-sha256": "1b880403bb8f31776d3a613e772853aaab8dfdef719a56bdf59680e5ccd0a67a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "cfbdbc7cab42b584baf2815aa9412803fd0ccf5fa2351d49dd149862f58661b3",
+                                "uncompressed-sha256": "ea3c90a5a06bf634be4c0ebcd4b5ea16014b70cb61c0c40fa915eb109ae72fb6"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20220227.2.0",
+                    "release": "35.20220227.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "ff5ba2f75cecae0b9889efe47a06ba15c7eaf552f099194b5006d1aa857a9d1f",
-                                "uncompressed-sha256": "4966d6364eea2ad1acda037008537a5630579b893b9d860f04a47b2e465ece35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "18de3118172679f332bb9c58f0a457d87474aa6ee5518b0ec7afb1c20a1fa1f0",
+                                "uncompressed-sha256": "7cf2a154a306851266018637d81e289c404d5867c67ade34613c48353ce2445d"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20220227.2.0",
+                    "release": "35.20220227.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "fa3c1bd44ee1d8ac1d19a279220446f56224b651d608644d8a9e5bb819814bc7",
-                                "uncompressed-sha256": "33097caa51c0eeab2207ba48c6a21a9de195386172d5768830008621e1fa6ef4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "fca26a98f7aafc7d4e7797f3c652ec5267439544efb05fa602371dcd6ddd46ea",
+                                "uncompressed-sha256": "6c9bde100504672299145722748333af8e0dffea332d5b883358f853f4b2df15"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20220227.2.0",
+                    "release": "35.20220227.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "3ace066f7f0b389aac6b806521a5a9e8cfa909dd7282e8880d650f32e220506f",
-                                "uncompressed-sha256": "2dc705dd1de682679d7dbe087809a1e99f1d9ea5a354420a35f5c53391e5df0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "9a433bdc627d1778de04988426f2f6ba4e42f0c2985b929bfd262a427f700854",
+                                "uncompressed-sha256": "b71853b069544c7916d0696c83ff85914870e24e8249199a4abb448d2448dc8f"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20220227.2.0",
+                    "release": "35.20220227.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "6b4e6014fcb12b6b3a3d3bc5a7ddf161488bc137fcfdd26baf33c6a10d73af37",
-                                "uncompressed-sha256": "fdca6f8001f1e2f1062fb5023e549d93b894a6d44c3959b0d3299a905bc2bc58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "3c2ef4abfbe0428930778c91ae6227020b94945e67d39b5bb84eaf1933dbeebd",
+                                "uncompressed-sha256": "85c8dfbd1fb2706d67b38beac601d522e912d66e540c5c0f1426d659fb9d21cb"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20220227.2.0",
+                    "release": "35.20220227.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "962749314ed1666270862e759a21dc08cf20e5d72fdbbb1899714ca229eb3295",
-                                "uncompressed-sha256": "ad77f0cca60625b2267ccad5d744b4f9755e29fe5b7c9db5aceecd6d8c27ec68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e5f3a360acbad04032d890a20438d5ee9d9b8b5e246d8b99eb9c95636b3b1297",
+                                "uncompressed-sha256": "72ca4e43f2625d6b1bc19fd4f6a49c2db99d62c85eaa440ff546398201c493ea"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220227.2.0",
+                    "release": "35.20220227.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "7f80b22ae44b9514259550664e1723b50867a55b261d3d8defe658af87b5bfba",
-                                "uncompressed-sha256": "fc48b62a62b9f5e08b7990b81f95c8654d61919b81174dfa4b5e15b927a699ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "ee423c03a7a1dee85c8f17b96e1267fa33c6513d43d0db1e847b8fb8f06cb822",
+                                "uncompressed-sha256": "64a1292cc9b8c002961bd2d95b3cfeaa062ce0059b91c17aef8137ddc03cfea0"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20220227.2.0",
+                    "release": "35.20220227.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "702baf88eff56083df4c3752fc197507d349fdbe8e56cac36bc991d844f003f9",
-                                "uncompressed-sha256": "56082cb72e6422a7b741925704590a07c6fa20bba75f1ecca318af5c6461a011"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "ecb985e6081e1892c0efd5b8c433e9ffde2f283556efb4b0e9644f472269d46e",
+                                "uncompressed-sha256": "ef1b373edbd13a87613340324f165d7efd25c0d7e76e7891790e250f6508f5be"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220227.2.0",
+                    "release": "35.20220227.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "2dee93ab0019062c1bcd1bac81ac4df158a4aaf52cc336753400bced496170d4",
-                                "uncompressed-sha256": "bb09e2a304f0710eeb0c7117cd1da99f80e3eefbe33b1efc1874bab460fb9ca1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "0dc67d5a2c00a5c7cf6c43a6cd3e69627ac90c56927db42e67061cf5aa2916bf",
+                                "uncompressed-sha256": "1eeb6650d489252a480548a088795510c348e8d45148467553fd1f2061423b15"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-live.x86_64.iso.sig",
-                                "sha256": "fb0c5fe1f0dc54ea94833bd6afb509fe154939480d4c468ca9794a9afad9e19e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-live.x86_64.iso.sig",
+                                "sha256": "1277085bd0ea2b872e149dd5a6e46c2783d06f77c77b4ec74da855c8b6c599ca"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-live-kernel-x86_64.sig",
-                                "sha256": "819fda78ef91bbb41809433c36e2047c5fcf4324b7d14b3a4a13b77d47565a3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-live-kernel-x86_64.sig",
+                                "sha256": "f8e91b01ece4d3b0aaebbe0f97d1ad3c639418cae8bf96b4e2b0d50f90f8a75d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "ee29eab5bcb168559d506978d2eda660f7e2de9d4044b2a3cdaf7847d8a17f5c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "727007a3e10bd558231492ac0b9f95d98e3e8a1c3154cc4c33a3c265a3c1020c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "9ec6ecf0cf69c3b6927fe94bb14fa0d4b5c9c4e0fccf464d8d7ac15157472f39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "c9322e488208387c761e1058f8c9131f67e7646f28f0aaa743bea9733b4f311a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "2765ec4948b399d2b1b36a17ae4f5a1c9e8b57f4b30ceaa33fc48fcd1921d113",
-                                "uncompressed-sha256": "df834a18658a391cad4e764dc073f1885e420f457e593432f36e515d5f1e0567"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "7568699ec3618b50b7e2281fd1859171420e03ebe2bcc59b33df5afea8bc5b79",
+                                "uncompressed-sha256": "bdb7f9c404cf1278f78be861f8df8cfb35b71210af943c021b2e0b28c507190b"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "35.20220227.2.0",
+                    "release": "35.20220227.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "a8dab9c45646475c6cbd67b38f39e7cb62ee8665b2e16d15cd878773d067ff5c",
-                                "uncompressed-sha256": "89a1ff3ef25ce05b4af6d15c8273a324f3090905727ded5edc7eb97511a3319b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "323fd67c0d0701c202aa609d8bea02afa06b6f89a3e882891818e8bf5e051cb8",
+                                "uncompressed-sha256": "7b25d8f390a0fd6b1b1d92a354f6df47ebbc3b129890efe6c72ab924c3c24eaa"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220227.2.0",
+                    "release": "35.20220227.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "301b94b5aacece1c7340f1869d6b911f962701ead16a6154b1d0874f0f0916bd",
-                                "uncompressed-sha256": "e67223f94b7efd3774d8d6dca13bab3c9fdc00da2f4679546cce8c0991c08334"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "821f2f10f1c25c446d2ad40bdfaeeadf4222e99bdfaaeabb1bf07d7936e70a24",
+                                "uncompressed-sha256": "75a1d4ecbf9ae28a612732a320724824704a68d1129e6027399dc54b430dcb59"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220227.2.0",
+                    "release": "35.20220227.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "c86d9a55ef3cb34ff11091eb8ae59507cf15db5295b4f8135ac1767ee1d56079",
-                                "uncompressed-sha256": "cfbf92403681ffb30e7fbee3a24413171b6fd000045f879ea18248b2736a6c65"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "82e6c86272b5d6aebdc768098de233892996e3f36e59f48b366522ec413f4e18",
+                                "uncompressed-sha256": "793f8bb67b98dea5a779e249947a4a340f08b949a7723a7466df1501b3354d41"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20220227.2.0",
+                    "release": "35.20220227.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "e858f4538649301c23ec72a56f516d5cf16accaa43606fd3d70669548e904134"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "240eee88b9a7143797968a0ef48e1e81ced0339aab3f57129fbb5d6732b572ed"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20220227.2.0",
+                    "release": "35.20220227.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.0/x86_64/fedora-coreos-35.20220227.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "975e1f249d609254a25a01385c2878ed88b16fc64978bdca57e6941dec76597c",
-                                "uncompressed-sha256": "b0d7dec63a4076162e25b2d02c1aaf7006575c586ac759d13ca9e2bf31147044"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "02440742f910d635cbbad43ef3b76ef1add6ce647cf00f4ce2ebb87696a899d4",
+                                "uncompressed-sha256": "c7232ecce3f0c8ac6f825c58ae5d1aab138bd65e59e30e2f77e9ffd1f514ff22"
                             }
                         }
                     }
@@ -407,100 +407,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-05ee326c89b6bae8a"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-0ba429f0acd66bc7a"
                         },
                         "ap-east-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0313e78cdb8c1bdd4"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-0f38a7160ef477069"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-03d4e3966f1695d75"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-0f9f39e9abc18bf94"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-09b7b6d724cfb97e2"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-0d44c3de9e59b6bb5"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0893f89fc65e26ca4"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-068b99c1be5095cad"
                         },
                         "ap-south-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0ae8d47e7687c018c"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-015098750d9439d12"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-08527cd789def68aa"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-0e4aed474cc8b6b3d"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0208a17c49c6de1af"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-02cd6e0657063ef79"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0cfacbf3b0d80c560"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-042cb163981cdd1ec"
                         },
                         "ca-central-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0717c610f13192456"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-0ca52a220863e3d41"
                         },
                         "eu-central-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0845998e65d78b93e"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-05f174f79ca889d78"
                         },
                         "eu-north-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-049c3560796ef880a"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-0570b02d7e6312464"
                         },
                         "eu-south-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-059947512130a4446"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-013ffc70ef40caa96"
                         },
                         "eu-west-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0ce59a6a1a7dfe560"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-0e0ea60acdfa4cc5d"
                         },
                         "eu-west-2": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-08ff894b65f456e36"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-042ba1e63d5bfa5d7"
                         },
                         "eu-west-3": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0b8c9513741b260b7"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-07a71d0873d2c6f10"
                         },
                         "me-south-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0d6948ab87710fa23"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-01339f9fb91467ca2"
                         },
                         "sa-east-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0f163c8623b78e616"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-00541605dd31678c8"
                         },
                         "us-east-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0fe28656b71691ab9"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-02afd6067c1505310"
                         },
                         "us-east-2": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-003d9a4bba01c47bd"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-01a46890c8b05f5fc"
                         },
                         "us-west-1": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-0b9a818b7116a51d7"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-0ba8c6ad180df4e84"
                         },
                         "us-west-2": {
-                            "release": "35.20220227.2.0",
-                            "image": "ami-088e6151725796cf6"
+                            "release": "35.20220227.2.1",
+                            "image": "ami-03f610397346afc9e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220227.2.0",
+                    "release": "35.20220227.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-35-20220227-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-35-20220227-2-1-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-03-01T18:21:45Z"
+    "last-modified": "2022-03-09T17:52:59Z"
   },
   "releases": [
     {
@@ -45,7 +45,7 @@
       }
     },
     {
-      "version": "35.20220213.1.0",
+      "version": "35.20220227.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -53,11 +53,11 @@
       }
     },
     {
-      "version": "35.20220227.1.0",
+      "version": "35.20220227.1.1",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1646168400,
+          "duration_minutes": 1440,
+          "start_epoch": 1646850600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-03-01T18:21:44Z"
+    "last-modified": "2022-03-09T17:52:58Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "35.20220213.2.0",
+      "version": "35.20220227.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "35.20220227.2.0",
+      "version": "35.20220227.2.1",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1646168400,
+          "duration_minutes": 1440,
+          "start_epoch": 1646850600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).