### PR TITLE
Roll out stable 36.20220605.3.0, testing 36.20220618.2.0, next 36.20220618.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-06-07T15:35:59Z",
+        "last-modified": "2022-06-21T14:08:35Z",
         "generator": "fedora-coreos-stream-generator v0.2.6"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220605.1.0",
+                    "release": "36.20220618.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "e52f8a97b795b2cba4d059e50e9dd9ea587a763691a440665472e1e270c4b8d7",
-                                "uncompressed-sha256": "2235819f17eb2a82ef8c7aacab9c6dfd904b24572c904c8b7d064efd31a9f677"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "2155605836562ce6f4d061ae015a5afbfe198df33d93f2c24294f8daa9985039",
+                                "uncompressed-sha256": "dfddd5b2b77479a29a132da4e50190316cd6f01f7d46010bb4fb5a046d2f3600"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220605.1.0",
+                    "release": "36.20220618.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "3c1cdaf2233200e6a76dead62260f03d1f244303f86bdc2e1f7896a7736acae3",
-                                "uncompressed-sha256": "2a19d545027b4b8c65d61f381cca8d0b4b057978011af469d79343529c890727"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "27bf1ecd1eb4d3bdad00d0dc03c75c71c8f1c72983ebbb8fc45c422767dd4bab",
+                                "uncompressed-sha256": "28ac62adb81af3e28de6e5164787756fc758be05e48d93e21b5491608e88af27"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-live.aarch64.iso.sig",
-                                "sha256": "9117c713c1e8e2513baee556ffe93120d214586a7744ae528d0280a9eee1b7fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-live.aarch64.iso.sig",
+                                "sha256": "887f09668d8e052e4c3d09ae61cad3e75d31c0c3d23fa7a1d6b7248a2a031d44"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-live-kernel-aarch64.sig",
-                                "sha256": "d43703f0f6eefa6ebc26dde5fde0252da632a847392904d5e2348dc215ce6fb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-live-kernel-aarch64.sig",
+                                "sha256": "fce2ccc1f09cef7709cb75274adc015836baf9e78d094335fd803252dc8c9622"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "0815b6876941f0f2ace8d1c48f7f9d13576f8b04670e556ede1052b6db1cd20a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "7813fa94969b00ecb7e67e111a7ddce3fd86a475dc9c9c8d6840bedad54cf900"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "5fa873d1dd7f090db611d20ef371d38b13284d2ee82cdbf5c6b762bd3ace10a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "fa9ffa43c3f2daaa7ddb8ef394f9018b3bf05df321c63f6aff3f8ccfd024cbb0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "04f42469242bda918f88a532329941c1fe9c7162296211ef05b64ac7f342b70c",
-                                "uncompressed-sha256": "c660db5d04cac22f5468e490fb9749b5da84f7ef16311d34ff1cddd4f376107d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "81a69b103465de74a32aef4688025b80a8aa36ef52994668347a01dee4af1bfa",
+                                "uncompressed-sha256": "3562e47f62a3eb87aec29d734fca71382772eb89a85e8c1214a35d8598856c1b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220605.1.0",
+                    "release": "36.20220618.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "c24792c61a34177c9b76b02b616446c97d89708a70bd69b236b07fc1a6bac9c2",
-                                "uncompressed-sha256": "731f75fdd19e366b8837b8fa2a0db70200e60c0f4cbee3cb41f68dc4fd2032ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "4ac5e84a179f715d8f8c27357ceb602a42c1b4ec7f1ba8ea4e85ab05fa28ea7f",
+                                "uncompressed-sha256": "0296e4809a4708be2e90acd961220f51baf77fd896fe5d4047369352c16625c7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220605.1.0",
+                    "release": "36.20220618.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/aarch64/fedora-coreos-36.20220605.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "8bf5a238220ec9addcb372502f2d0abfd4999546fbc0e2763d6033ac1355d6bf",
-                                "uncompressed-sha256": "4624492d41a3f51dd6d9f1a9654ba9b4b34fb2573d10860b028e0cd0ba5dfb06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "169ab06bc18df19baed53a01c199d5841102f6becf9abe9963e466fc41755d90",
+                                "uncompressed-sha256": "5b1a088bc7d85270f14300c2408ea5d0b3fb583f04a4ea6b9e7de1e6f212faf6"
                             }
                         }
                     }
@@ -96,319 +96,395 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-00458f8ae3242760b"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0b2f50b3ff2739730"
                         },
                         "ap-east-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-01052e85309435952"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-007c797c4c080f192"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-043f399cc632a3102"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0c8d6feff411e0a15"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-01934f011180f7bc8"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0c0ddac9056648276"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-0a0fc2c916072a05c"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-01b8faa44f8778e48"
                         },
                         "ap-south-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-0aebb271044241fa1"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-042d381bfde69b0b8"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-033eb902549e00ced"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0ca3a741fe901cbf5"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-024d04671b6184dca"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0f99b634cf5273908"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-0b26343fda75f4b51"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-04d13b22a3a7ec426"
                         },
                         "ca-central-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-034ce744e5c34f09e"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0b81e9efd4c4815ae"
                         },
                         "eu-central-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-051dabfe3eecc1d26"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0c37f96064ba7eb42"
                         },
                         "eu-north-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-012be854a23ac486e"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-080dec3474bac79d7"
                         },
                         "eu-south-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-03e878b9883c2abe6"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0f625ffba9fcb0ba3"
                         },
                         "eu-west-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-02c698b71efe531cf"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-091a8e1debd3670d8"
                         },
                         "eu-west-2": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-0db7eb5671dde1b74"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-08cb292e01e98c716"
                         },
                         "eu-west-3": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-025ec1d4cc6ca1db8"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-01bcc1241531fe926"
                         },
                         "me-south-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-048384e4394aed1e7"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0b91da8d40dc31a3e"
                         },
                         "sa-east-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-05eb9be2774060c68"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0448cdb1c7b8c0ebb"
                         },
                         "us-east-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-028c202655efbd62e"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0a1dde2fd7d4c7755"
                         },
                         "us-east-2": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-07e72b651dcdc1dc7"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0fa9407136ca1170d"
                         },
                         "us-west-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-095e25b6481ae6a4d"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-08c48869c1accaed4"
                         },
                         "us-west-2": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-010b570919e53a810"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-09b11a31a25c9cec2"
                         }
                     }
                 }
             }
         },
-        "x86_64": {
+        "s390x": {
             "artifacts": {
-                "aliyun": {
-                    "release": "36.20220605.1.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "8a414bc4de707d09728ba62910a6e74ec946176397c669984e8d687749c67cab",
-                                "uncompressed-sha256": "97bac2c400c08c2a0bca7dca6e66fba9e454eb15fd60808b7e8052fb78f44fb1"
-                            }
-                        }
-                    }
-                },
-                "aws": {
-                    "release": "36.20220605.1.0",
-                    "formats": {
-                        "vmdk.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "66dd102a9702b58714adf4971e11fab042f4ba26b35381af928f7fadaaab3753",
-                                "uncompressed-sha256": "513a132f4be735219a90ff4f5da80245372234bc97988fc944dc317e47677ba7"
-                            }
-                        }
-                    }
-                },
-                "azure": {
-                    "release": "36.20220605.1.0",
-                    "formats": {
-                        "vhd.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "939f0717482992d31649986b1b9397ac0fe16007bfa3b3ff34666bf32a9e85e8",
-                                "uncompressed-sha256": "da72fcce720531743464860bdf12582c730ac870748ac5880b203dc83eb79baa"
-                            }
-                        }
-                    }
-                },
-                "azurestack": {
-                    "release": "36.20220605.1.0",
-                    "formats": {
-                        "vhd.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "cddc1af5ac838a40e5842c420deef640122d61753117d40d3a4031a3fdfbd615",
-                                "uncompressed-sha256": "3642fb237f7c3ce47d08832a9ff0a4c8e2525f9291e66e29d941357bf739a706"
-                            }
-                        }
-                    }
-                },
-                "digitalocean": {
-                    "release": "36.20220605.1.0",
-                    "formats": {
-                        "qcow2.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "f1d43c07d313584a2f6a5431dcfc2b0ce1bcae52a147d8cb284e8687d789c063",
-                                "uncompressed-sha256": "cac6e2af0e9189ed989e8c81bbecefa571b132a03d11a0e07e7e76ef1ebcf631"
-                            }
-                        }
-                    }
-                },
-                "exoscale": {
-                    "release": "36.20220605.1.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "042d7d69ebeccc53600d152be09fe368492c5e5cad5c830cac5e1f51bee178e4",
-                                "uncompressed-sha256": "1ec15005c4d7b16b85b0d11620b52a5ed7c44788fb0194463156ff91d6f0f49f"
-                            }
-                        }
-                    }
-                },
-                "gcp": {
-                    "release": "36.20220605.1.0",
-                    "formats": {
-                        "tar.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "745a08588afdeadc707e1b21ba33a6afcec2be095238b5a10abfd0944d0da706",
-                                "uncompressed-sha256": "a6a65f30645b6c80633d47575452642820bb6f112af792db5e44d85b087ad6bd"
-                            }
-                        }
-                    }
-                },
                 "ibmcloud": {
-                    "release": "36.20220605.1.0",
+                    "release": "36.20220618.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "c42a3537f4064e00d154d70b2d78a491b841f3a383e4397c5f895abe4310a41d",
-                                "uncompressed-sha256": "346602694ef61e157572cd19739443eeea9a651dd4dfdb30c05a47587e2f5db9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "92251197017fd4d7afd3dd58bb15774dc7b7c90d725d30dfa3df222a0f0bd264",
+                                "uncompressed-sha256": "4d5845004edc38e020c0f100d3e09cbdc84d5eb614b0f6896d8de43b0933a7a7"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220605.1.0",
+                    "release": "36.20220618.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "4219e3d16b6fd69b98a70f1c61952b37897d1be62ebe82244b6d30dc204099b3",
-                                "uncompressed-sha256": "0cbb609677c60716aa03b0cb561c4f4f1db52b7f38d608da5bf2554d127b923a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "db21a7f02590eb122e7913b30b3a1a9e4c8f8bb9c8ab4804898ee077c7711c6a",
+                                "uncompressed-sha256": "586a6d34254052af84f282736e1a616aa51887a269ef7e4bbbcf5cc046ae4fc3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-live.x86_64.iso.sig",
-                                "sha256": "f7c94e20257c75c8fed9100cbef2d3d66c79165e2fc48a9cb94659d20fbf56d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-live.s390x.iso.sig",
+                                "sha256": "5f23572deda12ba86b3078c541828172887845dbc0c4fe621127780f4ad53be6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-live-kernel-x86_64.sig",
-                                "sha256": "ac47aa3d1a21b5665f885f3c85c9b3b9d4bca6f7dd94c38c016f10c735b48d0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-live-kernel-s390x.sig",
+                                "sha256": "bba8bd387bf722cc6feea585eae2037b071296a4622f18c51fd7138e886d78c7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "87d1c724067b77745e0ab8d744f2155820735ee21708061b51c37cb48e7483e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "be90bbac3b1093e1f0de1c7d96287a09991f9546f38b16ca49b7800108bd8fab"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "b6b385531ec2ad7a57814d280cd797ab6e72ef7f9c2fa7ab10433ef3c1067413"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "dc13ec0866fec3117af044ff3eab06a7ed4771346e84aa0b5fd0b3fe6bd88e9e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "dd45262bed79a99113995cb8ca926b5b791db7acaf72dd1f4df17b60b590df72",
-                                "uncompressed-sha256": "177fb4efa5445e2cac4c6f1f44927c5066ddb7b1ac6907e65a7f085214e7153f"
-                            }
-                        }
-                    }
-                },
-                "nutanix": {
-                    "release": "36.20220605.1.0",
-                    "formats": {
-                        "qcow2": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "6b69a11b0e1a5355ece5a8ff06b667696028dabb33d5faecb96124e0b5232a7c"
-                            }
-                        }
-                    }
-                },
-                "openstack": {
-                    "release": "36.20220605.1.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "07af79be24a7c6c33c1752b88474afbb004ef99d29e4d02e5f87c03f52c685bd",
-                                "uncompressed-sha256": "d6d8c6681e75bb159fc345301463d8d54cfbc36b113ca38e8a3f9ca8551b8d9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "4156a8492bd83c64bd2983c63807f05544b0d8dd5cc92f5971d45369d7e3b2a5",
+                                "uncompressed-sha256": "0c52a19f7b0a017e251dd66b5daf693906e7fbbe7d3acdab6f7625953e785473"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220605.1.0",
+                    "release": "36.20220618.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "1768e0d277391388d90e0c283992e6ba23e46b9dd8d6f818d2c33ab6fe852c75",
-                                "uncompressed-sha256": "85bd5392902a705878aa36573d67b0c75023a5d349b47c1bfe7d2c8eca7fd9ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "2d005de7f0d5a4f7cc38966bea2f14e55624894b5c7ba2a7838431bd34b07e37",
+                                "uncompressed-sha256": "a109bb605f16afb7734d077ed196fcf25fb59d7aa4ee3389f61f70c47453750b"
+                            }
+                        }
+                    }
+                }
+            },
+            "images": {}
+        },
+        "x86_64": {
+            "artifacts": {
+                "aliyun": {
+                    "release": "36.20220618.1.1",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "c44586a9ee5de97f2896ffda65c70ce5759731172692e4003a8c6b57f5b2fb6e",
+                                "uncompressed-sha256": "7ea1dc85bcb508c74ad021e5617645b0dca5f37b1659626ff0ff4c0435a86609"
+                            }
+                        }
+                    }
+                },
+                "aws": {
+                    "release": "36.20220618.1.1",
+                    "formats": {
+                        "vmdk.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "962ff411aa37231a13dad291bad956601fb1e5755c9588a0ebfb86e50655f908",
+                                "uncompressed-sha256": "1e4274c50a45b0c6ca0674833a3a103061f8a200f850f5e7e569d5b922dfdd8b"
+                            }
+                        }
+                    }
+                },
+                "azure": {
+                    "release": "36.20220618.1.1",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "2b413ebd3a453fbfb8b19abbf7f74f48b9d80ab2a74e6f0d5de7e61da8b18844",
+                                "uncompressed-sha256": "b3af628a80743e6abe21bdb5206c7194141c4e87e546c62309dcb22481c234ca"
+                            }
+                        }
+                    }
+                },
+                "azurestack": {
+                    "release": "36.20220618.1.1",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "94256ba98cb1d8f5d6c295dbd0a65bcb5a671ccb2abd12e44337d40498d101ec",
+                                "uncompressed-sha256": "6de51653a6c3d4ec1e90a5e41e90e1cba9147e793b1744e236977d67b6a0729c"
+                            }
+                        }
+                    }
+                },
+                "digitalocean": {
+                    "release": "36.20220618.1.1",
+                    "formats": {
+                        "qcow2.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "4a9096a9cf0905ffe3b976de16b495419805db592cae6b644d0b3bed7f32ebea",
+                                "uncompressed-sha256": "ee731371859189bcb168e3c5015880d7ead979606e670f6bbe108e939cbc3a63"
+                            }
+                        }
+                    }
+                },
+                "exoscale": {
+                    "release": "36.20220618.1.1",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "1f311eaeaa73d6e597768b9fef3b9926e41cb024037a0990b6fa266186e30010",
+                                "uncompressed-sha256": "daaca1cf469fc6c128d0be96a92aff2083f00c131a0e7a31bc557553a75cf7a2"
+                            }
+                        }
+                    }
+                },
+                "gcp": {
+                    "release": "36.20220618.1.1",
+                    "formats": {
+                        "tar.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "d2d789f799a9caffd722cbafb883691856e396c57b20f043f1ec389380849e48",
+                                "uncompressed-sha256": "6ac5a6e4da1fa0702aa6ec0ebb8458f9846f728c1974c50aaea0b6e6629033f7"
+                            }
+                        }
+                    }
+                },
+                "ibmcloud": {
+                    "release": "36.20220618.1.1",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "d1a6a55cb9abf63c52a283bf2264a6deaf7231818debe5a33a2f8dcc72d1d999",
+                                "uncompressed-sha256": "808c5d0c65bb2da313cf0229c23e30a3b671a044aa778117edae5a17de9cd4f3"
+                            }
+                        }
+                    }
+                },
+                "metal": {
+                    "release": "36.20220618.1.1",
+                    "formats": {
+                        "4k.raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "c2a89e887aeec04ad9bd114015eaca5a1622b3d39dfec8b274bf2d133c807221",
+                                "uncompressed-sha256": "36ffb0130ef4f547b4e38bc3ee9abfe96b120dc72e3ffb8919306f47b4a4dacd"
+                            }
+                        },
+                        "iso": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-live.x86_64.iso.sig",
+                                "sha256": "bc14006fc8bbf9f0c80a2c130cfdecea2ad51192e1ee7e68acadfcc116981cb8"
+                            }
+                        },
+                        "pxe": {
+                            "kernel": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-live-kernel-x86_64.sig",
+                                "sha256": "19a12d3b6287560362eb762c52610b7a8e371ba74ed96bd758fa15098480b623"
+                            },
+                            "initramfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "bff1b7bc83d5234a1c77e5b23c8a189286fa6a3851b76956afd6f2d839067d63"
+                            },
+                            "rootfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "3f669ea02f9a544fc8c48313e87f6e8ced937bedf0b2d9bc837711b1c4d7885f"
+                            }
+                        },
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "82bdc7c1f20dbf90acbdede8451baac14cac3e48286fae3c9616b3ccd4dc9fda",
+                                "uncompressed-sha256": "c9795a73833b22fef284cecf94edd616ab7523132b10610d353cd5b595ba7447"
+                            }
+                        }
+                    }
+                },
+                "nutanix": {
+                    "release": "36.20220618.1.1",
+                    "formats": {
+                        "qcow2": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "36d82ad8c6d673b375988cab63abe8bb04e94a00cb2fa405b2998b96178e4fdc"
+                            }
+                        }
+                    }
+                },
+                "openstack": {
+                    "release": "36.20220618.1.1",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "1cd890912396e96c5404c5755dec199ad545d0c1e1031217135f4e86029c39c4",
+                                "uncompressed-sha256": "f03086a68f8c63b0e6c6cd1f0cf8fe9e6b757eb8d3b883965522315541e3106f"
+                            }
+                        }
+                    }
+                },
+                "qemu": {
+                    "release": "36.20220618.1.1",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "96549cc75e1213fd378ec4df4d0acdcaa563bd46daff2fc5811371fdb77bf85d",
+                                "uncompressed-sha256": "9a8fe296d9fc39f92f1da66bff039021ba46741a4264dc5d559fcf8ff72c951e"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220605.1.0",
+                    "release": "36.20220618.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "b095a7346ad2670426b97d226b33400f5578b0fecfe5893732df5b275d651d92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "2b3258316c6fe65b29152030718cb16afacbbbd7f9159d8b620b26073bf4a123"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220605.1.0",
+                    "release": "36.20220618.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "fe2d4437946d7c30ad0a61195b83a242230daf2beb778ba321c4e13f4b23ae56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "5969e2ceaaf28e31082ae9264bfea05c1595404f1eda2d49ced38e1735759514"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220605.1.0",
+                    "release": "36.20220618.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220605.1.0/x86_64/fedora-coreos-36.20220605.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "a5e5e7e6d110dd50ef782a092427941b828bee51050a9057745e65e2f2ae01e3",
-                                "uncompressed-sha256": "74f3af3b6e4bcedd836b8762ce8296a6970ee653c100a81679b0ebfad23fa29b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "074c0c52c43188a8d27a1f4a8684e3b85a3993b4da3ccfd7a216c5bca23ebcf5",
+                                "uncompressed-sha256": "9a474588241e217b444bb706308f170891872e4fd376d38b0d14b89b0f70be34"
                             }
                         }
                     }
@@ -418,100 +494,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-023c702fa29d1bb55"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-07778f57b1ba6296f"
                         },
                         "ap-east-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-03e2b791902c49e06"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-08b9519e0c3b2bc03"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-0deea70de773791d1"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-02c6760e842541f3d"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-0c1407c844dc18679"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0735805e41624ff07"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-0984e5726e4a71611"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0b9a5eeffa87628f5"
                         },
                         "ap-south-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-0af6d40140668710f"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0f39fbcd7acb94626"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-0be7134e02b24ece1"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-08033e7263b637b63"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-0228e34694e7332c3"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-02c0152021c9cc9f3"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-0a7b8dbba305fb646"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-03072d3b22cb8148a"
                         },
                         "ca-central-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-0a5b4aa4622f4b059"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0469e0d96acd3538f"
                         },
                         "eu-central-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-0f1ba394bf4d39b37"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0794e72dea892abc3"
                         },
                         "eu-north-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-0e938a1cab6d5a334"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-06c7465f423b24f1f"
                         },
                         "eu-south-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-0834e45f552c1eb89"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-007f872a9381f27f1"
                         },
                         "eu-west-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-01b1a86214cbdb4d3"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-068292feac2a7a377"
                         },
                         "eu-west-2": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-085567153c9286f1f"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-02ef7e302306fe917"
                         },
                         "eu-west-3": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-0993b09a6857f4806"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-059d610712a3c2e2c"
                         },
                         "me-south-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-0c713189d80919b38"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0a0bc752da571045b"
                         },
                         "sa-east-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-09b4bdf651a4b970c"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-03ceb3c8972fe2fac"
                         },
                         "us-east-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-0a6808ab884675298"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0649961a33f15a398"
                         },
                         "us-east-2": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-0f92beb45038c23db"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0ba3699c77cbff059"
                         },
                         "us-west-1": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-051788604a6ff3c75"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0c21b32937718e45f"
                         },
                         "us-west-2": {
-                            "release": "36.20220605.1.0",
-                            "image": "ami-0345e8928ab4e49d7"
+                            "release": "36.20220618.1.1",
+                            "image": "ami-0e1ecd943f9ad7993"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220605.1.0",
+                    "release": "36.20220618.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-36-20220605-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220618-1-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,92 +1,92 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-06-07T15:35:56Z",
+        "last-modified": "2022-06-21T14:08:33Z",
         "generator": "fedora-coreos-stream-generator v0.2.6"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220522.3.0",
+                    "release": "36.20220605.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "dc05efe5448a59070ab5adf2741a574cfb6604a0187239f7bbb95b525c177b18",
-                                "uncompressed-sha256": "c8982e9e50e99dc38c0aeed93726f33940e2ae8102da50b7bb03438e497f18ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "0489fc927fc6792210ce56923b3da91251844df86bc9aed66cd56cefce95246b",
+                                "uncompressed-sha256": "2ef3f840961682bc9b49e3a2830c9b5e3a2ba4b187755daab105e04b21e2717c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220522.3.0",
+                    "release": "36.20220605.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "d7e62e3c5b92a0c6f63f4a07cb1d9b4ae81dd1dfb3ebcf7902c8b187f86516fb",
-                                "uncompressed-sha256": "38dc3b8f55bcf2b302884367de6154d54713fb4322151f990b2e9b09f9a1fab8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "2037937e69c5e9715eff42924df0fb63763c0da13ce7239ac3104bbf77b69bad",
+                                "uncompressed-sha256": "5ed618ad26349445e4416c14b5e8e4baef78f803e8c3127648ff132900427331"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-live.aarch64.iso.sig",
-                                "sha256": "a31923a78668dd0a29ed8f64ef0ac43b4dae123c295add10f55782c7f159513e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live.aarch64.iso.sig",
+                                "sha256": "b5d90aceaf0e0eed585877cd033f2447f6cb8dcff32283253393cec88e6ffcf5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-live-kernel-aarch64.sig",
-                                "sha256": "b314a92e590176a5208b9237e53351cbd52f6b883a7aaaf5ddb99ad8bee5ceaa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live-kernel-aarch64.sig",
+                                "sha256": "d43703f0f6eefa6ebc26dde5fde0252da632a847392904d5e2348dc215ce6fb4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "3bdc7dcb7b471012ef80b68775e1fb2b457935ea8bce1d103666572b4c64a61a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "7ac56ff4bd16d08eb6022043b3e72773f68768e6b1693a2719f394aba8af0325"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "c98d1c83b3ce27840905eb6bf14979694b7959e1e824eaec595e45cbb3b1f10e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "eb0a59d06b3103fbfa4b4aa659a14696b2454fc1910676d73a19ed1290568003"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "ada0f3e11e72e506088d2ee26cab6bae310ac13ed859c81521e621ee33b52282",
-                                "uncompressed-sha256": "ce452debefb91cfd81d1f9386e02a647caf27c7a9fe897f3b391cb54a0b0ec1f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "f43e282eb104649c2d8aed9bdb825a7921efc1374536659562b7bed17353fc4e",
+                                "uncompressed-sha256": "fe569075ff24fcf5ee1a70ab29f5692e249d5f70e012200519396e1021b66e50"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220522.3.0",
+                    "release": "36.20220605.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "1e1644c1514fda3bf8563bce0b401aa1147c214cbfe206cda9f39d4316e30119",
-                                "uncompressed-sha256": "49b6be1097926472e422887430a84f996145f2e6158d83a9415f4fd2ec41c06c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "241c235aa0377986f3d837939ade017456938e3e93cfdf1419bd59ef28438d81",
+                                "uncompressed-sha256": "b4d6a77f2a2b7b92c991d753aad6ae3010ed648b06104dc1d6ad14c4c29ee8bc"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220522.3.0",
+                    "release": "36.20220605.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/aarch64/fedora-coreos-36.20220522.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "a4f9681d9e15ac41fda15a8c7a15671100e1557ec8a6952c8e5fb0f248b0258a",
-                                "uncompressed-sha256": "cc5a025b981fd600c0a5f0bac00fb544529f1710cab2c9219424f652d0d360be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "c2a953b7e5a4f4f1f4c21dd489a352854eb204b176b5386fe4fe46ae1dd8be9d",
+                                "uncompressed-sha256": "9842087452d55c51578661875a1c2d96e148b00d8804f3e11e2f98ccfd486b07"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-090081dcfdde9a156"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-01c169e432b991a52"
                         },
                         "ap-east-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-08d35e10d990adc5c"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-037b9425f78e223e4"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-03fdc783e7657dd47"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-063ae04d36383ed0b"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-09ce955a168e4b72c"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-092914ed089113f9e"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-0bad08d741025d2da"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0ff7fc919b81ad551"
                         },
                         "ap-south-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-061c23835673bcf8c"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0691078078f5737f5"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-0d1f04801422995bd"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0930b69cf736a0937"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-0d570a809a97e026f"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0a11e4d49c5df91c5"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-0b1cadb7d03e0141c"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-05b330f432a7a5366"
                         },
                         "ca-central-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-00f9ef81a2c6174a2"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0de4d555ad68dca90"
                         },
                         "eu-central-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-062f87e32388d1edf"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-00f6a0df93b7d1a4b"
                         },
                         "eu-north-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-0cf9ed3bf42b69ef1"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-07f7f3dc3f68ca381"
                         },
                         "eu-south-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-031dc8741fd297aa0"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0a81cb2f749a3becc"
                         },
                         "eu-west-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-08b2dd890794d2563"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0f39059f7774198af"
                         },
                         "eu-west-2": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-020e2fd660aeca90c"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0d8f7464bc9110031"
                         },
                         "eu-west-3": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-038a3fdcb53651f8b"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-064db7b365f7a9760"
                         },
                         "me-south-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-03738a8e914c6d797"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-010f06d1a90f46985"
                         },
                         "sa-east-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-01693fd4ec68c9596"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-066d590f75fac95f0"
                         },
                         "us-east-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-01d60ea1e3fc94127"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-099d6b9b1339fa083"
                         },
                         "us-east-2": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-0c3d8eacc817acb20"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-09e2300f99c1530dc"
                         },
                         "us-west-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-046f9a9c22ccda34c"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-07cf4694ad649a069"
                         },
                         "us-west-2": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-0af2ab4d31d671de2"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-010f881571730769f"
                         }
                     }
                 }
@@ -190,225 +190,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220522.3.0",
+                    "release": "36.20220605.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "d62506b541bf238fa1a6aba08b3dddd30715ae6089b7e53f9605bc67197b84ea",
-                                "uncompressed-sha256": "b220e7aee8de81daa81c15d9f03c8c1a3d22a8072342b1e3dd68ec9b5860fd2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "99c1516f99f89f84c476aa327651c9b63ea0409e8c9ab1f171931ee8c80228c8",
+                                "uncompressed-sha256": "006efc926af451261f76ecb8cbf3f9cec16e583973dbd0fcfd1be7b8ea6a78c0"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220522.3.0",
+                    "release": "36.20220605.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "77300ee0ee91fa24a62e4b56d868669ca53136b4a9be92237a42683ffe294d88",
-                                "uncompressed-sha256": "c540815a6c5447f69d1d768fc1e94289169995bccb613100939248b64f0fbdad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "cf0f467255303f89b6ba61ad9b1c1bb546a4dd026aba8af5c97b54cc63694106",
+                                "uncompressed-sha256": "a030f4b55e585ff695ce3a24e96b763a1e117724dad52627d95d4f99ddbfb774"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220522.3.0",
+                    "release": "36.20220605.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "b7a110c49bee4a95a6d81c7c72698b3792d66b765ba84e3f6e5412825854afac",
-                                "uncompressed-sha256": "67ae90b2bba38dc824f7a3b500ed98d87ca8f08c53c50ae3b65a8933773e9e4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "4c5a42cb635cf4691b7107caddd08eeb6e039af4cf8f76f7f2e216fb55ad364d",
+                                "uncompressed-sha256": "2c5eb4a2060e3e547cc1103a4ed5857a819fab9f44b726151d3ca42ac2c419b8"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220522.3.0",
+                    "release": "36.20220605.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "332484b8eda595f40a12100580db0c0e4ea784a2a9b2b891a9cb6253f580b654",
-                                "uncompressed-sha256": "eca3735750d89aa1b7ffee6c0087a05ed678ad3a3dec226c95d7bd6af18c2c6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "06d94d70eb6474d59131184f645f0ca5f7e613a90aeb2f90e9aed80d73b00a36",
+                                "uncompressed-sha256": "0c750ba56a562061d301d435a587d30c728e050cb357db9e6139ef811bb70cc4"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220522.3.0",
+                    "release": "36.20220605.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "34ef499b5413ac9fc92b834b0b8950d3a08b07c0cc3f83a9703f2ae26f2691bd",
-                                "uncompressed-sha256": "a521fc64434f9c060357e6b8b94570a5835c18f2878d959f966be9bb78219a8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "048ca51487cab906187a4c2d0f5e1439e3db3da8e9d6e3a92cde32854a86fd8e",
+                                "uncompressed-sha256": "5cb234af18911989c579561d8e829d2fc8cc3f8014e2be04c4c6babbb9535903"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220522.3.0",
+                    "release": "36.20220605.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "e8afe2a773f3c9d48e947e979e556b22a7af187bc2f52b81a33c3c7a2a5451b1",
-                                "uncompressed-sha256": "e087d211402a3b2e9aac26fe99d60f35280a5e8101cefa819bd8f3be646025e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e41d201cc6812f44836afb18e4623f433a5b5e65c6e27fa38629f09e9d54a224",
+                                "uncompressed-sha256": "27f0fda33e1f0883faae2f89447cddaa63013f1ef231e772b42c8d3f333967d3"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220522.3.0",
+                    "release": "36.20220605.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "4dc9784e0f733240c1cb1d8fa6de77d5d1dd606fd538c42440a65efb3eda6232",
-                                "uncompressed-sha256": "9fd3622c5b552a6790bc02b316166c6aefc68735db2051a64cfed5f67c58f245"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "cd715f3d2daa501ee7af98e1ca11d09320b709bc4fe0f9e3c51e40d9bb5d71bc",
+                                "uncompressed-sha256": "90e4908cfd7e582ce5a3d02dfd4bede34934ea443bc09895a34bffbdb0ee1754"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220522.3.0",
+                    "release": "36.20220605.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "be86536829030fd964bb7773f13e5248d5c9b950e2c3bfbad2a33118a1a5cfd9",
-                                "uncompressed-sha256": "6cf067118339113c19860b0c6896273752b2328e421f348076ed8c66323831e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "a92442a998d805382929edb77725c0baa187f72a8eef20b03b3ec67ca0589df3",
+                                "uncompressed-sha256": "a4dd9def33468abbe08bf5363da5aaa9e8fa9ad83c560c74c2343938f18169eb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220522.3.0",
+                    "release": "36.20220605.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "5bd2baea6e18f3474661f840d94aaec51da52bf7dcc8bb56d3d03b2ae3405e05",
-                                "uncompressed-sha256": "a2f08164ba555449cc1743f9b10b9f64763eda9986be88b2d9955c0fc37d4204"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "dbc755e0bfd7414a7accfed88c21184a072f6ea8eacf82aa461ca39f279fac98",
+                                "uncompressed-sha256": "805d77570c82b796cfa83af3548053a86f208ce5506e59a7b0ba526d8b948667"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-live.x86_64.iso.sig",
-                                "sha256": "187d9119d00c4372daee08e06dc140055b1c74079e7cda5d183d574428e846f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live.x86_64.iso.sig",
+                                "sha256": "66941312564cb6b3de1ea536aa162a5ee747a4668faecde88fa38bc668df1100"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-live-kernel-x86_64.sig",
-                                "sha256": "79d20c0b674d84569db5824091286497ca93793a3acce4dea02f5e06e3f61ada"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live-kernel-x86_64.sig",
+                                "sha256": "ac47aa3d1a21b5665f885f3c85c9b3b9d4bca6f7dd94c38c016f10c735b48d0e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "19ad86d1486c6a6c4734e9fa443c39ed2bf2a76d680e208758cd4974c17dd676"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "2cbda89fa398ce9aa085492c291f83aacb8ed22f7e3c019c69ae10b03e0231f4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "c51705f763bfd7e46306fde3cc0fb3902cf9f41544812914fb9b0706f13f1065"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "e133a47f03d063ea90540dfe8401182b0f089c1bf2b170d2dae63c5433410f6d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "d60757aef7cf0c1695e15c3d7ab5980c174778697dd9e875585af47acbd583a5",
-                                "uncompressed-sha256": "a8b0e5f2d1c68a317d58188f638260ad5710f27a6248aea9bb581241be9e46d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "f09b9b2735cf69fcaf3a52ff8f8658aefb19bcaea2768a13824ec6735686552e",
+                                "uncompressed-sha256": "f8aed4a84e81f47a30c694e1e6dcb28a0e1653de39aad24eda17e532d68c5fce"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220522.3.0",
+                    "release": "36.20220605.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "e87f875674b6c38273561d1857fa012efca29923264606264b7425d84a514a78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "fa4a316641c77cff0086b39779e9d62d8496821da34c10c72e2f278e3a2cfdd7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220522.3.0",
+                    "release": "36.20220605.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "caed2fb2ba818d7867c14bd88fa30fa1ce3986f95b4ecaff07394d17b9992e92",
-                                "uncompressed-sha256": "5c56d3df1f9d4963131000bcc456a0ad0dc05a5257e1b06f0d39642a0bbfc726"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "7dda9700e5b4e6c15a8c81520a3613ac31105d61ad03e88ed265ba463c55f98c",
+                                "uncompressed-sha256": "e27205919b098a8f443296e7b0d6afbdd5a9f2cbdf389446f760e41f216c25fd"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220522.3.0",
+                    "release": "36.20220605.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "61972a3df0e1051b2dc61f0fb9ee6f94d69b9e7bd48576c316f6f119114ca35c",
-                                "uncompressed-sha256": "a2c01e0a69b75c1d164d68d7bb7370b85274113aefb9efdb0ef6e5cbba92ceaa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "21a1c0f408ca8817e0a4e969828ccabf26e8db121ee5a48dd191e9525ec16c90",
+                                "uncompressed-sha256": "c135a76958f093ab7d5c72d5ef8ad7ac4347caccec01e0998092a6a42061a4b9"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220522.3.0",
+                    "release": "36.20220605.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "efd4065d3355259f426a3b62ec465574a34a531d07b3d3c086b89b54a73a1e9d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "d582f891288a4b29a615f80c18bc94fac6025611318cc2b2149dc1dbfcc7814c"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220522.3.0",
+                    "release": "36.20220605.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "ca9bf44d702d1bd7c3c744f2916a8891ad12cf0ce8cc995e900588751fb18c18"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "1d6be531b1cf30e0657a6b9749de4be067fefecaa7f443d919040028eba28698"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220522.3.0",
+                    "release": "36.20220605.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220522.3.0/x86_64/fedora-coreos-36.20220522.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "2f8517826d8095ad61af8306346696cdf25baeeace5d266710957ce2e65af8ac",
-                                "uncompressed-sha256": "c6acd0c4e603d973205eda5e4a27d4bb4650ea7327f095f349ec83801de25d12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "3877ed1a9ee0a46a81e6e7993a9d24b8a78d90d4de6b5ab22d58d80df95ae029",
+                                "uncompressed-sha256": "9316b5dbae47e36ea8c00d6383f68d72dd63bb007cedb8299f2fee074409c1cf"
                             }
                         }
                     }
@@ -418,100 +418,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-0d46a5bc534d80176"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0082386ed3c7bde94"
                         },
                         "ap-east-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-042be30c47e1b41f2"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-071cdcba4d2279084"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-0baf3013ccf6ce0c6"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-03c92db560f4f9f7b"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-0b5df0b1afd245042"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0f1e8a2a7b1acbf11"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-07480eab1342b05e1"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-01ecd2d463f524375"
                         },
                         "ap-south-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-0cd4c61dfaf7f7401"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-07d493c6cc836d651"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-0a0974cf6d0c7d7e8"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0998769d3c22cdbdc"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-06ee1aaf6c6fa1c1b"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0f3545edc9142ccc2"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-0107636c1c50f233b"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0320015d4da80708d"
                         },
                         "ca-central-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-05b04b0c012eee258"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-03fce3c5b2103e866"
                         },
                         "eu-central-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-0b8490b038e35f28e"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0432542ca6340bbc6"
                         },
                         "eu-north-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-0cf37b318cc71dd44"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0826206f35baa28a6"
                         },
                         "eu-south-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-07a64b05889673f6f"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0acdd9d8ecd732ac5"
                         },
                         "eu-west-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-0bdc24edf292d8199"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-04dc67d11375529d9"
                         },
                         "eu-west-2": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-091de873a493a6866"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-03f56d07a739aa94c"
                         },
                         "eu-west-3": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-0040b0d64cb3b7b09"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0e572f0bb71f173fb"
                         },
                         "me-south-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-07bd556cd346e2d27"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0bc60ec5e634a73c9"
                         },
                         "sa-east-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-0612e14c5c86fbf3e"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-00d284737e8fc2edb"
                         },
                         "us-east-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-01ecc0dab7f3781f1"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0d604208402ac04e1"
                         },
                         "us-east-2": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-039c0e00b66e20cad"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0f70a909636c5fd14"
                         },
                         "us-west-1": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-0c9e063b3cf4c8b90"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-0286b6e1ea4e62caf"
                         },
                         "us-west-2": {
-                            "release": "36.20220522.3.0",
-                            "image": "ami-09afe7e4d56f13e85"
+                            "release": "36.20220605.3.0",
+                            "image": "ami-098f3c5f1a8e640f3"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220522.3.0",
+                    "release": "36.20220605.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-36-20220522-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220605-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-06-07T15:35:57Z",
+        "last-modified": "2022-06-21T14:08:34Z",
         "generator": "fedora-coreos-stream-generator v0.2.6"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220605.2.0",
+                    "release": "36.20220618.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "032c6576b16739b82fb3f2d9582d07cdff58666ee63dc957cc8ae6ecca395f33",
-                                "uncompressed-sha256": "dcc1ab11a2e48e29bdd43a64ca73a129de39b50ce539f4c7f49a8d22d64ef8b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "11eeb75ce55503abb40d8e7641ecf2fcd24e3a1831602c3e5bc469e6b25d5634",
+                                "uncompressed-sha256": "22297d2269add0538ae5747f1d7e2f7ef6e986afa604c5b599e3dfb483a723cd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220605.2.0",
+                    "release": "36.20220618.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "280f74bdbf5ade677f80183a43195ab43782d5327fbbcb9e03741ecbf439ce4b",
-                                "uncompressed-sha256": "661e832a86b235d1fc1fe572bbf5010fcd6ce0acdc56794edff92caccbc2fe11"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "e437bbacf7eaa06a4640e03db6386138ab7eb9fe4ea714664d35ab3f6a393dff",
+                                "uncompressed-sha256": "12933ded07e01a34f817b560229f0dae46279514368f49557a417699aa5bab2e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-live.aarch64.iso.sig",
-                                "sha256": "f4b939a1e68f096f7a7b6984facf337b3f70ba500ed641df2b706a3ebe2df657"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live.aarch64.iso.sig",
+                                "sha256": "54094ae0e43c894608785fde7d4935a5427f5bc4091327f147d3510133239904"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-live-kernel-aarch64.sig",
-                                "sha256": "d43703f0f6eefa6ebc26dde5fde0252da632a847392904d5e2348dc215ce6fb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live-kernel-aarch64.sig",
+                                "sha256": "fce2ccc1f09cef7709cb75274adc015836baf9e78d094335fd803252dc8c9622"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "c03290b0c6cefcc47af275ac99810a8065fa58a02c7ab346fa3bf771d20f35bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "5b42598a7afe9fc766337532212c0763d702c42414377d4d062ac328f4e1d34a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "f6d203a525bc51c7e660f71d3da718803072ff454ddf752e7cc55c123a2819bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "3aed0281ffc1b1c04cc982a05711c945896e48e74b57c3ec04f2f7f622d8f19c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "e507f146ed976dac16b6104c82aa696bdc5add5b5b0a4bcb8221f0b57c635e05",
-                                "uncompressed-sha256": "66f93d1098ac7fd3af8526493a7d8b92f56c3ca4eb2d90695b2235612207bf30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "bc5fec383a9919cd8c8813e9788a0d826c5432f417d5133e0bb9b40356aca3ca",
+                                "uncompressed-sha256": "5c4c0389c5fab9eb0395b063c836d86d74463e8c89590e1cf9a9c7b23fe01564"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220605.2.0",
+                    "release": "36.20220618.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "63c018cc6bec628ffc77ee0330f49d3153082e637813957280840d2ab7d4072a",
-                                "uncompressed-sha256": "9dcf6c7e4cc9df5cdb6dc760fb51663417b4a7f7851c23cf397aaa662cc3e0fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "eec36f7c6f91e215ba369a25eb30bd613e151cef650434e4e65351ac181a4426",
+                                "uncompressed-sha256": "31745f7fddc77b3307c166f72e6810d56edc3b9ff5cc34a3923ee0173cd87cca"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220605.2.0",
+                    "release": "36.20220618.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/aarch64/fedora-coreos-36.20220605.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "d6af2fc8e9cb63777bebd3cb4fb9ea8f6576810b65a98ca49252403c7aa5cb73",
-                                "uncompressed-sha256": "3760aeac428ec7f943fd2e78099ebebd9eb22f1d325d646a8f216189cfe05990"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "9b876cf1491655ec7f03d5be7e50d0c547a83d7a0736a1195016c8562395054b",
+                                "uncompressed-sha256": "f04f8c0e83a47e738ea0df158f638e8c199864e2483dc16c97832ce5194d7c29"
                             }
                         }
                     }
@@ -96,319 +96,395 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-0a7c77fbcd6bdaaf0"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-01e394f80d32f1d57"
                         },
                         "ap-east-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-08f5034680cb52c3b"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-050bbac0e88eab075"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-037b0c96706cb342a"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0216c60ef9911f8c1"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-09a39d1842ec23972"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0f4771fae51ea57fd"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-0b26ad7921090c01d"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0c2a92a0c0ae706e1"
                         },
                         "ap-south-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-0e7c59a108eef84d9"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0c0f5ccae08caa9d5"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-0ae07b427d539f8d8"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0bd3ed3356771771c"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-0aa9845b2a0fcbccb"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0905e0e9bb8a66fd4"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-042adda70b3d034a0"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-07a2bdc2f6ca5b47f"
                         },
                         "ca-central-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-027774257f90aa313"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0fbda341c2f5b2083"
                         },
                         "eu-central-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-06be430acf1e6b0fc"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0aeaef9c3e766d55c"
                         },
                         "eu-north-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-0f903106e01263a1f"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0ba8d8a6a968616d1"
                         },
                         "eu-south-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-09ac3dad0ece97d88"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-00e5e8c7289ade7e8"
                         },
                         "eu-west-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-0b669947e25b532b2"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0f23bfb81936997b4"
                         },
                         "eu-west-2": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-031a0acbf934caaf4"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0aaffca81ca29bb1e"
                         },
                         "eu-west-3": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-0b064108beb10ca59"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-07be9fc3b804fb136"
                         },
                         "me-south-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-0df322a3a6c84f36a"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-002285e5433bbe52b"
                         },
                         "sa-east-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-00b855bd166a0e727"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0b93af9197de2e4be"
                         },
                         "us-east-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-026d85acb4edf8cd1"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-01498eb06dac3520a"
                         },
                         "us-east-2": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-06ae94ca273f9f0f8"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-06750517062b27156"
                         },
                         "us-west-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-06a80ee9fb634e690"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0c0c4b06511ab929d"
                         },
                         "us-west-2": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-0545bfea13fc295ba"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-02a5976e743cbf8eb"
                         }
                     }
                 }
             }
         },
-        "x86_64": {
+        "s390x": {
             "artifacts": {
-                "aliyun": {
-                    "release": "36.20220605.2.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "c5ef90640172920c19f8a133b11a2b7811e3e3664f976c92be2918a032f22d35",
-                                "uncompressed-sha256": "a7808f273a1f6243c97acbac3cba7970da712d5d77509b85cddf3e1193e4b5fe"
-                            }
-                        }
-                    }
-                },
-                "aws": {
-                    "release": "36.20220605.2.0",
-                    "formats": {
-                        "vmdk.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "cc440c52c1ab6e58c8574626ccfce8d039567bea79ae22074deff70eda143399",
-                                "uncompressed-sha256": "18e43db53aaf4a9f5a9049b2abf4de70b60ee80cf5b99c4c1ac0e16e412ea128"
-                            }
-                        }
-                    }
-                },
-                "azure": {
-                    "release": "36.20220605.2.0",
-                    "formats": {
-                        "vhd.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "4a79993636c477baa866bbc9c3fb9a848137d16e8600fbee74a6650a8cc2ff8b",
-                                "uncompressed-sha256": "396dc51f88d3bcb12131025519a5175917e38c3ca845c00c5081ff6a6a5c1e43"
-                            }
-                        }
-                    }
-                },
-                "azurestack": {
-                    "release": "36.20220605.2.0",
-                    "formats": {
-                        "vhd.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "ce27060d242f355625af85c8aac0138a5bae7acfb59be5e2505f96684811b46b",
-                                "uncompressed-sha256": "fbbe555035c1b00cc62e0a70790a6719b7b325b0a5d3567e4152fa485771d6cb"
-                            }
-                        }
-                    }
-                },
-                "digitalocean": {
-                    "release": "36.20220605.2.0",
-                    "formats": {
-                        "qcow2.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "b56a761e471623822ed6c9830f325fa0fb8f4a4250e5bafd12812c37d8b3a5dc",
-                                "uncompressed-sha256": "e838328d1cf3c87f391c55c4a93299eaa5a53a951f3814ff3660a3b54421f3ca"
-                            }
-                        }
-                    }
-                },
-                "exoscale": {
-                    "release": "36.20220605.2.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "ddf145a8bfb9dd1a6f4d6dcda88327c80ee1685a44250371f24864e7f57e434e",
-                                "uncompressed-sha256": "727c589445bbea6f389cd941e39a35800c6e7c9de8123bb454c3e15a17c20d90"
-                            }
-                        }
-                    }
-                },
-                "gcp": {
-                    "release": "36.20220605.2.0",
-                    "formats": {
-                        "tar.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "b5db1d56743dbf32917753c4dd6009d873b0784caf7f39f8103aff4b0136cae5",
-                                "uncompressed-sha256": "219aa940c8465111611ddf862124666bd35bd4a620e409c65b0bdbd07498c225"
-                            }
-                        }
-                    }
-                },
                 "ibmcloud": {
-                    "release": "36.20220605.2.0",
+                    "release": "36.20220618.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "2526c7d2b1a2c35a2d2903019866c635e0ac954a87168d012a8fe3ea71d42ffd",
-                                "uncompressed-sha256": "0cc515f6fa7a3a087ca96ec2ab0db92f2699d5c102b136c7040921a2bf3d8338"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "505643eb16180c292db3a409fe491d943b292914cb46c3e2c53c61957de6fbbb",
+                                "uncompressed-sha256": "c3a1fb7087d7be9125d9307d6bab7b142be0f3ca5b6073a5e0d488b99ceeec53"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220605.2.0",
+                    "release": "36.20220618.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "9b661440d0a78274244ae3b31480002163f46db649611dc0083c9f8c4fb74044",
-                                "uncompressed-sha256": "f63bcf30449c5188d82300fe88f6fcf04a1a4926fee1a861f5d16ef248a5e558"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "fd0706770b76ad9b150899437f9779979e3b9185d007752dfdc68cf8449c7ca4",
+                                "uncompressed-sha256": "2c0485156a35203f5191df7d65d7588708570e00687c1dc0e14d45fdcea4dda8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-live.x86_64.iso.sig",
-                                "sha256": "2a4167c4258f16b9f2c19290e517e3b5e6a6adf9633dcf0207bc52faf0492fcf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live.s390x.iso.sig",
+                                "sha256": "27e8369bc1be3171fc459a769aca3ab39b71ae8c82f7bd10c1228f5242ad66ff"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-live-kernel-x86_64.sig",
-                                "sha256": "ac47aa3d1a21b5665f885f3c85c9b3b9d4bca6f7dd94c38c016f10c735b48d0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live-kernel-s390x.sig",
+                                "sha256": "bba8bd387bf722cc6feea585eae2037b071296a4622f18c51fd7138e886d78c7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "0ce4495887f43490dfec726ceeedc642224c08821c58f6948fa644b2f755905a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "df97a9223e847123ba5c1d43f61393d0f30a83245bfcd2782b9387f71e0963c0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "3950485ad332ae9d385434660bf179dc84a7e99c5a1c52ec72049e43e92d4ad6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "360c93aeeb5610e497ba8d49911a3ab90070d17d3696c09caa534f389cc1c7c1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "22b1d9ec3dc9267abb8b5707cf3cc75d4186fac9192d84f90746685301de412c",
-                                "uncompressed-sha256": "76f253a41ce1bbc00668971d07e28b855ea249238490368c4f2bff639dcfd640"
-                            }
-                        }
-                    }
-                },
-                "nutanix": {
-                    "release": "36.20220605.2.0",
-                    "formats": {
-                        "qcow2": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "ad3322443f926847c0b1c21fc41a7285da519c071acfb71f8d522f77e036e6de"
-                            }
-                        }
-                    }
-                },
-                "openstack": {
-                    "release": "36.20220605.2.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "786cc39b678175ec0e76d9afd36c0a689f8904107ef5b01959a2de1ab3014a4a",
-                                "uncompressed-sha256": "7f2faa0b967d80668b5bd6546711622a2e736a1f41c909ed67214f1f158f3eaa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "4751f71846a076b3c6a2a2569ad67f3fe67d08c6059b1a82bd8e3362950d5f7b",
+                                "uncompressed-sha256": "72cd06f6579e6377cd0d32506b6d1f97edac9aa1eb0d3b62d57f3616054fc123"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220605.2.0",
+                    "release": "36.20220618.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "46291e2b77177e803903f70e0e87c1c0265c8100b450de372538d6ad1df3b981",
-                                "uncompressed-sha256": "8c4fcd7c538764218183ccfeb90ff5623d4caf4097fc9c48402acdd1b39e1317"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "bf2d6ca9ff66671ac48e276dd6d7143f3db4980298e4e00f77001072f4460c36",
+                                "uncompressed-sha256": "8f039b8af8d2718f467f8598f7b9b02905353f4fd198b5d00f68c60b8d7e1705"
+                            }
+                        }
+                    }
+                }
+            },
+            "images": {}
+        },
+        "x86_64": {
+            "artifacts": {
+                "aliyun": {
+                    "release": "36.20220618.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "b754af10ee9480bce5cdd0c684f0a34f0ab8a322d384932c2d200d64f70826e4",
+                                "uncompressed-sha256": "9878778af173dc10b27aaa455172c1be660dcf1dc3f3bc9b56690c81dbffb609"
+                            }
+                        }
+                    }
+                },
+                "aws": {
+                    "release": "36.20220618.2.0",
+                    "formats": {
+                        "vmdk.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "383a471e4a17f0c049f7d67e0b8652308a291754d470b5f0782f7dfae7d00bd7",
+                                "uncompressed-sha256": "1cca3cc80da6425eca9fc5ef3a6e3c6f9f464d2c6622902f8a6cd75b924cb900"
+                            }
+                        }
+                    }
+                },
+                "azure": {
+                    "release": "36.20220618.2.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e887c6d37649019981de880d1999430c9bb56d8998828ce10a159a69371b6c3e",
+                                "uncompressed-sha256": "bf37c3214aa8ad68a25f7f5e634683b1dcb700a9c0cb9949b19a7bffeb239478"
+                            }
+                        }
+                    }
+                },
+                "azurestack": {
+                    "release": "36.20220618.2.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "c17939ea926a133c7127c2241fb56aba7e7edd7a70feedf969141a64f516b247",
+                                "uncompressed-sha256": "cfd496c7f4d65dc89c726d9f0a1f702dd86fb49b9097bdf062ea3d87f0865569"
+                            }
+                        }
+                    }
+                },
+                "digitalocean": {
+                    "release": "36.20220618.2.0",
+                    "formats": {
+                        "qcow2.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "aa19136a082f062bf1d9b0cd956b13cd6be5ef3af26472dd3e7ca272e95b1b3d",
+                                "uncompressed-sha256": "ca938d88b87a6c655df3efee0c95ea70015fda5df5b5308f2a793c3cbf16d066"
+                            }
+                        }
+                    }
+                },
+                "exoscale": {
+                    "release": "36.20220618.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "8e5cae785eebbc9afeb7512be459bcde0d76fa138b6307621d86579bf7681472",
+                                "uncompressed-sha256": "d7f210419d1cf5be9252b29095f2b2e7fe6e92aa553388c01379ccd65ba715c8"
+                            }
+                        }
+                    }
+                },
+                "gcp": {
+                    "release": "36.20220618.2.0",
+                    "formats": {
+                        "tar.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "ee78d7612bd472affd6189d5cf2130ac436f158b94b18401c49bc082206eea93",
+                                "uncompressed-sha256": "0609a01cb4b8509b7f916c037569fe68b554ddca57e38ac3eaeab7bd7361d584"
+                            }
+                        }
+                    }
+                },
+                "ibmcloud": {
+                    "release": "36.20220618.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "157cf2ea46bdd6e2a2866c18fefedbf2b78219bc7a3ab552ddd55692f53ddd76",
+                                "uncompressed-sha256": "402b28934bf3252ecb24b7031fcb6092a7c18bf21ebd600c2d2204c4c90e2090"
+                            }
+                        }
+                    }
+                },
+                "metal": {
+                    "release": "36.20220618.2.0",
+                    "formats": {
+                        "4k.raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "59ed361ab7f410140780929878a80610f0dc34a8d03a2b0c18c97c6c1e3d12e5",
+                                "uncompressed-sha256": "ba437f6c240dca68d705b738a35c51aafd3309880f2e279a8ca0300cee564b8b"
+                            }
+                        },
+                        "iso": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live.x86_64.iso.sig",
+                                "sha256": "b9220dae9d56e82d0f64098919166ff0b5c0eb410c8829b42c1c2c0a6fd68012"
+                            }
+                        },
+                        "pxe": {
+                            "kernel": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live-kernel-x86_64.sig",
+                                "sha256": "19a12d3b6287560362eb762c52610b7a8e371ba74ed96bd758fa15098480b623"
+                            },
+                            "initramfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "52adf78740bdbeca9fe9f222e29d1c74070fbd64e4843a8e03aff3759b13da7b"
+                            },
+                            "rootfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "f8848580c0fcf6af85805ea47c6fdbf2ab383fe8d4baea28a5ab0a912621113a"
+                            }
+                        },
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "20a13e3b324a0692ae63e0749b1c55734d2590760439cdaefdc5c9349eb26472",
+                                "uncompressed-sha256": "16a91382697587dc527d283cd387be7644ad30714a24b885193aae39599beafa"
+                            }
+                        }
+                    }
+                },
+                "nutanix": {
+                    "release": "36.20220618.2.0",
+                    "formats": {
+                        "qcow2": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "c3ac282267e0973ad7a327f0082bc2360e27412d93d268d451bf5f8a4452adbf"
+                            }
+                        }
+                    }
+                },
+                "openstack": {
+                    "release": "36.20220618.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "30a1dd323429c358b8c71c30a4de9d1bcbafe6fd8f1924178fb52d9edaa7d140",
+                                "uncompressed-sha256": "3c20f9d7876cd5cfd8f2b57c58e01c716b04118248d22f3cb661e9d962c7a159"
+                            }
+                        }
+                    }
+                },
+                "qemu": {
+                    "release": "36.20220618.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "54ad5e381fc63fe559328223252beca5f885e3903622ec1a164843cabe7d50e7",
+                                "uncompressed-sha256": "b4d805aa8b4f9479ddf208e7e9e29010c7879954afb982a29e0e854f4fed51a6"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220605.2.0",
+                    "release": "36.20220618.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "fb77ef7a4d14798621d8e712e6d2911d7a73a2f0797d0e364ba7412c1d805761"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "9596c3ae97edf234c51bb3b23156076ac59af2c5940842a0caf109e505c83e92"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220605.2.0",
+                    "release": "36.20220618.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "91e61177f72c84145a039f9c7f3618da025def0f19b917b0a6f5ead7c4fc68d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "b4a418479a6a0cbc47d2492bd7fee9d07d9950be5e728ba026937838d3791526"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220605.2.0",
+                    "release": "36.20220618.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220605.2.0/x86_64/fedora-coreos-36.20220605.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "c47af733a39cdd4e30ca0645edb5658e5735adfe31f5f2c066edf2b4a01cc483",
-                                "uncompressed-sha256": "ea55d17b4dd6b1ab39551e09e53899f02b324922dd68a9d8d18fa58b00382bce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "ae7e2917f4ae540c7d91c47b63fec9d37f86b8a986fb9a611102f9ae74aab5b5",
+                                "uncompressed-sha256": "dd8701d598fdd5296dded9cb01c7cf04f07e2f05429e4e9b3b41c6d435308bbe"
                             }
                         }
                     }
@@ -418,100 +494,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-079d0154277846051"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0ebcf3e68c324e723"
                         },
                         "ap-east-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-0bda41fde43a1bf23"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-091e2960e1ea97d5b"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-05134874ce89c55f5"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-00b7b17898c7cf7cd"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-058a6a8843cca16d1"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-05b2832e81ef7ee28"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-0abcadea989a01983"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-054a4adff598188af"
                         },
                         "ap-south-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-0e76a3cdf49a14e67"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-07dee4bcb67a0df59"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-0cfd68c984ed8a6bf"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0b2a20704ed7ffe5b"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-051a25ee723f35b14"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-03f4c84f93c7bd28b"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-00c52767d6c8ff75a"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-04a5a8cf6118c88c1"
                         },
                         "ca-central-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-08e0de0c5405cca10"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0b2b5bf3d428487f3"
                         },
                         "eu-central-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-059b69f48586e91dc"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-07cd2445397e76f0a"
                         },
                         "eu-north-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-0d84eef672c9a1254"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0804131510fb6ffff"
                         },
                         "eu-south-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-04643a9cd354c8766"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-090e372d14fceb7be"
                         },
                         "eu-west-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-0c55a81602f5f8940"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-03798764699e60de1"
                         },
                         "eu-west-2": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-0180f707e3df59588"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0245858872f8cfd1d"
                         },
                         "eu-west-3": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-004c0fd7c65a5d84c"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0400b1410bebdd61a"
                         },
                         "me-south-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-0debdcbee5c06cbc5"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-057f222bd8adf0f41"
                         },
                         "sa-east-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-00252327cb2592f51"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-01d9837e2302484e2"
                         },
                         "us-east-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-015f8395cb12feb19"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0845e1add6eb33715"
                         },
                         "us-east-2": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-00ddb771c107baeae"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0229aa4214e845178"
                         },
                         "us-west-1": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-0ec3f3d25cb71acb9"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0257adb1dd653b930"
                         },
                         "us-west-2": {
-                            "release": "36.20220605.2.0",
-                            "image": "ami-0900104dcd144f6fc"
+                            "release": "36.20220618.2.0",
+                            "image": "ami-0784fab64863eca70"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220605.2.0",
+                    "release": "36.20220618.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-36-20220605-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220618-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-06-07T15:35:59Z"
+    "last-modified": "2022-06-21T14:08:36Z"
   },
   "releases": [
     {
@@ -53,7 +53,7 @@
       }
     },
     {
-      "version": "36.20220522.1.0",
+      "version": "36.20220605.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -61,11 +61,11 @@
       }
     },
     {
-      "version": "36.20220605.1.0",
+      "version": "36.20220618.1.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1654621200,
+          "start_epoch": 1655823600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-06-07T15:35:57Z"
+    "last-modified": "2022-06-21T14:08:34Z"
   },
   "releases": [
     {
@@ -55,9 +55,6 @@
     {
       "version": "36.20220505.3.2",
       "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        },
         "barrier": {
           "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
@@ -67,8 +64,16 @@
       "version": "36.20220522.3.0",
       "metadata": {
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "36.20220605.3.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1654621200,
+          "start_epoch": 1655823600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-06-07T15:35:58Z"
+    "last-modified": "2022-06-21T14:08:35Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "36.20220522.2.1",
+      "version": "36.20220605.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "36.20220605.2.0",
+      "version": "36.20220618.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1654621200,
+          "start_epoch": 1655823600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @ravanelli via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).