### PR TITLE
Rollout next 35.20220313.1.0, testing 35.20220313.2.0 and stable 35.20220227.3.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-03-09T17:52:58Z",
-        "generator": "fedora-coreos-stream-generator v0.2.2"
+        "last-modified": "2022-03-16T11:03:26Z",
+        "generator": "fedora-coreos-stream-generator was not built properly"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220227.1.1",
+                    "release": "35.20220313.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "943dc9ecba7f19e7a8ef54170f84f980f98929ff4dd68d9f16cacf5144a402fd",
-                                "uncompressed-sha256": "686353aeccb10ef5fbb483f1e85d8b0ef6b615c9f651f090c4245e7fab00a69d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "e6332b58a487be5de6240867549fd9694abb2ee835255a934999519444ac12ea",
+                                "uncompressed-sha256": "6c1bbf75c17355a1b9aa4e18909b33d997e5ae1c9f4e1a3e381205aceb1f6dab"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220227.1.1",
+                    "release": "35.20220313.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "88a9ddd56fc57667c4a0e239086192d6cd0e0c4bc6f42d5a936bceee8d822ca4",
-                                "uncompressed-sha256": "2075c9a4c21763399c7d10dda24dd1f3628b4d44091770e1a65acafe1b0e4741"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "570f707e149de25fec38c645d21eabf7e456aa622abf1a5e13ce81a1c7233253",
+                                "uncompressed-sha256": "12ff840e309204a7471c3c51b447d61d6219872b456b91637f10789130bdcb97"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-live.aarch64.iso.sig",
-                                "sha256": "9f7c7df8216356d144200100d702d3b04f736345b95a528e26cdc635aa719d96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-live.aarch64.iso.sig",
+                                "sha256": "f79be6bd36727023829a08f2f2da904d059fd555331a49b81caac01a31d12576"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-live-kernel-aarch64.sig",
                                 "sha256": "162048a19a21d6302f2c00706a2fd48b13044120598e79db1cbe435bd20a5fc5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "d4d4509a3c5464bf5b4622460c46405a67b21a784d2a506e0e7167409df93a7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "2ca94b0f24d2e6479f3821a56ac7d99939af37d34129e42bdf8f6fa59481d9f5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "7fbb864f15fa0308a871412a3f8dc1dfc41d2c35c4a4dfda2fc1d77eaf6b60e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "2a5a72fdbadcba21a7fb09737c15f30c37d10d5925791b477d8fdccdabe9ddd5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "5e171e24bff19f96fe4207a546b2f77d45e46ad2100613bbf5068508aab1fa07",
-                                "uncompressed-sha256": "9c2ae9455eefe04d157ed2d54784011dfdccb5303ad8a874abd6dba597f761d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "ef33ed07c9b7590f50cd9794fe9d0f1ef0b8edf5d08469914676e3aaaf4480a1",
+                                "uncompressed-sha256": "875b61e4133d9416ffadc929187f958ca36ca8e974e6d9a2f7176891d2695367"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220227.1.1",
+                    "release": "35.20220313.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "2bbabb48c2455a5cc2c56b69ede7441587568d3b145938a235918f1a2eb355c1",
-                                "uncompressed-sha256": "7d05ece2a054993597eb9f575624a9e43aaa8a0d956db68b929b36274a222062"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "5d03d84074b335d2dde7c6f368fe2109db77a878993e10f7e151f737da1e1a89",
+                                "uncompressed-sha256": "1464c2291b85ca5bc2144cee02c165e489ac39aca55683b59fe17f244a1126b7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220227.1.1",
+                    "release": "35.20220313.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/aarch64/fedora-coreos-35.20220227.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "e4ae82ef49d545ddaa7502adf8b454a8495bb3e5c3db37ec5162fb29e934a442",
-                                "uncompressed-sha256": "37af35eb310f14fd9d0d1335bb6bbeba7296811ff4a889bf4cd79d79b1a8a88e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "cb42cbe83ec4fa197603d70d74e7f55d02de8331b63d5be268159ef345dd0805",
+                                "uncompressed-sha256": "1d51899f0b1c33fc86901cb9fb06a0afa757cce0b02a4afbbb4b1c2ba20d562f"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0c0f83c68669b5638"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0925e8c4f7f4c9a0a"
                         },
                         "ap-east-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0bc59427705fd0dd1"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-03119abc1d880acc1"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0552f8efaa0df0e85"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0e984afd203498733"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-03c09a92eef788efa"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0aa19e36333a53001"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-09b63d974b767e9dd"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-05d0b840812e18160"
                         },
                         "ap-south-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0265bd936b2005fee"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0a5124ebf02dd08a6"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0a85ebd0871534d93"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0b581a8675c5c3ec2"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0da09cfd3a9de3e76"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0f40e207a6842df10"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0a00b5189588bfaf0"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0e24724efd16faa69"
                         },
                         "ca-central-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0e92945778d5e4012"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-02bf07f966d2a20df"
                         },
                         "eu-central-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-007a006bdc48e4c29"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-02507ae32bdf2b93e"
                         },
                         "eu-north-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-07829af8bdfdec8d8"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-066dc940a402adce6"
                         },
                         "eu-south-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0cf92ec59b3e3d9e6"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-045010b8969568160"
                         },
                         "eu-west-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-09740f17b56565aff"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0bee4c0515d295347"
                         },
                         "eu-west-2": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0c631fc57ada5d138"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0c58b2c7549f570a7"
                         },
                         "eu-west-3": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-06be8c7901e94bdb0"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0a7d4cadf9a75104f"
                         },
                         "me-south-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0f69aa3d1e5b55ef2"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-051dec8134a4a413c"
                         },
                         "sa-east-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0b462a3f8d30d64eb"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0ca8562dfa5f86706"
                         },
                         "us-east-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-02412801cb40c39a2"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0a0713e03c9d1c6b7"
                         },
                         "us-east-2": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0d68341bdfe5559dd"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0126fa7ed8ca9a337"
                         },
                         "us-west-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0258e2dfc7a3ae8d8"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-05b40f4996a5df30e"
                         },
                         "us-west-2": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-02c5fc6d4fe2c321a"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0e4308a2edb1a28e5"
                         }
                     }
                 }
@@ -190,214 +190,214 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20220227.1.1",
+                    "release": "35.20220313.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "d71636ace25d999b31e92c3a0ed65a65521d16e4eab190128c52b31e930a4fad",
-                                "uncompressed-sha256": "d59956d1e17d870c2b85c59687ee09550ca8302d16934b4877a91ee538edfef6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d36ad15771492722607168197b98ff18a60d2ff62e3e11f64934a8a41a55983a",
+                                "uncompressed-sha256": "b88e485307017f1fbfe9946793557ee0fbbbb78502e2bb51cc700774feee79b8"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20220227.1.1",
+                    "release": "35.20220313.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "a8f4f2b3655aa136eea39f5bbf874e17602258fcccc579cb742b2481e903a6cc",
-                                "uncompressed-sha256": "6787b1cd54c044b867ed5242a20d82efe85ca4e66ab077e29ab1b1e2ce0f1009"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "aced507a6dd0bb270874419c7b545235642f78d3e03d0acb5ea9824fb6771222",
+                                "uncompressed-sha256": "47dbbf14110bdfc71b44c68c7e12bc749d469239357f2055480b58078201ca2d"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20220227.1.1",
+                    "release": "35.20220313.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "35c435ad14bcb6ef294ba5776af11303163c2496cfd9c480ddb0148757c249b8",
-                                "uncompressed-sha256": "6c7892a6c2eb261b50c05d1e2e9727acc16d35155280bdde840f18120f3754a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "3ecb9ace33458c47775e1cda6d7c622395dad3f2d2b4eb12f55322a9bcee2860",
+                                "uncompressed-sha256": "5d81d771dc84ddff7d3c6b60e8432a66099c4abba3d6c9cc5c0fe597f34e3b3f"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20220227.1.1",
+                    "release": "35.20220313.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "07d8439f1f7fba292d003d3b6d3cd6b4c495d863bfc4ed5923729c58370f26b2",
-                                "uncompressed-sha256": "09e8084864b4af6387191cfa68bde016854dc332c484e9deedc89832dca10249"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "1fad4e2bfac65829b336a4c899cddae8170d1409a8ae290ffccd134f969279c0",
+                                "uncompressed-sha256": "7a6ec9bc20ec2c23af18e3cfde14b88d96e92561f5f64aa309d2b3f66d377a3e"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20220227.1.1",
+                    "release": "35.20220313.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "8d1a2890bbbc6e0b587cad176baa6e5f2f87f29da294974231037739f2b45a96",
-                                "uncompressed-sha256": "166794bad7e564c2715e04da5d2cf21fb593c835075ce9f7261c23c026808ba2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "39a426451b880466073c63fc7cd5366db4e345b866a4d07f6881d5bf81e8c18a",
+                                "uncompressed-sha256": "f2eeb73a11fcb7d09354e91af90d7b25f818913b1ff42616c7976050cbf3236f"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20220227.1.1",
+                    "release": "35.20220313.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "7d37c441460cdc3aea190bd43e945ed2e5f26a70ac60319c12f6d70a7453e960",
-                                "uncompressed-sha256": "3303e3c041afba5e0bf63773c6aa903d64b2e9ab2cd96b2fe41cce04756ece75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "842a5b8ebfd73b9d13ac96ff4cbe84981e96e240735c19c64449a94325416fbd",
+                                "uncompressed-sha256": "fa6d019be892d178c3c2fe7a23658e1eb7a490609a58c0c603b903fd5731bc26"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220227.1.1",
+                    "release": "35.20220313.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "9df6734d52b3debd3216389388f1438d1f5243fd1f8f8752348c8778357dfa9f",
-                                "uncompressed-sha256": "bf7c6cb54ce0023a258bf2831d019c0f34a3dc09c3a9c6e2881a79e1ac27153e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "7262b74df03d47423d2343beb8b270b7a864dad92658291eacc7ebb60bc089be",
+                                "uncompressed-sha256": "8962c3e59e28f9305ab6210db0de3539e8534f002605424d35eade6442471370"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20220227.1.1",
+                    "release": "35.20220313.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "5c98e1c7ca9ea89087c912dd3bef64d47b4edd880364c58efedcd2407a9cdaac",
-                                "uncompressed-sha256": "0a346b66d6f4771ba16e1d61ee9d05eeecfecffb1c9df7ff68eec6b269f169fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "d3b21e77ab21cd086bb2cb3c1848e29a69cc3c5e27e91bafdb2e628e6077b20d",
+                                "uncompressed-sha256": "29aa9856c900050b6d82f7a95f92fd40156ef2f4e3eecf2c260949ab9da02a31"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220227.1.1",
+                    "release": "35.20220313.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "b16ea6ba61758a0edd009a7a821477375cb752f60a813f9dcb9b77b508b19212",
-                                "uncompressed-sha256": "036765bad47fe4a6678ef2aeb73bfbb75f75a0f5557d9cc1c6cb68dccdc85560"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "73a667f1bb376cd491d35372455913cba77be56fa77bfd80c69ec6086a693230",
+                                "uncompressed-sha256": "570ee6ca9e59b1ef40878e02e93b26205784517ba1161ce090a284b93cd054a0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-live.x86_64.iso.sig",
-                                "sha256": "a14821e79ecd6e105fcc90fd76798bcc4e479e0890cef082484d8a6d6f09a6a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-live.x86_64.iso.sig",
+                                "sha256": "dd11bfb1c7070e379a9c27370c0fce6c2591c9e80ad6df82befc562f0d507810"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-live-kernel-x86_64.sig",
                                 "sha256": "f8e91b01ece4d3b0aaebbe0f97d1ad3c639418cae8bf96b4e2b0d50f90f8a75d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "d58fe6d4e0b473a0856775f0ee5a06dc8c6bcba47ae9c337be060da233bef2d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "c050893972e5f8e1ee102236f261b4908e5dd0a57056878799b774f2db29362e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "0050d38a38af783b9be1afca776d27fed91cfad6dfdd68bc862d207fb3eeaf16"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "2bbd38ed10d05e043b350b14f7c6e326a6bd111ecdea1d0660f58c286eb0108b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "a7433887a074869710da4fb6466b501f9cb261455702cd4a34dff5c6a1c0cf4b",
-                                "uncompressed-sha256": "bfed03f33e8569a80d8ac9781fa55edec634937ae10e1b09a7aa6d3a007e8cc0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "19e0ce9b7d005232114192128d7c534025ab028d323d1ced01731f9ac9cd0a24",
+                                "uncompressed-sha256": "cd9260946dadc30b829f33b512f93a9b31aa3995d7e018b0b4ae3a86b491295a"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "35.20220227.1.1",
+                    "release": "35.20220313.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "4adafcd31bc113579ffb3db1792a9535150eb7dcf4a194f2988ecd3059f1074a",
-                                "uncompressed-sha256": "96fa52189052993f823e5b237eb3ad7de3fba0e2797ccbc772cc4ec338733b38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "95496e20f2309ae5900fff4bced3c726f6d38af257b53ab58cf4feef97b998f2",
+                                "uncompressed-sha256": "13962f7ce1cde89287103c82f393a53727b506e8a682af4df7195c88ff11eb8e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220227.1.1",
+                    "release": "35.20220313.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "6ab115b938f56653797a3a7c42e9291c7cda3230356c8f80437036b07fa7972c",
-                                "uncompressed-sha256": "eac5064e29b01347aaa18cda2c49f25ab60a820b5cad1dc55480ec333dfc2304"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "1e117e1500aa1e3115cb62247ca1c1503237503c2fe35add02d6f46daabda221",
+                                "uncompressed-sha256": "81f260619de5bae298df8ec369289f6db9be7cd3e075ffe49773b6ebb6ded0f5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220227.1.1",
+                    "release": "35.20220313.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "90a61177c3ef18c30c76d82a106758738b33fc80183541cebabdb9ff257a3d30",
-                                "uncompressed-sha256": "1cbfbd5f06d647a7df4647bb28f9c1a93638fffdff0b8bfa31fbde6921865824"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "b62253412839856cfb4983d0cd5d3217da1454bcfa947aa68213de63b3aacb8c",
+                                "uncompressed-sha256": "507f7b43d97baa4070c9c7e13502eb3537e49eceda896a422d1b4e6d32e559a6"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20220227.1.1",
+                    "release": "35.20220313.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "73017988a4b99b10f14e24a0ebc3429fdabd5ba3e4c168dc33349696b784193c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "f8e71f3c6b725c19261950e00f41c7d980bd834afaf83bc551485f89d369f78d"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20220227.1.1",
+                    "release": "35.20220313.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220227.1.1/x86_64/fedora-coreos-35.20220227.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "20688bf6543de2a2d33ca7432d57febc83266427705e103f35d97a8d9fcc1158",
-                                "uncompressed-sha256": "05d3157d0bac87756d034b1e244a965c35d34bca249ca9277d758f528349caa8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "b6c2fb2025f9894f32fd546084d98e9c7c59df41906edc5003f88d7d042f6c03",
+                                "uncompressed-sha256": "d484030e83e8994e4c6e77b51034fe84e38a40a06a7f1dabe91a5af98746dbb7"
                             }
                         }
                     }
@@ -407,100 +407,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0c67fa68a227a3324"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-00d2a2d36fbeefe9c"
                         },
                         "ap-east-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0fcb214cc92f36943"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0cabbaad0897ba5f0"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0b08fe4781c0f2818"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0eb7572b82180bfa4"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0abb897d72138ce72"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0476514ad4552a57e"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0da1b17722c6cef1f"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0b94ae15aa81d3330"
                         },
                         "ap-south-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-06ddedaa0890ac4a4"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0ca9c1fd397ee43b3"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0f9114937ff03596f"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-03fafed04a6c3649e"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0d9764f6639b31225"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0fd2005ac6d1b67f7"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0f4f4d54c8dd0a389"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-04f4eb6bb68b25cea"
                         },
                         "ca-central-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-006a0ac1765b60872"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-058a094e569350fa5"
                         },
                         "eu-central-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0eb6e992f9d7e9473"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-05ed2f2bb91bad77a"
                         },
                         "eu-north-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-023a4145e73ac6738"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0187c728d77364f5b"
                         },
                         "eu-south-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0f2bdea5781fe6431"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0aa6f43320f728b56"
                         },
                         "eu-west-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0d26f5722e73d7b12"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-04d2926f4d0840471"
                         },
                         "eu-west-2": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0e0bcdb8b085a1375"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-03eae89d520d56b5b"
                         },
                         "eu-west-3": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-07eb4ecff35b4f471"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-029f683cda52ddae5"
                         },
                         "me-south-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0cda070ae367f3fdb"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0b287b38f5f588818"
                         },
                         "sa-east-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-03be1049afa16a05e"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0819389cc6787203c"
                         },
                         "us-east-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0c72f4646d855a439"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-02067b904ed8ec874"
                         },
                         "us-east-2": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0c17c6f27a1d90aca"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-031a795e538ea5ed0"
                         },
                         "us-west-1": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-0171b6d1e69d2073f"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-011db9d98953e1177"
                         },
                         "us-west-2": {
-                            "release": "35.20220227.1.1",
-                            "image": "ami-031d77c4bad3bd77b"
+                            "release": "35.20220313.1.0",
+                            "image": "ami-0cc5aca94e41cbc29"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220227.1.1",
+                    "release": "35.20220313.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-35-20220227-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-35-20220313-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,92 +1,92 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-03-01T18:21:42Z",
-        "generator": "fedora-coreos-stream-generator v0.2.2"
+        "last-modified": "2022-03-16T11:03:20Z",
+        "generator": "fedora-coreos-stream-generator was not built properly"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220213.3.0",
+                    "release": "35.20220227.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "263c5f46efa8b6cc4b4c64f003187f6d37e05df8e8d063e4aa8f4be415dcd3b9",
-                                "uncompressed-sha256": "6fb3c700c8ff26968691771ae02be49cbf031bc826fef52a68f1986574b8f208"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/aarch64/fedora-coreos-35.20220227.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/aarch64/fedora-coreos-35.20220227.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "e5dbc880918a761e26b84884600c5127b559416ec49815f6762abe4d5cb9fe90",
+                                "uncompressed-sha256": "7231d2ab1e135b53bd1867fb51f971c49ebcfade9300288586a859b99aef8cc6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220213.3.0",
+                    "release": "35.20220227.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "229886dbed8cdd85427931a2665df8cc78583a3b25b6c125d3d6448f2f1e6042",
-                                "uncompressed-sha256": "e7b98657dda48913a1f4d1a5fdf70dc5d453ea95eab20b64c142255aab7230ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/aarch64/fedora-coreos-35.20220227.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/aarch64/fedora-coreos-35.20220227.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a1a37901e71ea5ce786964d3224c61189b621b00ece19ce843e80fe9914b3b08",
+                                "uncompressed-sha256": "3e23477d056fb2f73ede39b69cfd109f777e62194882dfe155b6e6c6cd72b699"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-live.aarch64.iso.sig",
-                                "sha256": "7d26bb3a9fc73c56693cd1025f52de29587e0df268c711edb9f2cb97bab486f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/aarch64/fedora-coreos-35.20220227.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/aarch64/fedora-coreos-35.20220227.3.0-live.aarch64.iso.sig",
+                                "sha256": "ace643d89b7bdda099e8d708aec5db5b5348178e09cbba766f2b257ba89df4f9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-live-kernel-aarch64.sig",
-                                "sha256": "497b13809b045f99031cdd1ba12d53014cd28a6798b7e504bb8b50d40e8c9f17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/aarch64/fedora-coreos-35.20220227.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/aarch64/fedora-coreos-35.20220227.3.0-live-kernel-aarch64.sig",
+                                "sha256": "162048a19a21d6302f2c00706a2fd48b13044120598e79db1cbe435bd20a5fc5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "59b7b842123e87611ce8f26994ae0b43e92bcc7dcb85eae7a04a2581883e6c4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/aarch64/fedora-coreos-35.20220227.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/aarch64/fedora-coreos-35.20220227.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "5a90068b9aa13241118a9cfd23ca256e5ebd3b40e657b0966acdd1192b6d93b5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "7925e994a7567fc204446cd1d3e53bd6f14c26557ebb8ccbe2bf537018e53504"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/aarch64/fedora-coreos-35.20220227.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/aarch64/fedora-coreos-35.20220227.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "2f976472248f8e7b9d0bf5bf9771bc5afcc9ac70d7685331fecedd5a9164e040"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "71af6a7d9e4247f0c2035bdeb4d21b4c61d5a773f83dc74f99547b7ba3330441",
-                                "uncompressed-sha256": "be0551da01d54519aae20caf21d9a5ae6a36e076137bc91db1801a292f68fe6a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/aarch64/fedora-coreos-35.20220227.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/aarch64/fedora-coreos-35.20220227.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "2027ad84df1b158484bfd126f6d46d7c14045b5892055ccacddd0f9f2767bdae",
+                                "uncompressed-sha256": "3d180a2698ac7b629b0358212835a2dd73b10e44a98aac19110889805bf2869e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220213.3.0",
+                    "release": "35.20220227.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "9fe3e878fe145b261ed615e39e5c9b103f3d7ae0625de413d71159dbf2d0bdfd",
-                                "uncompressed-sha256": "99e07dcf9882bf69ee08b6714f92953eeb0401337a474b8dba7e158be1111726"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/aarch64/fedora-coreos-35.20220227.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/aarch64/fedora-coreos-35.20220227.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c6f6a789b6c62dd4e76b536233ae847690375abf17b6afd114f53c7750c0bbcc",
+                                "uncompressed-sha256": "638ba0e076a8ce579ce5881971423c384f93692e49840f1162979a17abccfc46"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220213.3.0",
+                    "release": "35.20220227.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/aarch64/fedora-coreos-35.20220213.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "72a22f6fae15a8d1331e7a8d3037d8de3870b773b69d98bd8a1ff158c3c8731f",
-                                "uncompressed-sha256": "e60b33ecc99e5e9b0d742359440cb11d8d6d99c51177a8aa5d332dadffb98f9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/aarch64/fedora-coreos-35.20220227.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/aarch64/fedora-coreos-35.20220227.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "e139e1d770ce9b701b3dfb7eb89e0fcc05078d758e2ab83bcd3945754e284898",
+                                "uncompressed-sha256": "e9eb4fbed2bcf94c5527ff3845374021c7dacfafd95e4152bea0aec580f0843b"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0a2f7df8d86ad3331"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-053931f8f980d56a0"
                         },
                         "ap-east-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-03b8aaae7b797b6b5"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-072480f3b84f21235"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0438cdcb95093b8fd"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-02d5ceac2fad36263"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-00dce453e1a510ecd"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-0037d66991b77f25b"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0dde96280e829cb4d"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-0466a2f4d282518d6"
                         },
                         "ap-south-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-05de9ee0c730ff0f5"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-09c6ae6db3f348ca7"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-05bd4afd1b4979666"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-0978fbc9dfea15464"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-014828542cfe3451e"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-03a6270f9c6dde07b"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-07e849871c9089078"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-06a23fd1b3c3c9a29"
                         },
                         "ca-central-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0c31c0731184fc345"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-07c73bd39fbba1bf6"
                         },
                         "eu-central-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0bc126eca6515b6d9"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-01fd6ccae8b522a9f"
                         },
                         "eu-north-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-00a3e5a47b32118b1"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-072d1e81d2e82c2a9"
                         },
                         "eu-south-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0e6f88b10f972fbb6"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-0bb5f71382c7b8e79"
                         },
                         "eu-west-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0291741226a8558f8"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-0f7e0f50465a0819b"
                         },
                         "eu-west-2": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-03f1b759de3ba3e15"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-01d6d31bf4b5075f9"
                         },
                         "eu-west-3": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0ffdfef19643ac7f5"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-00c6e55b421da442e"
                         },
                         "me-south-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-01b200b88d399e6ee"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-0e214d7893c94410e"
                         },
                         "sa-east-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-02a09f1ddbd9660c4"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-0e507fda1e204b5c7"
                         },
                         "us-east-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0096b1f15ad6a702a"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-05e980ba8edbd2e8f"
                         },
                         "us-east-2": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0da3d12ea4bb2e9b6"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-047449c070a9f88a8"
                         },
                         "us-west-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-00fc16fb7b264ffc6"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-0d29dd37b6b7bb601"
                         },
                         "us-west-2": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-058fa5813155ee333"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-0d1601985848226ec"
                         }
                     }
                 }
@@ -190,214 +190,214 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20220213.3.0",
+                    "release": "35.20220227.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "5330a055352e620228b325b2cc678b46645f0cb8e2fa4059b36552a19e217699",
-                                "uncompressed-sha256": "9bce952457af527166aa3d740fb7d326fdaf0f129986a05fa3977ddafe05e62e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "7ba39ed32fa1bceccc46e1b8d9638230b1ddb1472e69b23061122d6843276725",
+                                "uncompressed-sha256": "2f487b3ffeac96ee50ade0d75bd8f7526c37dd44afe5b8b7ee0cbc573bf8dbea"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20220213.3.0",
+                    "release": "35.20220227.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "87560f75bee41c6d1cd663d2276d99f5f61a6301ab957e38acb604c05a46150b",
-                                "uncompressed-sha256": "3563ad3106a3a640007dce649c27b774a26f39caf574aeebd210d83aabe3c861"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "48c9c8913d8e8a81df667ba369e4fcfbd780940320d39ca9e6e0c7ab16c9bdc6",
+                                "uncompressed-sha256": "61a3986d7d7820a17bc1d076c66044b1eb8faad684368c579db68345995f699e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20220213.3.0",
+                    "release": "35.20220227.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "f48e47777f7d6087a2c94efa3c09178bb52bb5fcec1b861577e485468f2acf3a",
-                                "uncompressed-sha256": "b609f6f9029109cc8aa18828fd509de1a3fc000b1046747de266b055e4f8a557"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "900b3de0e33b1ec14deebcb77d7db51fc28b8d147eb8343f39aed00ded5e9f84",
+                                "uncompressed-sha256": "6ff910fa712c9f5fb6046f91f2228b1f7ac946e1484cad7163e5bec4f82addfc"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20220213.3.0",
+                    "release": "35.20220227.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "6b1ec4024a460fe8926afd4f293f029badfe4bbca66b6a0c6b8d928027d1179e",
-                                "uncompressed-sha256": "481c1d00b9df7391523e8a3a67706131f5f310476c61044e8122967fcc1a60c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "43348408f86a7a1e6f439dfca723ad5df466db3c3ab93f42a0311eddeb8b66f8",
+                                "uncompressed-sha256": "33fac9e2c4a6c142e67f5e1bf85ff38bd39a7f9b3eee1979be17990f74ff9b15"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20220213.3.0",
+                    "release": "35.20220227.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "ed9a27fe264ae9d02c9592f824c0c562545444e4022a2299590c13f7bc872eb8",
-                                "uncompressed-sha256": "f85a67236fdf199e1068e47e33a528db8741d151fa1d50df0536b6a688bf78b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "661ddbf2886817cca6023c27ed171b1e75d43dc43270a8e355f615f7e492b675",
+                                "uncompressed-sha256": "5ec7cd40342ea7735c49b379f3a81a40684cb4ae0be8ae48764d10020bf302b7"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20220213.3.0",
+                    "release": "35.20220227.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "d5df14adab71e18d2029ee2a0ded33e7c97f3aeed658152e87131abaea5684e2",
-                                "uncompressed-sha256": "31b971cb0c28a16b8db77bdc7dade325e8064c2a078c051204f9ddafe77296da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "53410ffa1e211aa9f2745829844e55b229958eb397455c5c36646b89d264d18f",
+                                "uncompressed-sha256": "ebcd99b1be1bfce4c4dca733705628b3382b796bd5f9b531e3629f323f403083"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220213.3.0",
+                    "release": "35.20220227.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "7508462fc0372c8021a00a1e113e7ee60526bd63304a5c62ce02bf600295562d",
-                                "uncompressed-sha256": "cd1b9eabc97d9fe782a446f31acbd4347c51024ef683415903e1d551d8efc5bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "cd1ac03db664a6e4a775e3428e205f3ac3eeb8aa076d2e44d0cfe747ad26906d",
+                                "uncompressed-sha256": "4322fdaa1c1033d02a84e3bb5fa5d3bea6798f8ec2496d80bd533124dc3e3c04"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20220213.3.0",
+                    "release": "35.20220227.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "9560ea678703879ae8bbdf1ac785bc5a5e0b10d5da05e4b848f7a6832fd9015d",
-                                "uncompressed-sha256": "39e30797b7ef03e8d47addf2605e43d232e246026e515cd8513b500c49840502"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "6113c63800b71f940166cf3065a9f094cf577d23103c7167e4d1cce149f8b1ce",
+                                "uncompressed-sha256": "217212d096fd06524dd01c5fb03e80b52124ba009db4e9907213633c19f32070"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220213.3.0",
+                    "release": "35.20220227.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "b3900038e2466935c12038692dbab5636d87614ba6e47525d88803c3592e1d77",
-                                "uncompressed-sha256": "df195a70a21025253e103c3c72300a01ec508754d54770e8b63e39e5e38dcbe5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "9af6322819a4063049d1ae76b8315961c202b88a305717326af77f2fbd064909",
+                                "uncompressed-sha256": "1cac3220add1cad6e5526c1927257a479d24d95a84a8e40b6651b02abd475fa8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-live.x86_64.iso.sig",
-                                "sha256": "889a35225dbed2f3d398e42e2508707d04f44fd7797f9fe6cfb0c1ce577c2121"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-live.x86_64.iso.sig",
+                                "sha256": "117d6ada5a128fa5d765d5e8ee0a60406bb110990ff6ffe4a0ee10c246354016"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-live-kernel-x86_64.sig",
-                                "sha256": "819fda78ef91bbb41809433c36e2047c5fcf4324b7d14b3a4a13b77d47565a3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-live-kernel-x86_64.sig",
+                                "sha256": "f8e91b01ece4d3b0aaebbe0f97d1ad3c639418cae8bf96b4e2b0d50f90f8a75d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "4e7a91b3125467d99f37f450160a74a597afd4713968ee1777c0011560a37933"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "3d88ac215706ca65e5441d3a2a76d7e217d5f5ccc33f387c68f620697c6dead1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "8dd30f01c078cc24704fcd62ab36756be784a4aef1c0d40f8da08ddb262b0b5c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "3ab16216504f3ae63acd2eb437f6b3642c29a6db150a0f117ba34c4f4bc72d01"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "cd6f33c028dc3ca668efa5299cd14ec24d5b20623ad62dc2282edacd932a51f8",
-                                "uncompressed-sha256": "75986d58d4b81802306d99bd8763feca89060d73d59de0582191104f1e4af4ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "f2d9c3d61088b42a1c70f0504cf2c8d17ecb8cf1fe0dc239273d39aa0f03169b",
+                                "uncompressed-sha256": "415aacd73bc25cc2a8b74726f7f748fe0d82076917decbcff7284f6bb41019bb"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "35.20220213.3.0",
+                    "release": "35.20220227.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "f207c7e73fb10acfd545f83a0625c4544625580da85a818cf0b5909e5160a9f1",
-                                "uncompressed-sha256": "903ba17b04dcfa9682bdd3645bce610ada33ba9b40b4a14f8ee06e7b7af5cd7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "9c5524212acad05a65462f76af8718c5b9070ef52c166d0ea9dba856cd89e9be",
+                                "uncompressed-sha256": "bbf4d12bed0b6016954fe74605cb256207fbfe730a4c49d0802b26507d278747"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220213.3.0",
+                    "release": "35.20220227.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "ae7eeb7829645043dd4d82de04423062d7dab7b08d2e55386b0597e855c65312",
-                                "uncompressed-sha256": "f7700a50455a2549f9b7c7608398d2d1968079dd7e5b5cf4cd885c6028677a76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "00434ac25fa1703fff58756ce5d19cf80adcdc01e3371012ed5b96819b43e653",
+                                "uncompressed-sha256": "46f68bf08cb900471743a4d47962ceb62292b8e151c2d737636b8f01edb67538"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220213.3.0",
+                    "release": "35.20220227.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "625429e1b15f3c4dd15def29a1876cf578046f2d63f8db972f1082c131896be7",
-                                "uncompressed-sha256": "2f5285290fe580d176b0daea8603010085818e5499747a2d7e9f3ecd445cdf28"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "7fcebc0efb1aa00246cf45bf48e07c2733c3d9cb73fc7dfaa8b60920dff08161",
+                                "uncompressed-sha256": "1212eb461fe3bfa8747c64241aea8f5235b2366a464dcbae9c3c17c7387f6f5a"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20220213.3.0",
+                    "release": "35.20220227.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "1afead99d281b036487575f59854f9a746a56793ac05e654ac6180fbaa5206dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "2a4363f0d1d75ff03468b015040710dc87575df7d4465fbdb2a4c9a09a4487b7"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20220213.3.0",
+                    "release": "35.20220227.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220213.3.0/x86_64/fedora-coreos-35.20220213.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "2973d22d64de353a86fe721f7bf8ac4a9691954cdb21d84a46abbd8deb30e6ac",
-                                "uncompressed-sha256": "f4db02f38e3ebd681d65b663e1a9071f5554220c24b0b89461c0ed5b5609f66e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220227.3.0/x86_64/fedora-coreos-35.20220227.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "76d447e2a816773d5a082f6d070a2e17dee27df75c3c597f91e6a8ce05da2e95",
+                                "uncompressed-sha256": "1b9722feeeb1536359ce52ca31ef3cf21653ec6e7774e9f2afd90f86a3af5ec4"
                             }
                         }
                     }
@@ -407,100 +407,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0bdbaa3b71e5533ff"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-01a99e3f12ad000a9"
                         },
                         "ap-east-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-01f95e3ef562facc1"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-042a7f6f8de4d6012"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-062f02717f3281d54"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-02802bd2de2bf6a7c"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-03258e226d3085a98"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-0a2029f2b49a9a682"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-028b6e9c968dc521d"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-0fb2247898fc7c9fc"
                         },
                         "ap-south-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-09275ca26766ba225"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-051ba4e6205e68785"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0dcdb18a273b945fd"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-022a4094e52d927ca"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0831e1e583aa2fc7b"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-029c832f05dfb5a90"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0923893ce69c79233"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-0deda548ca468df87"
                         },
                         "ca-central-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-050c6f96c6e3864ff"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-00d8d571cf3202847"
                         },
                         "eu-central-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0a58701048da1fad3"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-0d7e865b3536ced6a"
                         },
                         "eu-north-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-044a450f9c57819b5"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-02f4b83776133cf4f"
                         },
                         "eu-south-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-01c2ae669a24f802a"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-0f59e2460417b8b07"
                         },
                         "eu-west-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0ff530e464d386737"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-00f090601493b6462"
                         },
                         "eu-west-2": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0ab3c0791eff8b354"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-06774fe3ed34de00e"
                         },
                         "eu-west-3": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-00a105840e2f197df"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-015ca791a1973c851"
                         },
                         "me-south-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-070edc94e465906f0"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-0ff0c22dd9c75b9b1"
                         },
                         "sa-east-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0d866ec67524a52da"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-049bab814a19de264"
                         },
                         "us-east-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-06eec2310d4a15743"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-0bef118a8575f30e5"
                         },
                         "us-east-2": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0a4385dd87fd58ca7"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-035630ccaab3f6d2b"
                         },
                         "us-west-1": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0bbb617b1e32ad528"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-0062907680fa26a53"
                         },
                         "us-west-2": {
-                            "release": "35.20220213.3.0",
-                            "image": "ami-0429826b67e324e93"
+                            "release": "35.20220227.3.0",
+                            "image": "ami-0df560f4cbd223040"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220213.3.0",
+                    "release": "35.20220227.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-35-20220213-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-35-20220227-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-03-09T17:52:57Z",
-        "generator": "fedora-coreos-stream-generator v0.2.2"
+        "last-modified": "2022-03-16T11:03:23Z",
+        "generator": "fedora-coreos-stream-generator was not built properly"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220227.2.1",
+                    "release": "35.20220313.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "1c2d713e7a196fc222632653b5a3e88053aad8bffb7828ab36c6415bd2c7b91b",
-                                "uncompressed-sha256": "961da5cde8975907dc4bc3e7c80aff6d976acfce6ab6b5d358a5fec684735043"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/aarch64/fedora-coreos-35.20220313.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/aarch64/fedora-coreos-35.20220313.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "f8786f30050b27be2dc3c80bec0eaf0a6461d1e6de73c766dcbd041dbfde0f40",
+                                "uncompressed-sha256": "19e0c229e589cbfb5aa0a1ef33dc5fe5090f704e84d5f5fefefe113fdaa35341"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220227.2.1",
+                    "release": "35.20220313.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "b82a00fbd7a618d7ebf3a3e3aa358fdca3b8960903859d7a672fa087f42b9036",
-                                "uncompressed-sha256": "49d2b9dd75f9ef8c310546154816ac78bf485b5dc4314efe6b586be729ec91e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/aarch64/fedora-coreos-35.20220313.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/aarch64/fedora-coreos-35.20220313.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "c9aae0b7e8d843714974e7d917cc28cc0bd83132ebe1c4ad1b1ec2378af83c50",
+                                "uncompressed-sha256": "0194074835989b359d45f6e43a27403b6941a5c1955cf6b74a5ab0dce6e1f2ed"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-live.aarch64.iso.sig",
-                                "sha256": "6b0b34c5b1a79227056dcaa463f97bd983dfd47854d1022d05a1fd28597c11fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/aarch64/fedora-coreos-35.20220313.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/aarch64/fedora-coreos-35.20220313.2.0-live.aarch64.iso.sig",
+                                "sha256": "9022b43821ef39fbbe95f546a0f0a5cbbdf01d578ef21e4b6bb7f1601985fa4c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/aarch64/fedora-coreos-35.20220313.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/aarch64/fedora-coreos-35.20220313.2.0-live-kernel-aarch64.sig",
                                 "sha256": "162048a19a21d6302f2c00706a2fd48b13044120598e79db1cbe435bd20a5fc5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "70fd70a6d8051d2a9ab6b276d662a3272f2f343b8c25ac4df2c23e079bf3344e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/aarch64/fedora-coreos-35.20220313.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/aarch64/fedora-coreos-35.20220313.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "048b7f8b313f0250039590c76b93f4ecc685c1016905f57fd68ace49f70641ff"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "a0e48ec34f5d08fd1a0c1f5521e2c88449be6a5a0062ec80819facc8b383e689"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/aarch64/fedora-coreos-35.20220313.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/aarch64/fedora-coreos-35.20220313.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "3809f7d0e1de1a52935158c8e519618a0fdfeab61452f22e6357b7a91a185ff3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "09fc7d2f863b1fae9ebc044df54701886a780b09fb129aa62e9b8af6f2ade514",
-                                "uncompressed-sha256": "c71d31fdcd967d0cc7019db68da3706bcf769ba5625123c8ec293ac6a6cc5901"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/aarch64/fedora-coreos-35.20220313.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/aarch64/fedora-coreos-35.20220313.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "67dfe283c040332636f3595c96a56fa2f16d0cfad9d9d46e886175a612a986da",
+                                "uncompressed-sha256": "d1a8aa567f5d0c834fe32a5cb9a9d75ed6e7ea4d31fc0ed50eed898b746502b0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220227.2.1",
+                    "release": "35.20220313.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "2924ce82b5cbb16b15e7cbb575ac27fd10236125aa0d29e598872cd3f216bf5a",
-                                "uncompressed-sha256": "ddcf05ffe0753508127ba11a646eb8ef5b56d32db9e587dfd0b3e1ff47301307"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/aarch64/fedora-coreos-35.20220313.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/aarch64/fedora-coreos-35.20220313.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "5384a715752a5bbc6773f0917cc1e86e36e27115ed33cc8495ffb8d9efce8731",
+                                "uncompressed-sha256": "73433572306408098459a7e02baf282fa661c28aa69c70ba17c1f89a13e7b0ab"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220227.2.1",
+                    "release": "35.20220313.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/aarch64/fedora-coreos-35.20220227.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "1abc4af523e513c36712c25824c33d2342d5debf0bae7d80810843c0122c8657",
-                                "uncompressed-sha256": "3e70b8c72cd7f319b4b91a6ad53ff60126c3e9951a8894f9647333a3f2d3aaeb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/aarch64/fedora-coreos-35.20220313.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/aarch64/fedora-coreos-35.20220313.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "f9db2cedb42f36c8d67791bf7c813e0240603280aacc90847a563ed8f581221c",
+                                "uncompressed-sha256": "1ca3be1b14529c17d96c4f488b32dac7e0165bfc878903a9b5afb977ae8ce503"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-07b351fa954fc01d7"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0bc207b206e8cd7e8"
                         },
                         "ap-east-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-01d41ba1854e8a71c"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-07061b02793e96f24"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-0223212fcec5558a9"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0a935d066239a58bf"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-07baff9aa18687ec3"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-03deab57e394ca038"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-0dae6926d53d9761f"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0caf9bc4fcaef2f64"
                         },
                         "ap-south-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-0066ce47c90838f7c"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0e6f81d8e61aeae56"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-0f2bc74fc3b042f29"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0a4b900cf3ca73953"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-0056120ca73cb1ca0"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0f86c51de626432de"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-00bbbc2bb1b86440e"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0bbb55e10c4fb3899"
                         },
                         "ca-central-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-0785253714595aaf0"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0fd4cfe07e2ca7675"
                         },
                         "eu-central-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-04a9d7f81d2cfadda"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-039f0be796cef1040"
                         },
                         "eu-north-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-08082843943a9e2f1"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-014ffba00b7436b6e"
                         },
                         "eu-south-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-01bcbe48c57d5e685"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0144c3961f6f10078"
                         },
                         "eu-west-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-04bfb593a27dc0e89"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0f2a10ea8ca73745d"
                         },
                         "eu-west-2": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-0a9b6bd35d019240b"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0a153578a7821d043"
                         },
                         "eu-west-3": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-0f90ad6416da1f52b"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0e72283a9058e200b"
                         },
                         "me-south-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-0fa468916b50e0df1"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-01305e107ce051830"
                         },
                         "sa-east-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-03e429db4042590ef"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-077d0d3888e970080"
                         },
                         "us-east-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-049478f4119881fd2"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-03afff19c07a58c89"
                         },
                         "us-east-2": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-068e85162deecb72c"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0d252dd1a3a1f143a"
                         },
                         "us-west-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-06cd73532a1a31be9"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-00bddd42f27665cdf"
                         },
                         "us-west-2": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-0da8796da996deed1"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0146d5d27586ac7e8"
                         }
                     }
                 }
@@ -190,214 +190,214 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20220227.2.1",
+                    "release": "35.20220313.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "cfbdbc7cab42b584baf2815aa9412803fd0ccf5fa2351d49dd149862f58661b3",
-                                "uncompressed-sha256": "ea3c90a5a06bf634be4c0ebcd4b5ea16014b70cb61c0c40fa915eb109ae72fb6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "dee5bafa23ddca95ab4221cf7f842421e6d818a82e606d951216aa2416815408",
+                                "uncompressed-sha256": "e1f5f01c2ea2f72bb153feb2cc5920402f969e955588473bac6f4a4e71cb85ff"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20220227.2.1",
+                    "release": "35.20220313.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "18de3118172679f332bb9c58f0a457d87474aa6ee5518b0ec7afb1c20a1fa1f0",
-                                "uncompressed-sha256": "7cf2a154a306851266018637d81e289c404d5867c67ade34613c48353ce2445d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "6f53e01e9decb87089d42b560c1caf815b786b4c93434fa00441fe878ca497ff",
+                                "uncompressed-sha256": "11afdaa2736444fd6b8333a9af685753eb3ba4b5485cbd9bc1ef7f5ffbef93ff"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20220227.2.1",
+                    "release": "35.20220313.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "fca26a98f7aafc7d4e7797f3c652ec5267439544efb05fa602371dcd6ddd46ea",
-                                "uncompressed-sha256": "6c9bde100504672299145722748333af8e0dffea332d5b883358f853f4b2df15"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "547ae12c2ad4da5ba4f8947ea27d53b12a5278a8f2f9367863cb68b43254153e",
+                                "uncompressed-sha256": "1210d1c8f86128c9e4a6fe8c81ca9bf87dfaeef7ee90543c0bb5e247ccab589f"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20220227.2.1",
+                    "release": "35.20220313.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "9a433bdc627d1778de04988426f2f6ba4e42f0c2985b929bfd262a427f700854",
-                                "uncompressed-sha256": "b71853b069544c7916d0696c83ff85914870e24e8249199a4abb448d2448dc8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "d14cbf57284dec788a58d3115d4ee068d8ff11b0c8a07f4ce9841eb3ccea9f25",
+                                "uncompressed-sha256": "02d0da0915d063b80258648b5e8cd86fbf624650f3ed044b8143dc3be9d656d0"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20220227.2.1",
+                    "release": "35.20220313.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "3c2ef4abfbe0428930778c91ae6227020b94945e67d39b5bb84eaf1933dbeebd",
-                                "uncompressed-sha256": "85c8dfbd1fb2706d67b38beac601d522e912d66e540c5c0f1426d659fb9d21cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "c61cd7b43c6135d76fe334878d2f499955499f37ba00ae35f655503b2ea5d699",
+                                "uncompressed-sha256": "6a2d52aad4c15ed4c7c333778bfa8e751fba5d470d7873cfe91ff919bfb31233"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20220227.2.1",
+                    "release": "35.20220313.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "e5f3a360acbad04032d890a20438d5ee9d9b8b5e246d8b99eb9c95636b3b1297",
-                                "uncompressed-sha256": "72ca4e43f2625d6b1bc19fd4f6a49c2db99d62c85eaa440ff546398201c493ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "651e234f5055f013ed402a4c299cc4014f1df29e0e1504cdc12c7e296b6d53bf",
+                                "uncompressed-sha256": "f0aed5578de7ccecb2a6e9c62548ecc04bc732a8647be03ab5d75553eb0f32c1"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220227.2.1",
+                    "release": "35.20220313.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "ee423c03a7a1dee85c8f17b96e1267fa33c6513d43d0db1e847b8fb8f06cb822",
-                                "uncompressed-sha256": "64a1292cc9b8c002961bd2d95b3cfeaa062ce0059b91c17aef8137ddc03cfea0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "dc5553cb13449ca60fbe3a159f2d7daecda713fd184be01bffba29ebe93f0140",
+                                "uncompressed-sha256": "557c20c94744c8b46ffec0a91c11e946c1628db5fcc59adad6ef75aad5e54082"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20220227.2.1",
+                    "release": "35.20220313.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "ecb985e6081e1892c0efd5b8c433e9ffde2f283556efb4b0e9644f472269d46e",
-                                "uncompressed-sha256": "ef1b373edbd13a87613340324f165d7efd25c0d7e76e7891790e250f6508f5be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "622968cc94f80ab7fbc90fa908ed51dd9e763f8396d3b936b18e78d7e728ea72",
+                                "uncompressed-sha256": "954a46ca9f716876f1ad37dc7fe3c80e84cf2a168e902d43396cc8de5115b946"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220227.2.1",
+                    "release": "35.20220313.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "0dc67d5a2c00a5c7cf6c43a6cd3e69627ac90c56927db42e67061cf5aa2916bf",
-                                "uncompressed-sha256": "1eeb6650d489252a480548a088795510c348e8d45148467553fd1f2061423b15"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "3a80b4a3dfdeb544e7bf279b04b2394f876d6fb35ddb60daa789d43bcae97242",
+                                "uncompressed-sha256": "9f2c7eb422d262dfb390ec2e2390d642a65f1f5c407e969c49e81b4a5e43c64f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-live.x86_64.iso.sig",
-                                "sha256": "1277085bd0ea2b872e149dd5a6e46c2783d06f77c77b4ec74da855c8b6c599ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-live.x86_64.iso.sig",
+                                "sha256": "6d29f5ff3a16f5044e3ba4eb6a876be40c773948eefef9984a561f0de36043f9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-live-kernel-x86_64.sig",
                                 "sha256": "f8e91b01ece4d3b0aaebbe0f97d1ad3c639418cae8bf96b4e2b0d50f90f8a75d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "727007a3e10bd558231492ac0b9f95d98e3e8a1c3154cc4c33a3c265a3c1020c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "88ac947178211cd84cd3c18a7068024767d5e51723d4d9d78dd1dd41520f3c88"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "c9322e488208387c761e1058f8c9131f67e7646f28f0aaa743bea9733b4f311a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "c6d155947032aeeaca2ea7f4ad78c3c4584a09658528ae2cdb905d8d87af6712"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "7568699ec3618b50b7e2281fd1859171420e03ebe2bcc59b33df5afea8bc5b79",
-                                "uncompressed-sha256": "bdb7f9c404cf1278f78be861f8df8cfb35b71210af943c021b2e0b28c507190b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "d46d1a36eef3b47bdc769d092bc6f0f6ecb889c156da75577070ccd38f884bbb",
+                                "uncompressed-sha256": "6b7d2917f280556c1ef52f7cd68d1b2c3dc916c7dead9dfece188d6a0be21e10"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "35.20220227.2.1",
+                    "release": "35.20220313.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "323fd67c0d0701c202aa609d8bea02afa06b6f89a3e882891818e8bf5e051cb8",
-                                "uncompressed-sha256": "7b25d8f390a0fd6b1b1d92a354f6df47ebbc3b129890efe6c72ab924c3c24eaa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "14386282fb5995e93553ed24ec1d397d7e3a5e12341e2bc8947769f447588962",
+                                "uncompressed-sha256": "1c5cafd14efa87d1154668b6f30561a57a555fe07dd54222abe6a61e8ad8c20b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220227.2.1",
+                    "release": "35.20220313.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "821f2f10f1c25c446d2ad40bdfaeeadf4222e99bdfaaeabb1bf07d7936e70a24",
-                                "uncompressed-sha256": "75a1d4ecbf9ae28a612732a320724824704a68d1129e6027399dc54b430dcb59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "aa6208aa77db496c5d4ab2e3d65d7bc772bb44a32aed2a533fcf0887d9fbde2d",
+                                "uncompressed-sha256": "776f8aed37ccbe2da8d2c3496eba4a7768f81886c00678af44d7fd7268c1a93d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220227.2.1",
+                    "release": "35.20220313.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "82e6c86272b5d6aebdc768098de233892996e3f36e59f48b366522ec413f4e18",
-                                "uncompressed-sha256": "793f8bb67b98dea5a779e249947a4a340f08b949a7723a7466df1501b3354d41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "c431a6e0b128ae33572bdb010f6b76f43e86a802fcf684a2552e30aca60961f7",
+                                "uncompressed-sha256": "031cca1d80ee4b248048ba7adb86f62ab2a1c5b2a7510da65ac577a5c9688955"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20220227.2.1",
+                    "release": "35.20220313.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "240eee88b9a7143797968a0ef48e1e81ced0339aab3f57129fbb5d6732b572ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "e1165d3ce72420d71ee863b51a01021373c9e0b0dcee61c202da8bc61e5353b4"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20220227.2.1",
+                    "release": "35.20220313.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220227.2.1/x86_64/fedora-coreos-35.20220227.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "02440742f910d635cbbad43ef3b76ef1add6ce647cf00f4ce2ebb87696a899d4",
-                                "uncompressed-sha256": "c7232ecce3f0c8ac6f825c58ae5d1aab138bd65e59e30e2f77e9ffd1f514ff22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220313.2.0/x86_64/fedora-coreos-35.20220313.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "16b73a5415cc571b4b3070efd8e8e397f4887fd9144a6e71bd507e12a6c3f6ae",
+                                "uncompressed-sha256": "56e7198e2c24d166ab6b5aae0ff2c141416edef846f3525952a054b5daaa651f"
                             }
                         }
                     }
@@ -407,100 +407,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-0ba429f0acd66bc7a"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-053a8eca6e87e6e80"
                         },
                         "ap-east-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-0f38a7160ef477069"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-07e1ce22ff3ea796e"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-0f9f39e9abc18bf94"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-08a2d2904bc71ce95"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-0d44c3de9e59b6bb5"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0279c4faeedb672cc"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-068b99c1be5095cad"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0f287796cbcdfeb1a"
                         },
                         "ap-south-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-015098750d9439d12"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0559d437178ef4b47"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-0e4aed474cc8b6b3d"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0e9283c8a765d638b"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-02cd6e0657063ef79"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-05e770b742ae59524"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-042cb163981cdd1ec"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0df3e4688ed65ba65"
                         },
                         "ca-central-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-0ca52a220863e3d41"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-02ff0c3d10620a9af"
                         },
                         "eu-central-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-05f174f79ca889d78"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-02a13c9ab46d7f908"
                         },
                         "eu-north-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-0570b02d7e6312464"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0e297c68f6ad9f61a"
                         },
                         "eu-south-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-013ffc70ef40caa96"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0330feeeef75390d3"
                         },
                         "eu-west-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-0e0ea60acdfa4cc5d"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-04be74535f70318ce"
                         },
                         "eu-west-2": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-042ba1e63d5bfa5d7"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0b5b655799091b611"
                         },
                         "eu-west-3": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-07a71d0873d2c6f10"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-024953b8ae46e5328"
                         },
                         "me-south-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-01339f9fb91467ca2"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-00b156d6ea5d92044"
                         },
                         "sa-east-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-00541605dd31678c8"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-018e318653648d0a8"
                         },
                         "us-east-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-02afd6067c1505310"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0d90795be9c744744"
                         },
                         "us-east-2": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-01a46890c8b05f5fc"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-022cfd00eddddce7b"
                         },
                         "us-west-1": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-0ba8c6ad180df4e84"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-0a214b3851f683529"
                         },
                         "us-west-2": {
-                            "release": "35.20220227.2.1",
-                            "image": "ami-03f610397346afc9e"
+                            "release": "35.20220313.2.0",
+                            "image": "ami-063540ac24a0acd3d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220227.2.1",
+                    "release": "35.20220313.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-35-20220227-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-35-20220313-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-03-09T17:52:59Z"
+    "last-modified": "2022-03-16T11:03:27Z"
   },
   "releases": [
     {
@@ -45,7 +45,7 @@
       }
     },
     {
-      "version": "35.20220227.1.0",
+      "version": "35.20220227.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -53,11 +53,11 @@
       }
     },
     {
-      "version": "35.20220227.1.1",
+      "version": "35.20220313.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1646850600,
+          "duration_minutes": 2880,
+          "start_epoch": 1647439200,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-03-01T18:21:43Z"
+    "last-modified": "2022-03-16T11:03:21Z"
   },
   "releases": [
     {
@@ -53,7 +53,7 @@
       }
     },
     {
-      "version": "35.20220131.3.0",
+      "version": "35.20220213.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -61,11 +61,11 @@
       }
     },
     {
-      "version": "35.20220213.3.0",
+      "version": "35.20220227.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1646168400,
+          "start_epoch": 1647439200,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-03-09T17:52:58Z"
+    "last-modified": "2022-03-16T11:03:24Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "35.20220227.2.0",
+      "version": "35.20220227.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "35.20220227.2.1",
+      "version": "35.20220313.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1646850600,
+          "duration_minutes": 2880,
+          "start_epoch": 1647439200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
I had to run this manually since the github action failed a couple times (python error in the dateparser lib)