### PR TITLE
workflows: `apt-get update` before installing packages

### DIFF
--- a/.github/workflows/print-rollouts.yml
+++ b/.github/workflows/print-rollouts.yml
@@ -19,7 +19,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt-get install python3-dateutil
+        run: |
+          sudo apt-get update
+          sudo apt-get install python3-dateutil
       - name: Print rollouts
         run: |
           set -euo pipefail


### PR DESCRIPTION
Old package versions can be removed from the mirror, which could cause job failures.