### PR TITLE
workflows/rollout: don't bump metadata timestamps of unchanged streams

### DIFF
--- a/.github/workflows/rollout.yml
+++ b/.github/workflows/rollout.yml
@@ -113,6 +113,9 @@ jobs:
           fi
 
           rm -rf generator
+          # ensure create-pull-request doesn't commit stream metadata
+          # timestamp bumps for unchanged streams
+          git reset --hard
 
           echo "BRANCH_NAME=${branch_name}" >> ${GITHUB_ENV}
           echo "ROLLOUT_DESC=${rollout_desc}" >> ${GITHUB_ENV}


### PR DESCRIPTION
After regenerating stream metadata for an unchanged stream, we skip committing it, but leave the regenerated metadata in the work tree with an updated timestamp.  The create-pull-request action notices those changes and commits them with a generic commit title (`[create-pull-request] automated change`).

Discard any uncommitted changes to avoid the spurious automatic commit.

Fixes #446.