### PR TITLE
Roll out stable 36.20220522.3.0, testing 36.20220605.2.0, next 36.20220605.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-05-24T22:56:39Z",
+        "last-modified": "2022-06-07T15:35:59Z",
         "generator": "fedora-coreos-stream-generator v0.2.6"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220522.1.0",
+                    "release": "36.20220605.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "bebb238be160f5eeaedb1e00275125ad4544e45c78633861ec276d085337f654",
-                                "uncompressed-sha256": "e7d3b1ccdbf1f0c9b2c8af0fa5d4480c7e784e82b9d76a81dfecfda39aed3ea4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "e52f8a97b795b2cba4d059e50e9dd9ea587a763691a440665472e1e270c4b8d7",
+                                "uncompressed-sha256": "2235819f17eb2a82ef8c7aacab9c6dfd904b24572c904c8b7d064efd31a9f677"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220522.1.0",
+                    "release": "36.20220605.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "df58c84febc620d82f468a1b5bcb860239410afff6475b80c5d9ccfc0a4b369c",
-                                "uncompressed-sha256": "c5d4a621b34106fbdeb196a93d0cfd73ce4c001202f7c4a642c721cacdf983d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "3c1cdaf2233200e6a76dead62260f03d1f244303f86bdc2e1f7896a7736acae3",
+                                "uncompressed-sha256": "2a19d545027b4b8c65d61f381cca8d0b4b057978011af469d79343529c890727"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-live.aarch64.iso.sig",
-                                "sha256": "97f198e36aaa68a5bb023dbd1ef3c0bdd726ed93fcb64489649fa266a5f273d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-live.aarch64.iso.sig",
+                                "sha256": "9117c713c1e8e2513baee556ffe93120d214586a7744ae528d0280a9eee1b7fb"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-live-kernel-aarch64.sig",
-                                "sha256": "b314a92e590176a5208b9237e53351cbd52f6b883a7aaaf5ddb99ad8bee5ceaa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-live-kernel-aarch64.sig",
+                                "sha256": "d43703f0f6eefa6ebc26dde5fde0252da632a847392904d5e2348dc215ce6fb4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "e2b931ee8968d64f6df8b51c4e3665c853215c189b0f5dc33503f9677cf75ae1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "0815b6876941f0f2ace8d1c48f7f9d13576f8b04670e556ede1052b6db1cd20a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "22e928b81b28e1fec510698985ac53e96113e0b78a8b05949f811cf823d28077"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "5fa873d1dd7f090db611d20ef371d38b13284d2ee82cdbf5c6b762bd3ace10a0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "3d541441001c5fa92acea6ae68a05e4676d435be3dbe53ee0570b4368b49bfac",
-                                "uncompressed-sha256": "2e20599af022fc7fb8c4837f068a80cb4e87f2d6035051d722fcd65ccda57938"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "04f42469242bda918f88a532329941c1fe9c7162296211ef05b64ac7f342b70c",
+                                "uncompressed-sha256": "c660db5d04cac22f5468e490fb9749b5da84f7ef16311d34ff1cddd4f376107d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220522.1.0",
+                    "release": "36.20220605.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "cd8214b3260d9fcc2a52ab75b2d3d1bed7fb5c01366a94d4c4041b4d6d85fa7d",
-                                "uncompressed-sha256": "3e9275f56138d2abce847c02e499655e88a98fe0cc21a59a6a3f366b062e7285"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c24792c61a34177c9b76b02b616446c97d89708a70bd69b236b07fc1a6bac9c2",
+                                "uncompressed-sha256": "731f75fdd19e366b8837b8fa2a0db70200e60c0f4cbee3cb41f68dc4fd2032ac"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220522.1.0",
+                    "release": "36.20220605.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/aarch64/fedora-coreos-36.20220522.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "47f73c5e919350db6fe3270380ec6bd32a078dd2efd8e5d9a6c09b99014222de",
-                                "uncompressed-sha256": "b8c8173e51e9636ddebb72358e3b50f8f49fbf916914462aaedfc78055a20558"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "8bf5a238220ec9addcb372502f2d0abfd4999546fbc0e2763d6033ac1355d6bf",
+                                "uncompressed-sha256": "4624492d41a3f51dd6d9f1a9654ba9b4b34fb2573d10860b028e0cd0ba5dfb06"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0021fdbe0be5a87fb"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-00458f8ae3242760b"
                         },
                         "ap-east-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-02cf24a335872ab61"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-01052e85309435952"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-05541fca0db9fd56d"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-043f399cc632a3102"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0b802bb3b46d88125"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-01934f011180f7bc8"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-06349160c1d3d52be"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-0a0fc2c916072a05c"
                         },
                         "ap-south-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0861b34289c925e56"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-0aebb271044241fa1"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-092e14bf9156eb32f"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-033eb902549e00ced"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-025bd42580fa4a6ce"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-024d04671b6184dca"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0b0e2869312d10f8b"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-0b26343fda75f4b51"
                         },
                         "ca-central-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0882e17957f41f277"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-034ce744e5c34f09e"
                         },
                         "eu-central-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0041b77ab02c3f1a6"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-051dabfe3eecc1d26"
                         },
                         "eu-north-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0c0818c75d19ad29e"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-012be854a23ac486e"
                         },
                         "eu-south-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0a4098068ee467bfc"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-03e878b9883c2abe6"
                         },
                         "eu-west-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-05ffb5e2fb855cd85"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-02c698b71efe531cf"
                         },
                         "eu-west-2": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0c9fe66819377bfff"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-0db7eb5671dde1b74"
                         },
                         "eu-west-3": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0f6329f838b09ad76"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-025ec1d4cc6ca1db8"
                         },
                         "me-south-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-09aae801088308fd9"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-048384e4394aed1e7"
                         },
                         "sa-east-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0db0e1efe832acc8a"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-05eb9be2774060c68"
                         },
                         "us-east-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0191032a78fec85b6"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-028c202655efbd62e"
                         },
                         "us-east-2": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0395228a146be9d06"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-07e72b651dcdc1dc7"
                         },
                         "us-west-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-03cc6025de2480739"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-095e25b6481ae6a4d"
                         },
                         "us-west-2": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-06800c6e8968bbcd9"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-010b570919e53a810"
                         }
                     }
                 }
@@ -190,225 +190,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220522.1.0",
+                    "release": "36.20220605.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "1484401fa2932f02d7a836d55bbfba29592a08ce6f5c854cf4197d4c11aa1207",
-                                "uncompressed-sha256": "cdbee40fde0f1c6adf8c16d9134d1cbb4abd6e47a95dadcdff1fce1158c34979"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8a414bc4de707d09728ba62910a6e74ec946176397c669984e8d687749c67cab",
+                                "uncompressed-sha256": "97bac2c400c08c2a0bca7dca6e66fba9e454eb15fd60808b7e8052fb78f44fb1"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220522.1.0",
+                    "release": "36.20220605.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "4abeb70f8efa844e4d3ba9692c1f9d4f9dd1b385a36035c8634730a637e657e2",
-                                "uncompressed-sha256": "0e212423ec53c182444ca118d9d736cc60ebe2fa0cb292b3d600ab16ff2bfb71"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "66dd102a9702b58714adf4971e11fab042f4ba26b35381af928f7fadaaab3753",
+                                "uncompressed-sha256": "513a132f4be735219a90ff4f5da80245372234bc97988fc944dc317e47677ba7"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220522.1.0",
+                    "release": "36.20220605.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "4e4ea7ebf9f28f72e24d61f5fb5c4a4a23feca4a43eb9b5b8de583efe25ecc33",
-                                "uncompressed-sha256": "9125f8a4ef9d5cbdc1edbed50a624660c8f4f135e8d8a472831d35bea28d5923"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "939f0717482992d31649986b1b9397ac0fe16007bfa3b3ff34666bf32a9e85e8",
+                                "uncompressed-sha256": "da72fcce720531743464860bdf12582c730ac870748ac5880b203dc83eb79baa"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220522.1.0",
+                    "release": "36.20220605.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "4d5748cf88b7bda449d1bf9c573899d0a0eee8c0c308a0fd1111126bf5909505",
-                                "uncompressed-sha256": "017fc032c1d9128a902c27824c4820f81e0464a1bce062b689b3cbbd34c38bdd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "cddc1af5ac838a40e5842c420deef640122d61753117d40d3a4031a3fdfbd615",
+                                "uncompressed-sha256": "3642fb237f7c3ce47d08832a9ff0a4c8e2525f9291e66e29d941357bf739a706"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220522.1.0",
+                    "release": "36.20220605.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "f21335ce121a143c6c8d46b0130d8c60a80b3a8b5d23171d682aba55cac0f1dd",
-                                "uncompressed-sha256": "da3526cb4067eebb103694685bdfd25e762134e9480d308d1d83a2e85b339ac9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "f1d43c07d313584a2f6a5431dcfc2b0ce1bcae52a147d8cb284e8687d789c063",
+                                "uncompressed-sha256": "cac6e2af0e9189ed989e8c81bbecefa571b132a03d11a0e07e7e76ef1ebcf631"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220522.1.0",
+                    "release": "36.20220605.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "714261915a2835d809de604e7f337308f883dab3c6dfc86b66bf6679234a56a3",
-                                "uncompressed-sha256": "d6867fd1927fc11cc5c7c07071f1d955d0f1b2ef23c4cac6c8139eee6729d225"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "042d7d69ebeccc53600d152be09fe368492c5e5cad5c830cac5e1f51bee178e4",
+                                "uncompressed-sha256": "1ec15005c4d7b16b85b0d11620b52a5ed7c44788fb0194463156ff91d6f0f49f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220522.1.0",
+                    "release": "36.20220605.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "254f08e867821ea23f62394a7de5b8be7e48e9b405e40b29cbf3edd7ab452cd4",
-                                "uncompressed-sha256": "192e5c6bea54b6ffb15e98797f96b592caaaa691783d2a406a4676fd56bbf91f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "745a08588afdeadc707e1b21ba33a6afcec2be095238b5a10abfd0944d0da706",
+                                "uncompressed-sha256": "a6a65f30645b6c80633d47575452642820bb6f112af792db5e44d85b087ad6bd"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220522.1.0",
+                    "release": "36.20220605.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "310571d55b8f69e8906446c93ced7f8eb7fe8d0ab661bd9b33dcaf101a7e799b",
-                                "uncompressed-sha256": "4f0bb53d7dae99bf90934f6a67fdffa40ede3b88dc6f284fcf56a5d3f9e90960"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "c42a3537f4064e00d154d70b2d78a491b841f3a383e4397c5f895abe4310a41d",
+                                "uncompressed-sha256": "346602694ef61e157572cd19739443eeea9a651dd4dfdb30c05a47587e2f5db9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220522.1.0",
+                    "release": "36.20220605.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "bad558fb7e83829ae0a636ce0af6f1d6957b26326b6b3df5d493c9d20c54398c",
-                                "uncompressed-sha256": "72fe90cb555afe82ad268b995a7cb06f787ce241cc24591d05cb7d662d71b5c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "4219e3d16b6fd69b98a70f1c61952b37897d1be62ebe82244b6d30dc204099b3",
+                                "uncompressed-sha256": "0cbb609677c60716aa03b0cb561c4f4f1db52b7f38d608da5bf2554d127b923a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-live.x86_64.iso.sig",
-                                "sha256": "f9fcf2217a8e130bd63b7a958ea93fb5249a381b8c8a896927b0584ba097a7c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-live.x86_64.iso.sig",
+                                "sha256": "f7c94e20257c75c8fed9100cbef2d3d66c79165e2fc48a9cb94659d20fbf56d9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-live-kernel-x86_64.sig",
-                                "sha256": "79d20c0b674d84569db5824091286497ca93793a3acce4dea02f5e06e3f61ada"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-live-kernel-x86_64.sig",
+                                "sha256": "ac47aa3d1a21b5665f885f3c85c9b3b9d4bca6f7dd94c38c016f10c735b48d0e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "35a24dccfbd380dce5f1c3a0c43a89e0b390db85d49f8c12f8cd270f8e816130"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "87d1c724067b77745e0ab8d744f2155820735ee21708061b51c37cb48e7483e4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "db123fcccde4ee411faf7f446c0416fccf2fba672b524772999ed43668d4948e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "b6b385531ec2ad7a57814d280cd797ab6e72ef7f9c2fa7ab10433ef3c1067413"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "a83431816f50734cc272fd6680467dbbbf1c1169886114871d45d1f92d88caed",
-                                "uncompressed-sha256": "ee53cd36eaf80b9a1fecd429b8f8795f36a3425c06408f877297e3e5f3e90e1c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "dd45262bed79a99113995cb8ca926b5b791db7acaf72dd1f4df17b60b590df72",
+                                "uncompressed-sha256": "177fb4efa5445e2cac4c6f1f44927c5066ddb7b1ac6907e65a7f085214e7153f"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220522.1.0",
+                    "release": "36.20220605.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "ea532e6414440923731692dd3a7ced583c15569be8d942dcb58ca7bda2bbe231"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "6b69a11b0e1a5355ece5a8ff06b667696028dabb33d5faecb96124e0b5232a7c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220522.1.0",
+                    "release": "36.20220605.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "f5381dd21d0b6c0b9b7bc3e40f9b1ea222eb8e5d8e53f5effa98981122e72a1c",
-                                "uncompressed-sha256": "264184e80c6bc553aa32cdcc8f7f6027149e7093a1e026b07206ace5dfd60c3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "07af79be24a7c6c33c1752b88474afbb004ef99d29e4d02e5f87c03f52c685bd",
+                                "uncompressed-sha256": "d6d8c6681e75bb159fc345301463d8d54cfbc36b113ca38e8a3f9ca8551b8d9a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220522.1.0",
+                    "release": "36.20220605.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "95ca23745ea9777157f80389486416731314b95fba985a3a761eba869d6085ec",
-                                "uncompressed-sha256": "05efbf276d92c445618af4b22616691486be106747ac4b48d265369fd80e125c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "1768e0d277391388d90e0c283992e6ba23e46b9dd8d6f818d2c33ab6fe852c75",
+                                "uncompressed-sha256": "85bd5392902a705878aa36573d67b0c75023a5d349b47c1bfe7d2c8eca7fd9ce"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220522.1.0",
+                    "release": "36.20220605.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "8b77ab541849cd072e7c9a35e03a5709d3b9f59987d7c4bc52aa3d63f7940bc6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "b095a7346ad2670426b97d226b33400f5578b0fecfe5893732df5b275d651d92"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220522.1.0",
+                    "release": "36.20220605.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "ddbe11856408f23c43a6697bfe2384c2d879485a64084bd59ecaee24f4e5ac3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "fe2d4437946d7c30ad0a61195b83a242230daf2beb778ba321c4e13f4b23ae56"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220522.1.0",
+                    "release": "36.20220605.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220522.1.0/x86_64/fedora-coreos-36.20220522.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "0b0bbd026e5ec1e48d9954e3a985fa8cba7479d502cb3a5b6b6377d3382342cc",
-                                "uncompressed-sha256": "5c08df5fe79e78af64a096ccb912f81264e3b4616320e808c6575e04f6a5bcdf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "a5e5e7e6d110dd50ef782a092427941b828bee51050a9057745e65e2f2ae01e3",
+                                "uncompressed-sha256": "74f3af3b6e4bcedd836b8762ce8296a6970ee653c100a81679b0ebfad23fa29b"
                             }
                         }
                     }
@@ -418,100 +418,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-040e10ebe8134641b"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-023c702fa29d1bb55"
                         },
                         "ap-east-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-004ecacf2fc8ace8c"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-03e2b791902c49e06"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-04d41d3754226a63f"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-0deea70de773791d1"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-06e73e9918cc3ccdc"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-0c1407c844dc18679"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-04d241f317708cf50"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-0984e5726e4a71611"
                         },
                         "ap-south-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0536c3e9009a40466"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-0af6d40140668710f"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0af17b9b5f352d610"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-0be7134e02b24ece1"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-07e6623c8ea17de42"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-0228e34694e7332c3"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0fb40f891981e3850"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-0a7b8dbba305fb646"
                         },
                         "ca-central-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0f457f933c18de28f"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-0a5b4aa4622f4b059"
                         },
                         "eu-central-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0c5ce2c3a130a34a6"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-0f1ba394bf4d39b37"
                         },
                         "eu-north-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0e757e97cbe6214e6"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-0e938a1cab6d5a334"
                         },
                         "eu-south-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0b1cbcab47b0bd5d6"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-0834e45f552c1eb89"
                         },
                         "eu-west-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0a9949c21a0a1b32d"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-01b1a86214cbdb4d3"
                         },
                         "eu-west-2": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0b799cd0a01e18fa5"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-085567153c9286f1f"
                         },
                         "eu-west-3": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-00e93065da9795438"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-0993b09a6857f4806"
                         },
                         "me-south-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-07d3f69751d24a6eb"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-0c713189d80919b38"
                         },
                         "sa-east-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-05b2bb2abbe884ffc"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-09b4bdf651a4b970c"
                         },
                         "us-east-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-002d5487caff00999"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-0a6808ab884675298"
                         },
                         "us-east-2": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0229136edb10b77d8"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-0f92beb45038c23db"
                         },
                         "us-west-1": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-05d5bd2b6e99c3f16"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-051788604a6ff3c75"
                         },
                         "us-west-2": {
-                            "release": "36.20220522.1.0",
-                            "image": "ami-0e3324da59aa2e71b"
+                            "release": "36.20220605.1.0",
+                            "image": "ami-0345e8928ab4e49d7"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220522.1.0",
+                    "release": "36.20220605.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-36-20220522-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220605-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,92 +1,92 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-05-24T22:56:36Z",
+        "last-modified": "2022-06-07T15:35:56Z",
         "generator": "fedora-coreos-stream-generator v0.2.6"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220505.3.2",
+                    "release": "36.20220522.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "5330f886c69aebe3e195f61f693bb82c8d1def5809814811ebe7752ee76ef416",
-                                "uncompressed-sha256": "ef8fa8ee27ab20a47556ed1c325e58983a39ce9f5e35e5db11e788a4a484e625"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "dc05efe5448a59070ab5adf2741a574cfb6604a0187239f7bbb95b525c177b18",
+                                "uncompressed-sha256": "c8982e9e50e99dc38c0aeed93726f33940e2ae8102da50b7bb03438e497f18ca"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220505.3.2",
+                    "release": "36.20220522.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "ee072457cef4afb1f220cb32a3d44f2593ede2f525407ec7aec8aadc60171e47",
-                                "uncompressed-sha256": "7a5a9bf54b78f4f92d6e423c0a359afb36d2c1e2192b2c519199a2013b80ddab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "d7e62e3c5b92a0c6f63f4a07cb1d9b4ae81dd1dfb3ebcf7902c8b187f86516fb",
+                                "uncompressed-sha256": "38dc3b8f55bcf2b302884367de6154d54713fb4322151f990b2e9b09f9a1fab8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-live.aarch64.iso.sig",
-                                "sha256": "92c48bbf52ebedfa4052153ab1f04c88f10a39269731fcf97d9d64f962b40372"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-live.aarch64.iso.sig",
+                                "sha256": "a31923a78668dd0a29ed8f64ef0ac43b4dae123c295add10f55782c7f159513e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-live-kernel-aarch64.sig",
-                                "sha256": "6945ec2c3d5080fbe67ef64d757ee9ad4a95951e097a70e1cd159a80294a1cfa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-live-kernel-aarch64.sig",
+                                "sha256": "b314a92e590176a5208b9237e53351cbd52f6b883a7aaaf5ddb99ad8bee5ceaa"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-live-initramfs.aarch64.img.sig",
-                                "sha256": "be0d1e89c9ccd46e53c6d9eee67dea113396e3131420f9a97db8ef62b8270efe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "3bdc7dcb7b471012ef80b68775e1fb2b457935ea8bce1d103666572b4c64a61a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-live-rootfs.aarch64.img.sig",
-                                "sha256": "1344e0a3aed2e4bc42bc9e8ff6ef1900c7215397eaf3bba750241eda411ce4bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "c98d1c83b3ce27840905eb6bf14979694b7959e1e824eaec595e45cbb3b1f10e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-metal.aarch64.raw.xz.sig",
-                                "sha256": "11e05f6e27e61066f0aa2948eb7348e8cdc83856464cd1f2c15f46e9feea4b79",
-                                "uncompressed-sha256": "3bde9d29df6ebec341020b4c58ecc2e2fb5a8a709e21dcf2bbfb906e14debfb7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "ada0f3e11e72e506088d2ee26cab6bae310ac13ed859c81521e621ee33b52282",
+                                "uncompressed-sha256": "ce452debefb91cfd81d1f9386e02a647caf27c7a9fe897f3b391cb54a0b0ec1f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220505.3.2",
+                    "release": "36.20220522.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "c4cadc1a95f5587499c5491963d5fcc5b54b50f1c8b7156d61b9f0f3452140cc",
-                                "uncompressed-sha256": "c389b6add98d7630fc922badd4539abb72164fb428dacf85339ffab2333bfc09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "1e1644c1514fda3bf8563bce0b401aa1147c214cbfe206cda9f39d4316e30119",
+                                "uncompressed-sha256": "49b6be1097926472e422887430a84f996145f2e6158d83a9415f4fd2ec41c06c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220505.3.2",
+                    "release": "36.20220522.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/aarch64/fedora-coreos-36.20220505.3.2-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "31a0bee6d223f3ba38a425b59065e980488b7e88c0be8f10f92f172044d6222f",
-                                "uncompressed-sha256": "b9e39f55d580d42ff5978abe3b93ce53af4879d686d478a96a009292e22d0777"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "a4f9681d9e15ac41fda15a8c7a15671100e1557ec8a6952c8e5fb0f248b0258a",
+                                "uncompressed-sha256": "cc5a025b981fd600c0a5f0bac00fb544529f1710cab2c9219424f652d0d360be"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-01b1d0b066117690d"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-090081dcfdde9a156"
                         },
                         "ap-east-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-0d299c3dc78a288cc"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-08d35e10d990adc5c"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-0eec55fa8f33d6b72"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-03fdc783e7657dd47"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-028d829fe0207f27a"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-09ce955a168e4b72c"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-0bf55f1448a8eb7c9"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-0bad08d741025d2da"
                         },
                         "ap-south-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-0fbf642a8778e0bd6"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-061c23835673bcf8c"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-053dbac32defe4865"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-0d1f04801422995bd"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-06127b2793105c860"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-0d570a809a97e026f"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-0f5f41f6460333af0"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-0b1cadb7d03e0141c"
                         },
                         "ca-central-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-018c2358e5948a697"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-00f9ef81a2c6174a2"
                         },
                         "eu-central-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-0e4bc2122987dc252"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-062f87e32388d1edf"
                         },
                         "eu-north-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-096e597d3605d5717"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-0cf9ed3bf42b69ef1"
                         },
                         "eu-south-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-080538d32bbcddda8"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-031dc8741fd297aa0"
                         },
                         "eu-west-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-0149fc735a0fbce00"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-08b2dd890794d2563"
                         },
                         "eu-west-2": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-0bdadc1ef29aa68ca"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-020e2fd660aeca90c"
                         },
                         "eu-west-3": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-06bc3c13ecea3f8cc"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-038a3fdcb53651f8b"
                         },
                         "me-south-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-0bbf9032294f10326"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-03738a8e914c6d797"
                         },
                         "sa-east-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-043224407b511a17d"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-01693fd4ec68c9596"
                         },
                         "us-east-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-05a917c9912b17037"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-01d60ea1e3fc94127"
                         },
                         "us-east-2": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-02a8c1ce58c1c9425"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-0c3d8eacc817acb20"
                         },
                         "us-west-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-00940a76da53fba5d"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-046f9a9c22ccda34c"
                         },
                         "us-west-2": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-088d88c07ffac3dbc"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-0af2ab4d31d671de2"
                         }
                     }
                 }
@@ -190,226 +190,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220505.3.2",
+                    "release": "36.20220522.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "35bfa27ff9fb595f4b58ca1496ea4adf9c791c57ee31012bab6ab93fb6d41c7b",
-                                "uncompressed-sha256": "db1abf566a0d82d9728652560a03f035c2b2b92831b9795f094bb3aa1efc2c37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d62506b541bf238fa1a6aba08b3dddd30715ae6089b7e53f9605bc67197b84ea",
+                                "uncompressed-sha256": "b220e7aee8de81daa81c15d9f03c8c1a3d22a8072342b1e3dd68ec9b5860fd2f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220505.3.2",
+                    "release": "36.20220522.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "03c0f2bde12d6ecba65e86907605eed687ba309c28c21f234e687b1e55963ac4",
-                                "uncompressed-sha256": "405a594b9e22e0e6557264e9331b3845ddf37f6b1743a37337b38f5596373eff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "77300ee0ee91fa24a62e4b56d868669ca53136b4a9be92237a42683ffe294d88",
+                                "uncompressed-sha256": "c540815a6c5447f69d1d768fc1e94289169995bccb613100939248b64f0fbdad"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220505.3.2",
+                    "release": "36.20220522.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-azure.x86_64.vhd.xz.sig",
-                                "sha256": "cbf6560d0a2f392718c793981f3cf485f18f93e6a3ba9ae5f5994204825eafac",
-                                "uncompressed-sha256": "798d3e14740c712cee001fc6b04079799bd5c92dd151011b87adcbfd6d71b2e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "b7a110c49bee4a95a6d81c7c72698b3792d66b765ba84e3f6e5412825854afac",
+                                "uncompressed-sha256": "67ae90b2bba38dc824f7a3b500ed98d87ca8f08c53c50ae3b65a8933773e9e4a"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220505.3.2",
+                    "release": "36.20220522.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "5fa32ec64f9e7b4415240fe6fd499b4f8a13c0391c9f5118bffccf42c0a409fd",
-                                "uncompressed-sha256": "8a1bb0fb315caf2ad273d24c391039c8655262844ab9c1f1c966d145e36ef69c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "332484b8eda595f40a12100580db0c0e4ea784a2a9b2b891a9cb6253f580b654",
+                                "uncompressed-sha256": "eca3735750d89aa1b7ffee6c0087a05ed678ad3a3dec226c95d7bd6af18c2c6c"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220505.3.2",
+                    "release": "36.20220522.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "27d4b21bad5f70d9b73503a09db24a25326eee46d15e0b99b483a34f419cdb07",
-                                "uncompressed-sha256": "86e594804acff988e5a93c395789c40d15393c74474050002c5aba0fe842a37c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "34ef499b5413ac9fc92b834b0b8950d3a08b07c0cc3f83a9703f2ae26f2691bd",
+                                "uncompressed-sha256": "a521fc64434f9c060357e6b8b94570a5835c18f2878d959f966be9bb78219a8e"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220505.3.2",
+                    "release": "36.20220522.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "78f50c0fe64ee86e55d6f6a0ddc3445f89207fbbdded4a1b8b06155919aa203b",
-                                "uncompressed-sha256": "2e4fe6830e374e1d63f9bc737df317288775bb4c79788cc1350e70412db39d1b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e8afe2a773f3c9d48e947e979e556b22a7af187bc2f52b81a33c3c7a2a5451b1",
+                                "uncompressed-sha256": "e087d211402a3b2e9aac26fe99d60f35280a5e8101cefa819bd8f3be646025e7"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220505.3.2",
+                    "release": "36.20220522.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-gcp.x86_64.tar.gz.sig",
-                                "sha256": "d7e4a1520dabb5e41f86579cf0e280b7af51f0f4e03f1456c904255d262696fd",
-                                "uncompressed-sha256": "d1b04487ba07e1ca1c723b64e63fe362305cd3881c9c03d94ad61643c74a91e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "4dc9784e0f733240c1cb1d8fa6de77d5d1dd606fd538c42440a65efb3eda6232",
+                                "uncompressed-sha256": "9fd3622c5b552a6790bc02b316166c6aefc68735db2051a64cfed5f67c58f245"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220505.3.2",
+                    "release": "36.20220522.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "ebd06c1afb8babddc7dcb084a93e86a48283186c22a3c5b93011881f1ba535f5",
-                                "uncompressed-sha256": "19df5e54f7e24b75f49967c9b6d5e400c179d115030f6ea6667f4818d6ee6051"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "be86536829030fd964bb7773f13e5248d5c9b950e2c3bfbad2a33118a1a5cfd9",
+                                "uncompressed-sha256": "6cf067118339113c19860b0c6896273752b2328e421f348076ed8c66323831e1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220505.3.2",
+                    "release": "36.20220522.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "2fa323241afe1516cb6e881f481d5a7659951645f94a746162c427c9c12b51cf",
-                                "uncompressed-sha256": "f3a38392a1294691bea9bf5dd64f7e0d2757320d693b20fb0403afa2654cd9ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "5bd2baea6e18f3474661f840d94aaec51da52bf7dcc8bb56d3d03b2ae3405e05",
+                                "uncompressed-sha256": "a2f08164ba555449cc1743f9b10b9f64763eda9986be88b2d9955c0fc37d4204"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-live.x86_64.iso.sig",
-                                "sha256": "f74385486e671f499896eebe9f8236b7bc655d16adb90bd02a73d1892417ca68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-live.x86_64.iso.sig",
+                                "sha256": "187d9119d00c4372daee08e06dc140055b1c74079e7cda5d183d574428e846f4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-live-kernel-x86_64.sig",
-                                "sha256": "f5d8162b1e086f1a9d09d3d2c6decdbec84d7020cde4b6f32a98f21eacc8cf3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-live-kernel-x86_64.sig",
+                                "sha256": "79d20c0b674d84569db5824091286497ca93793a3acce4dea02f5e06e3f61ada"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-live-initramfs.x86_64.img.sig",
-                                "sha256": "8c7564f3f60ad798f71b350a73587093b0c85c766644cc9c70cba258eed18ab4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "19ad86d1486c6a6c4734e9fa443c39ed2bf2a76d680e208758cd4974c17dd676"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-live-rootfs.x86_64.img.sig",
-                                "sha256": "5d13f0d40d2774843eebd2b1ad1f10b16f207295663849515069ecb09cbfcf0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "c51705f763bfd7e46306fde3cc0fb3902cf9f41544812914fb9b0706f13f1065"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-metal.x86_64.raw.xz.sig",
-                                "sha256": "c5824077387bacec9a970087952d16840b5c4992cb6cedd5c6591592bcb4a687",
-                                "uncompressed-sha256": "c6c833872ce61d4f3bc6ae1e5ae07172c566f89d878a0e4e48993c11200ff3e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "d60757aef7cf0c1695e15c3d7ab5980c174778697dd9e875585af47acbd583a5",
+                                "uncompressed-sha256": "a8b0e5f2d1c68a317d58188f638260ad5710f27a6248aea9bb581241be9e46d4"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220505.3.2",
+                    "release": "36.20220522.3.0",
                     "formats": {
-                        "qcow2.xz": {
+                        "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-nutanix.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-nutanix.x86_64.qcow2.xz.sig",
-                                "sha256": "5ed799a381668cca722436ae7ab6d7a309ca89a801604a0e6915c7bcbeceae1e",
-                                "uncompressed-sha256": "7157c60d8a5bba1a5278ca60aebc7f718a6595077620f378ff9277c278274695"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "e87f875674b6c38273561d1857fa012efca29923264606264b7425d84a514a78"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220505.3.2",
+                    "release": "36.20220522.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "0c880eba7a431449446f447c3c57d2627ef1516682fd69613eb72211e3559a20",
-                                "uncompressed-sha256": "23954007c89ac0f6c6095bf4c62c26673e84aa53e818d32416859b28a0067174"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "caed2fb2ba818d7867c14bd88fa30fa1ce3986f95b4ecaff07394d17b9992e92",
+                                "uncompressed-sha256": "5c56d3df1f9d4963131000bcc456a0ad0dc05a5257e1b06f0d39642a0bbfc726"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220505.3.2",
+                    "release": "36.20220522.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "671eb590785d4df35fc5548544a490428c2d8996383330b481292d392b3d7f4f",
-                                "uncompressed-sha256": "a8276b925dbd656422ba60ba49228290ed3c7b787a7e3ac74f4f9483b09302bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "61972a3df0e1051b2dc61f0fb9ee6f94d69b9e7bd48576c316f6f119114ca35c",
+                                "uncompressed-sha256": "a2c01e0a69b75c1d164d68d7bb7370b85274113aefb9efdb0ef6e5cbba92ceaa"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220505.3.2",
+                    "release": "36.20220522.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-virtualbox.x86_64.ova.sig",
-                                "sha256": "8291a35a2fdfa2deff9d087c7fc756a5ef8b5d83bad054523338eecbf77a0709"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "efd4065d3355259f426a3b62ec465574a34a531d07b3d3c086b89b54a73a1e9d"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220505.3.2",
+                    "release": "36.20220522.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-vmware.x86_64.ova.sig",
-                                "sha256": "5a06ad5b33f08ab7255968adcbfa49ac61c0b730445f09010c6a743dc4ae5cc7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "ca9bf44d702d1bd7c3c744f2916a8891ad12cf0ce8cc995e900588751fb18c18"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220505.3.2",
+                    "release": "36.20220522.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-vultr.x86_64.raw.xz.sig",
-                                "sha256": "7d44443fd22a31c6ad408a64b4810c77cac7acd9fe6edb839aa54e7d8a071539",
-                                "uncompressed-sha256": "1ef15d1b1d2d513d93751fc429de9643daa6bdc5bfa956847207f01c363ad086"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "2f8517826d8095ad61af8306346696cdf25baeeace5d266710957ce2e65af8ac",
+                                "uncompressed-sha256": "c6acd0c4e603d973205eda5e4a27d4bb4650ea7327f095f349ec83801de25d12"
                             }
                         }
                     }
@@ -419,100 +418,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-05c3ba1beef237de7"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-0d46a5bc534d80176"
                         },
                         "ap-east-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-094f490fce152e74f"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-042be30c47e1b41f2"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-02f5f3209859659e1"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-0baf3013ccf6ce0c6"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-04ad3018c5cc1f985"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-0b5df0b1afd245042"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-0fb0bcb60f18fffc5"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-07480eab1342b05e1"
                         },
                         "ap-south-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-0c8e34b54ce0a1c92"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-0cd4c61dfaf7f7401"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-037f749e113578eee"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-0a0974cf6d0c7d7e8"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-0302cd3e0ca1d60f3"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-06ee1aaf6c6fa1c1b"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-017c7e667e42d3c49"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-0107636c1c50f233b"
                         },
                         "ca-central-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-021713086fc803832"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-05b04b0c012eee258"
                         },
                         "eu-central-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-057a5a4c8bb76983d"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-0b8490b038e35f28e"
                         },
                         "eu-north-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-0dc25790e29de2e4e"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-0cf37b318cc71dd44"
                         },
                         "eu-south-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-02c8aca787ece768e"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-07a64b05889673f6f"
                         },
                         "eu-west-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-06aa6e850cc72be1d"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-0bdc24edf292d8199"
                         },
                         "eu-west-2": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-0b9864872ed58e8dc"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-091de873a493a6866"
                         },
                         "eu-west-3": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-036e7cbc66d93b34a"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-0040b0d64cb3b7b09"
                         },
                         "me-south-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-08aadd6aaf2306522"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-07bd556cd346e2d27"
                         },
                         "sa-east-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-0e925cf98fd6a4cc9"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-0612e14c5c86fbf3e"
                         },
                         "us-east-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-09b2deb293bf2a1b8"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-01ecc0dab7f3781f1"
                         },
                         "us-east-2": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-02ce6d2d7012bd0af"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-039c0e00b66e20cad"
                         },
                         "us-west-1": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-038a4354904c74a1a"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-0c9e063b3cf4c8b90"
                         },
                         "us-west-2": {
-                            "release": "36.20220505.3.2",
-                            "image": "ami-04b578d32ced44d80"
+                            "release": "36.20220522.3.0",
+                            "image": "ami-09afe7e4d56f13e85"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220505.3.2",
+                    "release": "36.20220522.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-36-20220505-3-2-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220522-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-05-24T22:56:38Z",
+        "last-modified": "2022-06-07T15:35:57Z",
         "generator": "fedora-coreos-stream-generator v0.2.6"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220522.2.1",
+                    "release": "36.20220605.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "f1f6f0b6caeecc6996708610c3f15d1cdc592d454e8775ed146975a9d9165683",
-                                "uncompressed-sha256": "97cc6cdcb3518dbc7a24ceee7d3c4764d3bddc1772331e1b452d6b5e5d92c2f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "032c6576b16739b82fb3f2d9582d07cdff58666ee63dc957cc8ae6ecca395f33",
+                                "uncompressed-sha256": "dcc1ab11a2e48e29bdd43a64ca73a129de39b50ce539f4c7f49a8d22d64ef8b4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220522.2.1",
+                    "release": "36.20220605.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "788a191aedc4a50e2f039906a973fd5a259038717ce9198f88668393a582dae8",
-                                "uncompressed-sha256": "1e423e1ac31aa0986fb57e250de229cf080cdb72af34120a39eecee5d2905551"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "280f74bdbf5ade677f80183a43195ab43782d5327fbbcb9e03741ecbf439ce4b",
+                                "uncompressed-sha256": "661e832a86b235d1fc1fe572bbf5010fcd6ce0acdc56794edff92caccbc2fe11"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-live.aarch64.iso.sig",
-                                "sha256": "a347b369198d258022cc75913c0154f7ed61a2c7781ed0a6868130c8d3882729"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-live.aarch64.iso.sig",
+                                "sha256": "f4b939a1e68f096f7a7b6984facf337b3f70ba500ed641df2b706a3ebe2df657"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-live-kernel-aarch64.sig",
-                                "sha256": "b314a92e590176a5208b9237e53351cbd52f6b883a7aaaf5ddb99ad8bee5ceaa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-live-kernel-aarch64.sig",
+                                "sha256": "d43703f0f6eefa6ebc26dde5fde0252da632a847392904d5e2348dc215ce6fb4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "6cf74db5c47722e31d8bac0b0502528aa77910f1a48a8a107c05e49e6f0d054e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "c03290b0c6cefcc47af275ac99810a8065fa58a02c7ab346fa3bf771d20f35bb"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "16e0560d5026b406bc6776fdd6e0705c3abf41374cc56366307143347f2bfd8d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "f6d203a525bc51c7e660f71d3da718803072ff454ddf752e7cc55c123a2819bb"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "ada74ee8651c5538580f557b9a59d7b6db7cf9b90acf86e6b96ec23089be63b1",
-                                "uncompressed-sha256": "a10e8db9ad307018b01773e8afa3bf892942402d75291e54a176b459f6b14d4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "e507f146ed976dac16b6104c82aa696bdc5add5b5b0a4bcb8221f0b57c635e05",
+                                "uncompressed-sha256": "66f93d1098ac7fd3af8526493a7d8b92f56c3ca4eb2d90695b2235612207bf30"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220522.2.1",
+                    "release": "36.20220605.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "0506130defca13d5faca25647a52f2aa44d3730ade27a4e03cbb174a121fbd43",
-                                "uncompressed-sha256": "362497b3034437a913213fccba8006a4a39dbd679772bf2324b7c61048043607"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "63c018cc6bec628ffc77ee0330f49d3153082e637813957280840d2ab7d4072a",
+                                "uncompressed-sha256": "9dcf6c7e4cc9df5cdb6dc760fb51663417b4a7f7851c23cf397aaa662cc3e0fe"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220522.2.1",
+                    "release": "36.20220605.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/aarch64/fedora-coreos-36.20220522.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "80eb2b9c6fab7043d1bbcb75234dd6f0bc9f538a0ebee3e727859737503f501b",
-                                "uncompressed-sha256": "35b731287f687fbfdf736fa256122b2059bf70448fd543265d804abfa4ecb8ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "d6af2fc8e9cb63777bebd3cb4fb9ea8f6576810b65a98ca49252403c7aa5cb73",
+                                "uncompressed-sha256": "3760aeac428ec7f943fd2e78099ebebd9eb22f1d325d646a8f216189cfe05990"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-01152070628bc5a62"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-0a7c77fbcd6bdaaf0"
                         },
                         "ap-east-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0400081aea91d5854"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-08f5034680cb52c3b"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-036c758699343d67b"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-037b0c96706cb342a"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0802f67dd3c455415"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-09a39d1842ec23972"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-00ade86d05d97739c"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-0b26ad7921090c01d"
                         },
                         "ap-south-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0e39fdb2c51594bb0"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-0e7c59a108eef84d9"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0e4e18c53c8e7bb8f"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-0ae07b427d539f8d8"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-08665b277c3303920"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-0aa9845b2a0fcbccb"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-09e8bbd73d89ffe31"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-042adda70b3d034a0"
                         },
                         "ca-central-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-013a12a39ee382367"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-027774257f90aa313"
                         },
                         "eu-central-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0bf219368d231ff1d"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-06be430acf1e6b0fc"
                         },
                         "eu-north-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0ba0909bde963071c"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-0f903106e01263a1f"
                         },
                         "eu-south-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-07ca2c1c2ca53c251"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-09ac3dad0ece97d88"
                         },
                         "eu-west-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0397628878c466cf3"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-0b669947e25b532b2"
                         },
                         "eu-west-2": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-080798452b5ea92d5"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-031a0acbf934caaf4"
                         },
                         "eu-west-3": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-013df61f3785130c4"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-0b064108beb10ca59"
                         },
                         "me-south-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0e9f20d1e063a83eb"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-0df322a3a6c84f36a"
                         },
                         "sa-east-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-05dad207f1e1db08d"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-00b855bd166a0e727"
                         },
                         "us-east-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0ac021147175c37af"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-026d85acb4edf8cd1"
                         },
                         "us-east-2": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0968057d320b8fd8a"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-06ae94ca273f9f0f8"
                         },
                         "us-west-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0e4a43db9d6d987b5"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-06a80ee9fb634e690"
                         },
                         "us-west-2": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-09b4efe866ebf215e"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-0545bfea13fc295ba"
                         }
                     }
                 }
@@ -190,225 +190,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220522.2.1",
+                    "release": "36.20220605.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "4628c5b816c602be72bf4b251e3b5d95514dbf9309d4f04f5dd0dd7830c72460",
-                                "uncompressed-sha256": "16877f31c1cdfea855984c53dcf41e59bd2a3a310fbe9f52313b7453fb32d30b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "c5ef90640172920c19f8a133b11a2b7811e3e3664f976c92be2918a032f22d35",
+                                "uncompressed-sha256": "a7808f273a1f6243c97acbac3cba7970da712d5d77509b85cddf3e1193e4b5fe"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220522.2.1",
+                    "release": "36.20220605.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "29546caad2892bd952475490bdda2a766a5c5fe2406742c91f315c5c155ae24e",
-                                "uncompressed-sha256": "dfc1ab725836ffeb93a1e5823e4586ecd31e41b49d92f88c599f34da86c0e2e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "cc440c52c1ab6e58c8574626ccfce8d039567bea79ae22074deff70eda143399",
+                                "uncompressed-sha256": "18e43db53aaf4a9f5a9049b2abf4de70b60ee80cf5b99c4c1ac0e16e412ea128"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220522.2.1",
+                    "release": "36.20220605.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "24999ea2f4b816472d3a285a0fe1eecb00777b22776c6fd103c3161a31bb638b",
-                                "uncompressed-sha256": "04a0bddbc2ba766a4f5e673bfbd83dff662d17608f3e1137b8a00cc9f2c6b389"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "4a79993636c477baa866bbc9c3fb9a848137d16e8600fbee74a6650a8cc2ff8b",
+                                "uncompressed-sha256": "396dc51f88d3bcb12131025519a5175917e38c3ca845c00c5081ff6a6a5c1e43"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220522.2.1",
+                    "release": "36.20220605.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "0bd6441bac862bbddd00650335c39f6b5e8a147428b0106e7d0afbad27b60f27",
-                                "uncompressed-sha256": "796f0bb6d660e36f13860b40cfb72ef350e0c9bd9f1cc73ef63b6a9bb02a477b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "ce27060d242f355625af85c8aac0138a5bae7acfb59be5e2505f96684811b46b",
+                                "uncompressed-sha256": "fbbe555035c1b00cc62e0a70790a6719b7b325b0a5d3567e4152fa485771d6cb"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220522.2.1",
+                    "release": "36.20220605.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "f0bc2f29e688e2613f0d282eac11d610375c63c4c96ded9ee77f41a901d0b4e8",
-                                "uncompressed-sha256": "a2dbf2f631048a303b957dd6708a5d8c876fdfdaa2229592cb927f2c0cb28d55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "b56a761e471623822ed6c9830f325fa0fb8f4a4250e5bafd12812c37d8b3a5dc",
+                                "uncompressed-sha256": "e838328d1cf3c87f391c55c4a93299eaa5a53a951f3814ff3660a3b54421f3ca"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220522.2.1",
+                    "release": "36.20220605.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "8448e651ca927c73a8dcb6fb9338ff2f965129b7248196db51c8896c45977bbe",
-                                "uncompressed-sha256": "c181d84fb4bf963cbb43e33588e5a154d85874716b1c4bbd88ef03a6ac209790"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "ddf145a8bfb9dd1a6f4d6dcda88327c80ee1685a44250371f24864e7f57e434e",
+                                "uncompressed-sha256": "727c589445bbea6f389cd941e39a35800c6e7c9de8123bb454c3e15a17c20d90"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220522.2.1",
+                    "release": "36.20220605.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "caeba304fb7cfbdfa2df4148f0ea80116c00dcb636ccc5da118ccf86a620a2e5",
-                                "uncompressed-sha256": "8cc08de93df7474fa6b834a86f0e948a29b0208f741b4048e39830e19dcf0a34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "b5db1d56743dbf32917753c4dd6009d873b0784caf7f39f8103aff4b0136cae5",
+                                "uncompressed-sha256": "219aa940c8465111611ddf862124666bd35bd4a620e409c65b0bdbd07498c225"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220522.2.1",
+                    "release": "36.20220605.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "57ea0ec95b7a635d8928904178b2086b9a7e79ea42e082a233cd69e08027f0c9",
-                                "uncompressed-sha256": "6ae664e43b3c1358e55b9f1311ccb838ede5420f368e1aae772add753dec2341"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "2526c7d2b1a2c35a2d2903019866c635e0ac954a87168d012a8fe3ea71d42ffd",
+                                "uncompressed-sha256": "0cc515f6fa7a3a087ca96ec2ab0db92f2699d5c102b136c7040921a2bf3d8338"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220522.2.1",
+                    "release": "36.20220605.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "467831355cb5a2630937e80172b2ad98bb6ac4954994a88ad91ded9d157f5e96",
-                                "uncompressed-sha256": "242e19f447d314c93035f04e9a4fc1d5597a01868ad1693f006f8b7fa8e65431"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "9b661440d0a78274244ae3b31480002163f46db649611dc0083c9f8c4fb74044",
+                                "uncompressed-sha256": "f63bcf30449c5188d82300fe88f6fcf04a1a4926fee1a861f5d16ef248a5e558"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-live.x86_64.iso.sig",
-                                "sha256": "5f0ebe721636b990ac5c9cd7133512903e2c0a57c87b389a4b31124e52320284"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-live.x86_64.iso.sig",
+                                "sha256": "2a4167c4258f16b9f2c19290e517e3b5e6a6adf9633dcf0207bc52faf0492fcf"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-live-kernel-x86_64.sig",
-                                "sha256": "79d20c0b674d84569db5824091286497ca93793a3acce4dea02f5e06e3f61ada"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-live-kernel-x86_64.sig",
+                                "sha256": "ac47aa3d1a21b5665f885f3c85c9b3b9d4bca6f7dd94c38c016f10c735b48d0e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "b3ee043f70f457e0d8e08ecdb57a8f3fb98b1ad5e36a95b53afc363715332946"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "0ce4495887f43490dfec726ceeedc642224c08821c58f6948fa644b2f755905a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "177c45f4f49d9c2bebb33575b5ec0e113b32af098df486d19e4e4a7107ba2556"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "3950485ad332ae9d385434660bf179dc84a7e99c5a1c52ec72049e43e92d4ad6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "515dd9f506ec50919022a60e87fadb15de3ae02f4641a0a4995320812366ba0a",
-                                "uncompressed-sha256": "1cfcadccda9c39342cef8464bc044b545b884204c5d3df314adebfbde8888871"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "22b1d9ec3dc9267abb8b5707cf3cc75d4186fac9192d84f90746685301de412c",
+                                "uncompressed-sha256": "76f253a41ce1bbc00668971d07e28b855ea249238490368c4f2bff639dcfd640"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220522.2.1",
+                    "release": "36.20220605.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "0f3f79f8c00fdb87c624b5d9525625a788381f39dda58ee25c492ad35b1a3add"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "ad3322443f926847c0b1c21fc41a7285da519c071acfb71f8d522f77e036e6de"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220522.2.1",
+                    "release": "36.20220605.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "f2c1a9a077d6296b7070dc388fcec384cf6c9bebba0d0539cbfc12349467e797",
-                                "uncompressed-sha256": "0118d100b6d34a37a5112fa2f519f4b1fb46b2700ee2de6a59b4fe5832d50a35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "786cc39b678175ec0e76d9afd36c0a689f8904107ef5b01959a2de1ab3014a4a",
+                                "uncompressed-sha256": "7f2faa0b967d80668b5bd6546711622a2e736a1f41c909ed67214f1f158f3eaa"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220522.2.1",
+                    "release": "36.20220605.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "556625320d93e518890eaca4d0e07457e17f6dc87581cd9e9d321a6c68827404",
-                                "uncompressed-sha256": "ce9e59447f1c90315cba6251c4aee30bd097f3e0944505629a4b8fcda9a05abd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "46291e2b77177e803903f70e0e87c1c0265c8100b450de372538d6ad1df3b981",
+                                "uncompressed-sha256": "8c4fcd7c538764218183ccfeb90ff5623d4caf4097fc9c48402acdd1b39e1317"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220522.2.1",
+                    "release": "36.20220605.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "9003f67e73f0e900737be87af3161df000144a541fa20c7a0936db2463d7345a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "fb77ef7a4d14798621d8e712e6d2911d7a73a2f0797d0e364ba7412c1d805761"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220522.2.1",
+                    "release": "36.20220605.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "f994f7f7f0592aa9c5eaaa0a0e28ac09962cd489c489f7c05885aec13f8d6502"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "91e61177f72c84145a039f9c7f3618da025def0f19b917b0a6f5ead7c4fc68d9"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220522.2.1",
+                    "release": "36.20220605.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220522.2.1/x86_64/fedora-coreos-36.20220522.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "51f9a6b0d893b823c38ed464ae31df9284b8b82a82eb019034e6f5c4f138f0d1",
-                                "uncompressed-sha256": "b89093283a3d9d8cd3474dc820493c5123531ed5a0759d1cb29b1a493f55ac4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "c47af733a39cdd4e30ca0645edb5658e5735adfe31f5f2c066edf2b4a01cc483",
+                                "uncompressed-sha256": "ea55d17b4dd6b1ab39551e09e53899f02b324922dd68a9d8d18fa58b00382bce"
                             }
                         }
                     }
@@ -418,100 +418,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-09df2debbc02aef1a"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-079d0154277846051"
                         },
                         "ap-east-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-04f01b0d50fc0587f"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-0bda41fde43a1bf23"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-01369189b59beaebd"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-05134874ce89c55f5"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0f00ab05de5888e57"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-058a6a8843cca16d1"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-08727398f81e042fb"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-0abcadea989a01983"
                         },
                         "ap-south-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0939f3a599d172f0f"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-0e76a3cdf49a14e67"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0684fb773610bc5d4"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-0cfd68c984ed8a6bf"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0064e835b289af64a"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-051a25ee723f35b14"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0d0ff531999474c8d"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-00c52767d6c8ff75a"
                         },
                         "ca-central-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-024e350359384d436"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-08e0de0c5405cca10"
                         },
                         "eu-central-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0fc686bcef761d0bf"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-059b69f48586e91dc"
                         },
                         "eu-north-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0ef89757d6c8799ad"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-0d84eef672c9a1254"
                         },
                         "eu-south-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-052ad3e491d9a910a"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-04643a9cd354c8766"
                         },
                         "eu-west-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-04f236cbe1eacccb2"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-0c55a81602f5f8940"
                         },
                         "eu-west-2": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0b00e48880130a29f"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-0180f707e3df59588"
                         },
                         "eu-west-3": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-08413e074e1aecaa1"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-004c0fd7c65a5d84c"
                         },
                         "me-south-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-050f096d2b21062df"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-0debdcbee5c06cbc5"
                         },
                         "sa-east-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0ab97f3b7bdbe461c"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-00252327cb2592f51"
                         },
                         "us-east-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-01850c51dfbac8f7d"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-015f8395cb12feb19"
                         },
                         "us-east-2": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0dcbc82e1b7dd715a"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-00ddb771c107baeae"
                         },
                         "us-west-1": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0a91ffa349b4d1007"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-0ec3f3d25cb71acb9"
                         },
                         "us-west-2": {
-                            "release": "36.20220522.2.1",
-                            "image": "ami-0a8b67a9a8221542b"
+                            "release": "36.20220605.2.0",
+                            "image": "ami-0900104dcd144f6fc"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220522.2.1",
+                    "release": "36.20220605.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-36-20220522-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220605-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-05-24T22:56:40Z"
+    "last-modified": "2022-06-07T15:35:59Z"
   },
   "releases": [
     {
@@ -53,7 +53,7 @@
       }
     },
     {
-      "version": "36.20220507.1.0",
+      "version": "36.20220522.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -61,11 +61,11 @@
       }
     },
     {
-      "version": "36.20220522.1.0",
+      "version": "36.20220605.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1653487200,
+          "start_epoch": 1654621200,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-05-24T22:56:37Z"
+    "last-modified": "2022-06-07T15:35:57Z"
   },
   "releases": [
     {
@@ -53,23 +53,23 @@
       }
     },
     {
-      "version": "35.20220424.3.0",
+      "version": "36.20220505.3.2",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        },
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     },
     {
-      "version": "36.20220505.3.2",
+      "version": "36.20220522.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1653487200,
+          "start_epoch": 1654621200,
           "start_percentage": 0.0
-        },
-        "barrier": {
-          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-05-24T22:56:38Z"
+    "last-modified": "2022-06-07T15:35:58Z"
   },
   "releases": [
     {
@@ -71,9 +71,6 @@
     {
       "version": "36.20220505.2.0",
       "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        },
         "barrier": {
           "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
@@ -83,8 +80,16 @@
       "version": "36.20220522.2.1",
       "metadata": {
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "36.20220605.2.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1653487200,
+          "start_epoch": 1654621200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @gursewak1997 via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).