### PR TITLE
release-notes: Update for new releases

### DIFF
--- a/release-notes/next.yml
+++ b/release-notes/next.yml
@@ -1,4 +1,22 @@
 releases:
+  36.20220505.1.0:
+    issues:
+      - text: "kdump: save vmcore failed after trigger crash when enable kdump via ignition"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1079"
+  36.20220430.1.0:
+    issues:
+      - text: "F36: 36.20220325.1.0 NetworkManager not allowed to access NM dispatcher scripts"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1156"
+  36.20220426.1.0:
+    issues:
+      - text: "rebasing to another stream fails when deployment is staged"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1150"
+      - text: "Large and growing PXE RAM requirement"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1055"
+  36.20220418.1.0:
+    issues:
+      - text: "F36: No network on rpi4"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1145"
   36.20220410.1.1:
     issues:
       - text: "Drop libvarlink-utils from package set"
@@ -7,6 +25,8 @@ releases:
         url: "https://github.com/coreos/fedora-coreos-tracker/issues/1125"
   36.20220325.1.0:
     issues:
+      - text: "Encrypted docker overlay network breaks on update to 35.20220116.3.0"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1111"
       - text: "rdcore bind-boot fails with \"Error: Expected one vendor dir\""
         url: "https://github.com/coreos/fedora-coreos-tracker/issues/1116"
       - text: "20220227.2.1 breaks NFS mount for QNAP servers (kernel 5.16.x)"

--- a/release-notes/stable.yml
+++ b/release-notes/stable.yml
@@ -1,4 +1,16 @@
 releases:
+  35.20220424.3.0:
+    issues:
+      - text: "Large and growing PXE RAM requirement"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1055"
+      - text: "Encrypted docker overlay network breaks on update to 35.20220116.3.0"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1111"
+      - text: "rebasing to another stream fails when deployment is staged"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1150"
+  35.20220410.3.1:
+    issues:
+      - text: "Use MOTD to display Ignition warnings on the console"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1125"
   35.20220327.3.0:
     issues:
       - text: "rdcore bind-boot fails with \"Error: Expected one vendor dir\""

--- a/release-notes/testing.yml
+++ b/release-notes/testing.yml
@@ -1,4 +1,20 @@
 releases:
+  36.20220505.2.0:
+    issues:
+      - text: "kdump: save vmcore failed after trigger crash when enable kdump via ignition"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1079"
+      - text: "kola: 35.20220216.10.0: non-exclusive-test VM has journal failures"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1108"
+      - text: "Drop libvarlink-util from package set"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1130"
+  35.20220424.2.0:
+    issues:
+      - text: "Large and growing PXE RAM requirement"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1055"
+      - text: "Encrypted docker overlay network breaks on update to 35.20220116.3.0"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1111"
+      - text: "rebasing to another stream fails when deployment is staged"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1150"
   35.20220410.2.1:
     issues:
       - text: "Use MOTD to display Ignition warnings on the console"


### PR DESCRIPTION
Add notes for the following releases:
  - next: 36.20220505.1.0 36.20220430.1.0 36.20220426.1.0 36.20220418.1.0 36.20220325.1.0
  - testing: 36.20220505.2.0 35.20220424.2.0
  - stable: 35.20220424.3.0 35.20220410.3.1