### PR TITLE
Roll out stable 35.20220410.3.1, testing 35.20220424.2.0, next 36.20220426.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-04-19T02:09:15Z",
+        "last-modified": "2022-04-27T18:43:09Z",
         "generator": "fedora-coreos-stream-generator v0.2.6"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220418.1.0",
+                    "release": "36.20220426.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/aarch64/fedora-coreos-36.20220418.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/aarch64/fedora-coreos-36.20220418.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "af431af607d23aa10a65da9d3d3300fdecb4fd13cf0837bfd124a02715442a13",
-                                "uncompressed-sha256": "2ed040f941089c84204606aa724fad88eb290490595d647fa8a5cb435bfe9098"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/aarch64/fedora-coreos-36.20220426.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/aarch64/fedora-coreos-36.20220426.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "de8430069c0f7ad7efdf32c95674dc1d3b64d6b794068e41f36bbd9eeccdf92d",
+                                "uncompressed-sha256": "4908ee1a8a38eb648ca2002b59f8b9991f5b8935a5149db617ddaffdba67558d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220418.1.0",
+                    "release": "36.20220426.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/aarch64/fedora-coreos-36.20220418.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/aarch64/fedora-coreos-36.20220418.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "bcc17b37c2ef009674dd607fee7ffd69c0d02e1bfd7973ee97cf1a77c024fd6e",
-                                "uncompressed-sha256": "60be41b5fe65ec149c454f32b0af5a95e90e066725d013248f8a39eaf834d883"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/aarch64/fedora-coreos-36.20220426.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/aarch64/fedora-coreos-36.20220426.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "42746ba9016fbc8130bdd078528c583ce71f3820696a6f1245287fb1665d3221",
+                                "uncompressed-sha256": "14c78b5ffb94cdd5c211ec08151322c4551e334534e577dd9b6e5fcefc5bbd2e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/aarch64/fedora-coreos-36.20220418.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/aarch64/fedora-coreos-36.20220418.1.0-live.aarch64.iso.sig",
-                                "sha256": "482f49e864b43113f21bace0e23c22e8db184828b1c9c226e8e9b5bec7943759"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/aarch64/fedora-coreos-36.20220426.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/aarch64/fedora-coreos-36.20220426.1.0-live.aarch64.iso.sig",
+                                "sha256": "512b0166600ad1ef3127f40ee8c0c8b95d6cf805e7ca0c9376889a49b3f82e02"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/aarch64/fedora-coreos-36.20220418.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/aarch64/fedora-coreos-36.20220418.1.0-live-kernel-aarch64.sig",
-                                "sha256": "ae6d80db2703d357591b8fd2d1fab201417f9636205d6a198a5572a80eeacc5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/aarch64/fedora-coreos-36.20220426.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/aarch64/fedora-coreos-36.20220426.1.0-live-kernel-aarch64.sig",
+                                "sha256": "9061c50193c36aeaca23ef85af3a2a956e64e194d77306f78cd17b4d3e3457ba"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/aarch64/fedora-coreos-36.20220418.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/aarch64/fedora-coreos-36.20220418.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "93f519380edddbc3f0576f3af24a53c217fa513db9c78d48a25824ac3a91d316"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/aarch64/fedora-coreos-36.20220426.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/aarch64/fedora-coreos-36.20220426.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "37dfcb939121abe687c8944bb63f2340796449a270078420f719ecf6e80ec25f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/aarch64/fedora-coreos-36.20220418.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/aarch64/fedora-coreos-36.20220418.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "819c2458b2f882903127c669ead8bc69dea730d30d090322489be00e23ca3fae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/aarch64/fedora-coreos-36.20220426.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/aarch64/fedora-coreos-36.20220426.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "811027713a295c22c4f1d9ef51f7b91033e0505ca4df5daa21bd07fbbf80e84a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/aarch64/fedora-coreos-36.20220418.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/aarch64/fedora-coreos-36.20220418.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "e3e679c1433d78bc90ce5695f46491ff2791b38084b18dd2b7ce349b07b602f6",
-                                "uncompressed-sha256": "43aaa15dd00683486ed213540669c6c80f023ca2320675e4342457d23dacbed3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/aarch64/fedora-coreos-36.20220426.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/aarch64/fedora-coreos-36.20220426.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "223d45c66fb5e00e4d14fecd9a2a8f5e6a5923b1a60f775f5132e546a95a5c89",
+                                "uncompressed-sha256": "ea88d44ed4b212f1e2bfdf3741521475421cc269451088fa7cfb225e01e8933e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220418.1.0",
+                    "release": "36.20220426.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/aarch64/fedora-coreos-36.20220418.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/aarch64/fedora-coreos-36.20220418.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "058ae96561bb41b31bb6d6f7faff2379f8821906cdd9050705938210b86df76c",
-                                "uncompressed-sha256": "69cffd2298ea45ee3d35aa7f382775be8c3ac93a391da7d573348b79a1b80518"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/aarch64/fedora-coreos-36.20220426.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/aarch64/fedora-coreos-36.20220426.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "d12199b6efa0383dcd476467f01e63fef216df73bcdd37a760a55672d69da75f",
+                                "uncompressed-sha256": "5b2963aa6511b59db952872c0942451739c09125b6d5fe6e633e757797e88f85"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220418.1.0",
+                    "release": "36.20220426.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/aarch64/fedora-coreos-36.20220418.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/aarch64/fedora-coreos-36.20220418.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "3d1adae8152b7747de5f9f5db57a434c041e9aa32fdad1125806260f11505010",
-                                "uncompressed-sha256": "f056135c2803a507e62a01ab614d0ee9f0e278228a7ef8508dd2e5439dfa24fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/aarch64/fedora-coreos-36.20220426.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/aarch64/fedora-coreos-36.20220426.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "69c18396dc3a724715a94de494a2c4549a3a40d93c873bc4c43831253a5b2602",
+                                "uncompressed-sha256": "134200312df43108843f6490d83520e8ccdb0e22a69a10ccd85de8f8a5d474a3"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-08599d8a077e72a0d"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0d23b5418e4fc5a83"
                         },
                         "ap-east-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0e32b4087f7c66056"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-09a10276079a1102a"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0a972ab030d0e20d2"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-06259fada2d0cf48a"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-042355b9717bee2f9"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-02f53e19049cf9426"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-012e9bd0047d7319b"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0e4ca92495ce64f3c"
                         },
                         "ap-south-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0778724b1f4d495e4"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0361e4aab358b7392"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-07ac7311196b015f5"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0db8f671427dad833"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0c6f80036b0fca95c"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-02832c39426858e09"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-096a7316e3f9107fd"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0d276880da6cb699d"
                         },
                         "ca-central-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-05fa82c4deac4878c"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-03976aa900c50f960"
                         },
                         "eu-central-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0c80a1ece167c380b"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0c175bf320dfbcb2f"
                         },
                         "eu-north-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0ec866f14a0798c93"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-083bf10f38cb7bc60"
                         },
                         "eu-south-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0694262c8ce6ef312"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0e198a390f4650d4d"
                         },
                         "eu-west-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-070280eeac649be09"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-051ded2a226eb39a1"
                         },
                         "eu-west-2": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-05a7769d3517c4951"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0a695970cff98454d"
                         },
                         "eu-west-3": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-090974828ece31c39"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-08219c63a6ef1ba44"
                         },
                         "me-south-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0f4f924db585490af"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0362da6cb3f6a56ce"
                         },
                         "sa-east-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0cf49bc008f6f7723"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0b405f08035d4d519"
                         },
                         "us-east-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0f50de164b7fb6589"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-06b4cee3e9c55fd50"
                         },
                         "us-east-2": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0f275de8c683155af"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-00dd5774a9ff58a8f"
                         },
                         "us-west-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-02b836c3fe4030655"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0461289e585c6d070"
                         },
                         "us-west-2": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0a102f7c5795385a2"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-03b502fb52466511a"
                         }
                     }
                 }
@@ -190,226 +190,226 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220418.1.0",
+                    "release": "36.20220426.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "86d0450c57ab6d6706ee1b537543822022392f4be836f0efae48b5af530ec649",
-                                "uncompressed-sha256": "57ea834bd82892e67c51add73f9b12611b41725fa1ba244e70c46e9146d5b140"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8632105f44e5384bdfd49c319feddf994e9afd72771caccf7eac20bc8f6c57d1",
+                                "uncompressed-sha256": "fe2516d0c81f735bf5e2ca2fb0149055fba9e37352ba22cfbca98ce2af521801"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220418.1.0",
+                    "release": "36.20220426.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "7c213f52b0e39c597a8db6c98177ad9fd6334640cbd3e87cd3e0f1a04337447f",
-                                "uncompressed-sha256": "362a8172248dddf18664bcb7fe8aed449bdcc50083c82b5a31ab3e754d8234f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "9d8f69065a045ac7bbd867cf70de7f338410c341e07ffa8292068c04495ce472",
+                                "uncompressed-sha256": "f557afdb425322829d51f73a65034abd7afa7c213a694ca90b33cafca40402cb"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220418.1.0",
+                    "release": "36.20220426.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "56687edc07202e650994b084f74416ddd3b99cc97455c45c39eb0c9b05c02b3a",
-                                "uncompressed-sha256": "639a35e68d8e764f1729de0a6b73524d6424a9f04e55af29d42f050341c1d57e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "09a9618b74ea1219662b2ab1cff87783d2bbf660ddea19469d95f7f1738de434",
+                                "uncompressed-sha256": "b43becbe5e4b0a949382abad2a1db02ad56bb40d6bce23265d53139e9aabacfe"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220418.1.0",
+                    "release": "36.20220426.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "c37000758e590960cffa75d3edc3f436f0d0f64dbb2b8ef308d1be39c50158e3",
-                                "uncompressed-sha256": "50177955f781878fcb3909a2d2be0aae4e9513a65946220904b20a5138e990bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "1030312f7411a0a7969f799f58fdea9beec5cda8ba8026ac62c7e9a9f328110d",
+                                "uncompressed-sha256": "3db97aef51654ad341edfb0e9ebc1be6df120a5be880e203df6d12194b76693c"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220418.1.0",
+                    "release": "36.20220426.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "3c07a822d846eaf6cca30c9585ef96dcc8a5193f8965040726a41fcb6ab1df09",
-                                "uncompressed-sha256": "a4433950bf14bbc10e20331f38509070499db8417c735466e356d59c1074faf1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "8ae5a86da65ac369acc43ef4a75a8fcdebea98f99cb0a46faa4e460163cf7afe",
+                                "uncompressed-sha256": "c8d097f278991b480e7413afebf2a50901fbdea390daddf9ed9796a5a2b61905"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220418.1.0",
+                    "release": "36.20220426.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "bb48de68e6d8a5a7ef8aa57022f7d3973cee6e4bd04adfeaf8ee315efed2fc9a",
-                                "uncompressed-sha256": "07a147d16895c20a0576661b9036006cce2e8b682c367e1ca1f113ef062e53cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "3cca888217d4fa80757d201c09bbcc100871666d67afc175cf02bfbeab2f3f5d",
+                                "uncompressed-sha256": "5d2c1ba9cf43a4928e59c03e0cfb7517870ec378fcca67dfed98730017f49520"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220418.1.0",
+                    "release": "36.20220426.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "0b3c769ee247d3f8d3a887a14774db0b9338d78d8bc5d82b480c618793691bba",
-                                "uncompressed-sha256": "b5399c7fd6b41983658d9c843952629604a161b5ce783c7c789115ef4d2af9ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "70fb7f91931b184ac8afc78ddfac28bd03a425caed0d59d42fe35d0bc95c4fbf",
+                                "uncompressed-sha256": "3a919565cb36b94bbce1c4991f9937576586265485dd3ad865107a1ad042b7ae"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220418.1.0",
+                    "release": "36.20220426.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a0e4d5b52f5ef445cb27eee95546f7d5d1e3ac8f73c2e84e3c364823200ecff2",
-                                "uncompressed-sha256": "3c9b84a7bd2ffb0b6ed41406a98b2073663f93e8a82309fa072e8f003cbb97b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "963b59cf95f7b20b519750ffcaebbe4853e27281067a13d5b93cd897a5386819",
+                                "uncompressed-sha256": "f26b889c60ddb3d16c7233418026f3f86cd1b9375400f3a58a65656e468e166b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220418.1.0",
+                    "release": "36.20220426.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "6da9443c671755fff62a9fe51eb88a4a8ed792dd4a4135ea2f95079209cfbf07",
-                                "uncompressed-sha256": "4aaa213604a854de36731453771e4b05f77a305cb90e00619058f25e99dfb43c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "abcf1f2e310fbdf32fba3aad4b86cbb6d94eba30ccbfabd114b2b014fb4aa7ba",
+                                "uncompressed-sha256": "8ec4d7ea5eb3d7e7693db7cd3944460b37cf41ff1847504458c013bed3007634"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-live.x86_64.iso.sig",
-                                "sha256": "624d21d308c6a07961dd2208eae3ce917798a899bf3999c733d681ea99d50acf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-live.x86_64.iso.sig",
+                                "sha256": "b3fca85628f746dbc8eb67a8515a81c4b5a13364ce658985e9e3dc6b5701c117"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-live-kernel-x86_64.sig",
-                                "sha256": "d4c7a3ee39c7713cc88d0fb6dfd56e7d1b1c362a525e30d195dd20a77fb5246d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-live-kernel-x86_64.sig",
+                                "sha256": "3e218a67d3f5ac007c0360ec44871659d458c5a6aebcd0780d2aed777cd6902f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "24df7858bfdb2760b4a1cba02e2ee7b380578e9b2ab0f37880b8db0ecd633b43"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "0df553a9d3fa18ef06cb758053029930f6956f2ac66b871d0e8308a0a6ee37b8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "c351f37d757964d0cee806753ca2bc9410677b0470a0f070e50bd043fc9b08d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "b2fd63c1ac77396a0bdfa7cae850e336babe4146253544af96d594d94e88f837"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "ac169ac23c6408bf6af63306406c9e084a6301bd54ef4068f6ee44ad8aed1502",
-                                "uncompressed-sha256": "77940803d1002033427a4dd00ace73913f78d19109196fee09a61821060767e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "279db4f5c3ac2db1a8cc05b77a2c2138241933bb2eba4d94fef2c26b34a0dbdf",
+                                "uncompressed-sha256": "6f351ae0ea46929ebc4a155c46ab6871602f3d4f0190d332321919ec19265d86"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220418.1.0",
+                    "release": "36.20220426.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "1e2340995452b608d991b1934c33292a4588e98b22b5059190a2ef79ca14070f",
-                                "uncompressed-sha256": "c129880c77d40e6f558d7c8c59a2ac883b77a391fb31a5edc7f5c0a7f3285a74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "24103f5a427d0521b435810c420ad6ad130bc0f07583a0833697c1a7a0212867",
+                                "uncompressed-sha256": "2eb89713460fb24f9a1788d0cba97050854ad8237c3e4f8938cfb20022783a50"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220418.1.0",
+                    "release": "36.20220426.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "bc345c6181a54022c34aaa7fbe034bf53faaeb4a157924d76d3aff3e3528d9df",
-                                "uncompressed-sha256": "946e04b831ae963d52cffd8925d82bbda34b79105b77089afba2bd63ab68000f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "d6d75f052415db35b018df81b1c7e8062acd411e1956eacd2739803e0c3cdacc",
+                                "uncompressed-sha256": "2e7f6694ec72ab78fb652cea6e05c6871ee4f9e1e49be5b1c1a452dca7624a85"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220418.1.0",
+                    "release": "36.20220426.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "ea08a7cb08ffa3192b44bc80ab1d753f67da1fd62ff0a98489329df469e96a76",
-                                "uncompressed-sha256": "7d67ebe643b32adcc24ea1f95e9aefeb9a7d6da2447ea6b44fea442e3446dae2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "7e02aa361901a081ac2c7bea4a81242df3bec8d76b5029bfce79f43e9b080665",
+                                "uncompressed-sha256": "835a4739c0b3e33eff52a46d75a6a17f3075f55331ee74de2edbf3d2ac9c2b94"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220418.1.0",
+                    "release": "36.20220426.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "fc72f272e912b23821222deaf00f9c5ecb5e56ffab8d18d902d0e5863d4f33a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "d3e14a3ac4b57eb34fc08dae21b0808f5c05d083d9093af68947df08129a6943"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220418.1.0",
+                    "release": "36.20220426.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "64f859f9abac3c428f3eb89a696e0f825fcf25dbe23941ad9d98951ac1b46b3e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "76a7c0f7b3a89d4c79e87a033de21c6780832f90991e1337137ffaa1abd71bbd"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220418.1.0",
+                    "release": "36.20220426.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220418.1.0/x86_64/fedora-coreos-36.20220418.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "08f2b6341664b7eec85e17d348e14923b3d7800f56ddd8b3677b45af627af34c",
-                                "uncompressed-sha256": "c07666797ae21e0db6e84fe3fe7ae994474f412fb3170760cde3add178f3501f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220426.1.0/x86_64/fedora-coreos-36.20220426.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "c49057c9a82210968e360eec561744c0c59ca261cdf19c54fca26d6f07d52ca7",
+                                "uncompressed-sha256": "47e7a5d03cb994c01fe8e6876eb4244a8541a3e5a3c405bd663bdf735729c749"
                             }
                         }
                     }
@@ -419,100 +419,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-00e4bf16474fdf61e"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0a34fc231695aa6c0"
                         },
                         "ap-east-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-002dd7b6ff168cdaf"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-07a39c7305740dce4"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-07463aef7f2a36190"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0fa973f7d17553540"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-09ccd6ee6c437c4b7"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-03e4ed01481ad2bf0"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0fc41e655bf7e8fd4"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-01d82a0f3aad3af88"
                         },
                         "ap-south-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-05637d551de39e3b4"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0330a0253976e14cb"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0cedc7c5e631551b4"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0925b11050116b154"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0223296a5a28b45aa"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-01e52d7ac080848e3"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0937b6d914bb9456b"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-095d904ce540af19b"
                         },
                         "ca-central-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0e3097372b3a89143"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0bc8db809def55ed5"
                         },
                         "eu-central-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0aca39a413634b874"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0e61d6b7b72113d96"
                         },
                         "eu-north-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0353dcf962ea011cb"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-02024ab1f049970c8"
                         },
                         "eu-south-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0a6742c725a31882e"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0746bcf86f301ec44"
                         },
                         "eu-west-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-07561da3470d885ed"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-098fc9c71f3d9258f"
                         },
                         "eu-west-2": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0705c67d1aa9b48dd"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0576d918b80041f86"
                         },
                         "eu-west-3": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0e97b9ae27eb04c8c"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-065e9b178e8d47449"
                         },
                         "me-south-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-00ed770bc2705c48c"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0aba50b6d5cb2d9d5"
                         },
                         "sa-east-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0ab57aa9bd1789961"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-01f1e006efcc70ad3"
                         },
                         "us-east-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-0642f099cafed3401"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0a1f230a2ddd36fc6"
                         },
                         "us-east-2": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-06f2015e8f6f690a7"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0b2dcd18e5464f623"
                         },
                         "us-west-1": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-07fd17e7b106b21d9"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-07b352a0b7b9a78af"
                         },
                         "us-west-2": {
-                            "release": "36.20220418.1.0",
-                            "image": "ami-05b440ebd511074dc"
+                            "release": "36.20220426.1.0",
+                            "image": "ami-0ff460ced0596edc5"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220418.1.0",
+                    "release": "36.20220426.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-36-20220418-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220426-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,92 +1,92 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-04-12T18:02:17Z",
-        "generator": "fedora-coreos-stream-generator v0.2.5"
+        "last-modified": "2022-04-27T18:43:06Z",
+        "generator": "fedora-coreos-stream-generator v0.2.6"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220327.3.0",
+                    "release": "35.20220410.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "d2150075961639e01bf8665e48eb21223f38118cd3b68b5fb836d29788691eb2",
-                                "uncompressed-sha256": "183e74d5549878e1de090b0afe78dd94f27a42ba822597308070866efdccff3e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/aarch64/fedora-coreos-35.20220410.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/aarch64/fedora-coreos-35.20220410.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "9659c0d156786f81c6b89a1586bc09a643792064d4facd7fcdd8271e4dd574c9",
+                                "uncompressed-sha256": "a0b8427f7e1f7d64c98f1911de38c5c1e5f3c8a6cc83220ad5936666bdfc77c2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220327.3.0",
+                    "release": "35.20220410.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "332a6926c48127fe5c68f0650eb87561ee7bb8f51c8a7ce3d0d6ec6b3247aaab",
-                                "uncompressed-sha256": "7548a1cdd75a5fb15ab6a8c1df8285b5157b2ac9d04a0489b6d7acca92987bab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/aarch64/fedora-coreos-35.20220410.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/aarch64/fedora-coreos-35.20220410.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "b21b5ab69e6c6aec813af659f57508010b0eccc2392300bab8f54e314229812e",
+                                "uncompressed-sha256": "04a9afb6415c99acd5cc39cef6e7c7f4cbdbbade3f1f535de3fe1259154aa921"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-live.aarch64.iso.sig",
-                                "sha256": "d7f1accac2eb03f68089f30d921bd49310b24501a0364e7b9e28624bcf0b6fab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/aarch64/fedora-coreos-35.20220410.3.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/aarch64/fedora-coreos-35.20220410.3.1-live.aarch64.iso.sig",
+                                "sha256": "b6bdc5975d938720b6864eddaecf0e29fddbc14b514f831dae3b5289b90ca18d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-live-kernel-aarch64.sig",
-                                "sha256": "bde4aa910e2db3cf0e9ddb476fd85325925d25d021e7c046c2b92e82846deecc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/aarch64/fedora-coreos-35.20220410.3.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/aarch64/fedora-coreos-35.20220410.3.1-live-kernel-aarch64.sig",
+                                "sha256": "ebf1ba14fa42477e4d34df6d6f2b892b755db1fd86f4c3a1164c3531667e01f1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "5a7c41ee810bc2b3ae57e5ebc4e16b45c7875c3d558bfcfc7d3396b114679161"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/aarch64/fedora-coreos-35.20220410.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/aarch64/fedora-coreos-35.20220410.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "3dad6f31ffd787557aaf7009d8ebd9c2d3c5689a9ae89b5c58da2a6d1a0d5a24"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "0b939381eac8b8dfa5e7c7c8cd2503f8de63299b7b28deefbc6894faab1b28d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/aarch64/fedora-coreos-35.20220410.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/aarch64/fedora-coreos-35.20220410.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "4aecab8aa71053eecdd45951fea524047fe70e3550efcf661c5c7fc711bbc566"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "442f72e31321c819fcb0998606f3663c9d9266a88617324eacc03a31ccff6fbb",
-                                "uncompressed-sha256": "cbd7e60cc15cd109a4d15a8cf8436a30077920be2cfdfbf2fe2552f9d536eefa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/aarch64/fedora-coreos-35.20220410.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/aarch64/fedora-coreos-35.20220410.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "9961305f81ec3f914ec1edca26e499e92a9bfb49bed869180cff4e0ceb20330b",
+                                "uncompressed-sha256": "8498b4825a5b4fecf8e435c9f9bb9188a760fd3ead9a5a9471623b56cd904e55"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220327.3.0",
+                    "release": "35.20220410.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "07d2e3caee70b80a983ac9cdb7a9a1a8c9ba60bf681044d7d129e18b7ef05895",
-                                "uncompressed-sha256": "7385ab816be0ca7c32bea174a6fa7b0b83bdc851b6eecfe4b89d6e2ce246bbfc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/aarch64/fedora-coreos-35.20220410.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/aarch64/fedora-coreos-35.20220410.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c05db9096d8f19a482fef9796796cbfd861aa9dbc7affbac840cb3f6e64c788f",
+                                "uncompressed-sha256": "ea196a10bf4dfbf0a016c2c15bae1c09093e78f855c353dcc6f727ea79a31118"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220327.3.0",
+                    "release": "35.20220410.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/aarch64/fedora-coreos-35.20220327.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "d307e22957ba923af7a852619c77a151f5d94636f83e016529c06cf40e911f12",
-                                "uncompressed-sha256": "b9e7478798d531f81e9d628b155c76d0b12970e22dc3e16e05488d7de9a5ae4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/aarch64/fedora-coreos-35.20220410.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/aarch64/fedora-coreos-35.20220410.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "c747d34adebc12bdbd77ffc957e878b5a693fce3e10cdfeadf313d38dd70dc96",
+                                "uncompressed-sha256": "2edb59b218fc3edd46a30cfc4033c863e7682742427ec53ef6143de44623591c"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0eb2195220a64b140"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-06b2ba9f6802b6b5e"
                         },
                         "ap-east-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0401a7af2a7cda259"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-000837852d1b3a5c0"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-05243b8ca233b1eb3"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-056bd47c3fff451aa"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-01efc8d3c9bdfb6de"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-01c0deb1524975575"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0dff7e96e6dcb4bcf"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-027e13d14346e9520"
                         },
                         "ap-south-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-01043486b86697dbd"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-0c8429470128f21e1"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-086a2e38431e248a3"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-0e491ea9674c24b69"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-030ddb1d9e377c2e1"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-027485e35a6b10cb2"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-011472aef784e90a0"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-0660b8580bebaa339"
                         },
                         "ca-central-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-00c86559cb53910c2"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-0f7289961a2c94da6"
                         },
                         "eu-central-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0149e7b11c5432cb1"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-09b27261322bb318c"
                         },
                         "eu-north-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-01599380482ad2c86"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-0832147eb4fae7ae9"
                         },
                         "eu-south-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-01ad90353ad3f4325"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-07256568d550f62fc"
                         },
                         "eu-west-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0e3f24046c20b0c5f"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-015cc6a5922bfd487"
                         },
                         "eu-west-2": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-04bd8beadcda63827"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-0c5ca72ee9a2396b1"
                         },
                         "eu-west-3": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-009d09eea85a614f8"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-06bd87253e0ad7b91"
                         },
                         "me-south-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-08a1154bbcef7a389"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-00d1eb930ef192c72"
                         },
                         "sa-east-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-03a5007ed6e10aa95"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-07285241c029c3433"
                         },
                         "us-east-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-073a87a8b59d74b49"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-0f56f7a9f56874843"
                         },
                         "us-east-2": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-07ae278988a8e9f10"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-0ded951f601e8da3c"
                         },
                         "us-west-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-09f144cf5b47d1e98"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-05fdc837cb609db77"
                         },
                         "us-west-2": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0aa6e2bdc8254d379"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-01eb245e8b1f8cf8d"
                         }
                     }
                 }
@@ -190,226 +190,226 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20220327.3.0",
+                    "release": "35.20220410.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "8a9597672344b051fb73806817ae0b943e1e3d64b5a778d40b713ee1f2ff1c7a",
-                                "uncompressed-sha256": "be12ec7a1aa543aa9ea356febfd7d81905b75651f834a3609e195419a705eca0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "a89a4417b2e58c390728d36481d450234cd213976f7155062c07602d825d23dd",
+                                "uncompressed-sha256": "63b1ff4c92f0611922eb6466c1f754595ea5c52c5ec6612f2035968453fdba2a"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20220327.3.0",
+                    "release": "35.20220410.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "ce63e08f9f1df4f4db090a7fb0bb215d76bbef7560e3ae94d0e49653021a1526",
-                                "uncompressed-sha256": "0e086d809fae1a0e987321719d8e58f5442971ced8c118321129f23291e76fac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "56a6c2fa0edff1195eefad9a1991e1d427a78681db0c7ffe552af9a0b61997e1",
+                                "uncompressed-sha256": "9ecee77311c7d36e77afa7562fad2f12c35d4dda97d2aaccfa3c99a754ffa6c6"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20220327.3.0",
+                    "release": "35.20220410.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "66222ef415403c5fc023221068cf3905f0880b0802cc437635a85a7df6a05fe1",
-                                "uncompressed-sha256": "f6cdd341278fd7f34e5e1c6e3803a84d6cfe4e0d907021724b9399c9b7bdd396"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "be28df7226b2bb94116d9c1663fb69bafbbeb14bc6eb9c4038312d0db69d402a",
+                                "uncompressed-sha256": "67bedd6b693364304145062a353c70e46ad0fce6333e588ad546d6b87b96938e"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20220327.3.0",
+                    "release": "35.20220410.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "f7931b749411d7fd6a1f9b9943afe52246170c3b8120e28a13d336d7deb0a9b9",
-                                "uncompressed-sha256": "477307a072e31c8e7c84aa903b1c0bcca156e8b8d7e147b83533a03bed9684dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "3e04e6be9378d95d26fbf8b089915629b21b909e92bb58e4fb8cb8604fef556b",
+                                "uncompressed-sha256": "54ecd3a76ae2e4203473eef9dafb1b1126985831c1c03d7cdf2045df499506e2"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20220327.3.0",
+                    "release": "35.20220410.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "73cfa79258d1f82b9adea94877197784e7f621a1dd14e3655fbc1b6dc2d58371",
-                                "uncompressed-sha256": "f22890caba26d45285a3ae70f1acbfe56951975c1625aadfa2d6479f37b5261a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "ffa991c268b06aae95c44d7c720ade76a868e92b1ba10af87636546e422ef911",
+                                "uncompressed-sha256": "d164cfd89a1026986d836011017b96a9577d63d7aee030f59cd33f5fec73cbb8"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20220327.3.0",
+                    "release": "35.20220410.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "7c564329c7d12aefecd319d869818d63fb7da674ae5f3e1128006e1f88ac6eae",
-                                "uncompressed-sha256": "888554969f6b99ea07e316d3dd851916a14e5e73b731a35b8a9779f5fb2a9a01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "d6b0a24a88d57e707ec53be24a0456a8c1bc572cad27a5065ebe21f2066ef089",
+                                "uncompressed-sha256": "7d3f4f8be29721027ed08adbe6d86c7cfcdc32ba537e7cf6749f62c4177901c8"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220327.3.0",
+                    "release": "35.20220410.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "4a5b3c360ee60588cf969c87b9a2d7ccef306add80fe37c4a9a1f17adf812ebe",
-                                "uncompressed-sha256": "9bcbf0fa4c57f4374204be13ef37c8240cc9ed3ddfb23a0cc1e6ebf7d77795d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "52997fca635575334f0907d5f1651ad8ae7d512e20eb73ff58270d74e95ad658",
+                                "uncompressed-sha256": "9819fe52edb1b44a4b9d1c795db5006059a94dd0e08c403ab4632a69187664ab"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20220327.3.0",
+                    "release": "35.20220410.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "1dcfb3d3a764abfc6e4dbeb8b8842ee4e5ccd309a79f1e6b2697b3ba2cb30e4c",
-                                "uncompressed-sha256": "d7e3826bc1264293eb3f503e07a2b8e848a821f37fdf4d8f875281ae120b388b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "598c29289d360ec3835602f3698fde388c023437832ef74f9cb6b71a4359bb59",
+                                "uncompressed-sha256": "b6a5de0e6893ee4e6a5509807f8eb0ae76db4318d0bf3f78f35fe31dc9872659"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220327.3.0",
+                    "release": "35.20220410.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "165c25e730071a868954fb97d39daf1d8f3e0aec96a22851aa8089b58150817e",
-                                "uncompressed-sha256": "79f533130ec04cf01142d052c3120aa660b80a59292ac75ff1df46c8385e83f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "7038334a5fc16b74a3d90a36093d7a627a7e7c07616447e89019b294e76f0d52",
+                                "uncompressed-sha256": "26e4778acf48274ca767ceab7ba41030b014da7268973ea014740c766648a257"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-live.x86_64.iso.sig",
-                                "sha256": "c42ddc92bc7672a624b9aae461b286962e6f89eba426379c8a9eef308cc1afad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-live.x86_64.iso.sig",
+                                "sha256": "9026a98649909e2007db4b85e741a5215afbed0731232f5c0cecfbe548977004"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-live-kernel-x86_64.sig",
-                                "sha256": "4c8a7257e1180bb552842a298f93f15dd014a74076c68f85e67c59fab46cdc5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-live-kernel-x86_64.sig",
+                                "sha256": "4fa5e6dcddcf507fe62e7b979a799e6f37b31d79e84bf70a851858135b0c34d6"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "752d6b8d72502b46da05d66d7c12cc1a8ba8bc915e671b0601477aab398f3607"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "82be01089acab5af252d6c75890289653e33c7a3c242444c5513c5024bf7a9c4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "bb9f4c9f3d2ba9b9fa15c998730c7cf568739aa4677436f4b62deec52e8dea9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "e6ec825bb3d98e319cbf760bedf3c7cb2218409e8fc5ea57d51d688c8fbb82f2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "de0ba478d782fc97b1d0a35a26b32445a09410f4d394b3fe7d2b606d7173bb33",
-                                "uncompressed-sha256": "7e241aa6c87e53d5ec6c31430b382f5fc3c1f4ffb7543cecc1e4be9afe039eb6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "a3c32003ab2c22866a2877299efb01b72e07f85a71e41a6a455d673d20ac4aa0",
+                                "uncompressed-sha256": "a1e75fd5a4c3fd86bc36d0ddf6982a8996af601aad1609121672bfcf20038b2f"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "35.20220327.3.0",
+                    "release": "35.20220410.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "5fb9015a0a322082294f14aef12b04811e904584dd5794a36c7133eb9242479a",
-                                "uncompressed-sha256": "5a22edf1b57fb7dfcfdb5106597f7d2d20b6b7a223af358943cf4e63cffb0e1b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "cc968addf3f1ac47fe8cbaad253f78be09efedf8f47002eee0d25594440c876c",
+                                "uncompressed-sha256": "6ebfb5ca36972e1d0cc90d934635180e0a66b6c722ef6b05aab8ca90e29a4e2f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220327.3.0",
+                    "release": "35.20220410.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "f5e1c5243c9b7d417d752642617e2af1814f4b3ada874f085ff068d4a2f513ad",
-                                "uncompressed-sha256": "5e3e40723288aa56735caa5e5fcb58079da5b27df392ee185a09f9b6742fa93f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "aa5f357178b175a5c55ff1a0e790e8f4eef81a388c0508c7cd4a4c64f0d36847",
+                                "uncompressed-sha256": "7849c877814160815aef5f2715ee6022c58b657e846304e16aa9c36052d8362c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220327.3.0",
+                    "release": "35.20220410.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "1c235c83d4036f31a676a77dd8a0aff71a7c4f0d5558de2330e2deff92905a82",
-                                "uncompressed-sha256": "935ef3fc65b79344ebc006e89f45f67606afa5d39f2222377bc3dba89f6adb7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "8b120b06bcfaac4ca8831e0959152b52b4b75ddbe1983e4644c4fd0b26402662",
+                                "uncompressed-sha256": "00e155e93a0f75c54121de1fbe2ab802ee78b286e1b4fdbedf6c4ce83ea37ef2"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "35.20220327.3.0",
+                    "release": "35.20220410.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "219f9c58abf1657f0c0300340f22c30aff4e7423db702f36176703aae0fcae3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "d52ab30e244ce018c269a6b878a04cab5a13b9aaa0d14bdf0be8bd2a0cc90e98"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20220327.3.0",
+                    "release": "35.20220410.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "80d900470a98eb725b51d172e97dc0e2801107d08f1e1d0f179e9668f0f447a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "66d2cbece120883e9e1fd02ed1f47d199d2659259fff3baf082a85010241fff7"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20220327.3.0",
+                    "release": "35.20220410.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220327.3.0/x86_64/fedora-coreos-35.20220327.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "39064209a4c3b4b66f0474dc8b5edb7cba19ed5648be1e9f75fc4edf08d9758b",
-                                "uncompressed-sha256": "41b80e9639c72b1895a204f033af0d6ff8d0ef2c98c97f583b7aec6e696cb748"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220410.3.1/x86_64/fedora-coreos-35.20220410.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "7d49e1fcf9a3ef7b20808e01de60234bb263b758ce5e2f6f67b9f060d1e5fa06",
+                                "uncompressed-sha256": "630116b195b9f8527fecf9176c510bfb662556726edb729695073c4f26c55b4b"
                             }
                         }
                     }
@@ -419,100 +419,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0bcb21532b5d142d1"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-0798b37cbd6a37aee"
                         },
                         "ap-east-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-058e26ec063fa5604"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-0df60b921781e22f3"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-09b92b1a38e39431a"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-0eaf5c64ff23cd0bc"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0805694483d11563f"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-0f00ebd9a1f164b89"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0bddc0a0ab0bbd1ee"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-01612e08cc2e5f43d"
                         },
                         "ap-south-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-07906a47b782f35b5"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-08144ad76e167c51e"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0157e9ed5d6ca9e02"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-0bfd6eb8f6363b683"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-01103d7c4afd70cb9"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-04a074315a23993da"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0e43ec024e9e961fb"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-00d8b39e9184f5e93"
                         },
                         "ca-central-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0f970c1189a91cde1"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-046afa6c75cbadf37"
                         },
                         "eu-central-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0122f59a1fa07f6ae"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-0933b4edec5f5327a"
                         },
                         "eu-north-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0577b8c9bf4936777"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-0b11c1958c7090d7e"
                         },
                         "eu-south-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0753d7b4303936a75"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-041ba5487b159c0ec"
                         },
                         "eu-west-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0e21be71fdf31829e"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-03466c7900a5327ab"
                         },
                         "eu-west-2": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0e15a5f241b5c0b5d"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-0b1120f65699237cd"
                         },
                         "eu-west-3": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0370c4844e6c0236b"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-0372c233c32ee3ae6"
                         },
                         "me-south-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0be190d5cb3b70f7f"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-071498530b0ef7369"
                         },
                         "sa-east-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0dee841e4acf3ddd1"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-0885ae86b9f282b56"
                         },
                         "us-east-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0389fff7e72ebe8e0"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-06145e7cf9ee240ce"
                         },
                         "us-east-2": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-04cf2aa16f1d40adb"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-05a0dfe3e246be467"
                         },
                         "us-west-1": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-045b298bbc41f32fe"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-000fa547c8ed111d5"
                         },
                         "us-west-2": {
-                            "release": "35.20220327.3.0",
-                            "image": "ami-0f6c0278f0122ce00"
+                            "release": "35.20220410.3.1",
+                            "image": "ami-07bf38e3bbb2b2bc0"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220327.3.0",
+                    "release": "35.20220410.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-35-20220327-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-35-20220410-3-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-04-12T18:02:19Z",
-        "generator": "fedora-coreos-stream-generator v0.2.5"
+        "last-modified": "2022-04-27T18:43:07Z",
+        "generator": "fedora-coreos-stream-generator v0.2.6"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220410.2.1",
+                    "release": "35.20220424.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "348a5b0ee13f03b62b15ba6077dc95d4a6737dd49e3aafb04d2ca1246b834cf0",
-                                "uncompressed-sha256": "ac86d16f83496411ca79f6eda99f1e1ffdcedb9c321057ab323d379195dc9346"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/aarch64/fedora-coreos-35.20220424.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/aarch64/fedora-coreos-35.20220424.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "2ba35184791e8826125cb78471537a2f0c36124a5bc3d62f470c9a019d6ebe5b",
+                                "uncompressed-sha256": "eb922bb12b286ee0d05ab0e1658a6cacb5fa4086bd0206fbc88c8657542bde70"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220410.2.1",
+                    "release": "35.20220424.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "6b48ada68a9dbdc1d5e522020ad444c4fd8908f192cc312508145aa665352e83",
-                                "uncompressed-sha256": "241d1b4bad7b4c162d6ed4ac1039f50266e3fa204ff8ffb06ad49b8dc0219f50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/aarch64/fedora-coreos-35.20220424.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/aarch64/fedora-coreos-35.20220424.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "17dadd92b472d3062a05c07725c91d939233e7ca3aded593525d0dacc8f92475",
+                                "uncompressed-sha256": "890aa5104adfbe9007734ab8a205a5167697de9dc38e66ff92f6e121b19061b7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-live.aarch64.iso.sig",
-                                "sha256": "55da5e4000e5e71f6c5131e5748f28a46cbbab090dc2e85a550038680acfcd52"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/aarch64/fedora-coreos-35.20220424.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/aarch64/fedora-coreos-35.20220424.2.0-live.aarch64.iso.sig",
+                                "sha256": "bd6bef1bee1de1146a9b39cb3c367cc6cd4f3aed45331e26d1f712d22e7a8406"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-live-kernel-aarch64.sig",
-                                "sha256": "ebf1ba14fa42477e4d34df6d6f2b892b755db1fd86f4c3a1164c3531667e01f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/aarch64/fedora-coreos-35.20220424.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/aarch64/fedora-coreos-35.20220424.2.0-live-kernel-aarch64.sig",
+                                "sha256": "958b4de4e079dfbc0e72321fc3b56e345d3158801f33ae98d20ff8127c2b4567"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "8feef7938bcfbeb5462392229d4ab9ad0c26b38b3719d828271b2ad588dad3ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/aarch64/fedora-coreos-35.20220424.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/aarch64/fedora-coreos-35.20220424.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "e55b0d544107f203894330f771fb5e2d8c9af659e9b40fea60c74c616552903c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "a96b988436878b94046a55b2904578f1342dce0a97598d4227fb0d975c5bf476"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/aarch64/fedora-coreos-35.20220424.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/aarch64/fedora-coreos-35.20220424.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "4671e8b99f489bdc28d94f270330362668031222e5789d54a28e5945a82205f1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "3f634f28ecdc76d0a518313cc6723eb4b05034ee180f957937627db058e3786a",
-                                "uncompressed-sha256": "78ca9adf8cd3bead26346da8fd2e6781837c6a89f3d52c78ed219d2baa113d23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/aarch64/fedora-coreos-35.20220424.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/aarch64/fedora-coreos-35.20220424.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "47dbf7672ba68b1a342185a2b3115758238e1048987f3846fdf1343236d4e1b1",
+                                "uncompressed-sha256": "509ca0422ebacf86a09d3d7e9c1cd728c40bde259eede217f9bcbfec30fc6807"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220410.2.1",
+                    "release": "35.20220424.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "4b1202596b65bbcb7adb85b7cb1013150100d4c64616fa87141fb5597e2a480e",
-                                "uncompressed-sha256": "f035ae041b06945345ca9b4cea2d6a367d7f3c60c883fc6c6b3877fe14990de9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/aarch64/fedora-coreos-35.20220424.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/aarch64/fedora-coreos-35.20220424.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "9fe73a01d4cf6fc7bda6b2ab6e5c80b4d8ced05d5c6bf8a06a40a8a847417ed2",
+                                "uncompressed-sha256": "bf93279ba2fe1d57f5e8fdbf05a5cdb1478365d789bde5260de532afefbdf539"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220410.2.1",
+                    "release": "35.20220424.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/aarch64/fedora-coreos-35.20220410.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "e703bdf2bf381f76c68045d79d300a7522966293bb6c43ad82512a2ec0151643",
-                                "uncompressed-sha256": "16e19566358c66791d91eda314becfbce24ae593529b9d5d931b917478774515"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/aarch64/fedora-coreos-35.20220424.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/aarch64/fedora-coreos-35.20220424.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "7e2bf878a82013f1981ba47a06c233e45a567ce4248cd23858a5f45fa22e0160",
+                                "uncompressed-sha256": "05a158b531b1bf95b7671e59af51fa4257c83c8f92be35a6b5fcd5620f888eb0"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-032811f72b5d2398f"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-06952af425d3dcf1a"
                         },
                         "ap-east-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-06df4869ed3e1d349"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0ae2257a79bf31337"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-0de6671c603eab51e"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0fb9a359013688281"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-0eda714c6a9096d3d"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0ce8266d2c57f3abb"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-02fc2a3a5bdf54709"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-06f074a5b6138d22c"
                         },
                         "ap-south-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-00ed65f0e46310d0c"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0d70022733fae8d97"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-02ca88cbabb4139a6"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0c807d15a698ce8f9"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-0b3dd6e3b7b3d6812"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-07fea3be53a6147ed"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-0fc7c562917fcc70a"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-00b9e2746f84cc16f"
                         },
                         "ca-central-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-02c7f69a69e6b9aae"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-08bff944cddceb209"
                         },
                         "eu-central-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-01cc43c739c9bcfed"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-02eede678c81046a8"
                         },
                         "eu-north-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-0fc98c4f90ae4bbf0"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0bfcc28dc8736b546"
                         },
                         "eu-south-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-0081e9b4265ec1ba5"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-075e3871241b4a54b"
                         },
                         "eu-west-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-0ce170dd890b7b7bc"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0d0df4f533e31d791"
                         },
                         "eu-west-2": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-0563b860fe9936b40"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0aad1e5514b7a2672"
                         },
                         "eu-west-3": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-0314b27ae2944ee55"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0eae13bd38362563c"
                         },
                         "me-south-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-0ce1a06b6cf43e1d6"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-09e3fda39c570510a"
                         },
                         "sa-east-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-01053f35558bb0399"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0cccd4042845b1993"
                         },
                         "us-east-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-041f49c02127bf8c9"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-04fd724ee16c4e742"
                         },
                         "us-east-2": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-04c4f1fecedf78f6b"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0e242f74d1a78a8be"
                         },
                         "us-west-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-0d67dafc915dc5715"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-05a2cf27cdbb53865"
                         },
                         "us-west-2": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-053c700c38afa7e53"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0b347ab64ac95b69b"
                         }
                     }
                 }
@@ -190,226 +190,226 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20220410.2.1",
+                    "release": "35.20220424.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "e298b923a0699354190f4443fe277ab102c62921205b7bfec9c55f5e79b3806b",
-                                "uncompressed-sha256": "471f63d03d00800595891edb180efcb5f1b09f689b57655ab9ba544ff7f93943"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "e07dad1b5cfafb8e098235a73193d85925c33b98413ba995c2e7cfc1b90abe63",
+                                "uncompressed-sha256": "94675c08c28ef1e175dcb2068c4136f828aa9f20fe66facd2cc302ae2171f7cb"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20220410.2.1",
+                    "release": "35.20220424.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "8537846b52311f34589d37dc112f3e0cac136ddc139c586f470345d089bb9fae",
-                                "uncompressed-sha256": "72bd2dd17cb8926895195e730aeb143489e2fd5ff0dc2a17d849241f91cb76fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "594f0427c7d217d9dfd5ae3ba652cf9217032e55bc4354eaa462c112d434e870",
+                                "uncompressed-sha256": "fdeadfea5c55bc76478872334ef578b510fea3a79ca40baeb1a5f430241cd69c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20220410.2.1",
+                    "release": "35.20220424.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "522bba8b26d925c435982f0856c346f3b3e9ed383be740e9c4bb4e4ce71dc9ef",
-                                "uncompressed-sha256": "234a5b041af1fbe01bd1f786c4b2552b77924e7d85b4d22d695a42d87d91d0e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e7cb38ca5cbd946e4721eace891be341b042de9ba62a176aa2ce29f135283afa",
+                                "uncompressed-sha256": "079fb59155ff95e344d364bcf676d00294521752e33b85dcc0ebde4f137803a8"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20220410.2.1",
+                    "release": "35.20220424.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "032abd03c409d0a350e460a44263a6cb33d06a797c944553d49f5fd2ef2b8a57",
-                                "uncompressed-sha256": "9660139fbb53fb89596451ce9dbbbafce322c73d7946303170469961e74a8e4d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "0e9da2edcb9b0aba0cb11725b7b6647ea68ee754b4a89fbbda7db2e04c3ea688",
+                                "uncompressed-sha256": "34b7ba874aac20add1f23182be775cae585a71f80462338db0cdec53be08cb4b"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20220410.2.1",
+                    "release": "35.20220424.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "beb1dff1f18ce5c3277af693642aaa7b800e8350deb6c8c23a96b537c2db3f7d",
-                                "uncompressed-sha256": "62ebfc9e0e9f443b353907debfb4191a9e69b809bf6a2df019df4b46a886ae7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "a98596146e95e9733a0c75c26bfbc1747f085ca93fd05de4f954f78ad22dc8de",
+                                "uncompressed-sha256": "858c351c8b8a3fd9c84701139ce19936d0f4f8ce0c314347a314bfba32415968"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20220410.2.1",
+                    "release": "35.20220424.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "32fbdf9753f219457baba3a868b530ab9e2702a6a56a8fc084b9ebab60736af8",
-                                "uncompressed-sha256": "790f6606f027e25ed73b92b97e323c818cd161edad7c2fc478871614710fe96e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "841d8c851c30a033b0108b76c0f5d05689039e4fa02680b18d3d4cce351939bb",
+                                "uncompressed-sha256": "aca133ef0caf63943525d92deceacc9c1a3f3da2f5175c5f2b72c354fe08e204"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220410.2.1",
+                    "release": "35.20220424.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "c73c92759464e05e1bc67d3e199f2250eb62b76cbcd11f1dec9c88f15d40550d",
-                                "uncompressed-sha256": "579d164d3e41252a24f37ccc00f0712bff9776ef9606701b9e59a56ad54ea3e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "7c5244fa3385214459375b0625090195d912ed0fa3c02be9bf678da01e2bd5aa",
+                                "uncompressed-sha256": "7ce721d5b3de53bad90969d95bed989c5c91ac51d6f3fd6df8c10a613d9caefb"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20220410.2.1",
+                    "release": "35.20220424.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a80ab699c2e2605d29b0d177e8765914a7f1dfda0bd559b9848a28827d70325b",
-                                "uncompressed-sha256": "d7fb66e2ea0e8663e810f6cfcf993d25d49b78beca204912c4e002024fa1268d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "9ad4bf16e67a63e7271e1f3bf5c2a98b80aecd6432da6bdeec17382fc8a978cc",
+                                "uncompressed-sha256": "f54d34426d36f0ec9dae48c18e884fe0a2189f3c1ee84b6467dde24efea7fbe7"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220410.2.1",
+                    "release": "35.20220424.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "1f89f6d45372094a19efdf4a15629de6c0466f2234e462074c8d34b3ccd9cd1d",
-                                "uncompressed-sha256": "7bbc35afdc47eabc1b55684bdab4de504cbefda9c18d40557bec8d47b7f357e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "db2b0460458e171354d4410af5a2dbaabc510ce0a144ae0791e0e10b78a0dcbe",
+                                "uncompressed-sha256": "4bafeb9778ab948ebe3c94a1639b170260125004ae00bda81e787d39de77476d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-live.x86_64.iso.sig",
-                                "sha256": "1bd3a69b4089bb92c8f767d0a4fe7ef551d72bb52b5588ac40709b8850ac603e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-live.x86_64.iso.sig",
+                                "sha256": "972714a9c316e65254b9385f23999accdb50da2d035e0ba71968c45a2ec5e0b8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-live-kernel-x86_64.sig",
-                                "sha256": "4fa5e6dcddcf507fe62e7b979a799e6f37b31d79e84bf70a851858135b0c34d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-live-kernel-x86_64.sig",
+                                "sha256": "ac0ee21103bf5c186181792eff7aedb123f5875967b5cdef85dd27c31901d583"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "0c8fb14499335240e54fb87943be585528863164a8a4b97a647dcef7c7027936"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "b9beb23915c58c60b8df3548fe950864d39fe636c50b0666d82afd75bc273a45"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "de0c63877151748ca55610ecb44beb472e0b156acbe6729c8bbe0e628da8f036"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "06550718d66cb9390f20501d8ab24439c4dfb3ff268e8ec994534e4689378377"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "4182e61a8941bc96df9fb999251371250a621da585f06bed7563e6c3d62ce7eb",
-                                "uncompressed-sha256": "ca300ac8f82b8c645e481920411800dab7896841025183e43888f2efb1a762f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "8bbbb3140740c0a2e3a8ea069c94667f2135f1b54db52c12bf6a62ff74f3defa",
+                                "uncompressed-sha256": "c38ba889d1cdd2cc8f1a67fdb38d15e3e21e3405ab869b1138ce9d4b80b62ed8"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "35.20220410.2.1",
+                    "release": "35.20220424.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "f44da44c5e449ab8bf4fca10dcda2b24a9b92aebf9254db9b54921386b4f3dfe",
-                                "uncompressed-sha256": "3599c14e798a73d5e2017da9355d0e32da8ef111b16db3a8c59f3eeecdb0db26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "b3877fea154bd55bc657e4d7956746eadef661cb7c2a8315b920ba4df7914cb2",
+                                "uncompressed-sha256": "28994a3fea49b1de38b9e6c377e9d4d4cc98bf128f0b154b0330f60a06ae2333"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220410.2.1",
+                    "release": "35.20220424.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "22b7228a0ff4b8f8a432407cc26b69f2234737fd04517a4050577a472b703ceb",
-                                "uncompressed-sha256": "108812dcb3b38879d0c51d5b9d72b5c00f344ce9fea1f110d645c40e57c5f719"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "2a30c6d860ef70a4dc94cb71f1be41c806ea086effa9ba56a5269721e967d688",
+                                "uncompressed-sha256": "477d63a8a2bb515b05e565b8400bb6b6166242b36f595da0b7052e6ef2546666"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220410.2.1",
+                    "release": "35.20220424.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "2c05e33b19d3474c6aac337f3eb3c13917a6a2840f593e28891a58e3a2e7f923",
-                                "uncompressed-sha256": "8111c421d4a5284e6828be7983ec5954f5dc17e1ce68a605513d610084f87095"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "d9dbfa59cd819c654bd4f7fb1ad79b4c02604d6fcecd7c23d991008c8c634789",
+                                "uncompressed-sha256": "22848d73086750b8d61908a4dfdfcfcb443cb2feb560e56a762432601893de23"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "35.20220410.2.1",
+                    "release": "35.20220424.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "467868d94834dbcd2a287681139a4aa4a9508d5511e89246b60353d95392c6a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "9f34a5d1bf7ddb4f7e5ad464e6472ea5a584acc5f71b459d205e2f5ff67725dc"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20220410.2.1",
+                    "release": "35.20220424.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "2454a0617d8deb75db9a68e0c2f8e015a209966efcb7549e07db21350602b3d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "47fb166e3abde225cc44a6486282b33b55a2b80f363cb43cabf860f4c1374617"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20220410.2.1",
+                    "release": "35.20220424.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220410.2.1/x86_64/fedora-coreos-35.20220410.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "b23b282c082f1cb080c42354d3fe0a4535467a12c1996803bd15ad6ee2ad689e",
-                                "uncompressed-sha256": "8a00250bbcda39c79c59e984906db5054c78b05435f6a463aeb1c706872952d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220424.2.0/x86_64/fedora-coreos-35.20220424.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "b8dca00ab2c5baaf906f5af947c1f37e2039423f8bc10b7570b7a71abca4fd6a",
+                                "uncompressed-sha256": "9c350031905f5f8f20bb8128d57fbd5900fda6fff065c986abc022ffa64ca050"
                             }
                         }
                     }
@@ -419,100 +419,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-05854bb8881ad1d2d"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0840126a6858974e1"
                         },
                         "ap-east-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-0478976b3f5730dbe"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0cb0ae9a65533624e"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-0af7d4736a185eb4d"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0212946f0cccfc9fc"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-0118cd82ec8e5c0b7"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-06e78d3eef2240272"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-0a61e89d762957398"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0719845d2e1140ed7"
                         },
                         "ap-south-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-011478f200ef9b240"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0550b444a139f6af4"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-03f1e64310e711959"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-02316be2daa9a611c"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-04f37029fee7e328f"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-04b0ce3b94bdd1b5e"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-06a697b5bba5de4d2"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0eed33ee256481b71"
                         },
                         "ca-central-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-0ec66427b35bd507d"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-06b509f52e0af8f44"
                         },
                         "eu-central-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-05af1de24faf51036"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-05feda1eb7aa34f64"
                         },
                         "eu-north-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-0811cde0f6bb4fc35"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-06942187647546336"
                         },
                         "eu-south-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-08a34f2242007383e"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-04ac020e1a16a43be"
                         },
                         "eu-west-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-018ba833fc3e1d6ae"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0f5d537fcd4fe3d2d"
                         },
                         "eu-west-2": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-0e91c235bbe88de97"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0311f4fba7a92e64c"
                         },
                         "eu-west-3": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-00d7b05231e7ed0e7"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-06c29db682a4ded97"
                         },
                         "me-south-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-076cb0cd8d8beee19"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0a22d7a01eaa37a24"
                         },
                         "sa-east-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-05eb5fb00e01a8482"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-06b3dd0fc0eda81bd"
                         },
                         "us-east-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-04be36ffe79705c74"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-087cd52b5f43d48be"
                         },
                         "us-east-2": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-03b60925b879ecc37"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0ed02432e18eb6314"
                         },
                         "us-west-1": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-05f917f0225af307d"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-00dd6cf26f04a9c1e"
                         },
                         "us-west-2": {
-                            "release": "35.20220410.2.1",
-                            "image": "ami-0c8277d7313376fb7"
+                            "release": "35.20220424.2.0",
+                            "image": "ami-0a253c9c92c043ea3"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220410.2.1",
+                    "release": "35.20220424.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-35-20220410-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-35-20220424-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-04-19T02:09:17Z"
+    "last-modified": "2022-04-27T18:43:10Z"
   },
   "releases": [
     {
@@ -45,23 +45,23 @@
       }
     },
     {
-      "version": "36.20220410.1.1",
+      "version": "36.20220418.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        },
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     },
     {
-      "version": "36.20220418.1.0",
+      "version": "36.20220426.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1650376800,
+          "start_epoch": 1651086000,
           "start_percentage": 0.0
-        },
-        "barrier": {
-          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-04-12T18:02:18Z"
+    "last-modified": "2022-04-27T18:43:07Z"
   },
   "releases": [
     {
@@ -53,7 +53,7 @@
       }
     },
     {
-      "version": "35.20220313.3.1",
+      "version": "35.20220327.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -61,11 +61,11 @@
       }
     },
     {
-      "version": "35.20220327.3.0",
+      "version": "35.20220410.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1649790000,
+          "start_epoch": 1651086000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-04-12T18:02:20Z"
+    "last-modified": "2022-04-27T18:43:08Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "35.20220327.2.0",
+      "version": "35.20220410.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "35.20220410.2.1",
+      "version": "35.20220424.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1649790000,
+          "start_epoch": 1651086000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @gursewak1997 via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).