### PR TITLE
templates: re-add manual steps for config promotion

### DIFF
--- a/ISSUE_TEMPLATE/next.md
+++ b/ISSUE_TEMPLATE/next.md
@@ -7,8 +7,21 @@ Edit the issue title to include today's date. Once the pipeline spits out the ne
 ## Promote next-devel changes to next
 
 - [ ] Add the `ok-to-promote` label to the issue
-- [ ] Review the promotion PR opened by the bot against the `next` branch on https://github.com/coreos/fedora-coreos-config
+- [ ] Review the promotion PR against the `next` branch on https://github.com/coreos/fedora-coreos-config
 - [ ] Once CI has passed, merge it
+
+<details>
+<summary>Manual alternative</summary>
+
+Sometimes you need to run the process manually like if you need to add an extra commit to change something in `manifest.yaml`. The steps for this are:
+
+- `git fetch upstream`
+- `git checkout next`
+- `git reset --hard upstream/next`
+- `/path/to/fedora-coreos-releng-automation/scripts/promote-config.sh next-devel`
+- Open PR against the `next` branch on https://github.com/coreos/fedora-coreos-config
+
+</details>
 
 ## Build
 

--- a/ISSUE_TEMPLATE/stable.md
+++ b/ISSUE_TEMPLATE/stable.md
@@ -7,8 +7,21 @@ Edit the issue title to include today's date. Once the pipeline spits out the ne
 ## Promote testing changes to stable
 
 - [ ] Add the `ok-to-promote` label to the issue
-- [ ] Review the promotion PR opened by the bot against the `stable` branch on https://github.com/coreos/fedora-coreos-config
+- [ ] Review the promotion PR against the `stable` branch on https://github.com/coreos/fedora-coreos-config
 - [ ] Once CI has passed, merge it
+
+<details>
+<summary>Manual alternative</summary>
+
+Sometimes you need to run the process manually like if you need to add an extra commit to change something in `manifest.yaml`. The steps for this are:
+
+- `git fetch upstream`
+- `git checkout stable`
+- `git reset --hard upstream/stable`
+- `/path/to/fedora-coreos-releng-automation/scripts/promote-config.sh testing`
+- Open PR against the `stable` branch on https://github.com/coreos/fedora-coreos-config
+
+</details>
 
 ## Build
 

--- a/ISSUE_TEMPLATE/testing.md
+++ b/ISSUE_TEMPLATE/testing.md
@@ -7,8 +7,21 @@ Edit the issue title to include today's date. Once the pipeline spits out the ne
 ## Promote testing-devel changes to testing
 
 - [ ] Add the `ok-to-promote` label to the issue
-- [ ] Review the promotion PR opened by the bot against the `testing` branch on https://github.com/coreos/fedora-coreos-config
+- [ ] Review the promotion PR against the `testing` branch on https://github.com/coreos/fedora-coreos-config
 - [ ] Once CI has passed, merge it
+
+<details>
+<summary>Manual alternative</summary>
+
+Sometimes you need to run the process manually like if you need to add an extra commit to change something in `manifest.yaml`. The steps for this are:
+
+- `git fetch upstream`
+- `git checkout testing`
+- `git reset --hard upstream/testing`
+- `/path/to/fedora-coreos-releng-automation/scripts/promote-config.sh testing-devel`
+- Open PR against the `testing` branch on https://github.com/coreos/fedora-coreos-config
+
+</details>
 
 ## Build
 


### PR DESCRIPTION
Sometimes we need this and it would be nice to have it accessible
in the templates rather than having to find the steps when you do
need it.