### PR TITLE
workflows: don't warn on expected fedora-coreos-stream-generator bumps

### DIFF
--- a/.github/workflows/stream-diff.yml
+++ b/.github/workflows/stream-diff.yml
@@ -16,20 +16,22 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Genericize new metadata
+      - name: Genericize metadata
         run: |
-          mkdir -p new/streams
-          for stream in streams/*.json; do
-              echo "${stream}"
-              ci/genericize-stream.py "${stream}" > "new/${stream}"
-          done
-      - name: Genericize old metadata
-        run: |
+          # Cache data from PR head
+          mkdir head
+          cp -r streams ci/genericize-stream.py head
+
+          # Switch to base
           git checkout "${GITHUB_BASE_REF}"
-          mkdir -p old/streams
+
+          # Genericize metadata
+          mkdir -p {old,new}/streams
           for stream in streams/*.json; do
-              echo "${stream}"
-              ci/genericize-stream.py "${stream}" > "old/${stream}"
+              echo "${stream}, old"
+              head/genericize-stream.py "${stream}" > "old/${stream}"
+              echo "${stream}, new"
+              head/genericize-stream.py "head/${stream}" > "new/${stream}"
           done
       - name: Compare genericized metadata
         uses: coreos/actions-lib/check-diff@main

--- a/.github/workflows/stream-diff.yml
+++ b/.github/workflows/stream-diff.yml
@@ -25,11 +25,28 @@ jobs:
           # Switch to base
           git checkout "${GITHUB_BASE_REF}"
 
+          # Get the numerically latest fedora-coreos-stream-generator tag
+          generator_tag=$(
+              curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/coreos/fedora-coreos-stream-generator/git/matching-refs/tags/ |
+              jq -r .[].ref |
+              sed s:^refs/tags/:: |
+              sort -V |
+              tail -n 1)
+          echo "Current fedora-coreos-stream-generator: ${generator_tag}"
+
           # Genericize metadata
           mkdir -p {old,new}/streams
           for stream in streams/*.json; do
+              if cmp -s "${stream}" "head/${stream}"; then
+                  # Base and head identical; ignore stream to avoid false
+                  # positives if the generator field is stale
+                  echo "${stream} unchanged, skipping"
+                  continue
+              fi
               echo "${stream}, old"
-              head/genericize-stream.py "${stream}" > "old/${stream}"
+              # Pretend the old metadata used the latest tag of
+              # fedora-coreos-stream-generator.
+              head/genericize-stream.py -g "${generator_tag}" "${stream}" > "old/${stream}"
               echo "${stream}, new"
               head/genericize-stream.py "head/${stream}" > "new/${stream}"
           done

--- a/ci/genericize-stream.py
+++ b/ci/genericize-stream.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import argparse
 import json
 import sys
 
@@ -80,5 +81,15 @@ def genericize_stream(path):
     return output
 
 
+def main():
+    parser = argparse.ArgumentParser(
+            description='Remove release-specific items from stream metadata.')
+    parser.add_argument('path',
+            help='path to stream metadata')
+    args = parser.parse_args()
+
+    print(genericize_stream(args.path))
+
+
 if __name__ == '__main__':
-    print(genericize_stream(sys.argv[1]))
+    main()

--- a/ci/genericize-stream.py
+++ b/ci/genericize-stream.py
@@ -53,7 +53,7 @@ def get_releases(stream):
     return releases
 
 
-def genericize_stream(path):
+def genericize_stream(path, generator=None):
     '''Load the stream metadata at path and remove all version-specific
     references.'''
     with open(path) as f:
@@ -61,6 +61,8 @@ def genericize_stream(path):
 
     stream = json.loads(input)
     stream['metadata']['last-modified'] = 'LAST-MODIFIED'
+    if generator is not None:
+        stream['metadata']['generator'] = f'fedora-coreos-stream-generator {generator}'
     stream = replace_key(stream, 'sha256', 'HASH')
     stream = replace_key(stream, 'uncompressed-sha256', 'HASH')
     for release in get_releases(stream):
@@ -86,9 +88,11 @@ def main():
             description='Remove release-specific items from stream metadata.')
     parser.add_argument('path',
             help='path to stream metadata')
+    parser.add_argument('-g', '--generator', metavar='vX.Y.Z',
+            help='set generator Git tag in output')
     args = parser.parse_args()
 
-    print(genericize_stream(args.path))
+    print(genericize_stream(args.path, args.generator))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The stream diff currently warns on fedora-coreos-stream-generator version changes, even routine ones, and the false positive can lead to confusion.  Assume that stream metadata is built with the latest tag of fedora-coreos-stream-generator.  For all streams that have been changed in the current PR, update the old genericized metadata to reference the new tag, avoiding the change warning.  For streams that haven't, we can skip the comparison entirely.

This will still warn if stream metadata is built from an old generator tag, or from a generator commit that has not been tagged.