### PR TITLE
Roll out next 36.20220325.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-03-16T11:17:58Z",
+        "last-modified": "2022-03-29T01:16:20Z",
         "generator": "fedora-coreos-stream-generator v0.2.3"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220313.1.0",
+                    "release": "36.20220325.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "e6332b58a487be5de6240867549fd9694abb2ee835255a934999519444ac12ea",
-                                "uncompressed-sha256": "6c1bbf75c17355a1b9aa4e18909b33d997e5ae1c9f4e1a3e381205aceb1f6dab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "d11ebdeb55c7a025579935971f1ad33c7862d9792d8ae299aa4c795506fcc319",
+                                "uncompressed-sha256": "a339666f6185419d5f90b0515c71ff30129f6599b964311811c067283cccb7fa"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220313.1.0",
+                    "release": "36.20220325.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "570f707e149de25fec38c645d21eabf7e456aa622abf1a5e13ce81a1c7233253",
-                                "uncompressed-sha256": "12ff840e309204a7471c3c51b447d61d6219872b456b91637f10789130bdcb97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "6ca2c14b4de929c7922a0c234cd975f368ab26a10b863ee780794624e6cf3585",
+                                "uncompressed-sha256": "d2343a5837de1389ab9612625151075df2cdf2218346beb41ba8d070382a2a61"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-live.aarch64.iso.sig",
-                                "sha256": "f79be6bd36727023829a08f2f2da904d059fd555331a49b81caac01a31d12576"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-live.aarch64.iso.sig",
+                                "sha256": "aa3896f69cf6bbe30333562bb4512fbbf3c810bcfae7ca743ce2af00d5b48974"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-live-kernel-aarch64.sig",
-                                "sha256": "162048a19a21d6302f2c00706a2fd48b13044120598e79db1cbe435bd20a5fc5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-live-kernel-aarch64.sig",
+                                "sha256": "05487fa6ce64427dde965d0c7931c867886017b3d1286091cec96a2f33f24fdf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "2ca94b0f24d2e6479f3821a56ac7d99939af37d34129e42bdf8f6fa59481d9f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "730f05e395a40facd3da879bd14343f9fcb8f6f0ec4820d2d03567b96e165be9"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "2a5a72fdbadcba21a7fb09737c15f30c37d10d5925791b477d8fdccdabe9ddd5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "3112274044fc6123ddbaf082e5a2ba207c9a715189ebd4a777b4b314ba4d3541"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "ef33ed07c9b7590f50cd9794fe9d0f1ef0b8edf5d08469914676e3aaaf4480a1",
-                                "uncompressed-sha256": "875b61e4133d9416ffadc929187f958ca36ca8e974e6d9a2f7176891d2695367"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "7d278f7b22913b03d2a7f890953af0204ade4caef22b100c1f34c13f03e87ce0",
+                                "uncompressed-sha256": "8d13637a22e67c014219475c837c5d5294c67774c0ea62988fb532e814e65388"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220313.1.0",
+                    "release": "36.20220325.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "5d03d84074b335d2dde7c6f368fe2109db77a878993e10f7e151f737da1e1a89",
-                                "uncompressed-sha256": "1464c2291b85ca5bc2144cee02c165e489ac39aca55683b59fe17f244a1126b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "ee18f92bc61882686e7e3d5a957611df773f6e95366665cb920ac4ca609e5317",
+                                "uncompressed-sha256": "69976797c0910f34616d290872f5960a017cfb99687012c079522393e52f171f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220313.1.0",
+                    "release": "36.20220325.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/aarch64/fedora-coreos-35.20220313.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "cb42cbe83ec4fa197603d70d74e7f55d02de8331b63d5be268159ef345dd0805",
-                                "uncompressed-sha256": "1d51899f0b1c33fc86901cb9fb06a0afa757cce0b02a4afbbb4b1c2ba20d562f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "81302189d99a1e2ae5b2cb6bfc0af881920e78857e19ad607705b90d2ccbf77d",
+                                "uncompressed-sha256": "70f6e271fd86095840bd8df25e7727bd27d621c2738bc307eceb8c2c2f21c56f"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0925e8c4f7f4c9a0a"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-0a536cee16736af11"
                         },
                         "ap-east-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-03119abc1d880acc1"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-04772c5cbd3602482"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0e984afd203498733"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-03340003742a62cf2"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0aa19e36333a53001"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-0b428b15bd939e0ec"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-05d0b840812e18160"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-063d0950f8b63c0ee"
                         },
                         "ap-south-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0a5124ebf02dd08a6"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-0a3621324939cc13d"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0b581a8675c5c3ec2"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-035283ae1722aafae"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0f40e207a6842df10"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-09b1748dd3eb3e2f6"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0e24724efd16faa69"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-0d1cde2e86840a76b"
                         },
                         "ca-central-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-02bf07f966d2a20df"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-041f21a57c4d60583"
                         },
                         "eu-central-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-02507ae32bdf2b93e"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-0e72173796a6f1ca4"
                         },
                         "eu-north-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-066dc940a402adce6"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-06a56ceb7c34486fe"
                         },
                         "eu-south-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-045010b8969568160"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-03d3cfe41c6dbe72e"
                         },
                         "eu-west-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0bee4c0515d295347"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-09c55ea3a39278410"
                         },
                         "eu-west-2": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0c58b2c7549f570a7"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-0ea8c84a871393de2"
                         },
                         "eu-west-3": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0a7d4cadf9a75104f"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-0e668542412025491"
                         },
                         "me-south-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-051dec8134a4a413c"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-088cd484e7c2d5ad6"
                         },
                         "sa-east-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0ca8562dfa5f86706"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-0f530bb972887902f"
                         },
                         "us-east-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0a0713e03c9d1c6b7"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-0c5872c51d14a9572"
                         },
                         "us-east-2": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0126fa7ed8ca9a337"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-0291223e89909cf0f"
                         },
                         "us-west-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-05b40f4996a5df30e"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-017334396b05e6832"
                         },
                         "us-west-2": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0e4308a2edb1a28e5"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-0ff08203de78fbfa8"
                         }
                     }
                 }
@@ -190,214 +190,214 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20220313.1.0",
+                    "release": "36.20220325.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "d36ad15771492722607168197b98ff18a60d2ff62e3e11f64934a8a41a55983a",
-                                "uncompressed-sha256": "b88e485307017f1fbfe9946793557ee0fbbbb78502e2bb51cc700774feee79b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "31b6bef0574a55fd02c3d042a3167798947aff764a1b688f541d0a71c1408584",
+                                "uncompressed-sha256": "5159bf0b05e3249144968f58b4e3a23820444956e36f92a9ee02f3013fd3875f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20220313.1.0",
+                    "release": "36.20220325.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "aced507a6dd0bb270874419c7b545235642f78d3e03d0acb5ea9824fb6771222",
-                                "uncompressed-sha256": "47dbbf14110bdfc71b44c68c7e12bc749d469239357f2055480b58078201ca2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "7dd4fda28d16fa16de3b56f4827eda7869f59de57e0cdfe385ebb0613ff4e54b",
+                                "uncompressed-sha256": "0d38b5cc2275b273af1e2cb6a6ca2d4f96876f0004845fe127fd0022683ad186"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20220313.1.0",
+                    "release": "36.20220325.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "3ecb9ace33458c47775e1cda6d7c622395dad3f2d2b4eb12f55322a9bcee2860",
-                                "uncompressed-sha256": "5d81d771dc84ddff7d3c6b60e8432a66099c4abba3d6c9cc5c0fe597f34e3b3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "de3d5572c42f7378876b5e3756082b6a03a80811eff57226da836534446f293a",
+                                "uncompressed-sha256": "84e615f17bad150f2de4aa6ffe31bc1e7c978722a612252140eba7695c91d175"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20220313.1.0",
+                    "release": "36.20220325.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "1fad4e2bfac65829b336a4c899cddae8170d1409a8ae290ffccd134f969279c0",
-                                "uncompressed-sha256": "7a6ec9bc20ec2c23af18e3cfde14b88d96e92561f5f64aa309d2b3f66d377a3e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "385de110559f3af64d04764aad49661b298a2124dc38380fca694f0efe568304",
+                                "uncompressed-sha256": "d47e40f967a94482591303e30e2cb7365a8d72b1d34d50a9f2395551f3863712"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20220313.1.0",
+                    "release": "36.20220325.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "39a426451b880466073c63fc7cd5366db4e345b866a4d07f6881d5bf81e8c18a",
-                                "uncompressed-sha256": "f2eeb73a11fcb7d09354e91af90d7b25f818913b1ff42616c7976050cbf3236f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "0b9b72f4a88b1d3e09e710da0a2a12ec207172c7e9a12f0ba71f557f306976f4",
+                                "uncompressed-sha256": "e12c88e8e22237b84795f169738d05ea398f3019a30f4c716ee2ca109737debc"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20220313.1.0",
+                    "release": "36.20220325.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "842a5b8ebfd73b9d13ac96ff4cbe84981e96e240735c19c64449a94325416fbd",
-                                "uncompressed-sha256": "fa6d019be892d178c3c2fe7a23658e1eb7a490609a58c0c603b903fd5731bc26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "b785c4921c421bb7d4d1773710ea33105b965bba54283be4856b1c295c1e0bec",
+                                "uncompressed-sha256": "71d5457be0558300ee89b458988ac3fd1d11c1b3912faf5aecf7b053d199b898"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220313.1.0",
+                    "release": "36.20220325.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "7262b74df03d47423d2343beb8b270b7a864dad92658291eacc7ebb60bc089be",
-                                "uncompressed-sha256": "8962c3e59e28f9305ab6210db0de3539e8534f002605424d35eade6442471370"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "59e8f754beb10591cdaf8c2853044e3abed9aa97c36ecd24f52c8940138ce2fe",
+                                "uncompressed-sha256": "d1352de4ab714596d17548c3ba69b8536df011981bc1afd86c6b02138b2aad52"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20220313.1.0",
+                    "release": "36.20220325.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "d3b21e77ab21cd086bb2cb3c1848e29a69cc3c5e27e91bafdb2e628e6077b20d",
-                                "uncompressed-sha256": "29aa9856c900050b6d82f7a95f92fd40156ef2f4e3eecf2c260949ab9da02a31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "aa516afe84e4932d937fea7570fcaceaaeb0daff756ec8e5f5e33f03123364a5",
+                                "uncompressed-sha256": "14e03a93362dcc6d5d58cde60fb6ed9f062f552dc6c90499a0e8367b3dac2527"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220313.1.0",
+                    "release": "36.20220325.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "73a667f1bb376cd491d35372455913cba77be56fa77bfd80c69ec6086a693230",
-                                "uncompressed-sha256": "570ee6ca9e59b1ef40878e02e93b26205784517ba1161ce090a284b93cd054a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "583c46d3cb4f16a0099a5d2d9e2ce35ce0970a41cea8fefa765df82e9566fbe3",
+                                "uncompressed-sha256": "267efb8f941da6d04fcd67a7a5fb5d92c128930b3d468d4e126918f5422b7a8c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-live.x86_64.iso.sig",
-                                "sha256": "dd11bfb1c7070e379a9c27370c0fce6c2591c9e80ad6df82befc562f0d507810"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-live.x86_64.iso.sig",
+                                "sha256": "493f427ff0c2f470daa022132d8c28821ea2f320a9f85c96cfbb6201ca58cec9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-live-kernel-x86_64.sig",
-                                "sha256": "f8e91b01ece4d3b0aaebbe0f97d1ad3c639418cae8bf96b4e2b0d50f90f8a75d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-live-kernel-x86_64.sig",
+                                "sha256": "7e26316a926a473a9e2dc3b3b9517d7a34f88334396deaf32cd4a0d874da984d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "c050893972e5f8e1ee102236f261b4908e5dd0a57056878799b774f2db29362e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "bed70e1ddedacdc2013a9e94de42c1c7902f77dd486f14fc6a19784afbff6abb"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "2bbd38ed10d05e043b350b14f7c6e326a6bd111ecdea1d0660f58c286eb0108b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "6ba6bd45e107250e38d377804bd3ca6c720412c7c5a5643156818968d6a7f784"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "19e0ce9b7d005232114192128d7c534025ab028d323d1ced01731f9ac9cd0a24",
-                                "uncompressed-sha256": "cd9260946dadc30b829f33b512f93a9b31aa3995d7e018b0b4ae3a86b491295a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "ac281bcf784dbdffb4a3390ca8c383ce76d7a86d11388f515c4b6e103b5e5b7a",
+                                "uncompressed-sha256": "848354d0a911e1f2c16b5bab282c20c959c9945d2a71bb442e97dd47cb6efe84"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "35.20220313.1.0",
+                    "release": "36.20220325.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "95496e20f2309ae5900fff4bced3c726f6d38af257b53ab58cf4feef97b998f2",
-                                "uncompressed-sha256": "13962f7ce1cde89287103c82f393a53727b506e8a682af4df7195c88ff11eb8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "e0d052690f109b1948586df2db74980b4017e31ab06561604aea357c03d0142e",
+                                "uncompressed-sha256": "efabe5ed9eca5425ba8b2d4b4793763413336b9f5eb48d72018d90c09d090234"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220313.1.0",
+                    "release": "36.20220325.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "1e117e1500aa1e3115cb62247ca1c1503237503c2fe35add02d6f46daabda221",
-                                "uncompressed-sha256": "81f260619de5bae298df8ec369289f6db9be7cd3e075ffe49773b6ebb6ded0f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "92bc6e9285b645d86189bb6e6fb86fe3a21545da369f7e721e9d34fd6dbed222",
+                                "uncompressed-sha256": "cc9d2b9991694c3a99f2aa7c861fdc46a1b48ac5255a069b87e0c4407245b691"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220313.1.0",
+                    "release": "36.20220325.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "b62253412839856cfb4983d0cd5d3217da1454bcfa947aa68213de63b3aacb8c",
-                                "uncompressed-sha256": "507f7b43d97baa4070c9c7e13502eb3537e49eceda896a422d1b4e6d32e559a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "23eb6b8dd3e15de9477a51d44087c9816a0f6a51ed59d64c4ca7398fa49f887a",
+                                "uncompressed-sha256": "c305e2e31064165fadc32a7896c74d369a662131a740902a219547e2add886f5"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20220313.1.0",
+                    "release": "36.20220325.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "f8e71f3c6b725c19261950e00f41c7d980bd834afaf83bc551485f89d369f78d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "48e9b6842dc8a32ca1f7ad1e8ed2ebd8f75e0c5693f846977693ea1633944889"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20220313.1.0",
+                    "release": "36.20220325.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/35.20220313.1.0/x86_64/fedora-coreos-35.20220313.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "b6c2fb2025f9894f32fd546084d98e9c7c59df41906edc5003f88d7d042f6c03",
-                                "uncompressed-sha256": "d484030e83e8994e4c6e77b51034fe84e38a40a06a7f1dabe91a5af98746dbb7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "06e4e78bc916254ef7bf7ce0e7b889005719c7cf0570c1cba11d5e8d4fe7df9d",
+                                "uncompressed-sha256": "44702e521c05cdd940f39aff447bd909a4fab3f8327282790d633e5f090f693f"
                             }
                         }
                     }
@@ -407,100 +407,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-00d2a2d36fbeefe9c"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-0af6bc89bc6657cbe"
                         },
                         "ap-east-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0cabbaad0897ba5f0"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-0d5c56faf51d57d96"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0eb7572b82180bfa4"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-074cc25ba7cad8b4c"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0476514ad4552a57e"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-05d6a436853d3ae37"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0b94ae15aa81d3330"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-07d06b2491fd01b1b"
                         },
                         "ap-south-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0ca9c1fd397ee43b3"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-01044057cbd8b9741"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-03fafed04a6c3649e"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-003278d19709aa57d"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0fd2005ac6d1b67f7"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-0dd66beccfc8ac9c3"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-04f4eb6bb68b25cea"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-09e124daf9cc8ecde"
                         },
                         "ca-central-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-058a094e569350fa5"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-09b4c2b8e3e2bea41"
                         },
                         "eu-central-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-05ed2f2bb91bad77a"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-00cea549cad79eca9"
                         },
                         "eu-north-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0187c728d77364f5b"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-00a4e02e2fffa8699"
                         },
                         "eu-south-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0aa6f43320f728b56"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-0c595b35b07acf87a"
                         },
                         "eu-west-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-04d2926f4d0840471"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-019b37828ac0f6ffd"
                         },
                         "eu-west-2": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-03eae89d520d56b5b"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-066cecb9413b78d1c"
                         },
                         "eu-west-3": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-029f683cda52ddae5"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-0f5c0a51f370c5155"
                         },
                         "me-south-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0b287b38f5f588818"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-0b3c6a825d193add3"
                         },
                         "sa-east-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0819389cc6787203c"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-09a55863c07529111"
                         },
                         "us-east-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-02067b904ed8ec874"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-066680d6ebe90fce1"
                         },
                         "us-east-2": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-031a795e538ea5ed0"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-0623f57bbbc70e611"
                         },
                         "us-west-1": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-011db9d98953e1177"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-0babe35890b06688c"
                         },
                         "us-west-2": {
-                            "release": "35.20220313.1.0",
-                            "image": "ami-0cc5aca94e41cbc29"
+                            "release": "36.20220325.1.0",
+                            "image": "ami-0bec43aee672d1733"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220313.1.0",
+                    "release": "36.20220325.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-35-20220313-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220325-1-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-03-16T11:17:58Z"
+    "last-modified": "2022-03-29T00:27:05Z"
   },
   "releases": [
     {
@@ -45,7 +45,7 @@
       }
     },
     {
-      "version": "35.20220227.1.1",
+      "version": "35.20220313.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -53,12 +53,15 @@
       }
     },
     {
-      "version": "35.20220313.1.0",
+      "version": "36.20220325.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1647439200,
+          "start_epoch": 1648562400,
           "start_percentage": 0.0
+        },
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     }


### PR DESCRIPTION
next
    version: 36.20220325.1.0 (latest)
    start: 2022-03-29 14:00:00+00:00 UTC (in 13:32:54)
           2022-03-29 10:00:00-04:00 Raleigh/New York/Toronto
           2022-03-29 16:00:00+02:00 Berlin/France/Poland
    duration: 2880m (48.0h)

Signed-off-by: Renata Andrade Matos Ravanelli <rravanel@redhat.com>