### PR TITLE
Roll out stable 36.20220505.3.2, testing 36.20220522.2.1, next 36.20220522.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-05-10T14:24:41Z",
+        "last-modified": "2022-05-24T22:56:39Z",
         "generator": "fedora-coreos-stream-generator v0.2.6"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220507.1.0",
+                    "release": "36.20220522.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/aarch64/fedora-coreos-36.20220507.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/aarch64/fedora-coreos-36.20220507.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "6cd7b578525215d0916c4d75e4de75af316198f0738a71d1ee707cf42b08e4cb",
-                                "uncompressed-sha256": "2a1e6bd9e7112e875bf2d5a06d5c9de4abbd56173941758046a790ee0cfcb7e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "bebb238be160f5eeaedb1e00275125ad4544e45c78633861ec276d085337f654",
+                                "uncompressed-sha256": "e7d3b1ccdbf1f0c9b2c8af0fa5d4480c7e784e82b9d76a81dfecfda39aed3ea4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220507.1.0",
+                    "release": "36.20220522.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/aarch64/fedora-coreos-36.20220507.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/aarch64/fedora-coreos-36.20220507.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "908c875fbe70235417ee633296754207ceddea72455cbacfe6729e8c567faf11",
-                                "uncompressed-sha256": "b6c459cd6c4016c8a6daf4d5f245856f1557c07fa8df8044b2d9c5da5dff3141"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "df58c84febc620d82f468a1b5bcb860239410afff6475b80c5d9ccfc0a4b369c",
+                                "uncompressed-sha256": "c5d4a621b34106fbdeb196a93d0cfd73ce4c001202f7c4a642c721cacdf983d5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/aarch64/fedora-coreos-36.20220507.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/aarch64/fedora-coreos-36.20220507.1.0-live.aarch64.iso.sig",
-                                "sha256": "bd560927ea541d0db783367cdc27d8161d9eb4fc2d4e6c36205e85c5e69e5e91"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-live.aarch64.iso.sig",
+                                "sha256": "97f198e36aaa68a5bb023dbd1ef3c0bdd726ed93fcb64489649fa266a5f273d6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/aarch64/fedora-coreos-36.20220507.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/aarch64/fedora-coreos-36.20220507.1.0-live-kernel-aarch64.sig",
-                                "sha256": "6945ec2c3d5080fbe67ef64d757ee9ad4a95951e097a70e1cd159a80294a1cfa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-live-kernel-aarch64.sig",
+                                "sha256": "b314a92e590176a5208b9237e53351cbd52f6b883a7aaaf5ddb99ad8bee5ceaa"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/aarch64/fedora-coreos-36.20220507.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/aarch64/fedora-coreos-36.20220507.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "595ad85faa00c43caaefc36c3b9878fb78487c5703054fabf3f6e760afd65c9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "e2b931ee8968d64f6df8b51c4e3665c853215c189b0f5dc33503f9677cf75ae1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/aarch64/fedora-coreos-36.20220507.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/aarch64/fedora-coreos-36.20220507.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "3d4c65d32715634c9d4c65e45c1c00cc885f27405eaf2bc53683a00d3c9dde0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "22e928b81b28e1fec510698985ac53e96113e0b78a8b05949f811cf823d28077"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/aarch64/fedora-coreos-36.20220507.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/aarch64/fedora-coreos-36.20220507.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "4fdd80b0f094a288028efa7710abf3a7baace6cfe052f01ebccdfeb209d91705",
-                                "uncompressed-sha256": "552f64be056f568aa16a6af19781c3975a2d1367327067b29e241019eab1ec44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "3d541441001c5fa92acea6ae68a05e4676d435be3dbe53ee0570b4368b49bfac",
+                                "uncompressed-sha256": "2e20599af022fc7fb8c4837f068a80cb4e87f2d6035051d722fcd65ccda57938"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220507.1.0",
+                    "release": "36.20220522.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/aarch64/fedora-coreos-36.20220507.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/aarch64/fedora-coreos-36.20220507.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "8a684020e714a6169ab150ed69aecd7f8abfac5b18344290d135fc281f1a0488",
-                                "uncompressed-sha256": "0b3a2880f93abf6cbdb635c7a1b85e84dd1ed2e9421a2839e1b79cdc7cddbda4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "cd8214b3260d9fcc2a52ab75b2d3d1bed7fb5c01366a94d4c4041b4d6d85fa7d",
+                                "uncompressed-sha256": "3e9275f56138d2abce847c02e499655e88a98fe0cc21a59a6a3f366b062e7285"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220507.1.0",
+                    "release": "36.20220522.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/aarch64/fedora-coreos-36.20220507.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/aarch64/fedora-coreos-36.20220507.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "362e4f5334dd5e22044a8cfff6426abc030ac6353386ee62b945ea7ae4ed48cf",
-                                "uncompressed-sha256": "6b14976a2e18ebd9b0310a92952f98127be1fa5ea5f669885f1268be6af915e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "47f73c5e919350db6fe3270380ec6bd32a078dd2efd8e5d9a6c09b99014222de",
+                                "uncompressed-sha256": "b8c8173e51e9636ddebb72358e3b50f8f49fbf916914462aaedfc78055a20558"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-08848f322164721d3"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0021fdbe0be5a87fb"
                         },
                         "ap-east-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-02067795983da9750"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-02cf24a335872ab61"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-08188399d0f51420b"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-05541fca0db9fd56d"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-0f9a3549cfc0e472e"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0b802bb3b46d88125"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-0098569421dcd415c"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-06349160c1d3d52be"
                         },
                         "ap-south-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-0a11a4259849de3f6"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0861b34289c925e56"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-03e3cc4fd9140a47e"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-092e14bf9156eb32f"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-0aacc597634aed740"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-025bd42580fa4a6ce"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-0dd528caf0d73af3c"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0b0e2869312d10f8b"
                         },
                         "ca-central-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-0eff81a69f70d0284"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0882e17957f41f277"
                         },
                         "eu-central-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-0491e7a430ff91592"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0041b77ab02c3f1a6"
                         },
                         "eu-north-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-081d0d587701e4c1e"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0c0818c75d19ad29e"
                         },
                         "eu-south-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-040b2560eeef4ae67"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0a4098068ee467bfc"
                         },
                         "eu-west-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-062da22cf4740975f"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-05ffb5e2fb855cd85"
                         },
                         "eu-west-2": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-0023acd9b0e41d6ef"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0c9fe66819377bfff"
                         },
                         "eu-west-3": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-0ed1353edc9895189"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0f6329f838b09ad76"
                         },
                         "me-south-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-0fe1bfc4fe6179b54"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-09aae801088308fd9"
                         },
                         "sa-east-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-095c0bd62e9159de8"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0db0e1efe832acc8a"
                         },
                         "us-east-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-0736ce62e36169f0f"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0191032a78fec85b6"
                         },
                         "us-east-2": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-0d65a44b1313631e4"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0395228a146be9d06"
                         },
                         "us-west-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-051a6fd05fef7a296"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-03cc6025de2480739"
                         },
                         "us-west-2": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-0ae6fb35da69e47d7"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-06800c6e8968bbcd9"
                         }
                     }
                 }
@@ -190,226 +190,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220507.1.0",
+                    "release": "36.20220522.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "fc2f4becd3f1eae2119095a451cc6d7fd42bc295938836b8035d44ae8a8061f6",
-                                "uncompressed-sha256": "a3815c0d4f20436f53a8253c7e05ad14c8efb99dc884b93a2ad245ba0b41cab1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "1484401fa2932f02d7a836d55bbfba29592a08ce6f5c854cf4197d4c11aa1207",
+                                "uncompressed-sha256": "cdbee40fde0f1c6adf8c16d9134d1cbb4abd6e47a95dadcdff1fce1158c34979"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220507.1.0",
+                    "release": "36.20220522.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "b698b6f5188920841c51bfcc3255a0367d9f34d12b534576e9d2225f7151a6cb",
-                                "uncompressed-sha256": "76252bfd1e0e47f0a4adfc514a6312b81df69d846663589bf3c1a5a0d860cf62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "4abeb70f8efa844e4d3ba9692c1f9d4f9dd1b385a36035c8634730a637e657e2",
+                                "uncompressed-sha256": "0e212423ec53c182444ca118d9d736cc60ebe2fa0cb292b3d600ab16ff2bfb71"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220507.1.0",
+                    "release": "36.20220522.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "816d610c47ce39f0a08ef879dea0c7a9ef5a36cdc3b7867bfdc1a101c73235e7",
-                                "uncompressed-sha256": "5f9806d28cdbd99d24890b3450209bd7cd35c0d2e2fa8be1939682a342ce8ed8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "4e4ea7ebf9f28f72e24d61f5fb5c4a4a23feca4a43eb9b5b8de583efe25ecc33",
+                                "uncompressed-sha256": "9125f8a4ef9d5cbdc1edbed50a624660c8f4f135e8d8a472831d35bea28d5923"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220507.1.0",
+                    "release": "36.20220522.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "7174f30faa7b385a483b7ab6217215828d6a73c1733a32ca0da126f181f8e54b",
-                                "uncompressed-sha256": "87e25e6b0dded9c7de2b20afc2ff0a383f3a250b7330d9c5dc403c94989e4a38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "4d5748cf88b7bda449d1bf9c573899d0a0eee8c0c308a0fd1111126bf5909505",
+                                "uncompressed-sha256": "017fc032c1d9128a902c27824c4820f81e0464a1bce062b689b3cbbd34c38bdd"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220507.1.0",
+                    "release": "36.20220522.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "07d02afb9eb384c8849d550579e45642855044f0a8f5e56e2988efa70db874cb",
-                                "uncompressed-sha256": "a08887b3838597d16d951a2e223b4cde4e9feffb332a06b33b4e64591712b7ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "f21335ce121a143c6c8d46b0130d8c60a80b3a8b5d23171d682aba55cac0f1dd",
+                                "uncompressed-sha256": "da3526cb4067eebb103694685bdfd25e762134e9480d308d1d83a2e85b339ac9"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220507.1.0",
+                    "release": "36.20220522.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "aad1249e7c8a42586e3d8343f3b7b3712a3f08119bafed6b41e37a5ccfceb874",
-                                "uncompressed-sha256": "29a92f2798f49aae95c40f1c15292bb98b1090d4280ca7aaad91320aa8f8c03f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "714261915a2835d809de604e7f337308f883dab3c6dfc86b66bf6679234a56a3",
+                                "uncompressed-sha256": "d6867fd1927fc11cc5c7c07071f1d955d0f1b2ef23c4cac6c8139eee6729d225"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220507.1.0",
+                    "release": "36.20220522.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "c9a234f20babf88183a583f163e63ce1150b4b4c2bd19f5b1cd757ac035d5f13",
-                                "uncompressed-sha256": "9e773625240ee5e6504aa498e52df21f0b2728c4bcb570541b7eaa4beee1834c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "254f08e867821ea23f62394a7de5b8be7e48e9b405e40b29cbf3edd7ab452cd4",
+                                "uncompressed-sha256": "192e5c6bea54b6ffb15e98797f96b592caaaa691783d2a406a4676fd56bbf91f"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220507.1.0",
+                    "release": "36.20220522.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "6cbbf169b9cd59b7cef34f2be0fb04c6e4e9d91f96452e5ef3d4ca097ada04e4",
-                                "uncompressed-sha256": "b4234f81e503918fa9d4a8f623b6d58e2f6d68d968a1e266b00fcae04b705fc5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "310571d55b8f69e8906446c93ced7f8eb7fe8d0ab661bd9b33dcaf101a7e799b",
+                                "uncompressed-sha256": "4f0bb53d7dae99bf90934f6a67fdffa40ede3b88dc6f284fcf56a5d3f9e90960"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220507.1.0",
+                    "release": "36.20220522.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "5851a1b6d12fde81824fbf801f2c3afcbf3778246158218092a204839ab38a8f",
-                                "uncompressed-sha256": "bed32bf9577795737d113ecda554e96265e110f6cf613cc483d3fb8e1e33d411"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "bad558fb7e83829ae0a636ce0af6f1d6957b26326b6b3df5d493c9d20c54398c",
+                                "uncompressed-sha256": "72fe90cb555afe82ad268b995a7cb06f787ce241cc24591d05cb7d662d71b5c6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-live.x86_64.iso.sig",
-                                "sha256": "72ee5b1f7fe5fa9aa8c603ea04d938b5f5827b8ed1baa8c4d5e4c0bfbb3880fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-live.x86_64.iso.sig",
+                                "sha256": "f9fcf2217a8e130bd63b7a958ea93fb5249a381b8c8a896927b0584ba097a7c9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-live-kernel-x86_64.sig",
-                                "sha256": "f5d8162b1e086f1a9d09d3d2c6decdbec84d7020cde4b6f32a98f21eacc8cf3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-live-kernel-x86_64.sig",
+                                "sha256": "79d20c0b674d84569db5824091286497ca93793a3acce4dea02f5e06e3f61ada"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "4119bb6b0ddbb4b23d57ebc3ef34083633b5f0cd5c84f9f2787c855ed9d31211"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "35a24dccfbd380dce5f1c3a0c43a89e0b390db85d49f8c12f8cd270f8e816130"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "a7c4ce80aba34ac8c14d7f14490fd70459a32bbd947391a7f679b990b3ac2c56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "db123fcccde4ee411faf7f446c0416fccf2fba672b524772999ed43668d4948e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "91f918de35db779f9fcb50353fe0559b0be8cd3149e3afa8f8e40ef94ec658c6",
-                                "uncompressed-sha256": "821e7e4227ddd64f5d873f954462e0c20b6f490770f65363970a5558ad3a4af6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "a83431816f50734cc272fd6680467dbbbf1c1169886114871d45d1f92d88caed",
+                                "uncompressed-sha256": "ee53cd36eaf80b9a1fecd429b8f8795f36a3425c06408f877297e3e5f3e90e1c"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220507.1.0",
+                    "release": "36.20220522.1.0",
                     "formats": {
-                        "qcow2.xz": {
+                        "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "72dbbf0ec84715a06c4e74b78c276567d47a5f04fbe0083ea61961f8aa6fd9eb",
-                                "uncompressed-sha256": "116f582f0040e7b6b776eee474d2a1e8c21dd2a71257656ca1f1f3a40d6576e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "ea532e6414440923731692dd3a7ced583c15569be8d942dcb58ca7bda2bbe231"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220507.1.0",
+                    "release": "36.20220522.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "5d42f97e33723a5facc9840e6d0ab04febf7bf7b3b09b6020fa0ff010e7d3241",
-                                "uncompressed-sha256": "acf9e1e776037a6f98ced85738b445858544d2c645a2a6f05c64c4a79ea2e900"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "f5381dd21d0b6c0b9b7bc3e40f9b1ea222eb8e5d8e53f5effa98981122e72a1c",
+                                "uncompressed-sha256": "264184e80c6bc553aa32cdcc8f7f6027149e7093a1e026b07206ace5dfd60c3c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220507.1.0",
+                    "release": "36.20220522.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "d0109f31412bed58971b3b74c3306ebc5e09527ba042fadff7ba9ba2c117ef34",
-                                "uncompressed-sha256": "c067dcab85adf213e4664eb13c7ce26fe1e7d2fc6d2436a1676a01e555cf12bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "95ca23745ea9777157f80389486416731314b95fba985a3a761eba869d6085ec",
+                                "uncompressed-sha256": "05efbf276d92c445618af4b22616691486be106747ac4b48d265369fd80e125c"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220507.1.0",
+                    "release": "36.20220522.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "d01db036027d370e4ca006da73b1f63ef303b1bb505c6f2456eb4a235005088f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "8b77ab541849cd072e7c9a35e03a5709d3b9f59987d7c4bc52aa3d63f7940bc6"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220507.1.0",
+                    "release": "36.20220522.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "1377a1636938068ea9b63bf5b099e13485c312d34f8363ebc6e0b640b1f987b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "ddbe11856408f23c43a6697bfe2384c2d879485a64084bd59ecaee24f4e5ac3d"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220507.1.0",
+                    "release": "36.20220522.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220507.1.0/x86_64/fedora-coreos-36.20220507.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "45f4a91ea0636cf4e32da68b03c4c94532027930159bb01bec21cc12eed53b20",
-                                "uncompressed-sha256": "ae6a06fc4f06a145078b13ad37b3fbc9470e3e1282e978f26a8242317253d99f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "0b0bbd026e5ec1e48d9954e3a985fa8cba7479d502cb3a5b6b6377d3382342cc",
+                                "uncompressed-sha256": "5c08df5fe79e78af64a096ccb912f81264e3b4616320e808c6575e04f6a5bcdf"
                             }
                         }
                     }
@@ -419,100 +418,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-00f3525087c598733"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-040e10ebe8134641b"
                         },
                         "ap-east-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-00111d3ca10873b57"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-004ecacf2fc8ace8c"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-0ccdb80c5db9d38e5"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-04d41d3754226a63f"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-04cd91476eb2b9378"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-06e73e9918cc3ccdc"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-033d13441d36be632"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-04d241f317708cf50"
                         },
                         "ap-south-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-05db617a84cc370db"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0536c3e9009a40466"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-071bab237604ea663"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0af17b9b5f352d610"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-04a31b6df6f21812d"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-07e6623c8ea17de42"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-0ed43963bfcbaf5be"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0fb40f891981e3850"
                         },
                         "ca-central-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-097252ef0a70a4262"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0f457f933c18de28f"
                         },
                         "eu-central-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-05172812004ee163b"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0c5ce2c3a130a34a6"
                         },
                         "eu-north-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-0bb9ca77bb68a9f87"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0e757e97cbe6214e6"
                         },
                         "eu-south-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-05297ad8c5462826d"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0b1cbcab47b0bd5d6"
                         },
                         "eu-west-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-07357388d5e775c94"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0a9949c21a0a1b32d"
                         },
                         "eu-west-2": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-0cf899146f6955d3e"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0b799cd0a01e18fa5"
                         },
                         "eu-west-3": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-0ef7a6358ab30ec68"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-00e93065da9795438"
                         },
                         "me-south-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-0ed02dfb89f4c62b3"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-07d3f69751d24a6eb"
                         },
                         "sa-east-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-080f2a6dcd0d9fad3"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-05b2bb2abbe884ffc"
                         },
                         "us-east-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-02abb99a13a18f0c1"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-002d5487caff00999"
                         },
                         "us-east-2": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-04e20bed5ad2af0eb"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0229136edb10b77d8"
                         },
                         "us-west-1": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-0ceb8f4ec70adc7bd"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-05d5bd2b6e99c3f16"
                         },
                         "us-west-2": {
-                            "release": "36.20220507.1.0",
-                            "image": "ami-083e5b1cce35d8ead"
+                            "release": "36.20220522.1.0",
+                            "image": "ami-0e3324da59aa2e71b"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220507.1.0",
+                    "release": "36.20220522.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-36-20220507-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220522-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,92 +1,92 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-05-10T14:31:28Z",
+        "last-modified": "2022-05-24T22:56:36Z",
         "generator": "fedora-coreos-stream-generator v0.2.6"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "35.20220424.3.0",
+                    "release": "36.20220505.3.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/aarch64/fedora-coreos-35.20220424.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/aarch64/fedora-coreos-35.20220424.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "46c8e4fa534ff9ca80d3145ef35f3fdf598e394a425f310e3a9b96189ea9af10",
-                                "uncompressed-sha256": "31e1c766b6577995fab6ee044279563a91ea0cf0750ef76ecec1fa6fd03d2d41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "5330f886c69aebe3e195f61f693bb82c8d1def5809814811ebe7752ee76ef416",
+                                "uncompressed-sha256": "ef8fa8ee27ab20a47556ed1c325e58983a39ce9f5e35e5db11e788a4a484e625"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220424.3.0",
+                    "release": "36.20220505.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/aarch64/fedora-coreos-35.20220424.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/aarch64/fedora-coreos-35.20220424.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "11c7038eebe18fd88ee24fed908de97c8ebcea79b238a7dd2125d021413f5466",
-                                "uncompressed-sha256": "57a2396eda662b7789a8ca563a9818c3979ab7a6b6fe2b2084706bd8ea046f32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "ee072457cef4afb1f220cb32a3d44f2593ede2f525407ec7aec8aadc60171e47",
+                                "uncompressed-sha256": "7a5a9bf54b78f4f92d6e423c0a359afb36d2c1e2192b2c519199a2013b80ddab"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/aarch64/fedora-coreos-35.20220424.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/aarch64/fedora-coreos-35.20220424.3.0-live.aarch64.iso.sig",
-                                "sha256": "537141f70f691160d572dd6ce3d726f5e6b269c9a045ab5fa1469286c1c00f12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-live.aarch64.iso.sig",
+                                "sha256": "92c48bbf52ebedfa4052153ab1f04c88f10a39269731fcf97d9d64f962b40372"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/aarch64/fedora-coreos-35.20220424.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/aarch64/fedora-coreos-35.20220424.3.0-live-kernel-aarch64.sig",
-                                "sha256": "958b4de4e079dfbc0e72321fc3b56e345d3158801f33ae98d20ff8127c2b4567"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-live-kernel-aarch64.sig",
+                                "sha256": "6945ec2c3d5080fbe67ef64d757ee9ad4a95951e097a70e1cd159a80294a1cfa"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/aarch64/fedora-coreos-35.20220424.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/aarch64/fedora-coreos-35.20220424.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "aea054d16a6387667d6fdd2c4d101513d9b40cfd24e4928a58edff2b00c24151"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-live-initramfs.aarch64.img.sig",
+                                "sha256": "be0d1e89c9ccd46e53c6d9eee67dea113396e3131420f9a97db8ef62b8270efe"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/aarch64/fedora-coreos-35.20220424.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/aarch64/fedora-coreos-35.20220424.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "9cfd7e32fc25e5de89f0674d4ba490f011ac53a4b50b9b1b23e20bf74d76f241"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-live-rootfs.aarch64.img.sig",
+                                "sha256": "1344e0a3aed2e4bc42bc9e8ff6ef1900c7215397eaf3bba750241eda411ce4bb"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/aarch64/fedora-coreos-35.20220424.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/aarch64/fedora-coreos-35.20220424.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "755bdbcece0acad49edeb3591690cdc5721655399ba047a99d611d141d763dc1",
-                                "uncompressed-sha256": "fcdf830c617215f23378f2d14bb0d17fbc7c1e64d1062652546b08395e9280c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-metal.aarch64.raw.xz.sig",
+                                "sha256": "11e05f6e27e61066f0aa2948eb7348e8cdc83856464cd1f2c15f46e9feea4b79",
+                                "uncompressed-sha256": "3bde9d29df6ebec341020b4c58ecc2e2fb5a8a709e21dcf2bbfb906e14debfb7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220424.3.0",
+                    "release": "36.20220505.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/aarch64/fedora-coreos-35.20220424.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/aarch64/fedora-coreos-35.20220424.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "17a46af7cdc5b5f8086d7d1f6dad9ecbb7010c7fecd19a80f79ed711df4bb03b",
-                                "uncompressed-sha256": "7abf3718e54a116e61d59bdbce70fa12915665e554c5d26bbbc509101629b4bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c4cadc1a95f5587499c5491963d5fcc5b54b50f1c8b7156d61b9f0f3452140cc",
+                                "uncompressed-sha256": "c389b6add98d7630fc922badd4539abb72164fb428dacf85339ffab2333bfc09"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220424.3.0",
+                    "release": "36.20220505.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/aarch64/fedora-coreos-35.20220424.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/aarch64/fedora-coreos-35.20220424.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "4a15438460cc2a19eb0ceaf634355b3dc7196d1b1475c7be366d2f5e1a9efb3d",
-                                "uncompressed-sha256": "0dd70d203e7c9fee57e3dd6f10de92928a3264a860ecab107b242654edd66751"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "31a0bee6d223f3ba38a425b59065e980488b7e88c0be8f10f92f172044d6222f",
+                                "uncompressed-sha256": "b9e39f55d580d42ff5978abe3b93ce53af4879d686d478a96a009292e22d0777"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-06878f63398944be9"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-01b1d0b066117690d"
                         },
                         "ap-east-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-097c7aa682ffa62ce"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-0d299c3dc78a288cc"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-07a1d11c59a2f4ead"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-0eec55fa8f33d6b72"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0e0d01f1915fd86c0"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-028d829fe0207f27a"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0f81ad1801c255c39"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-0bf55f1448a8eb7c9"
                         },
                         "ap-south-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-088bb1be053156b05"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-0fbf642a8778e0bd6"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-03c05a188d20430c7"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-053dbac32defe4865"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-02c3fd450635be3f7"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-06127b2793105c860"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-041194cebb5c8b971"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-0f5f41f6460333af0"
                         },
                         "ca-central-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-003bc3978b2c6313f"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-018c2358e5948a697"
                         },
                         "eu-central-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-080cd831e71a697dc"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-0e4bc2122987dc252"
                         },
                         "eu-north-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0c67e95cdad1605a4"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-096e597d3605d5717"
                         },
                         "eu-south-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0cf1904cac2ba27c2"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-080538d32bbcddda8"
                         },
                         "eu-west-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0715aac11ed0ceb0d"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-0149fc735a0fbce00"
                         },
                         "eu-west-2": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-09f30842b5c05d9bd"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-0bdadc1ef29aa68ca"
                         },
                         "eu-west-3": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-02cee8053c9b76a00"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-06bc3c13ecea3f8cc"
                         },
                         "me-south-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0698fe155052bedad"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-0bbf9032294f10326"
                         },
                         "sa-east-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-01537c8cd02b3ff58"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-043224407b511a17d"
                         },
                         "us-east-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0560e1583a204b92b"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-05a917c9912b17037"
                         },
                         "us-east-2": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0ccff63b96ede63e2"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-02a8c1ce58c1c9425"
                         },
                         "us-west-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0ba281624d3e637d1"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-00940a76da53fba5d"
                         },
                         "us-west-2": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-079e48a3bfd0c3720"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-088d88c07ffac3dbc"
                         }
                     }
                 }
@@ -190,226 +190,226 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "35.20220424.3.0",
+                    "release": "36.20220505.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "f982c93819d11f65126147ebe3f4d71d2b85edfa51c5f162bc476f9391efbc15",
-                                "uncompressed-sha256": "c80b49b04585e30ef16305f8c3d277ff248eef71bcd29d39f630fe117e491518"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "35bfa27ff9fb595f4b58ca1496ea4adf9c791c57ee31012bab6ab93fb6d41c7b",
+                                "uncompressed-sha256": "db1abf566a0d82d9728652560a03f035c2b2b92831b9795f094bb3aa1efc2c37"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "35.20220424.3.0",
+                    "release": "36.20220505.3.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "59d7cdbd957e78735f2abad377e8c3c6be586d3c232eb82a62e0a29784f9aa32",
-                                "uncompressed-sha256": "493d76182d24bb892e0ad54e38aedab1550c55c540a4ee70744349023f09967b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "03c0f2bde12d6ecba65e86907605eed687ba309c28c21f234e687b1e55963ac4",
+                                "uncompressed-sha256": "405a594b9e22e0e6557264e9331b3845ddf37f6b1743a37337b38f5596373eff"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "35.20220424.3.0",
+                    "release": "36.20220505.3.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "0e505ed8043c9f980638a8f46ea516a78d0978b6408018d68e68f9db55e27db5",
-                                "uncompressed-sha256": "362180ceaecd64c4bbc7f811717a73b6168af6e01d72f247d0c4001882f48bc1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "cbf6560d0a2f392718c793981f3cf485f18f93e6a3ba9ae5f5994204825eafac",
+                                "uncompressed-sha256": "798d3e14740c712cee001fc6b04079799bd5c92dd151011b87adcbfd6d71b2e8"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "35.20220424.3.0",
+                    "release": "36.20220505.3.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "dbf0ba8017650ff7746c66044d91e8914b9de02c704760302c12f82742da7d67",
-                                "uncompressed-sha256": "d073fdfa2c12a7d017be01fa93c7bbd913da2827227d8f156881563343a4314a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "5fa32ec64f9e7b4415240fe6fd499b4f8a13c0391c9f5118bffccf42c0a409fd",
+                                "uncompressed-sha256": "8a1bb0fb315caf2ad273d24c391039c8655262844ab9c1f1c966d145e36ef69c"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "35.20220424.3.0",
+                    "release": "36.20220505.3.2",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "72dcc0b851903a18e1755ab9d54a120e0639196751f52c74bfd6da43c9861ca9",
-                                "uncompressed-sha256": "b8566c2d8d4bee1c2f68d8a89874b0adb74d87c092747efb497ec3bb07a322af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "27d4b21bad5f70d9b73503a09db24a25326eee46d15e0b99b483a34f419cdb07",
+                                "uncompressed-sha256": "86e594804acff988e5a93c395789c40d15393c74474050002c5aba0fe842a37c"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "35.20220424.3.0",
+                    "release": "36.20220505.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "9e4a3e9c2fac45ed19e7ceaa7742133abed763700b5995e92bc836a327167c34",
-                                "uncompressed-sha256": "ba2d4ce5a749784a1ac4b8b7910ec5eda4831606378af793080b21277f97a362"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "78f50c0fe64ee86e55d6f6a0ddc3445f89207fbbdded4a1b8b06155919aa203b",
+                                "uncompressed-sha256": "2e4fe6830e374e1d63f9bc737df317288775bb4c79788cc1350e70412db39d1b"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220424.3.0",
+                    "release": "36.20220505.3.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "43133197b6544cfd1ca665a308d55f04485f47c902a65a61a3c625303d7f4e12",
-                                "uncompressed-sha256": "356f41723a98bb30bfff4f8eed6bab1920e0c13d6d95a7053bee2b5a7fc4bbb1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "d7e4a1520dabb5e41f86579cf0e280b7af51f0f4e03f1456c904255d262696fd",
+                                "uncompressed-sha256": "d1b04487ba07e1ca1c723b64e63fe362305cd3881c9c03d94ad61643c74a91e2"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "35.20220424.3.0",
+                    "release": "36.20220505.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "27f593775bbbe50b0de5cd518c905e111e9b54d305e6df7e4ed3cdcb3d394ac1",
-                                "uncompressed-sha256": "cf353c680bf472fcc6871848487b41428d27615d88a09649ae2fc9159e304871"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "ebd06c1afb8babddc7dcb084a93e86a48283186c22a3c5b93011881f1ba535f5",
+                                "uncompressed-sha256": "19df5e54f7e24b75f49967c9b6d5e400c179d115030f6ea6667f4818d6ee6051"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "35.20220424.3.0",
+                    "release": "36.20220505.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "defb5797de00926a771210aa1cc1fea517af2c1088e5cb2d0cbf7f2df04c5d10",
-                                "uncompressed-sha256": "69532d6539bb749842b35c07da71934d8e9f5a585a2043d801587d3d6d0d806e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "2fa323241afe1516cb6e881f481d5a7659951645f94a746162c427c9c12b51cf",
+                                "uncompressed-sha256": "f3a38392a1294691bea9bf5dd64f7e0d2757320d693b20fb0403afa2654cd9ad"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-live.x86_64.iso.sig",
-                                "sha256": "0285040476e77baab4419514ab9f03f02a3ef965ae7ed6fa123df66465576a7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-live.x86_64.iso.sig",
+                                "sha256": "f74385486e671f499896eebe9f8236b7bc655d16adb90bd02a73d1892417ca68"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-live-kernel-x86_64.sig",
-                                "sha256": "ac0ee21103bf5c186181792eff7aedb123f5875967b5cdef85dd27c31901d583"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-live-kernel-x86_64.sig",
+                                "sha256": "f5d8162b1e086f1a9d09d3d2c6decdbec84d7020cde4b6f32a98f21eacc8cf3b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "d0e091121232aed1c436b818e285a1da7fdcaee92b34c2166dc5e3f344d6eb1f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "8c7564f3f60ad798f71b350a73587093b0c85c766644cc9c70cba258eed18ab4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "ca156c81c678a7a537ec68fc34187646f4893fd0e5747bb15b31b83b837c8b6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-live-rootfs.x86_64.img.sig",
+                                "sha256": "5d13f0d40d2774843eebd2b1ad1f10b16f207295663849515069ecb09cbfcf0b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "b2ec388082fe00ab8f165119bb6757e40e057468b8cba81a9b7efcb441e77f24",
-                                "uncompressed-sha256": "9f38cfaaaf2547214093f245f603cfd7681a6375ff4afce3686da118b47509e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "c5824077387bacec9a970087952d16840b5c4992cb6cedd5c6591592bcb4a687",
+                                "uncompressed-sha256": "c6c833872ce61d4f3bc6ae1e5ae07172c566f89d878a0e4e48993c11200ff3e8"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "35.20220424.3.0",
+                    "release": "36.20220505.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "48d608cbc41593fdf420d50d0a33b4aaa2c6e2b9728d61a1e2f22bd92dc82d69",
-                                "uncompressed-sha256": "9f3542b90596125356fcf7a3486014caf3b93ec555f528acf93e18f6ce4c5abf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "5ed799a381668cca722436ae7ab6d7a309ca89a801604a0e6915c7bcbeceae1e",
+                                "uncompressed-sha256": "7157c60d8a5bba1a5278ca60aebc7f718a6595077620f378ff9277c278274695"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "35.20220424.3.0",
+                    "release": "36.20220505.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "55e1741989ee38fb023528bfc9038f6362cae472aeb724add02309e47aa6acbd",
-                                "uncompressed-sha256": "4faef2a445c23b51f38111df619ee7e0ad4c63af799974523e407f204573a636"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "0c880eba7a431449446f447c3c57d2627ef1516682fd69613eb72211e3559a20",
+                                "uncompressed-sha256": "23954007c89ac0f6c6095bf4c62c26673e84aa53e818d32416859b28a0067174"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "35.20220424.3.0",
+                    "release": "36.20220505.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "8928558a1c48ef7e444d9fc630ea28938476af8c8f870d7b6cf873fec00ed1cc",
-                                "uncompressed-sha256": "578757bcddb1319f13505a93de9b489f3965b9479e196fe1fa54ce0df41b1579"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "671eb590785d4df35fc5548544a490428c2d8996383330b481292d392b3d7f4f",
+                                "uncompressed-sha256": "a8276b925dbd656422ba60ba49228290ed3c7b787a7e3ac74f4f9483b09302bc"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "35.20220424.3.0",
+                    "release": "36.20220505.3.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "8d2dcf55f81766ed636e6a982d69aef7480284cd75edda94b29f3a7f8e73887f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-virtualbox.x86_64.ova.sig",
+                                "sha256": "8291a35a2fdfa2deff9d087c7fc756a5ef8b5d83bad054523338eecbf77a0709"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "35.20220424.3.0",
+                    "release": "36.20220505.3.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "f961e24f4bac56c9bc5f0a344a5e366857e09a18a07146e9336f939bcd69a978"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-vmware.x86_64.ova.sig",
+                                "sha256": "5a06ad5b33f08ab7255968adcbfa49ac61c0b730445f09010c6a743dc4ae5cc7"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "35.20220424.3.0",
+                    "release": "36.20220505.3.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220424.3.0/x86_64/fedora-coreos-35.20220424.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "fd6efae8c854dbcdccb4209656e1bc783b76f96dda81f6e909d19a8fd1d8c6e0",
-                                "uncompressed-sha256": "d320295c0cd8bd431a76064643a9023ccb210de5b374bfcb03381d6bed033e83"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-vultr.x86_64.raw.xz.sig",
+                                "sha256": "7d44443fd22a31c6ad408a64b4810c77cac7acd9fe6edb839aa54e7d8a071539",
+                                "uncompressed-sha256": "1ef15d1b1d2d513d93751fc429de9643daa6bdc5bfa956847207f01c363ad086"
                             }
                         }
                     }
@@ -419,100 +419,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0f49b75af016edc95"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-05c3ba1beef237de7"
                         },
                         "ap-east-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-09a781e5254ecf749"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-094f490fce152e74f"
                         },
                         "ap-northeast-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-027dd522596e98491"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-02f5f3209859659e1"
                         },
                         "ap-northeast-2": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0d80f7755ffe90ff4"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-04ad3018c5cc1f985"
                         },
                         "ap-northeast-3": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0ce767054e074fa88"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-0fb0bcb60f18fffc5"
                         },
                         "ap-south-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0374054479d8042ac"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-0c8e34b54ce0a1c92"
                         },
                         "ap-southeast-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-003af922d00229cb3"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-037f749e113578eee"
                         },
                         "ap-southeast-2": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0369f0aa219e0ca43"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-0302cd3e0ca1d60f3"
                         },
                         "ap-southeast-3": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0a926ffa6657cbb62"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-017c7e667e42d3c49"
                         },
                         "ca-central-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-09e3055f18a494ae7"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-021713086fc803832"
                         },
                         "eu-central-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-008f90bcfbabb2434"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-057a5a4c8bb76983d"
                         },
                         "eu-north-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-078d4040784e59a02"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-0dc25790e29de2e4e"
                         },
                         "eu-south-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-06bc761baff5b3f68"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-02c8aca787ece768e"
                         },
                         "eu-west-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0fd5f74f0cb085393"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-06aa6e850cc72be1d"
                         },
                         "eu-west-2": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-01cda6a12035efcda"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-0b9864872ed58e8dc"
                         },
                         "eu-west-3": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0a49e388d7aabd75f"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-036e7cbc66d93b34a"
                         },
                         "me-south-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0911a4d21f23e2939"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-08aadd6aaf2306522"
                         },
                         "sa-east-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0a0ea3e20c324aad7"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-0e925cf98fd6a4cc9"
                         },
                         "us-east-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-04a183f7a13130882"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-09b2deb293bf2a1b8"
                         },
                         "us-east-2": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0e0df7a5a99b79e8c"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-02ce6d2d7012bd0af"
                         },
                         "us-west-1": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-05254bd86175b9023"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-038a4354904c74a1a"
                         },
                         "us-west-2": {
-                            "release": "35.20220424.3.0",
-                            "image": "ami-0c5f762c6fcaaaffd"
+                            "release": "36.20220505.3.2",
+                            "image": "ami-04b578d32ced44d80"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "35.20220424.3.0",
+                    "release": "36.20220505.3.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-35-20220424-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220505-3-2-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-05-10T13:48:40Z",
+        "last-modified": "2022-05-24T22:56:38Z",
         "generator": "fedora-coreos-stream-generator v0.2.6"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220505.2.0",
+                    "release": "36.20220522.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/aarch64/fedora-coreos-36.20220505.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/aarch64/fedora-coreos-36.20220505.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "8620b95b94c5006026cdf17562ca0cc1c457ea837e7c8b1a10821dee50696171",
-                                "uncompressed-sha256": "fa5e656179d984a039e5dc35704022bd5148777f4a1358f7957463d853411ac8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "f1f6f0b6caeecc6996708610c3f15d1cdc592d454e8775ed146975a9d9165683",
+                                "uncompressed-sha256": "97cc6cdcb3518dbc7a24ceee7d3c4764d3bddc1772331e1b452d6b5e5d92c2f0"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220505.2.0",
+                    "release": "36.20220522.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/aarch64/fedora-coreos-36.20220505.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/aarch64/fedora-coreos-36.20220505.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "c4844d7f033f198f4a95839b14f8c1e50892050ae244b9b41c4a420490cb7ed9",
-                                "uncompressed-sha256": "3a28a7aa554d43824b2b06adeb77445fcd94f1ff201332531975bb97bfb87d72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "788a191aedc4a50e2f039906a973fd5a259038717ce9198f88668393a582dae8",
+                                "uncompressed-sha256": "1e423e1ac31aa0986fb57e250de229cf080cdb72af34120a39eecee5d2905551"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/aarch64/fedora-coreos-36.20220505.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/aarch64/fedora-coreos-36.20220505.2.0-live.aarch64.iso.sig",
-                                "sha256": "787768053f9780c112f631381f130517b4bf47bcee559fe50c7f8d199adf7682"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-live.aarch64.iso.sig",
+                                "sha256": "a347b369198d258022cc75913c0154f7ed61a2c7781ed0a6868130c8d3882729"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/aarch64/fedora-coreos-36.20220505.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/aarch64/fedora-coreos-36.20220505.2.0-live-kernel-aarch64.sig",
-                                "sha256": "6945ec2c3d5080fbe67ef64d757ee9ad4a95951e097a70e1cd159a80294a1cfa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-live-kernel-aarch64.sig",
+                                "sha256": "b314a92e590176a5208b9237e53351cbd52f6b883a7aaaf5ddb99ad8bee5ceaa"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/aarch64/fedora-coreos-36.20220505.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/aarch64/fedora-coreos-36.20220505.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "abcb3d7bef6d8340f380e7ffa738f67b1fa84345d059fc437c2efbf55a135a6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "6cf74db5c47722e31d8bac0b0502528aa77910f1a48a8a107c05e49e6f0d054e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/aarch64/fedora-coreos-36.20220505.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/aarch64/fedora-coreos-36.20220505.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "1201b785e729df92c2625a9274c15d881c76a06bb04cf80c7425a7bed351a703"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "16e0560d5026b406bc6776fdd6e0705c3abf41374cc56366307143347f2bfd8d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/aarch64/fedora-coreos-36.20220505.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/aarch64/fedora-coreos-36.20220505.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "4753f32af9cc78561c1e881997bc21fecc26ce3efbbdb9328d190b4f81cb11f0",
-                                "uncompressed-sha256": "bc7bd81200e8402e7eb1e642bbf5d1dad444a1cff11e6209083e14768d4fa7c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "ada74ee8651c5538580f557b9a59d7b6db7cf9b90acf86e6b96ec23089be63b1",
+                                "uncompressed-sha256": "a10e8db9ad307018b01773e8afa3bf892942402d75291e54a176b459f6b14d4b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220505.2.0",
+                    "release": "36.20220522.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/aarch64/fedora-coreos-36.20220505.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/aarch64/fedora-coreos-36.20220505.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "29cbb578b2fabda7b933bbcec03c7a69d767c48d51808ba487e69fdfa655b0e7",
-                                "uncompressed-sha256": "1cd28e2707e8ffe9e3cef5de964d2765f076b8fd10b83e7bd7a4594fa634a369"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "0506130defca13d5faca25647a52f2aa44d3730ade27a4e03cbb174a121fbd43",
+                                "uncompressed-sha256": "362497b3034437a913213fccba8006a4a39dbd679772bf2324b7c61048043607"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220505.2.0",
+                    "release": "36.20220522.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/aarch64/fedora-coreos-36.20220505.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/aarch64/fedora-coreos-36.20220505.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "0b95c915806ea302c5fb177e0d4f7a3d777d0740099673097ea0d70e65ea9e1d",
-                                "uncompressed-sha256": "ae67b38a580b5de540ee7c1dea66f2fd47cad5b2ead2cd3e930c0a22d3d13845"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "80eb2b9c6fab7043d1bbcb75234dd6f0bc9f538a0ebee3e727859737503f501b",
+                                "uncompressed-sha256": "35b731287f687fbfdf736fa256122b2059bf70448fd543265d804abfa4ecb8ff"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0c190190d6325a84d"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-01152070628bc5a62"
                         },
                         "ap-east-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0ab5cd756dacb5847"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0400081aea91d5854"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-073980149399f51aa"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-036c758699343d67b"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-08e3a2afd79a9f8c9"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0802f67dd3c455415"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-02844c19c01000ad3"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-00ade86d05d97739c"
                         },
                         "ap-south-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-03392c8851bd98a20"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0e39fdb2c51594bb0"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0e4dea8f4d6ae51dc"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0e4e18c53c8e7bb8f"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-09a5af85776a9d150"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-08665b277c3303920"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-073a4a82297a68660"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-09e8bbd73d89ffe31"
                         },
                         "ca-central-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-08fa3bab02fcdc5cd"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-013a12a39ee382367"
                         },
                         "eu-central-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-07d453a69c558d0a3"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0bf219368d231ff1d"
                         },
                         "eu-north-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0d29a627f93fa5dd7"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0ba0909bde963071c"
                         },
                         "eu-south-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0910cf6a9db9787df"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-07ca2c1c2ca53c251"
                         },
                         "eu-west-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0835f8545410025cd"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0397628878c466cf3"
                         },
                         "eu-west-2": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0574536eeb0b903d9"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-080798452b5ea92d5"
                         },
                         "eu-west-3": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0ffcb730a17ffd428"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-013df61f3785130c4"
                         },
                         "me-south-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0f03ef30efa74d0b6"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0e9f20d1e063a83eb"
                         },
                         "sa-east-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0007d55e3b36d4dd1"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-05dad207f1e1db08d"
                         },
                         "us-east-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-09253652082332cd1"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0ac021147175c37af"
                         },
                         "us-east-2": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-00249b138c103354f"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0968057d320b8fd8a"
                         },
                         "us-west-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0c143a29f01fe8100"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0e4a43db9d6d987b5"
                         },
                         "us-west-2": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0290d0d26cc714880"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-09b4efe866ebf215e"
                         }
                     }
                 }
@@ -190,226 +190,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220505.2.0",
+                    "release": "36.20220522.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "c5a5a4f52a8b81e14b2af2b773bf699169ebfe1e57978b7f8d980c89895f67b5",
-                                "uncompressed-sha256": "c7b53997aaff122f99e8bac5e75bd939ffc81a847a7397b54e2c4cef97235dde"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "4628c5b816c602be72bf4b251e3b5d95514dbf9309d4f04f5dd0dd7830c72460",
+                                "uncompressed-sha256": "16877f31c1cdfea855984c53dcf41e59bd2a3a310fbe9f52313b7453fb32d30b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220505.2.0",
+                    "release": "36.20220522.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "830bc5d3bb1581cdf372140369371e520456a729f2a7bea7769af239203d710f",
-                                "uncompressed-sha256": "37db3994250afaab22b19199a543e1153e393bfad417f0c74a7a8d7c1c7d3df5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "29546caad2892bd952475490bdda2a766a5c5fe2406742c91f315c5c155ae24e",
+                                "uncompressed-sha256": "dfc1ab725836ffeb93a1e5823e4586ecd31e41b49d92f88c599f34da86c0e2e2"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220505.2.0",
+                    "release": "36.20220522.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "ff17feff99f8abaedb025d785dca293b28d0ff607c9ca77bebe49040c723c059",
-                                "uncompressed-sha256": "709257c84a997cc463f23dee6f72ac6e8ec54c492af97dd0f0b7ec58ad87f5c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "24999ea2f4b816472d3a285a0fe1eecb00777b22776c6fd103c3161a31bb638b",
+                                "uncompressed-sha256": "04a0bddbc2ba766a4f5e673bfbd83dff662d17608f3e1137b8a00cc9f2c6b389"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220505.2.0",
+                    "release": "36.20220522.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "6085dd36f492a8c18ab554a6070f8aff873d3dcba3d053b270ba8a47c997daca",
-                                "uncompressed-sha256": "05fe5fb42cefca9c0d1b3b8288282b331c8d63e7805d06f0416f69d04937c146"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "0bd6441bac862bbddd00650335c39f6b5e8a147428b0106e7d0afbad27b60f27",
+                                "uncompressed-sha256": "796f0bb6d660e36f13860b40cfb72ef350e0c9bd9f1cc73ef63b6a9bb02a477b"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220505.2.0",
+                    "release": "36.20220522.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c439bcaac47426047f8c672fc42b4da5f2f55e7a5ed70c4b3fceb1371ac781c0",
-                                "uncompressed-sha256": "814548ce1a6e4f3a493201fa8af5bfc2595c4c4667627dea585029eadb5d6007"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "f0bc2f29e688e2613f0d282eac11d610375c63c4c96ded9ee77f41a901d0b4e8",
+                                "uncompressed-sha256": "a2dbf2f631048a303b957dd6708a5d8c876fdfdaa2229592cb927f2c0cb28d55"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220505.2.0",
+                    "release": "36.20220522.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "82d1d0ff71819a9ca29cad0078da5c3091601cf43e31d15d868bcae9c489e97d",
-                                "uncompressed-sha256": "e44d7bf1d12677cec3747b6b994c96d7868e86df6341a2f0baa336ebccc283b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "8448e651ca927c73a8dcb6fb9338ff2f965129b7248196db51c8896c45977bbe",
+                                "uncompressed-sha256": "c181d84fb4bf963cbb43e33588e5a154d85874716b1c4bbd88ef03a6ac209790"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220505.2.0",
+                    "release": "36.20220522.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "d66d20330b185bbe3c357a81333434aa9a502724d3f4c2f8dfce955358e4fd53",
-                                "uncompressed-sha256": "12bb2599fc6b85ecd00113a87e24f4991480a0833af8e4a43d5fd7e3b37104d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "caeba304fb7cfbdfa2df4148f0ea80116c00dcb636ccc5da118ccf86a620a2e5",
+                                "uncompressed-sha256": "8cc08de93df7474fa6b834a86f0e948a29b0208f741b4048e39830e19dcf0a34"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220505.2.0",
+                    "release": "36.20220522.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "f0b95b2237d9bac60240d73537ddd590f486bd638ec38fb0808c3849b0b74d82",
-                                "uncompressed-sha256": "3bd12670055dc4c7d78531be2d6deaaddadefe514152cf8c75fe15872eb0051b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "57ea0ec95b7a635d8928904178b2086b9a7e79ea42e082a233cd69e08027f0c9",
+                                "uncompressed-sha256": "6ae664e43b3c1358e55b9f1311ccb838ede5420f368e1aae772add753dec2341"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220505.2.0",
+                    "release": "36.20220522.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "62a196bf858f89955b7fe983069360e2db3600ee951bee30d5c2d7fc148fbcf9",
-                                "uncompressed-sha256": "49ef9e8dd64307fe083b9cd1745e7375e8b707f95e71985608295f1f63561ec0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "467831355cb5a2630937e80172b2ad98bb6ac4954994a88ad91ded9d157f5e96",
+                                "uncompressed-sha256": "242e19f447d314c93035f04e9a4fc1d5597a01868ad1693f006f8b7fa8e65431"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-live.x86_64.iso.sig",
-                                "sha256": "1cd5a690cbf0e2224daec00d3c54ae9aa1fe55faf59d93cb1a4530a3ce3cb91e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-live.x86_64.iso.sig",
+                                "sha256": "5f0ebe721636b990ac5c9cd7133512903e2c0a57c87b389a4b31124e52320284"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-live-kernel-x86_64.sig",
-                                "sha256": "f5d8162b1e086f1a9d09d3d2c6decdbec84d7020cde4b6f32a98f21eacc8cf3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-live-kernel-x86_64.sig",
+                                "sha256": "79d20c0b674d84569db5824091286497ca93793a3acce4dea02f5e06e3f61ada"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "b26301cc20acd3ae49694bbc11d96839bc30b5fea0edc429b85505d55416d957"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "b3ee043f70f457e0d8e08ecdb57a8f3fb98b1ad5e36a95b53afc363715332946"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "77e23a124857b0cb122dc7358fd4b17873939047c717c1be4bac9cd1f429ffc7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "177c45f4f49d9c2bebb33575b5ec0e113b32af098df486d19e4e4a7107ba2556"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "718207e87ecee669ceafe4ab09652502aad6495ce74ff8868ea20ad095da5331",
-                                "uncompressed-sha256": "b36c98e6c3b746dcf5eac5cc716a24fb49d6de327178a6561fe86ae39318faf4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "515dd9f506ec50919022a60e87fadb15de3ae02f4641a0a4995320812366ba0a",
+                                "uncompressed-sha256": "1cfcadccda9c39342cef8464bc044b545b884204c5d3df314adebfbde8888871"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220505.2.0",
+                    "release": "36.20220522.2.1",
                     "formats": {
-                        "qcow2.xz": {
+                        "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "ebd951bb93a7199ac2df57cb20d65d89a8db8ffef52bebafaa82f109275c8ff6",
-                                "uncompressed-sha256": "b5cd1000c6cd6213583c8a89209eace83b5255685355ecf3b9d18d54efd6b3cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "0f3f79f8c00fdb87c624b5d9525625a788381f39dda58ee25c492ad35b1a3add"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220505.2.0",
+                    "release": "36.20220522.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "400b45439602e45afbb9cf4d6ea09edd0cc917d5e25ce65f4e57dcdb26558816",
-                                "uncompressed-sha256": "dbe0c654cd7b3861d1d590ea9fa4fa701481e4f61b929b403c1b93e1d3b90aba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "f2c1a9a077d6296b7070dc388fcec384cf6c9bebba0d0539cbfc12349467e797",
+                                "uncompressed-sha256": "0118d100b6d34a37a5112fa2f519f4b1fb46b2700ee2de6a59b4fe5832d50a35"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220505.2.0",
+                    "release": "36.20220522.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "644f8f9f12762fb186f56c75f4a7c658aaa113d9199f10246eaff9a10b9b5195",
-                                "uncompressed-sha256": "852db62c34246beb5976d78fde4b7b43bee03f38622fb334e9975949a982d0df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "556625320d93e518890eaca4d0e07457e17f6dc87581cd9e9d321a6c68827404",
+                                "uncompressed-sha256": "ce9e59447f1c90315cba6251c4aee30bd097f3e0944505629a4b8fcda9a05abd"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220505.2.0",
+                    "release": "36.20220522.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "ba53337a94cfbe227565c729ce4b85cec20e982bf85e5962b7ace4c21e09ea8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "9003f67e73f0e900737be87af3161df000144a541fa20c7a0936db2463d7345a"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220505.2.0",
+                    "release": "36.20220522.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "bf9794b64204a0c73333b9e6d8b40e7af69c3e3ca261eeae0deab7199a890a5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "f994f7f7f0592aa9c5eaaa0a0e28ac09962cd489c489f7c05885aec13f8d6502"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220505.2.0",
+                    "release": "36.20220522.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220505.2.0/x86_64/fedora-coreos-36.20220505.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "de409c9de8acad2eef5f70689d9369a12bd91b9f27c5c6555410f5bf0a8712d8",
-                                "uncompressed-sha256": "0320b8374f5b1c4152eb764eda4ad12564c0cc4b020751cccb2a046689c59e1c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "51f9a6b0d893b823c38ed464ae31df9284b8b82a82eb019034e6f5c4f138f0d1",
+                                "uncompressed-sha256": "b89093283a3d9d8cd3474dc820493c5123531ed5a0759d1cb29b1a493f55ac4c"
                             }
                         }
                     }
@@ -419,100 +418,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0ba9984ec06937990"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-09df2debbc02aef1a"
                         },
                         "ap-east-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0cd50499bc0230b86"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-04f01b0d50fc0587f"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0185a0fb78826c01d"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-01369189b59beaebd"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0a1e1e45f6ac2cac9"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0f00ab05de5888e57"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0d5f7571449e2d0e5"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-08727398f81e042fb"
                         },
                         "ap-south-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-01121a904e9bfe0bd"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0939f3a599d172f0f"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-09173d0503afc2f8b"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0684fb773610bc5d4"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-08f2a016116ea672c"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0064e835b289af64a"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-018a0373ea0f71938"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0d0ff531999474c8d"
                         },
                         "ca-central-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0daaf2774023fadb9"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-024e350359384d436"
                         },
                         "eu-central-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0f26a4dc463f80f26"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0fc686bcef761d0bf"
                         },
                         "eu-north-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-084e66de274a25235"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0ef89757d6c8799ad"
                         },
                         "eu-south-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-088d418b1b0ead6aa"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-052ad3e491d9a910a"
                         },
                         "eu-west-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0d30c298630b685f7"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-04f236cbe1eacccb2"
                         },
                         "eu-west-2": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-098907d689c5b0309"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0b00e48880130a29f"
                         },
                         "eu-west-3": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0f08210bf891353ec"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-08413e074e1aecaa1"
                         },
                         "me-south-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0f5db8aaca08580a7"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-050f096d2b21062df"
                         },
                         "sa-east-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0e19bf049fd110c8b"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0ab97f3b7bdbe461c"
                         },
                         "us-east-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-09a12ee09a55ab989"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-01850c51dfbac8f7d"
                         },
                         "us-east-2": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0fcd8d937f35489a2"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0dcbc82e1b7dd715a"
                         },
                         "us-west-1": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0f46b6ee06ec9518a"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0a91ffa349b4d1007"
                         },
                         "us-west-2": {
-                            "release": "36.20220505.2.0",
-                            "image": "ami-0e1a6047c28a0c5c5"
+                            "release": "36.20220522.2.1",
+                            "image": "ami-0a8b67a9a8221542b"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220505.2.0",
+                    "release": "36.20220522.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-36-20220505-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220522-2-1-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-05-10T15:44:06Z"
+    "last-modified": "2022-05-24T22:56:40Z"
   },
   "releases": [
     {
@@ -53,7 +53,7 @@
       }
     },
     {
-      "version": "36.20220505.1.0",
+      "version": "36.20220507.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -61,11 +61,11 @@
       }
     },
     {
-      "version": "36.20220507.1.0",
+      "version": "36.20220522.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1652198400,
+          "start_epoch": 1653487200,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -67,6 +67,9 @@
           "duration_minutes": 2880,
           "start_epoch": 1653487200,
           "start_percentage": 0.0
+        },
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-05-10T15:42:59Z"
+    "last-modified": "2022-05-24T22:56:37Z"
   },
   "releases": [
     {
@@ -53,7 +53,7 @@
       }
     },
     {
-      "version": "35.20220410.3.1",
+      "version": "35.20220424.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -61,11 +61,11 @@
       }
     },
     {
-      "version": "35.20220424.3.0",
+      "version": "36.20220505.3.2",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1652198400,
+          "start_epoch": 1653487200,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-05-10T15:39:52Z"
+    "last-modified": "2022-05-24T22:56:38Z"
   },
   "releases": [
     {
@@ -69,23 +69,23 @@
       }
     },
     {
-      "version": "35.20220424.2.0",
+      "version": "36.20220505.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        },
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     },
     {
-      "version": "36.20220505.2.0",
+      "version": "36.20220522.2.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1652198400,
+          "start_epoch": 1653487200,
           "start_percentage": 0.0
-        },
-        "barrier": {
-          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     }


### PR DESCRIPTION
Requested by @saqibali-2k via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).