### PR TITLE
Roll out stable 35.20220327.3.0, testing 35.20220410.2.1, next 36.20220410.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-03-29T01:16:20Z",
-        "generator": "fedora-coreos-stream-generator v0.2.3"
+        "last-modified": "2022-04-12T18:02:21Z",
+        "generator": "fedora-coreos-stream-generator v0.2.5"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220325.1.0",
+                    "release": "36.20220410.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "d11ebdeb55c7a025579935971f1ad33c7862d9792d8ae299aa4c795506fcc319",
-                                "uncompressed-sha256": "a339666f6185419d5f90b0515c71ff30129f6599b964311811c067283cccb7fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/aarch64/fedora-coreos-36.20220410.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/aarch64/fedora-coreos-36.20220410.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "25e69b210e88dcd1e9cf90a7a40366c3bf7b5c25ac1cc8ce4d89ce52c61fa32f",
+                                "uncompressed-sha256": "b7cddcba15074b4e58a07df5001d90f1e6dbc6b8505c9a18c91b0031060ab752"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220325.1.0",
+                    "release": "36.20220410.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "6ca2c14b4de929c7922a0c234cd975f368ab26a10b863ee780794624e6cf3585",
-                                "uncompressed-sha256": "d2343a5837de1389ab9612625151075df2cdf2218346beb41ba8d070382a2a61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/aarch64/fedora-coreos-36.20220410.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/aarch64/fedora-coreos-36.20220410.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "16345fc5bc8828b94bd67e48a18d34dac9f460bc67604b6a41c39cb7eae159c9",
+                                "uncompressed-sha256": "010fe017b623b6aea911a2ee51f8d6f011b72f9b1e6f83a02288c103b992c3bf"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-live.aarch64.iso.sig",
-                                "sha256": "aa3896f69cf6bbe30333562bb4512fbbf3c810bcfae7ca743ce2af00d5b48974"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/aarch64/fedora-coreos-36.20220410.1.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/aarch64/fedora-coreos-36.20220410.1.1-live.aarch64.iso.sig",
+                                "sha256": "67d3382f5a92de5ccec9838964d6b76d2df5969ffd99fcb192e86c912f978e0f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-live-kernel-aarch64.sig",
-                                "sha256": "05487fa6ce64427dde965d0c7931c867886017b3d1286091cec96a2f33f24fdf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/aarch64/fedora-coreos-36.20220410.1.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/aarch64/fedora-coreos-36.20220410.1.1-live-kernel-aarch64.sig",
+                                "sha256": "7d6b13cae04ae5522ec4cb936029ddfbdbc4786ef68c7fa4714f15de743489a4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "730f05e395a40facd3da879bd14343f9fcb8f6f0ec4820d2d03567b96e165be9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/aarch64/fedora-coreos-36.20220410.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/aarch64/fedora-coreos-36.20220410.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "96ad1a1b52206330c0bc2813a2330993e3c7a4f5e8594b4183f4e46447f30313"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "3112274044fc6123ddbaf082e5a2ba207c9a715189ebd4a777b4b314ba4d3541"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/aarch64/fedora-coreos-36.20220410.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/aarch64/fedora-coreos-36.20220410.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "f264b8e14cea3511381b210b5ede28994f6b9dd63ad042545e44142d0fca357f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "7d278f7b22913b03d2a7f890953af0204ade4caef22b100c1f34c13f03e87ce0",
-                                "uncompressed-sha256": "8d13637a22e67c014219475c837c5d5294c67774c0ea62988fb532e814e65388"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/aarch64/fedora-coreos-36.20220410.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/aarch64/fedora-coreos-36.20220410.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "60d3f9cb678188d9cb27390ac3e33955e2dc45354269c0f88fcaaa755cdc6c72",
+                                "uncompressed-sha256": "07d6890a2f455d7d96782d2b8e996752033dfd23eba9395b51042787cdf2ebe5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220325.1.0",
+                    "release": "36.20220410.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "ee18f92bc61882686e7e3d5a957611df773f6e95366665cb920ac4ca609e5317",
-                                "uncompressed-sha256": "69976797c0910f34616d290872f5960a017cfb99687012c079522393e52f171f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/aarch64/fedora-coreos-36.20220410.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/aarch64/fedora-coreos-36.20220410.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "7bc2ed99bcc06fcc985b469fc0b730eaf925d2415c4a5a307a87b6017644c8a5",
+                                "uncompressed-sha256": "c58eb14704946df0beca5c2a69d324d4f7eef2e325d18cfb1d92c6c9c1fd18f9"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220325.1.0",
+                    "release": "36.20220410.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/aarch64/fedora-coreos-36.20220325.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "81302189d99a1e2ae5b2cb6bfc0af881920e78857e19ad607705b90d2ccbf77d",
-                                "uncompressed-sha256": "70f6e271fd86095840bd8df25e7727bd27d621c2738bc307eceb8c2c2f21c56f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/aarch64/fedora-coreos-36.20220410.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/aarch64/fedora-coreos-36.20220410.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "07faa192e7e3211d75eef0a8d0e2d274c2173ec99981013f470a46888410d89b",
+                                "uncompressed-sha256": "529e5b976562d409a1800dfc3e366975357c9a6e9eab7b576e6feb3969761b82"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-0a536cee16736af11"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-052d96b97e659aced"
                         },
                         "ap-east-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-04772c5cbd3602482"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0857956879d23bb3c"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-03340003742a62cf2"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0394f5485f30b8980"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-0b428b15bd939e0ec"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0f20f99c3b1bc828e"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-063d0950f8b63c0ee"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0653d5b82fc32040b"
                         },
                         "ap-south-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-0a3621324939cc13d"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0f1fb9372bd681f0a"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-035283ae1722aafae"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-00ecbe7a1f3ece1f6"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-09b1748dd3eb3e2f6"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0b7ef7ae87b80f600"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-0d1cde2e86840a76b"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0e52529366c6d045a"
                         },
                         "ca-central-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-041f21a57c4d60583"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-073197ae55f1f156e"
                         },
                         "eu-central-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-0e72173796a6f1ca4"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0aa794b216e2db801"
                         },
                         "eu-north-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-06a56ceb7c34486fe"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0a12d96dffd8d5eda"
                         },
                         "eu-south-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-03d3cfe41c6dbe72e"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0db82247cf192542d"
                         },
                         "eu-west-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-09c55ea3a39278410"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0aff8867454b72d67"
                         },
                         "eu-west-2": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-0ea8c84a871393de2"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-015d899400c363cab"
                         },
                         "eu-west-3": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-0e668542412025491"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-055fceec3ea0eb168"
                         },
                         "me-south-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-088cd484e7c2d5ad6"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-05396040b8b36edef"
                         },
                         "sa-east-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-0f530bb972887902f"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-057d2526080bf0cdc"
                         },
                         "us-east-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-0c5872c51d14a9572"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0f3926ba28eb1883b"
                         },
                         "us-east-2": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-0291223e89909cf0f"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-00e416041767c30d1"
                         },
                         "us-west-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-017334396b05e6832"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0877eb3fafb4cf55f"
                         },
                         "us-west-2": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-0ff08203de78fbfa8"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0d7756d4d839daab1"
                         }
                     }
                 }
@@ -190,214 +190,226 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220325.1.0",
+                    "release": "36.20220410.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "31b6bef0574a55fd02c3d042a3167798947aff764a1b688f541d0a71c1408584",
-                                "uncompressed-sha256": "5159bf0b05e3249144968f58b4e3a23820444956e36f92a9ee02f3013fd3875f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d0166c9af02ddb1962c42e710290a5f61bc0d657f97e5501d5b9f19bd3503536",
+                                "uncompressed-sha256": "3e1f1e5ff6ad63e63d13b5fc0f247a5eab4ed9c33f320712c4560a5d6f79a187"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220325.1.0",
+                    "release": "36.20220410.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "7dd4fda28d16fa16de3b56f4827eda7869f59de57e0cdfe385ebb0613ff4e54b",
-                                "uncompressed-sha256": "0d38b5cc2275b273af1e2cb6a6ca2d4f96876f0004845fe127fd0022683ad186"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "0644886daa1e2585804d794bfac5a215fd664d56513259e966df6e9310ce63fc",
+                                "uncompressed-sha256": "e615ac43e8ae9461560fe5fa6a0d70248b63511e5956830d7c0bc45801c8c9fd"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220325.1.0",
+                    "release": "36.20220410.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "de3d5572c42f7378876b5e3756082b6a03a80811eff57226da836534446f293a",
-                                "uncompressed-sha256": "84e615f17bad150f2de4aa6ffe31bc1e7c978722a612252140eba7695c91d175"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e4c17b8dfa8063930d25822d7aaed958f334cd078bf1ea58bcecafa91088b8c4",
+                                "uncompressed-sha256": "9f3e21609019deda30ea8cd3aedd6d8369c7af63811b02441c9f859e7ffd6f96"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220325.1.0",
+                    "release": "36.20220410.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "385de110559f3af64d04764aad49661b298a2124dc38380fca694f0efe568304",
-                                "uncompressed-sha256": "d47e40f967a94482591303e30e2cb7365a8d72b1d34d50a9f2395551f3863712"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "35497b386b0e2db8fde6b85c6db8b0cd14f5ed976a9bcff6708d28cebe57dd91",
+                                "uncompressed-sha256": "7e5029e15c894b401e20275a26e31abd048b04b921057b03b1165c28ee9e3574"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220325.1.0",
+                    "release": "36.20220410.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "0b9b72f4a88b1d3e09e710da0a2a12ec207172c7e9a12f0ba71f557f306976f4",
-                                "uncompressed-sha256": "e12c88e8e22237b84795f169738d05ea398f3019a30f4c716ee2ca109737debc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "eac7546366b7b32edebfcff9e5deee6d03cdf5874ce0c29acd0853532a8a2864",
+                                "uncompressed-sha256": "50ca24cf9167e4817d564f25704a28a00ed75189760bc6370b348cd926dcd7e7"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220325.1.0",
+                    "release": "36.20220410.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "b785c4921c421bb7d4d1773710ea33105b965bba54283be4856b1c295c1e0bec",
-                                "uncompressed-sha256": "71d5457be0558300ee89b458988ac3fd1d11c1b3912faf5aecf7b053d199b898"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "dedcc4b33f70199f18635b0bc38899bffe97b27151ba42ce88bb936ad93daeb8",
+                                "uncompressed-sha256": "2c06a7290b4bc5ca61ef1161d25b93ae67961abc34877bf2b3506e260e632226"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220325.1.0",
+                    "release": "36.20220410.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "59e8f754beb10591cdaf8c2853044e3abed9aa97c36ecd24f52c8940138ce2fe",
-                                "uncompressed-sha256": "d1352de4ab714596d17548c3ba69b8536df011981bc1afd86c6b02138b2aad52"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "d6123955c4939ee8149ef11c9c169221168e97de4a1945d7c7379d6d2002e16b",
+                                "uncompressed-sha256": "a4e03c3c726681043296ebe4c0e4401b2fec70aa0f111746066fe09b6d2e93cc"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220325.1.0",
+                    "release": "36.20220410.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "aa516afe84e4932d937fea7570fcaceaaeb0daff756ec8e5f5e33f03123364a5",
-                                "uncompressed-sha256": "14e03a93362dcc6d5d58cde60fb6ed9f062f552dc6c90499a0e8367b3dac2527"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "6e7db101783aeb1c4ff22445145d7b2167ababfe7813b073c158adf19aeda07e",
+                                "uncompressed-sha256": "f985dcba02708875f1c2b254b4251c3d1e7b14d4e9dbf3eaebb23aac5e395660"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220325.1.0",
+                    "release": "36.20220410.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "583c46d3cb4f16a0099a5d2d9e2ce35ce0970a41cea8fefa765df82e9566fbe3",
-                                "uncompressed-sha256": "267efb8f941da6d04fcd67a7a5fb5d92c128930b3d468d4e126918f5422b7a8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "1fe50acd683a273ac61ef1100f3f5a1116ff2360dd636770318cb69407704e18",
+                                "uncompressed-sha256": "5a2d17f7b0875535f793f8482facca4012f7dce1d979b055127216ce0f8dd448"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-live.x86_64.iso.sig",
-                                "sha256": "493f427ff0c2f470daa022132d8c28821ea2f320a9f85c96cfbb6201ca58cec9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-live.x86_64.iso.sig",
+                                "sha256": "972d8ae219e4fc0d13b1e5f69352492e0f96d375f774d410377ed7e57d7c1ffd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-live-kernel-x86_64.sig",
-                                "sha256": "7e26316a926a473a9e2dc3b3b9517d7a34f88334396deaf32cd4a0d874da984d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-live-kernel-x86_64.sig",
+                                "sha256": "d43789ecad741ef67e6d787da5bcb7c08078fed097d7f1bf27c0c2a2f2ba93b2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "bed70e1ddedacdc2013a9e94de42c1c7902f77dd486f14fc6a19784afbff6abb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "0d70a6d1f0061ca6ab4fdd67f662b23d675e16302433828a777a92984fdd5037"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "6ba6bd45e107250e38d377804bd3ca6c720412c7c5a5643156818968d6a7f784"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "da381c6bad7985eae819a4320558846a80caaa6af98d3b118fe1b6d12baee9dc"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "ac281bcf784dbdffb4a3390ca8c383ce76d7a86d11388f515c4b6e103b5e5b7a",
-                                "uncompressed-sha256": "848354d0a911e1f2c16b5bab282c20c959c9945d2a71bb442e97dd47cb6efe84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "ed9482cd95f9325bd96994fc6eaeaf63332bac21d7df54211070c048c5d463fd",
+                                "uncompressed-sha256": "4c145a202dc7943d5cd6c7cc9c92dd484c481281e94c2839d630a1851de609eb"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220325.1.0",
+                    "release": "36.20220410.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "e0d052690f109b1948586df2db74980b4017e31ab06561604aea357c03d0142e",
-                                "uncompressed-sha256": "efabe5ed9eca5425ba8b2d4b4793763413336b9f5eb48d72018d90c09d090234"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "bb2e7c84c7d709a9c5cd1ce46d664fde271d9b909dad51cdc86a13bd1654e16c",
+                                "uncompressed-sha256": "78f2fc96e8e8300c18bf8fe7bafdc4fbe7daae9626aad90bc0f761700b19bf42"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220325.1.0",
+                    "release": "36.20220410.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "92bc6e9285b645d86189bb6e6fb86fe3a21545da369f7e721e9d34fd6dbed222",
-                                "uncompressed-sha256": "cc9d2b9991694c3a99f2aa7c861fdc46a1b48ac5255a069b87e0c4407245b691"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "9dcec0d1d628928e97fb464612f03981d6894306f927467effe53bd53b5e3d94",
+                                "uncompressed-sha256": "5bb8824fd0e982685d19da00ad1064fd1ecd96943b566575e6a65a69c2a03df4"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220325.1.0",
+                    "release": "36.20220410.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "23eb6b8dd3e15de9477a51d44087c9816a0f6a51ed59d64c4ca7398fa49f887a",
-                                "uncompressed-sha256": "c305e2e31064165fadc32a7896c74d369a662131a740902a219547e2add886f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "9741f8ad6fb594357ee1a36a2e321b836f40d3ad85b77974920095e341a4cec8",
+                                "uncompressed-sha256": "45b4cf864c1868712a40769bb3cd5f0cb8b4755ab4cfaa2ec8699bd147913101"
+                            }
+                        }
+                    }
+                },
+                "virtualbox": {
+                    "release": "36.20220410.1.1",
+                    "formats": {
+                        "ova": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "d3197f4c3e9fd7d7bef3f03091db4d9e9b13572c9e19f2770ee6cdb47ce7b2b5"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220325.1.0",
+                    "release": "36.20220410.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "48e9b6842dc8a32ca1f7ad1e8ed2ebd8f75e0c5693f846977693ea1633944889"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "6b7f99f166088bac0dfb31132d6869357f7ddf496d6d7f80f4db33ae27ab83bd"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220325.1.0",
+                    "release": "36.20220410.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220325.1.0/x86_64/fedora-coreos-36.20220325.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "06e4e78bc916254ef7bf7ce0e7b889005719c7cf0570c1cba11d5e8d4fe7df9d",
-                                "uncompressed-sha256": "44702e521c05cdd940f39aff447bd909a4fab3f8327282790d633e5f090f693f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220410.1.1/x86_64/fedora-coreos-36.20220410.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "1bfa79da92765af9567f0c51f85800e6f1f44e73d4d7ec3a35a7d41837fedc9f",
+                                "uncompressed-sha256": "cba576fa2d2c1306b54ba7ef67c7ebc58a1ba66e0beda1ef612312a3b08a2116"
                             }
                         }
                     }
@@ -407,100 +419,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-0af6bc89bc6657cbe"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-01ae820b8d16124af"
                         },
                         "ap-east-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-0d5c56faf51d57d96"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-05118f17a8e0cb4a4"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-074cc25ba7cad8b4c"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-07b30a0dc5b94f59c"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-05d6a436853d3ae37"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0a82611d733a5b73e"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-07d06b2491fd01b1b"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-00208eecccfac807a"
                         },
                         "ap-south-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-01044057cbd8b9741"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0e827fa756f8d0cee"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-003278d19709aa57d"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-061b1b85bf56b338d"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-0dd66beccfc8ac9c3"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-09de97ff4ea23baf4"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-09e124daf9cc8ecde"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-09b394183ece46593"
                         },
                         "ca-central-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-09b4c2b8e3e2bea41"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0f63b5922292c0f4c"
                         },
                         "eu-central-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-00cea549cad79eca9"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0217dd73d538ffc8d"
                         },
                         "eu-north-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-00a4e02e2fffa8699"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-06104f5c07cc4d389"
                         },
                         "eu-south-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-0c595b35b07acf87a"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-06bf9942bb0166ba1"
                         },
                         "eu-west-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-019b37828ac0f6ffd"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-01ff7429ffa1b22b5"
                         },
                         "eu-west-2": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-066cecb9413b78d1c"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-02186ab3c6136a3a1"
                         },
                         "eu-west-3": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-0f5c0a51f370c5155"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0066290e495f9849d"
                         },
                         "me-south-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-0b3c6a825d193add3"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-006b0582d4700140f"
                         },
                         "sa-east-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-09a55863c07529111"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0f3f55bb09439e0f4"
                         },
                         "us-east-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-066680d6ebe90fce1"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0a06057cf84ad557d"
                         },
                         "us-east-2": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-0623f57bbbc70e611"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-032d0dbe05a05caf6"
                         },
                         "us-west-1": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-0babe35890b06688c"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-0b406d4794cee0a93"
                         },
                         "us-west-2": {
-                            "release": "36.20220325.1.0",
-                            "image": "ami-0bec43aee672d1733"
+                            "release": "36.20220410.1.1",
+                            "image": "ami-054e90ea70df198b7"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220325.1.0",
+                    "release": "36.20220410.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-36-20220325-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220410-1-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,92 +1,92 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-03-29T04:30:41Z",
-        "generator": "fedora-coreos-stream-generator v0.2.3"
+        "last-modified": "2022-04-12T18:02:17Z",
+        "generator": "fedora-coreos-stream-generator v0.2.5"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220313.3.1",
+                    "release": "35.20220327.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/aarch64/fedora-coreos-35.20220313.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/aarch64/fedora-coreos-35.20220313.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "d032bb9b0da27bbe362a5172f928a2ffb84f303b0f56fc46039086d0e4433e2d",
-                                "uncompressed-sha256": "83eb9c00d1df5abefd61746a4ed2fdb2e1ef007bc88ee94ef48d82db2cbea18b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "d2150075961639e01bf8665e48eb21223f38118cd3b68b5fb836d29788691eb2",
+                                "uncompressed-sha256": "183e74d5549878e1de090b0afe78dd94f27a42ba822597308070866efdccff3e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220313.3.1",
+                    "release": "35.20220327.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/aarch64/fedora-coreos-35.20220313.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/aarch64/fedora-coreos-35.20220313.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "66b237671773440719481805c438682f4bf77f671ca14c43906bb93ab67f399f",
-                                "uncompressed-sha256": "63768b37f9efd63b5be83a9e2af68ddb0f896685ddb7659332ad13d280fd1860"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "332a6926c48127fe5c68f0650eb87561ee7bb8f51c8a7ce3d0d6ec6b3247aaab",
+                                "uncompressed-sha256": "7548a1cdd75a5fb15ab6a8c1df8285b5157b2ac9d04a0489b6d7acca92987bab"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/aarch64/fedora-coreos-35.20220313.3.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/aarch64/fedora-coreos-35.20220313.3.1-live.aarch64.iso.sig",
-                                "sha256": "31c772bc8518399ddf4e86f07f0cddab6a5219dd184139a32e7c2fb04b431a4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-live.aarch64.iso.sig",
+                                "sha256": "d7f1accac2eb03f68089f30d921bd49310b24501a0364e7b9e28624bcf0b6fab"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/aarch64/fedora-coreos-35.20220313.3.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/aarch64/fedora-coreos-35.20220313.3.1-live-kernel-aarch64.sig",
-                                "sha256": "162048a19a21d6302f2c00706a2fd48b13044120598e79db1cbe435bd20a5fc5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-live-kernel-aarch64.sig",
+                                "sha256": "bde4aa910e2db3cf0e9ddb476fd85325925d25d021e7c046c2b92e82846deecc"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/aarch64/fedora-coreos-35.20220313.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/aarch64/fedora-coreos-35.20220313.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "62afab1250676627c9d81045d184f97362d11c8f67c71059ece52e25183a4596"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "5a7c41ee810bc2b3ae57e5ebc4e16b45c7875c3d558bfcfc7d3396b114679161"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/aarch64/fedora-coreos-35.20220313.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/aarch64/fedora-coreos-35.20220313.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "87da516b0c274ea61825b82a4433edebb698dc3c36fa990c72484d3c58d36e3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "0b939381eac8b8dfa5e7c7c8cd2503f8de63299b7b28deefbc6894faab1b28d4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/aarch64/fedora-coreos-35.20220313.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/aarch64/fedora-coreos-35.20220313.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "81beb13661b336868b03da3d75038935e7a68b581a604313e781542c9e45c850",
-                                "uncompressed-sha256": "4ef4b902b15c27acbe74cc6c34563a6d49d6fbee5f246033b9914d3a66890a1a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "442f72e31321c819fcb0998606f3663c9d9266a88617324eacc03a31ccff6fbb",
+                                "uncompressed-sha256": "cbd7e60cc15cd109a4d15a8cf8436a30077920be2cfdfbf2fe2552f9d536eefa"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220313.3.1",
+                    "release": "35.20220327.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/aarch64/fedora-coreos-35.20220313.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/aarch64/fedora-coreos-35.20220313.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "c79dd581efcc6fa3e38b9b2cfbbc9763104625997a89bf54ae08c2961976f580",
-                                "uncompressed-sha256": "21080949574474976f39dbeaeab8f9db24afc5edd17745528604ea8139342047"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "07d2e3caee70b80a983ac9cdb7a9a1a8c9ba60bf681044d7d129e18b7ef05895",
+                                "uncompressed-sha256": "7385ab816be0ca7c32bea174a6fa7b0b83bdc851b6eecfe4b89d6e2ce246bbfc"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220313.3.1",
+                    "release": "35.20220327.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/aarch64/fedora-coreos-35.20220313.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/aarch64/fedora-coreos-35.20220313.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "1fd62e6d3d2f117e9feb7ac223887a249a2ebddba5346c93b6f009d5dc0a0f0f",
-                                "uncompressed-sha256": "420f1912d5838ab6e12f9f032432b9bd27143a32798f6af326da7382649e7d0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "d307e22957ba923af7a852619c77a151f5d94636f83e016529c06cf40e911f12",
+                                "uncompressed-sha256": "b9e7478798d531f81e9d628b155c76d0b12970e22dc3e16e05488d7de9a5ae4c"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-01767da7ba5aa1956"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0eb2195220a64b140"
                         },
                         "ap-east-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-049f149708a421526"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0401a7af2a7cda259"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-0351485c0902dd8c2"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-05243b8ca233b1eb3"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-08d3b6e843d185d44"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-01efc8d3c9bdfb6de"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-0e3f3ff7d6390624b"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0dff7e96e6dcb4bcf"
                         },
                         "ap-south-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-0e9ff161e3885ef7f"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-01043486b86697dbd"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-0e63301823126cdb1"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-086a2e38431e248a3"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-01972403fb09257f1"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-030ddb1d9e377c2e1"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-04e816a0e5e0dbc34"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-011472aef784e90a0"
                         },
                         "ca-central-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-0afc66733e64a40e0"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-00c86559cb53910c2"
                         },
                         "eu-central-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-04e5d8f17929ec282"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0149e7b11c5432cb1"
                         },
                         "eu-north-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-01cac1c1ceef1af1f"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-01599380482ad2c86"
                         },
                         "eu-south-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-09280561d33e593e5"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-01ad90353ad3f4325"
                         },
                         "eu-west-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-04732e43e490e6875"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0e3f24046c20b0c5f"
                         },
                         "eu-west-2": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-04b3739550669d769"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-04bd8beadcda63827"
                         },
                         "eu-west-3": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-0cdaca1e0f529d96d"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-009d09eea85a614f8"
                         },
                         "me-south-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-01a9aa2a6254fa16f"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-08a1154bbcef7a389"
                         },
                         "sa-east-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-03bae5c1ead4cd07a"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-03a5007ed6e10aa95"
                         },
                         "us-east-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-08a1e2c28212daa26"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-073a87a8b59d74b49"
                         },
                         "us-east-2": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-0049af8c169f1cb29"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-07ae278988a8e9f10"
                         },
                         "us-west-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-0a623dcc61562f28e"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-09f144cf5b47d1e98"
                         },
                         "us-west-2": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-0b8f3bd6ae8d4ae71"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0aa6e2bdc8254d379"
                         }
                     }
                 }
@@ -190,214 +190,226 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20220313.3.1",
+                    "release": "35.20220327.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "2e5bfc41b4cc9ae1ead2366457511fcea606f71f510a6f86707335d99b4381f5",
-                                "uncompressed-sha256": "8d312b3c4fa80563e5008f7ede02326eb4e975e1fc661660efb3a072aaa9025c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8a9597672344b051fb73806817ae0b943e1e3d64b5a778d40b713ee1f2ff1c7a",
+                                "uncompressed-sha256": "be12ec7a1aa543aa9ea356febfd7d81905b75651f834a3609e195419a705eca0"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20220313.3.1",
+                    "release": "35.20220327.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "d435574349c2573753e471622c14c809b22299ec31731d1118d718b0ed591d3d",
-                                "uncompressed-sha256": "4702b6fe619e29a970977bf934b4d3c1333d89ffc0d86165ea09384d340113e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "ce63e08f9f1df4f4db090a7fb0bb215d76bbef7560e3ae94d0e49653021a1526",
+                                "uncompressed-sha256": "0e086d809fae1a0e987321719d8e58f5442971ced8c118321129f23291e76fac"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20220313.3.1",
+                    "release": "35.20220327.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "404696437c7f03e3497addd1da8398c0f1a8febf4a9094ab90331385e109555b",
-                                "uncompressed-sha256": "1f42eb9331d7e5fd83c221be629a675c2ff10a06bf400ee36760def9625df579"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "66222ef415403c5fc023221068cf3905f0880b0802cc437635a85a7df6a05fe1",
+                                "uncompressed-sha256": "f6cdd341278fd7f34e5e1c6e3803a84d6cfe4e0d907021724b9399c9b7bdd396"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20220313.3.1",
+                    "release": "35.20220327.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "edf068e9c685b2e28ea889aca56ed3fb8280618d2d2407cfc585a93e71095c2f",
-                                "uncompressed-sha256": "f014ae7c139a4cf0b170eb73cc305d21cafaf7fdbb3d1f5cf42bf8fba60dc76b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "f7931b749411d7fd6a1f9b9943afe52246170c3b8120e28a13d336d7deb0a9b9",
+                                "uncompressed-sha256": "477307a072e31c8e7c84aa903b1c0bcca156e8b8d7e147b83533a03bed9684dc"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20220313.3.1",
+                    "release": "35.20220327.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "808ed9960737d976bf973e27569cb8f706abc855f39f09b0b5a0503403341fc7",
-                                "uncompressed-sha256": "68aaf0573518bfa893df359e604db9a5f94af163879fcfbd4d73cce4e8d9b4ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "73cfa79258d1f82b9adea94877197784e7f621a1dd14e3655fbc1b6dc2d58371",
+                                "uncompressed-sha256": "f22890caba26d45285a3ae70f1acbfe56951975c1625aadfa2d6479f37b5261a"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20220313.3.1",
+                    "release": "35.20220327.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "884ba7e5ab0e80c499d3abc08525d97926de26d5dd172df273f441a854e50962",
-                                "uncompressed-sha256": "ea0215430ff21aa89a0964a48aa2a444f47f8f9d00288144fce63a3f33559fb2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "7c564329c7d12aefecd319d869818d63fb7da674ae5f3e1128006e1f88ac6eae",
+                                "uncompressed-sha256": "888554969f6b99ea07e316d3dd851916a14e5e73b731a35b8a9779f5fb2a9a01"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220313.3.1",
+                    "release": "35.20220327.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "678346fd3820e5007320056a51a1cc05c1f41c5eda9f287a59b6670a7d161a98",
-                                "uncompressed-sha256": "462d8e9008bf8092332955ed3947aea9c7de0c637b3b4335330a1acd3f7aa0d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "4a5b3c360ee60588cf969c87b9a2d7ccef306add80fe37c4a9a1f17adf812ebe",
+                                "uncompressed-sha256": "9bcbf0fa4c57f4374204be13ef37c8240cc9ed3ddfb23a0cc1e6ebf7d77795d7"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20220313.3.1",
+                    "release": "35.20220327.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "9452ba174b932a51d9d30451c862a1580b308196ac30bdef49cba1eff2fb2819",
-                                "uncompressed-sha256": "20a9ec70ccbcc5d71b71018eba01990c92da1061017194ff49bc7a9a32898484"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "1dcfb3d3a764abfc6e4dbeb8b8842ee4e5ccd309a79f1e6b2697b3ba2cb30e4c",
+                                "uncompressed-sha256": "d7e3826bc1264293eb3f503e07a2b8e848a821f37fdf4d8f875281ae120b388b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220313.3.1",
+                    "release": "35.20220327.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "4a3697ac8af2f442933110ef3f03df8e462c6f41ae7c08634b6985d00781b55d",
-                                "uncompressed-sha256": "3690bd80b6a64ac74c3ce18c2ec3b5d284d5098396bfa3f516826d94aa5ce8b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "165c25e730071a868954fb97d39daf1d8f3e0aec96a22851aa8089b58150817e",
+                                "uncompressed-sha256": "79f533130ec04cf01142d052c3120aa660b80a59292ac75ff1df46c8385e83f7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-live.x86_64.iso.sig",
-                                "sha256": "13e06e8816d4c7c1d295f0506be6b9dc8d8dca972d990c4373cef9f72bef043b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-live.x86_64.iso.sig",
+                                "sha256": "c42ddc92bc7672a624b9aae461b286962e6f89eba426379c8a9eef308cc1afad"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-live-kernel-x86_64.sig",
-                                "sha256": "f8e91b01ece4d3b0aaebbe0f97d1ad3c639418cae8bf96b4e2b0d50f90f8a75d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-live-kernel-x86_64.sig",
+                                "sha256": "4c8a7257e1180bb552842a298f93f15dd014a74076c68f85e67c59fab46cdc5a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "64ea98b2fa1657e864a09f7478df09999a3d3cbfd5f1e4a097c717567d085781"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "752d6b8d72502b46da05d66d7c12cc1a8ba8bc915e671b0601477aab398f3607"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "350e3feebef99dd6fb3947628783e358868bebcf7ea1cbcf7dca38e06dab2d05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "bb9f4c9f3d2ba9b9fa15c998730c7cf568739aa4677436f4b62deec52e8dea9a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "3cf712ffc219449756bfb780436f98c76c0c6e01c0c420e2ba93dd3e693e5311",
-                                "uncompressed-sha256": "740240ed470a46fd50d51af66f434240deb11b4560a8c91d0031cf6739c4d722"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "de0ba478d782fc97b1d0a35a26b32445a09410f4d394b3fe7d2b606d7173bb33",
+                                "uncompressed-sha256": "7e241aa6c87e53d5ec6c31430b382f5fc3c1f4ffb7543cecc1e4be9afe039eb6"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "35.20220313.3.1",
+                    "release": "35.20220327.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "e8d1cf5970c45399d3ee7a48d0387f2465a090d9a8b4fc02aece2c2289a403c4",
-                                "uncompressed-sha256": "c33efbbd3d4332c0a3b4aeb3d3e597fd18b6db02c8ee7df39435294c27455275"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "5fb9015a0a322082294f14aef12b04811e904584dd5794a36c7133eb9242479a",
+                                "uncompressed-sha256": "5a22edf1b57fb7dfcfdb5106597f7d2d20b6b7a223af358943cf4e63cffb0e1b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220313.3.1",
+                    "release": "35.20220327.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "3bb2e8e3eb7a03aa48e9fcf8438228ca8c0d9225d6af6089f641d8d368ec4272",
-                                "uncompressed-sha256": "4f52a38b45dab1d520868a63316a0e59e011ff57d4f5b0c80991897a1f80d05a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "f5e1c5243c9b7d417d752642617e2af1814f4b3ada874f085ff068d4a2f513ad",
+                                "uncompressed-sha256": "5e3e40723288aa56735caa5e5fcb58079da5b27df392ee185a09f9b6742fa93f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220313.3.1",
+                    "release": "35.20220327.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "ef779f355a103cd70a5f3107030749f7cbe3ebc942bc7c4f03265b42ceeb0c3e",
-                                "uncompressed-sha256": "877c1b39d49527daa26df5a361069d27dbeeb6f082fe48e2c9ce7a73cccacff2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "1c235c83d4036f31a676a77dd8a0aff71a7c4f0d5558de2330e2deff92905a82",
+                                "uncompressed-sha256": "935ef3fc65b79344ebc006e89f45f67606afa5d39f2222377bc3dba89f6adb7d"
+                            }
+                        }
+                    }
+                },
+                "virtualbox": {
+                    "release": "35.20220327.3.0",
+                    "formats": {
+                        "ova": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "219f9c58abf1657f0c0300340f22c30aff4e7423db702f36176703aae0fcae3d"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20220313.3.1",
+                    "release": "35.20220327.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "a39f25257125e270361aebc31d69d36ae7bc5562496c5ef4e3b758289c7b79d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "80d900470a98eb725b51d172e97dc0e2801107d08f1e1d0f179e9668f0f447a5"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20220313.3.1",
+                    "release": "35.20220327.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220313.3.1/x86_64/fedora-coreos-35.20220313.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "e2fab67acd1c809795e38d8f643322eb656ed5215e67a3f1c7e5b7321d06d5a6",
-                                "uncompressed-sha256": "555c3f123af164922f51bd1e9cfa768dbd5b70bd2438fa5302dfd729e7e21301"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "39064209a4c3b4b66f0474dc8b5edb7cba19ed5648be1e9f75fc4edf08d9758b",
+                                "uncompressed-sha256": "41b80e9639c72b1895a204f033af0d6ff8d0ef2c98c97f583b7aec6e696cb748"
                             }
                         }
                     }
@@ -407,100 +419,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-09ed93cefaee35e7f"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0bcb21532b5d142d1"
                         },
                         "ap-east-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-0dae02d37d468037a"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-058e26ec063fa5604"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-042a235ccc30bfd27"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-09b92b1a38e39431a"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-04014856c9db7d9a4"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0805694483d11563f"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-03a6be0f924459cf5"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0bddc0a0ab0bbd1ee"
                         },
                         "ap-south-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-0d078c4161a10605a"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-07906a47b782f35b5"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-0dcf331d79c7ff99d"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0157e9ed5d6ca9e02"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-02a0ffd9f492b7241"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-01103d7c4afd70cb9"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-0c735929982f73b2a"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0e43ec024e9e961fb"
                         },
                         "ca-central-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-08d42e1eb02a87b98"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0f970c1189a91cde1"
                         },
                         "eu-central-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-0ebf2a7e3da4f31b3"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0122f59a1fa07f6ae"
                         },
                         "eu-north-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-037d7a72abf9c0174"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0577b8c9bf4936777"
                         },
                         "eu-south-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-08b698e22eed8a2c2"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0753d7b4303936a75"
                         },
                         "eu-west-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-0b9b19cb1ab9365bf"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0e21be71fdf31829e"
                         },
                         "eu-west-2": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-06606880c9d416f8e"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0e15a5f241b5c0b5d"
                         },
                         "eu-west-3": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-06c0fa2831df2ee13"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0370c4844e6c0236b"
                         },
                         "me-south-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-0af04e033300a4ca1"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0be190d5cb3b70f7f"
                         },
                         "sa-east-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-0b7c3426dcdff25d3"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0dee841e4acf3ddd1"
                         },
                         "us-east-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-0d8d0331237a68b4a"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0389fff7e72ebe8e0"
                         },
                         "us-east-2": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-07dda3854ad2f0752"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-04cf2aa16f1d40adb"
                         },
                         "us-west-1": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-02d553e325379640a"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-045b298bbc41f32fe"
                         },
                         "us-west-2": {
-                            "release": "35.20220313.3.1",
-                            "image": "ami-044c0e56087efe691"
+                            "release": "35.20220327.3.0",
+                            "image": "ami-0f6c0278f0122ce00"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220313.3.1",
+                    "release": "35.20220327.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-35-20220313-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-35-20220327-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-03-29T04:41:22Z",
-        "generator": "fedora-coreos-stream-generator v0.2.3"
+        "last-modified": "2022-04-12T18:02:19Z",
+        "generator": "fedora-coreos-stream-generator v0.2.5"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220327.2.0",
+                    "release": "35.20220410.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/aarch64/fedora-coreos-35.20220327.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/aarch64/fedora-coreos-35.20220327.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "70735b03989643642df3de812f4aea10debfb41e3e2209ee2f252e7411dc4bb7",
-                                "uncompressed-sha256": "cd9169448d205802cfda1f43f1548cc6b920f150599a7388d2a07d63319835e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "348a5b0ee13f03b62b15ba6077dc95d4a6737dd49e3aafb04d2ca1246b834cf0",
+                                "uncompressed-sha256": "ac86d16f83496411ca79f6eda99f1e1ffdcedb9c321057ab323d379195dc9346"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220327.2.0",
+                    "release": "35.20220410.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/aarch64/fedora-coreos-35.20220327.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/aarch64/fedora-coreos-35.20220327.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "5e2440bae4ce7efb077d43ad990f3103e37f535befd825d7176f12bb37530119",
-                                "uncompressed-sha256": "58169eb7bca5fd0eeb14e3e2c32e692d3c4adc505ea79046420c5d97e9a33abd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "6b48ada68a9dbdc1d5e522020ad444c4fd8908f192cc312508145aa665352e83",
+                                "uncompressed-sha256": "241d1b4bad7b4c162d6ed4ac1039f50266e3fa204ff8ffb06ad49b8dc0219f50"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/aarch64/fedora-coreos-35.20220327.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/aarch64/fedora-coreos-35.20220327.2.0-live.aarch64.iso.sig",
-                                "sha256": "a81ebb1e9d6835a6dd6ad9c916b13ddf2cca122dec10e7747eebcdde701d2f19"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-live.aarch64.iso.sig",
+                                "sha256": "55da5e4000e5e71f6c5131e5748f28a46cbbab090dc2e85a550038680acfcd52"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/aarch64/fedora-coreos-35.20220327.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/aarch64/fedora-coreos-35.20220327.2.0-live-kernel-aarch64.sig",
-                                "sha256": "bde4aa910e2db3cf0e9ddb476fd85325925d25d021e7c046c2b92e82846deecc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-live-kernel-aarch64.sig",
+                                "sha256": "ebf1ba14fa42477e4d34df6d6f2b892b755db1fd86f4c3a1164c3531667e01f1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/aarch64/fedora-coreos-35.20220327.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/aarch64/fedora-coreos-35.20220327.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "f7930ab8a5dace076d429574396397d12a45c94e24ffe3e3050ae304c20dfeee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "8feef7938bcfbeb5462392229d4ab9ad0c26b38b3719d828271b2ad588dad3ea"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/aarch64/fedora-coreos-35.20220327.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/aarch64/fedora-coreos-35.20220327.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "560c1392d0c89513c42216444c08f4f6587cc8b78931b236889acf3d0d4ac004"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "a96b988436878b94046a55b2904578f1342dce0a97598d4227fb0d975c5bf476"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/aarch64/fedora-coreos-35.20220327.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/aarch64/fedora-coreos-35.20220327.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "3f13d81ee95171af11fa41de30fb7539e91a399c7cb017062cc150a91d153dad",
-                                "uncompressed-sha256": "264e2b36d4c1329a8663f7f3f32d09e7e67cd318871d7406a3c6c9506880fd42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "3f634f28ecdc76d0a518313cc6723eb4b05034ee180f957937627db058e3786a",
+                                "uncompressed-sha256": "78ca9adf8cd3bead26346da8fd2e6781837c6a89f3d52c78ed219d2baa113d23"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220327.2.0",
+                    "release": "35.20220410.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/aarch64/fedora-coreos-35.20220327.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/aarch64/fedora-coreos-35.20220327.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "37354bb3685aea443a6b1a238012f59a06f8e139f8f1753b3343d7c421fadd3f",
-                                "uncompressed-sha256": "d93aba5bbf18b316e83f4ab3cb1e4a24522390c1adb4945ed346ad88c76f93f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "4b1202596b65bbcb7adb85b7cb1013150100d4c64616fa87141fb5597e2a480e",
+                                "uncompressed-sha256": "f035ae041b06945345ca9b4cea2d6a367d7f3c60c883fc6c6b3877fe14990de9"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220327.2.0",
+                    "release": "35.20220410.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/aarch64/fedora-coreos-35.20220327.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/aarch64/fedora-coreos-35.20220327.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "4decb0117fa2fb16c0e3798679be42976099e6fecd96a3e9d0e4adff19789fd1",
-                                "uncompressed-sha256": "c61303c8686eb9c6c178c59bfa2c95f1f190fe0ad9c4949b9dd7691571de081d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "e703bdf2bf381f76c68045d79d300a7522966293bb6c43ad82512a2ec0151643",
+                                "uncompressed-sha256": "16e19566358c66791d91eda314becfbce24ae593529b9d5d931b917478774515"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-09f08ebc3a8de063d"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-032811f72b5d2398f"
                         },
                         "ap-east-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-0a2adca6436edf3a7"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-06df4869ed3e1d349"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-06f9aa63bd4cf90a9"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-0de6671c603eab51e"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-06c60070b80bf8b06"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-0eda714c6a9096d3d"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-01ee91bb5a8a69960"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-02fc2a3a5bdf54709"
                         },
                         "ap-south-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-0480cec05cf7dccd1"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-00ed65f0e46310d0c"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-023b27b9c8ae596b9"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-02ca88cbabb4139a6"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-0de4eea87c7de733c"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-0b3dd6e3b7b3d6812"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-0a1d661ac59f08079"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-0fc7c562917fcc70a"
                         },
                         "ca-central-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-0069cab64a900097a"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-02c7f69a69e6b9aae"
                         },
                         "eu-central-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-0809bee1941716b16"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-01cc43c739c9bcfed"
                         },
                         "eu-north-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-035bc0cb84a0388cf"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-0fc98c4f90ae4bbf0"
                         },
                         "eu-south-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-094138473d3d8dfa8"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-0081e9b4265ec1ba5"
                         },
                         "eu-west-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-041b8d3ac7c17fab0"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-0ce170dd890b7b7bc"
                         },
                         "eu-west-2": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-02f5dda3b93c5def0"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-0563b860fe9936b40"
                         },
                         "eu-west-3": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-046663f8d8aaaa02f"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-0314b27ae2944ee55"
                         },
                         "me-south-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-073be090c6a1ac638"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-0ce1a06b6cf43e1d6"
                         },
                         "sa-east-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-0bdc8d16fef324aef"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-01053f35558bb0399"
                         },
                         "us-east-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-0e1650a6a8a1539b7"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-041f49c02127bf8c9"
                         },
                         "us-east-2": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-040d8741e79159988"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-04c4f1fecedf78f6b"
                         },
                         "us-west-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-02b00f4df4e2edb7a"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-0d67dafc915dc5715"
                         },
                         "us-west-2": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-05413e7786def6446"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-053c700c38afa7e53"
                         }
                     }
                 }
@@ -190,214 +190,226 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20220327.2.0",
+                    "release": "35.20220410.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "134399daa08813d266e6539958d7f1c10a34914e78f722781242c836be7aa771",
-                                "uncompressed-sha256": "0b49f9ae7c8e5c3db04022a3c57023dca65a6a069dbe709ccc29496df1238d86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "e298b923a0699354190f4443fe277ab102c62921205b7bfec9c55f5e79b3806b",
+                                "uncompressed-sha256": "471f63d03d00800595891edb180efcb5f1b09f689b57655ab9ba544ff7f93943"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20220327.2.0",
+                    "release": "35.20220410.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "c0145c1d83ba5e482e766c22ee8d0a3de061bba5f5ea5f8effc91b937fff64e5",
-                                "uncompressed-sha256": "e0c3d84b7f7e6ab83b1016d1f20a5a822176b8adf1937ab8711bd75a379cac19"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "8537846b52311f34589d37dc112f3e0cac136ddc139c586f470345d089bb9fae",
+                                "uncompressed-sha256": "72bd2dd17cb8926895195e730aeb143489e2fd5ff0dc2a17d849241f91cb76fa"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20220327.2.0",
+                    "release": "35.20220410.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "86f0a03f42a79c50e52b5686e451f0b078b93ba06e5acb994c57babbb9b1153c",
-                                "uncompressed-sha256": "1cafb8d4095734951287a6415362a7cd272626cab012f6adf65f0602754c64e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "522bba8b26d925c435982f0856c346f3b3e9ed383be740e9c4bb4e4ce71dc9ef",
+                                "uncompressed-sha256": "234a5b041af1fbe01bd1f786c4b2552b77924e7d85b4d22d695a42d87d91d0e2"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20220327.2.0",
+                    "release": "35.20220410.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "a797f6d3008b084580b669d29099e4057be0561a5d635294144e1537e3257d7a",
-                                "uncompressed-sha256": "ee25e91d3d0c456c514ec0843cebf342440698fa33f096f9589d3669bec93532"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "032abd03c409d0a350e460a44263a6cb33d06a797c944553d49f5fd2ef2b8a57",
+                                "uncompressed-sha256": "9660139fbb53fb89596451ce9dbbbafce322c73d7946303170469961e74a8e4d"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20220327.2.0",
+                    "release": "35.20220410.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "f26908de6c2fdfb38430ab12383d4d5dc6cc64ddbdd88561d05f93224793a173",
-                                "uncompressed-sha256": "117f04d3f16f53541a229474004f82440f04da7d7fa5d2d71c8d7d6f590f0917"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "beb1dff1f18ce5c3277af693642aaa7b800e8350deb6c8c23a96b537c2db3f7d",
+                                "uncompressed-sha256": "62ebfc9e0e9f443b353907debfb4191a9e69b809bf6a2df019df4b46a886ae7d"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20220327.2.0",
+                    "release": "35.20220410.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "36a33f70f8322c2d61b0030222e4077ae53be9c3f99fd973ccca44b6a589b0b3",
-                                "uncompressed-sha256": "f40f9bab41fb88e7494125a541e921b2ccd8bd9d6e3e50e233e7de39ce44865a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "32fbdf9753f219457baba3a868b530ab9e2702a6a56a8fc084b9ebab60736af8",
+                                "uncompressed-sha256": "790f6606f027e25ed73b92b97e323c818cd161edad7c2fc478871614710fe96e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220327.2.0",
+                    "release": "35.20220410.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "abe0a49400d3040581f5e832dde483a12e1a5297154db7067b133722c1c70f9d",
-                                "uncompressed-sha256": "38f9c8eae6cd609d0505a1714bbdbcbf5e2e0c914b648e201bb0d5238ec20d27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "c73c92759464e05e1bc67d3e199f2250eb62b76cbcd11f1dec9c88f15d40550d",
+                                "uncompressed-sha256": "579d164d3e41252a24f37ccc00f0712bff9776ef9606701b9e59a56ad54ea3e1"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20220327.2.0",
+                    "release": "35.20220410.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "d8d79b9e721b7eaeab3052f9d86e8c90e46de0556512fa13a6031ac1dd19c93b",
-                                "uncompressed-sha256": "3ab318a67428a8af6f6e1a420b7fcd2501fe8cffc9cfe11b864bc7b7c50ae523"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "a80ab699c2e2605d29b0d177e8765914a7f1dfda0bd559b9848a28827d70325b",
+                                "uncompressed-sha256": "d7fb66e2ea0e8663e810f6cfcf993d25d49b78beca204912c4e002024fa1268d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220327.2.0",
+                    "release": "35.20220410.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "f79b3ce50808ff68b41f0f54c1bbfd6f793ccb70d9c19075c288be0aa66716ae",
-                                "uncompressed-sha256": "31e9788ee0ea23ae157bc762a6284a83ce6bdf02e45e1750b948a30f0a97e10b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "1f89f6d45372094a19efdf4a15629de6c0466f2234e462074c8d34b3ccd9cd1d",
+                                "uncompressed-sha256": "7bbc35afdc47eabc1b55684bdab4de504cbefda9c18d40557bec8d47b7f357e5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-live.x86_64.iso.sig",
-                                "sha256": "c4203c374af47624d0714e7c5d2b93e26575952b4998bb8ca7acd69afc912d9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-live.x86_64.iso.sig",
+                                "sha256": "1bd3a69b4089bb92c8f767d0a4fe7ef551d72bb52b5588ac40709b8850ac603e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-live-kernel-x86_64.sig",
-                                "sha256": "4c8a7257e1180bb552842a298f93f15dd014a74076c68f85e67c59fab46cdc5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-live-kernel-x86_64.sig",
+                                "sha256": "4fa5e6dcddcf507fe62e7b979a799e6f37b31d79e84bf70a851858135b0c34d6"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "744296650520789c96eaaf3ce3b24e2057d57269f8a43450eec3c039243ada00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "0c8fb14499335240e54fb87943be585528863164a8a4b97a647dcef7c7027936"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "0a7e1ca1f87b0e5731db6cf001d5f76aff1c682deabd363a45ca297b9dc8da91"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "de0c63877151748ca55610ecb44beb472e0b156acbe6729c8bbe0e628da8f036"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "156d717f9c9ac0416231b424df3ae7a1af38631f74a3b62488b9bf71d65a61f7",
-                                "uncompressed-sha256": "2d2271a4f8849a600a4230584bf2d2442b2af57f8fb054a0f7362c8504bd5475"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "4182e61a8941bc96df9fb999251371250a621da585f06bed7563e6c3d62ce7eb",
+                                "uncompressed-sha256": "ca300ac8f82b8c645e481920411800dab7896841025183e43888f2efb1a762f0"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "35.20220327.2.0",
+                    "release": "35.20220410.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "ad06e3e20c3b1a120191ec3d83a7f3db2e3f21e2d59f2729c1376abf004108e9",
-                                "uncompressed-sha256": "577fa905d05fc933a82b36fb408e7eba71d4c53d78b7e021438988baf9ab8fcb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "f44da44c5e449ab8bf4fca10dcda2b24a9b92aebf9254db9b54921386b4f3dfe",
+                                "uncompressed-sha256": "3599c14e798a73d5e2017da9355d0e32da8ef111b16db3a8c59f3eeecdb0db26"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220327.2.0",
+                    "release": "35.20220410.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "c7d95fe717d7303f5bbee2a1a9ef63fa6e040870140ba727eca5fbb8901151e1",
-                                "uncompressed-sha256": "372798576b189fc702f40eb4147b76f09c1b9ed9577ee380c85d74527d4d61fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "22b7228a0ff4b8f8a432407cc26b69f2234737fd04517a4050577a472b703ceb",
+                                "uncompressed-sha256": "108812dcb3b38879d0c51d5b9d72b5c00f344ce9fea1f110d645c40e57c5f719"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220327.2.0",
+                    "release": "35.20220410.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "78bf916430a5fa9a5516117e2f0f53b890df178b625f28c9801b46c5d65698b8",
-                                "uncompressed-sha256": "725e723886231ba88de2d82d5736e21b4f0a9597b0b6c0747c20be01205c6074"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "2c05e33b19d3474c6aac337f3eb3c13917a6a2840f593e28891a58e3a2e7f923",
+                                "uncompressed-sha256": "8111c421d4a5284e6828be7983ec5954f5dc17e1ce68a605513d610084f87095"
+                            }
+                        }
+                    }
+                },
+                "virtualbox": {
+                    "release": "35.20220410.2.1",
+                    "formats": {
+                        "ova": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "467868d94834dbcd2a287681139a4aa4a9508d5511e89246b60353d95392c6a5"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20220327.2.0",
+                    "release": "35.20220410.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "239a7711126797d48bd96de494be952e234f393f86a6933b41a52e0bea8991b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "2454a0617d8deb75db9a68e0c2f8e015a209966efcb7549e07db21350602b3d3"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20220327.2.0",
+                    "release": "35.20220410.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220327.2.0/x86_64/fedora-coreos-35.20220327.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "b3e19047b4b1273e092275a09aa98f27c7142ce8746900b18aaebfe90321f290",
-                                "uncompressed-sha256": "766a0479cfd08e6d3375286a6e383cac5dc4f1d16b380ad33d44c06346197d70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "b23b282c082f1cb080c42354d3fe0a4535467a12c1996803bd15ad6ee2ad689e",
+                                "uncompressed-sha256": "8a00250bbcda39c79c59e984906db5054c78b05435f6a463aeb1c706872952d7"
                             }
                         }
                     }
@@ -407,100 +419,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-0748422b8f4761351"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-05854bb8881ad1d2d"
                         },
                         "ap-east-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-03d9ea449a6f00ab8"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-0478976b3f5730dbe"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-04d4aa55323f9312e"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-0af7d4736a185eb4d"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-0ba7a803cf6728e55"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-0118cd82ec8e5c0b7"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-01529f8464ec5e2f0"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-0a61e89d762957398"
                         },
                         "ap-south-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-0c93962273ac52bee"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-011478f200ef9b240"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-0dc7fd86d54d8f1ab"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-03f1e64310e711959"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-0fc1b7fbe587f8c9c"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-04f37029fee7e328f"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-02f1b67be7ab8c4a2"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-06a697b5bba5de4d2"
                         },
                         "ca-central-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-07daf4d721eb6e447"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-0ec66427b35bd507d"
                         },
                         "eu-central-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-08c16c4f5c557470b"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-05af1de24faf51036"
                         },
                         "eu-north-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-0c34e67c90b0afa93"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-0811cde0f6bb4fc35"
                         },
                         "eu-south-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-066a1ecfc1199a79e"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-08a34f2242007383e"
                         },
                         "eu-west-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-08e371453358cc1ac"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-018ba833fc3e1d6ae"
                         },
                         "eu-west-2": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-0044a85aac20d9c00"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-0e91c235bbe88de97"
                         },
                         "eu-west-3": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-029897180c39ccaa3"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-00d7b05231e7ed0e7"
                         },
                         "me-south-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-0373da0ed91aeecca"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-076cb0cd8d8beee19"
                         },
                         "sa-east-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-0d84a6a7e5904d190"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-05eb5fb00e01a8482"
                         },
                         "us-east-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-03167030b996f9374"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-04be36ffe79705c74"
                         },
                         "us-east-2": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-018094b9ec8ebcb8d"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-03b60925b879ecc37"
                         },
                         "us-west-1": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-0e625223a62c18173"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-05f917f0225af307d"
                         },
                         "us-west-2": {
-                            "release": "35.20220327.2.0",
-                            "image": "ami-01c7a8b45f99ba4a7"
+                            "release": "35.20220410.2.1",
+                            "image": "ami-0c8277d7313376fb7"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220327.2.0",
+                    "release": "35.20220410.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-35-20220327-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-35-20220410-2-1-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-03-29T00:27:05Z"
+    "last-modified": "2022-04-12T18:02:22Z"
   },
   "releases": [
     {
@@ -45,23 +45,23 @@
       }
     },
     {
-      "version": "35.20220313.1.0",
+      "version": "36.20220325.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        },
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     },
     {
-      "version": "36.20220325.1.0",
+      "version": "36.20220410.1.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1648562400,
+          "start_epoch": 1649790000,
           "start_percentage": 0.0
-        },
-        "barrier": {
-          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-03-29T04:58:32Z"
+    "last-modified": "2022-04-12T18:02:18Z"
   },
   "releases": [
     {
@@ -53,7 +53,7 @@
       }
     },
     {
-      "version": "35.20220227.3.0",
+      "version": "35.20220313.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -61,11 +61,11 @@
       }
     },
     {
-      "version": "35.20220313.3.1",
+      "version": "35.20220327.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1648569600,
+          "start_epoch": 1649790000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-03-29T05:00:17Z"
+    "last-modified": "2022-04-12T18:02:20Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "35.20220313.2.0",
+      "version": "35.20220327.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "35.20220327.2.0",
+      "version": "35.20220410.2.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1648569600,
+          "start_epoch": 1649790000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @saqibali-2k via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).