### PR TITLE
workflows/promote-config: print nicer error if issue title is malformed

### DIFF
--- a/.github/workflows/promote-config.yml
+++ b/.github/workflows/promote-config.yml
@@ -37,6 +37,9 @@ jobs:
               ;;
             esac
             echo "Promoting from ${src_stream}"
+          else
+            echo "Title must start with 'stable:', 'testing:', or 'next:'"
+            exit 1
           fi
           echo "target_stream=${title%:*}" >> $GITHUB_ENV
           echo "src_stream=${src_stream}" >> $GITHUB_ENV


### PR DESCRIPTION
Let's say exactly what we expect instead of failing on `src_stream`
being undefined.