### PR TITLE
Roll out stable 36.20220618.3.1, testing 36.20220703.2.1

### DIFF
--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,92 +1,92 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-06-21T14:08:33Z",
+        "last-modified": "2022-07-06T10:25:19Z",
         "generator": "fedora-coreos-stream-generator v0.2.6"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "0489fc927fc6792210ce56923b3da91251844df86bc9aed66cd56cefce95246b",
-                                "uncompressed-sha256": "2ef3f840961682bc9b49e3a2830c9b5e3a2ba4b187755daab105e04b21e2717c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "cf8b082a4b67e7be0e1e0926e970b39c3be8644445f32093fbd67a939ea73082",
+                                "uncompressed-sha256": "72d8c3448c28aaafd3aecc36bc982bc9eb118d08be804ca35875deeacd79d464"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "2037937e69c5e9715eff42924df0fb63763c0da13ce7239ac3104bbf77b69bad",
-                                "uncompressed-sha256": "5ed618ad26349445e4416c14b5e8e4baef78f803e8c3127648ff132900427331"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "efee10b610f054836d64906b924e62373ab92729f57b35eeb585afd8cad17c6d",
+                                "uncompressed-sha256": "88f4f3655e4c2198bc3370edabeac4aad57c8f32a630fc3c5d30167d21a01e8b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live.aarch64.iso.sig",
-                                "sha256": "b5d90aceaf0e0eed585877cd033f2447f6cb8dcff32283253393cec88e6ffcf5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live.aarch64.iso.sig",
+                                "sha256": "b1cf82b51c40f5ea319eb8651ab092ec3588de4ec817a12fbafe5b01fa399d98"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live-kernel-aarch64.sig",
-                                "sha256": "d43703f0f6eefa6ebc26dde5fde0252da632a847392904d5e2348dc215ce6fb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live-kernel-aarch64.sig",
+                                "sha256": "fce2ccc1f09cef7709cb75274adc015836baf9e78d094335fd803252dc8c9622"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "7ac56ff4bd16d08eb6022043b3e72773f68768e6b1693a2719f394aba8af0325"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "b8f180244a8eda6098c17cb3ce2296f9a97c1871651248e9e7b2e4b314bd5624"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "eb0a59d06b3103fbfa4b4aa659a14696b2454fc1910676d73a19ed1290568003"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "9dffddfb3cbb89828305e9aa8d1c4f8d422752d379f4254e6b35683d9e741e7d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "f43e282eb104649c2d8aed9bdb825a7921efc1374536659562b7bed17353fc4e",
-                                "uncompressed-sha256": "fe569075ff24fcf5ee1a70ab29f5692e249d5f70e012200519396e1021b66e50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "d792a2e8826e47726cf899bbc9e4a8fc6ad0eaf0f3935b929cc9302927554ac2",
+                                "uncompressed-sha256": "8e3027a954da11be7cd868933e0759a201cae11335c70ea97eb88163bf15a53c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "241c235aa0377986f3d837939ade017456938e3e93cfdf1419bd59ef28438d81",
-                                "uncompressed-sha256": "b4d6a77f2a2b7b92c991d753aad6ae3010ed648b06104dc1d6ad14c4c29ee8bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "434c283a81a5a104953f9f69c38593ef25ed488e78ced68c24b9b099afcd7408",
+                                "uncompressed-sha256": "01ab79135ed3e1bd98405803f076de75edd008266b38bee7d3555f0195cc5c16"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "c2a953b7e5a4f4f1f4c21dd489a352854eb204b176b5386fe4fe46ae1dd8be9d",
-                                "uncompressed-sha256": "9842087452d55c51578661875a1c2d96e148b00d8804f3e11e2f98ccfd486b07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "cc9aaa639313cf772fd0c2699da1cd8edd71510d8ae7621dee584384018df0a7",
+                                "uncompressed-sha256": "7072b7fd699c82b04ad1346aa04e32dfab41fd38ad2e2437fd2e69affb9ae037"
                             }
                         }
                     }
@@ -96,319 +96,395 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-01c169e432b991a52"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0e8ae97c082d002f6"
                         },
                         "ap-east-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-037b9425f78e223e4"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0365a794f16c7744a"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-063ae04d36383ed0b"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0ae6e0422a215e2e3"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-092914ed089113f9e"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-065cea2b66a8f4d6e"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0ff7fc919b81ad551"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-089d98530667bc354"
                         },
                         "ap-south-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0691078078f5737f5"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0bd3b92d9440cd31c"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0930b69cf736a0937"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0e44b29d45d2ee9b5"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0a11e4d49c5df91c5"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0be993005e99d16f5"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-05b330f432a7a5366"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-01ec571f2bbf28114"
                         },
                         "ca-central-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0de4d555ad68dca90"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-033ad50458df19b0a"
                         },
                         "eu-central-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-00f6a0df93b7d1a4b"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0fdf3419612fd2dc0"
                         },
                         "eu-north-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-07f7f3dc3f68ca381"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-09c108728ab6242c8"
                         },
                         "eu-south-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0a81cb2f749a3becc"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0e2c5901cac0fefe6"
                         },
                         "eu-west-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0f39059f7774198af"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-069ee8919bb018aab"
                         },
                         "eu-west-2": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0d8f7464bc9110031"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-016aa50c449a0b2f0"
                         },
                         "eu-west-3": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-064db7b365f7a9760"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0b481a7e699ce9c89"
                         },
                         "me-south-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-010f06d1a90f46985"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0ec748c557eabbfc6"
                         },
                         "sa-east-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-066d590f75fac95f0"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-054481f90e8d45a40"
                         },
                         "us-east-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-099d6b9b1339fa083"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0c0ab89211e0767d6"
                         },
                         "us-east-2": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-09e2300f99c1530dc"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-03350b9dae604191f"
                         },
                         "us-west-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-07cf4694ad649a069"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-012f10df6179bfe22"
                         },
                         "us-west-2": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-010f881571730769f"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-05fac706885df7ead"
                         }
                     }
                 }
             }
         },
-        "x86_64": {
+        "s390x": {
             "artifacts": {
-                "aliyun": {
-                    "release": "36.20220605.3.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "99c1516f99f89f84c476aa327651c9b63ea0409e8c9ab1f171931ee8c80228c8",
-                                "uncompressed-sha256": "006efc926af451261f76ecb8cbf3f9cec16e583973dbd0fcfd1be7b8ea6a78c0"
-                            }
-                        }
-                    }
-                },
-                "aws": {
-                    "release": "36.20220605.3.0",
-                    "formats": {
-                        "vmdk.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "cf0f467255303f89b6ba61ad9b1c1bb546a4dd026aba8af5c97b54cc63694106",
-                                "uncompressed-sha256": "a030f4b55e585ff695ce3a24e96b763a1e117724dad52627d95d4f99ddbfb774"
-                            }
-                        }
-                    }
-                },
-                "azure": {
-                    "release": "36.20220605.3.0",
-                    "formats": {
-                        "vhd.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "4c5a42cb635cf4691b7107caddd08eeb6e039af4cf8f76f7f2e216fb55ad364d",
-                                "uncompressed-sha256": "2c5eb4a2060e3e547cc1103a4ed5857a819fab9f44b726151d3ca42ac2c419b8"
-                            }
-                        }
-                    }
-                },
-                "azurestack": {
-                    "release": "36.20220605.3.0",
-                    "formats": {
-                        "vhd.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "06d94d70eb6474d59131184f645f0ca5f7e613a90aeb2f90e9aed80d73b00a36",
-                                "uncompressed-sha256": "0c750ba56a562061d301d435a587d30c728e050cb357db9e6139ef811bb70cc4"
-                            }
-                        }
-                    }
-                },
-                "digitalocean": {
-                    "release": "36.20220605.3.0",
-                    "formats": {
-                        "qcow2.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "048ca51487cab906187a4c2d0f5e1439e3db3da8e9d6e3a92cde32854a86fd8e",
-                                "uncompressed-sha256": "5cb234af18911989c579561d8e829d2fc8cc3f8014e2be04c4c6babbb9535903"
-                            }
-                        }
-                    }
-                },
-                "exoscale": {
-                    "release": "36.20220605.3.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "e41d201cc6812f44836afb18e4623f433a5b5e65c6e27fa38629f09e9d54a224",
-                                "uncompressed-sha256": "27f0fda33e1f0883faae2f89447cddaa63013f1ef231e772b42c8d3f333967d3"
-                            }
-                        }
-                    }
-                },
-                "gcp": {
-                    "release": "36.20220605.3.0",
-                    "formats": {
-                        "tar.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "cd715f3d2daa501ee7af98e1ca11d09320b709bc4fe0f9e3c51e40d9bb5d71bc",
-                                "uncompressed-sha256": "90e4908cfd7e582ce5a3d02dfd4bede34934ea443bc09895a34bffbdb0ee1754"
-                            }
-                        }
-                    }
-                },
                 "ibmcloud": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a92442a998d805382929edb77725c0baa187f72a8eef20b03b3ec67ca0589df3",
-                                "uncompressed-sha256": "a4dd9def33468abbe08bf5363da5aaa9e8fa9ad83c560c74c2343938f18169eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "f6365ce14e95dc895b0d2ff54e62e62051a72db9d5883b8b1c859d619800c53d",
+                                "uncompressed-sha256": "8875e84c8a498fa5197bbc39b4894372c7cdd9138663906e0e2ea64a0e6fedd6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "dbc755e0bfd7414a7accfed88c21184a072f6ea8eacf82aa461ca39f279fac98",
-                                "uncompressed-sha256": "805d77570c82b796cfa83af3548053a86f208ce5506e59a7b0ba526d8b948667"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "39b8a1d08986fd8785952c2370f174c88df0167b7391e5bdce2bde2bcf3c63ac",
+                                "uncompressed-sha256": "ce84b2032433bfa90eb133cd8ef144f5b6265daff66890b10704e4394e628449"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live.x86_64.iso.sig",
-                                "sha256": "66941312564cb6b3de1ea536aa162a5ee747a4668faecde88fa38bc668df1100"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live.s390x.iso.sig",
+                                "sha256": "caff6c12eec2e6dfbaa207f6da005b3343f3bfb9be4601d6c2a4e6610e14a2e9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live-kernel-x86_64.sig",
-                                "sha256": "ac47aa3d1a21b5665f885f3c85c9b3b9d4bca6f7dd94c38c016f10c735b48d0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live-kernel-s390x.sig",
+                                "sha256": "bba8bd387bf722cc6feea585eae2037b071296a4622f18c51fd7138e886d78c7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "2cbda89fa398ce9aa085492c291f83aacb8ed22f7e3c019c69ae10b03e0231f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "f092a82256b3445576f743de7ce47858b76c567d1cce33bac88427916ffe0ed0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "e133a47f03d063ea90540dfe8401182b0f089c1bf2b170d2dae63c5433410f6d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "abd1f507a018d880e069144f65b824f7eed2373dcef570659e184887aac9f4f9"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f09b9b2735cf69fcaf3a52ff8f8658aefb19bcaea2768a13824ec6735686552e",
-                                "uncompressed-sha256": "f8aed4a84e81f47a30c694e1e6dcb28a0e1653de39aad24eda17e532d68c5fce"
-                            }
-                        }
-                    }
-                },
-                "nutanix": {
-                    "release": "36.20220605.3.0",
-                    "formats": {
-                        "qcow2": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "fa4a316641c77cff0086b39779e9d62d8496821da34c10c72e2f278e3a2cfdd7"
-                            }
-                        }
-                    }
-                },
-                "openstack": {
-                    "release": "36.20220605.3.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "7dda9700e5b4e6c15a8c81520a3613ac31105d61ad03e88ed265ba463c55f98c",
-                                "uncompressed-sha256": "e27205919b098a8f443296e7b0d6afbdd5a9f2cbdf389446f760e41f216c25fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "647c2cdb8117f36a98b8743cacb85e4f6efef49d79e6be3080cbe0253e446be8",
+                                "uncompressed-sha256": "cd0a261135306caacc7091cab3a32b276d02dd580f6169e090c37623a58c017a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "21a1c0f408ca8817e0a4e969828ccabf26e8db121ee5a48dd191e9525ec16c90",
-                                "uncompressed-sha256": "c135a76958f093ab7d5c72d5ef8ad7ac4347caccec01e0998092a6a42061a4b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "74b5c35e46a41d32a50e2c9abae3b862f6ee84a61a8ede0825604ed85f2eafbf",
+                                "uncompressed-sha256": "ace8ffe45f2cff27417163bbce35019aca54d5fa7c41538eaa34b71dce4825d0"
+                            }
+                        }
+                    }
+                }
+            },
+            "images": {}
+        },
+        "x86_64": {
+            "artifacts": {
+                "aliyun": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "655fd7ca5b33fa10687b0f16b2dbcd0b8475ea71ba9ac76dd91fe4608a272e26",
+                                "uncompressed-sha256": "d861bfc6ffe1aa247d7d6279f17618cee85cbbf140302d41b71b841e76617d70"
+                            }
+                        }
+                    }
+                },
+                "aws": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "vmdk.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "6a0a0bd38289f4d51708b6cffd9f9718cb1542e85d97a81244f3f734a9616152",
+                                "uncompressed-sha256": "077b7928d855fb26712fcbabc90ff5fd6a635f1d71616777db3f960bddb7fdc4"
+                            }
+                        }
+                    }
+                },
+                "azure": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "f5ffda1a68f26b6512e4e035bd79e772803afc3e6a9baa7cf507d5a641838a94",
+                                "uncompressed-sha256": "b0cb9a782926cb55e85d503b0ef7e715091783c168cf7963dcac74efc7f3f70e"
+                            }
+                        }
+                    }
+                },
+                "azurestack": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "34cf287e75c3e6a435332678a47db99b3b341d82989020103d5dc911cf03099b",
+                                "uncompressed-sha256": "42feb8ac932b8005cae6d3878c0d25f16c5838d5704635a0c5c382ad5a10ecd6"
+                            }
+                        }
+                    }
+                },
+                "digitalocean": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "qcow2.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "d199503afeddd9bcbca6cf3ce22a44379c2de4945f9632ed273d68868c884baf",
+                                "uncompressed-sha256": "25d7212c03f86bc279bf8aa062ea86d17cb80b5073988465bb35ae131679dc4d"
+                            }
+                        }
+                    }
+                },
+                "exoscale": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "82e90fbae9a885f5023da7552a5ac7a6354b53919cb8de096f7b892801484717",
+                                "uncompressed-sha256": "bc4f74276e1d774ca7e3f2fbac40cb6c0287b2461756319090e80746bd885b4d"
+                            }
+                        }
+                    }
+                },
+                "gcp": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "tar.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "c91de9dc1441c80ec1e22ed78d100e22c13ed4c64835eb1615d7ca8ec3d70828",
+                                "uncompressed-sha256": "1c376dd49e570eb76724f79caa2b4dc0c3df41b5c55a819f5913951673eb5916"
+                            }
+                        }
+                    }
+                },
+                "ibmcloud": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "2ef74c2c6a9cd4fd5b14b9fcb3c22695335f7b8846106d55b7ac34093b8a512d",
+                                "uncompressed-sha256": "9856a0fbfad6ecebd8b10b62a96b380755819be6671e07897686a47b04100d30"
+                            }
+                        }
+                    }
+                },
+                "metal": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "4k.raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "f737ce150651f639a87b2206b8b81464b446d6b72a767b3bdfe83d190655c2ab",
+                                "uncompressed-sha256": "9288a525dd249699944515ecf4f919d6b415fef9d893e070814241acf7c1cb25"
+                            }
+                        },
+                        "iso": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live.x86_64.iso.sig",
+                                "sha256": "4fcda251b318f006aac823dc0954747361ef2723ddd1a35c1c5caeb911c5eae5"
+                            }
+                        },
+                        "pxe": {
+                            "kernel": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live-kernel-x86_64.sig",
+                                "sha256": "19a12d3b6287560362eb762c52610b7a8e371ba74ed96bd758fa15098480b623"
+                            },
+                            "initramfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "890adf70fcb615c78857af3de1fa7aef607f3579d8c8f1385ec4c0439bb7bbde"
+                            },
+                            "rootfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "18b52ac0a4b3dde3a094e66616dde90a710e2e720338c520dfd3700cd55f1706"
+                            }
+                        },
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "c0369a7bc36de121771c6d3b10e6c6bdb0f37e62fa78023578e869dc33db03f0",
+                                "uncompressed-sha256": "26612eb86a6b9bede28399725fce6b1678d0605e7401b045faca0fb878c320af"
+                            }
+                        }
+                    }
+                },
+                "nutanix": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "qcow2": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "00c53804428700bba6924caf0724c1854d99ea7768a26fda1d45e555f7c78694"
+                            }
+                        }
+                    }
+                },
+                "openstack": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "71c0624a90d0993b39c2a1f4bae4fa4e5d6554da0b4c6bc53022094202f29db0",
+                                "uncompressed-sha256": "a766aea069f3c5ff491822a23b0b0ca11e10e956871adb8c9912540e759290c8"
+                            }
+                        }
+                    }
+                },
+                "qemu": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "dfe190390d1e4e751f8b3978b15a466744022db1801673614744886b38d498cc",
+                                "uncompressed-sha256": "62c05da2208b8af3f9a7ddf6e4632ef6f7fc252a6b76ae2a452341f05e6e1733"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "d582f891288a4b29a615f80c18bc94fac6025611318cc2b2149dc1dbfcc7814c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "cf4ba506f271b50d437af59f50bbf6b4ed05de97d3d9eeaaf30496087364a34b"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "1d6be531b1cf30e0657a6b9749de4be067fefecaa7f443d919040028eba28698"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "e02faf1a1f5c86f7a9b49853ab6b8a56e551b918a4ce2502bae5362a0fbe131f"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "3877ed1a9ee0a46a81e6e7993a9d24b8a78d90d4de6b5ab22d58d80df95ae029",
-                                "uncompressed-sha256": "9316b5dbae47e36ea8c00d6383f68d72dd63bb007cedb8299f2fee074409c1cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "126f02f7e8e28bc8064592512bdf5856b920df40ec921ffdbb43433f0c2ba93c",
+                                "uncompressed-sha256": "19bd19d4849fe518694f10c5f7dd6b528098af19278d5b62f65b6797a63b8ca6"
                             }
                         }
                     }
@@ -418,100 +494,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0082386ed3c7bde94"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-077d2db1977a340f8"
                         },
                         "ap-east-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-071cdcba4d2279084"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-03394caca36940099"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-03c92db560f4f9f7b"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0b52486c2645b8763"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0f1e8a2a7b1acbf11"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0f8550fb21d2c5e9c"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-01ecd2d463f524375"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-030a1e8c9dc52b0c0"
                         },
                         "ap-south-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-07d493c6cc836d651"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-03123403cd0acb925"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0998769d3c22cdbdc"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0af9b6899c022fee5"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0f3545edc9142ccc2"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-01f43ca3c433c7f04"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0320015d4da80708d"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0f17e539211213f82"
                         },
                         "ca-central-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-03fce3c5b2103e866"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-09b6fced48017dcaf"
                         },
                         "eu-central-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0432542ca6340bbc6"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-013c43dc5efbab770"
                         },
                         "eu-north-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0826206f35baa28a6"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0582fcca2f226ba2b"
                         },
                         "eu-south-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0acdd9d8ecd732ac5"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0eb34462bc63428aa"
                         },
                         "eu-west-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-04dc67d11375529d9"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0ae9b5e521f641134"
                         },
                         "eu-west-2": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-03f56d07a739aa94c"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-05ef2120b391eab14"
                         },
                         "eu-west-3": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0e572f0bb71f173fb"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-027f69d71b0500c6a"
                         },
                         "me-south-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0bc60ec5e634a73c9"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0a03687bab4df2238"
                         },
                         "sa-east-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-00d284737e8fc2edb"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0c78ce635c2a22bf6"
                         },
                         "us-east-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0d604208402ac04e1"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-09268db52299b7bb4"
                         },
                         "us-east-2": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0f70a909636c5fd14"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0b537df7f00f60dfd"
                         },
                         "us-west-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0286b6e1ea4e62caf"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-08875bfe9a15c7361"
                         },
                         "us-west-2": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-098f3c5f1a8e640f3"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0f1f42acc3476dc19"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-36-20220605-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220618-3-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-06-21T14:08:34Z",
+        "last-modified": "2022-07-06T10:25:19Z",
         "generator": "fedora-coreos-stream-generator v0.2.6"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "11eeb75ce55503abb40d8e7641ecf2fcd24e3a1831602c3e5bc469e6b25d5634",
-                                "uncompressed-sha256": "22297d2269add0538ae5747f1d7e2f7ef6e986afa604c5b599e3dfb483a723cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "96f6c1412348bd0df752197a2dcf0c70c35177f8e314a9913bcb2944bae150a0",
+                                "uncompressed-sha256": "a70ce44fc5993eb2232779c76c05529562d0c56033b2eee7caec464793acd218"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "e437bbacf7eaa06a4640e03db6386138ab7eb9fe4ea714664d35ab3f6a393dff",
-                                "uncompressed-sha256": "12933ded07e01a34f817b560229f0dae46279514368f49557a417699aa5bab2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "43d6a435a3c94add4b56e0a0ab6f9e83ae1a6ae02af44b4432f5eed1405c5296",
+                                "uncompressed-sha256": "da8b34192d6707a397ac5e3a0e4789d81d4caefcbabea3250ceaf77d6821313e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live.aarch64.iso.sig",
-                                "sha256": "54094ae0e43c894608785fde7d4935a5427f5bc4091327f147d3510133239904"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live.aarch64.iso.sig",
+                                "sha256": "09da685c6e9ee6297fa23eb17b6681f26782edbc059a1a1e853f1cc0bfc364e3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live-kernel-aarch64.sig",
-                                "sha256": "fce2ccc1f09cef7709cb75274adc015836baf9e78d094335fd803252dc8c9622"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live-kernel-aarch64.sig",
+                                "sha256": "850152289a68aea396c4f422a4570165680f3cf27dc7a956fbf5bedb98e8b12f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "5b42598a7afe9fc766337532212c0763d702c42414377d4d062ac328f4e1d34a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "04d665437233a33fa2cd9ccbf22032331fe71e9fd30ea3049df59cbd3d597187"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "3aed0281ffc1b1c04cc982a05711c945896e48e74b57c3ec04f2f7f622d8f19c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "c0afbd9f3845666944b1eaa7b5c14c6a7503c494f9faa8f8bff87125b6fbabf2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "bc5fec383a9919cd8c8813e9788a0d826c5432f417d5133e0bb9b40356aca3ca",
-                                "uncompressed-sha256": "5c4c0389c5fab9eb0395b063c836d86d74463e8c89590e1cf9a9c7b23fe01564"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "cb29cff457dcf2a145df928a2ce8456777db5a409602da0a65419b6d4b142155",
+                                "uncompressed-sha256": "bc669207bf407f3a34953e20888309035cf0ffd480efb8157f294e4b49caa941"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "eec36f7c6f91e215ba369a25eb30bd613e151cef650434e4e65351ac181a4426",
-                                "uncompressed-sha256": "31745f7fddc77b3307c166f72e6810d56edc3b9ff5cc34a3923ee0173cd87cca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "db0c214738bef555658edcb5fd35cfbb1fc9b660462deab947540ab7fd80de84",
+                                "uncompressed-sha256": "52b36e7a507d6ebc9031968aaf405bf4075aa581806731cc0236792a5c26eef6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "9b876cf1491655ec7f03d5be7e50d0c547a83d7a0736a1195016c8562395054b",
-                                "uncompressed-sha256": "f04f8c0e83a47e738ea0df158f638e8c199864e2483dc16c97832ce5194d7c29"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "65bf42b023e82c31475ea37afa7bd6706fb25748a7deedc1bc76a0b7fad4c7c8",
+                                "uncompressed-sha256": "57e74a440e2bd8c8d867c94fb58d097811e4166c733985f77913a5784c86c755"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-01e394f80d32f1d57"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0ac32b388d381d383"
                         },
                         "ap-east-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-050bbac0e88eab075"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-04549f80f1c154904"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0216c60ef9911f8c1"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0dc232786d5a0edf9"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0f4771fae51ea57fd"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-03e1d54e2275c56e8"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0c2a92a0c0ae706e1"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-07f9110893d77ba04"
                         },
                         "ap-south-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0c0f5ccae08caa9d5"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0cb90c19a3036f24e"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0bd3ed3356771771c"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-01b03ab6bbe851e78"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0905e0e9bb8a66fd4"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0e0ca26c365a9f919"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-07a2bdc2f6ca5b47f"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0982cb61ca7d2f35a"
                         },
                         "ca-central-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0fbda341c2f5b2083"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-096d9357bc2501430"
                         },
                         "eu-central-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0aeaef9c3e766d55c"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0b5512b7425d20bb7"
                         },
                         "eu-north-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0ba8d8a6a968616d1"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0cfca40446c0d0807"
                         },
                         "eu-south-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-00e5e8c7289ade7e8"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0f26ed10adf72b64b"
                         },
                         "eu-west-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0f23bfb81936997b4"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-08d67f452581957a9"
                         },
                         "eu-west-2": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0aaffca81ca29bb1e"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-02ecf0467a9370b95"
                         },
                         "eu-west-3": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-07be9fc3b804fb136"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-04b780f75c31db697"
                         },
                         "me-south-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-002285e5433bbe52b"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-04218e475837e432c"
                         },
                         "sa-east-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0b93af9197de2e4be"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0c98706f0ccc4480d"
                         },
                         "us-east-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-01498eb06dac3520a"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-029e44a6a9d76e4d1"
                         },
                         "us-east-2": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-06750517062b27156"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-01cec8422dbfe7fb3"
                         },
                         "us-west-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0c0c4b06511ab929d"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0eb97ff18a670d856"
                         },
                         "us-west-2": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-02a5976e743cbf8eb"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0690f706e41ffae7f"
                         }
                     }
                 }
@@ -190,72 +190,72 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "505643eb16180c292db3a409fe491d943b292914cb46c3e2c53c61957de6fbbb",
-                                "uncompressed-sha256": "c3a1fb7087d7be9125d9307d6bab7b142be0f3ca5b6073a5e0d488b99ceeec53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "4199493100f2a5277bda997de8794f0a5ac83e8beaaa511ed0a7891faa421cb9",
+                                "uncompressed-sha256": "cbee3f66efa5e6e609abdc17ded6c067199372c97f6555a2e0d594f7b40230c7"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "fd0706770b76ad9b150899437f9779979e3b9185d007752dfdc68cf8449c7ca4",
-                                "uncompressed-sha256": "2c0485156a35203f5191df7d65d7588708570e00687c1dc0e14d45fdcea4dda8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "e53ed3faee46b197a48d6a80dc9996ecec76f6fcbf00fcf85900f79d1c0efd23",
+                                "uncompressed-sha256": "df4e51bf0c4960c06d28e6e1d109b382b34aef31c63d90be8c41bdf97efee883"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live.s390x.iso.sig",
-                                "sha256": "27e8369bc1be3171fc459a769aca3ab39b71ae8c82f7bd10c1228f5242ad66ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live.s390x.iso.sig",
+                                "sha256": "8cabf48de51443fc3d1bc92201214d59e8147695e42555b263569cafd8c2c9a3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live-kernel-s390x.sig",
-                                "sha256": "bba8bd387bf722cc6feea585eae2037b071296a4622f18c51fd7138e886d78c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live-kernel-s390x.sig",
+                                "sha256": "8b468ae0ad9a39f31d59b897bc49638e3790adc83f725a608b56b1b2fd830b8d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "df97a9223e847123ba5c1d43f61393d0f30a83245bfcd2782b9387f71e0963c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "3007ea5dded487f2a2a72e15f6c1c5dd53c4e68cb6b4411eb21929d1556a4d8e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "360c93aeeb5610e497ba8d49911a3ab90070d17d3696c09caa534f389cc1c7c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "3367c701d5d52475d0bae177d85712eacb04323ff5af7bc1aadeb69e0dee4703"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "4751f71846a076b3c6a2a2569ad67f3fe67d08c6059b1a82bd8e3362950d5f7b",
-                                "uncompressed-sha256": "72cd06f6579e6377cd0d32506b6d1f97edac9aa1eb0d3b62d57f3616054fc123"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "b73b6a825cb2cad725ebf60eb7195d473169adb35c72c7e6d25739be1a4e3a30",
+                                "uncompressed-sha256": "0f0410d1026e7b8dfc63b437e106eaf4be1c3664317197df3b7ae95bc8b0cd60"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "bf2d6ca9ff66671ac48e276dd6d7143f3db4980298e4e00f77001072f4460c36",
-                                "uncompressed-sha256": "8f039b8af8d2718f467f8598f7b9b02905353f4fd198b5d00f68c60b8d7e1705"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "357d71763962803a0299ceb9d7bc7a39186bc013da5878bc51ca12ac43140b3c",
+                                "uncompressed-sha256": "e4631ff1a1f2b13f146b16dc24674e33172a7eda80c8ab913b67bc76fd8a74a9"
                             }
                         }
                     }
@@ -266,225 +266,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "b754af10ee9480bce5cdd0c684f0a34f0ab8a322d384932c2d200d64f70826e4",
-                                "uncompressed-sha256": "9878778af173dc10b27aaa455172c1be660dcf1dc3f3bc9b56690c81dbffb609"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "4a2c7544b0e0354576e00ee8b2225573bcf47d454a8411ba7b539c2a8627d580",
+                                "uncompressed-sha256": "7f6e62a3d4047cdacfb307057584bd4e58b77e5ef61d44176eb7a03be832cda0"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "383a471e4a17f0c049f7d67e0b8652308a291754d470b5f0782f7dfae7d00bd7",
-                                "uncompressed-sha256": "1cca3cc80da6425eca9fc5ef3a6e3c6f9f464d2c6622902f8a6cd75b924cb900"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "95957c1cdc1b3936a9df63764afe2766939ceeec096e33cac88b89d8b49f528a",
+                                "uncompressed-sha256": "068f19b77e39eaee449029362189ec15b87d4fb1231d316527637c2871dddf81"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "e887c6d37649019981de880d1999430c9bb56d8998828ce10a159a69371b6c3e",
-                                "uncompressed-sha256": "bf37c3214aa8ad68a25f7f5e634683b1dcb700a9c0cb9949b19a7bffeb239478"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "edd698de2f7a2b02e77cf15e3745a8627c1af68e7920b91a036ad95f762f0d72",
+                                "uncompressed-sha256": "cb9d9a12486444e57f16e564ba8abe9e0d84aebc2efe543838ea0adad79c6547"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "c17939ea926a133c7127c2241fb56aba7e7edd7a70feedf969141a64f516b247",
-                                "uncompressed-sha256": "cfd496c7f4d65dc89c726d9f0a1f702dd86fb49b9097bdf062ea3d87f0865569"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "125d40c8668f27a695e5ab0c55816810afc0567ef46d308bbccf1cdce2bbef52",
+                                "uncompressed-sha256": "7e5bbecdb38b83ca7087da8bfa29dd08b6647cd6083ab06dfd9981910c2d7af2"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "aa19136a082f062bf1d9b0cd956b13cd6be5ef3af26472dd3e7ca272e95b1b3d",
-                                "uncompressed-sha256": "ca938d88b87a6c655df3efee0c95ea70015fda5df5b5308f2a793c3cbf16d066"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "8a3a2696d7ae5135a7d90651ddc6cf2d2ca3d9c2e9ad215ff340721ed58ea725",
+                                "uncompressed-sha256": "1739c8c26f106a2c3ea5af78af2d5790d26fc50dcc72ed1dc2b9440682e105cc"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "8e5cae785eebbc9afeb7512be459bcde0d76fa138b6307621d86579bf7681472",
-                                "uncompressed-sha256": "d7f210419d1cf5be9252b29095f2b2e7fe6e92aa553388c01379ccd65ba715c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "7622d93d7a604cdacaa355db03b313cb0a52161e9317f6cc9a5a17130002984a",
+                                "uncompressed-sha256": "8822909fd1102f4483f35a85661be7e694878c7fbe646dfda535ac6a8872dfba"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "ee78d7612bd472affd6189d5cf2130ac436f158b94b18401c49bc082206eea93",
-                                "uncompressed-sha256": "0609a01cb4b8509b7f916c037569fe68b554ddca57e38ac3eaeab7bd7361d584"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "d72d408d27351e376e1841de3cdd06b18bb92b5a0d4f139528eb7d17de4a35fa",
+                                "uncompressed-sha256": "b9cc788e732584b94090c14b253315159359e4609338f744ac202b820fc5c270"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "157cf2ea46bdd6e2a2866c18fefedbf2b78219bc7a3ab552ddd55692f53ddd76",
-                                "uncompressed-sha256": "402b28934bf3252ecb24b7031fcb6092a7c18bf21ebd600c2d2204c4c90e2090"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "77476765424cc89e062488dfa2023cbc282df0d5c185ca02cfbc8b50dbdca80f",
+                                "uncompressed-sha256": "ddb71543c44efc2b00a460e9eabbc4f1bcd6adcb24000f9615fc944db0ccec4e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "59ed361ab7f410140780929878a80610f0dc34a8d03a2b0c18c97c6c1e3d12e5",
-                                "uncompressed-sha256": "ba437f6c240dca68d705b738a35c51aafd3309880f2e279a8ca0300cee564b8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "7977843eafcb349f39c82942973335c1431c2c64ebb96ff6a84215d0fc57a6d8",
+                                "uncompressed-sha256": "c250350fc7716bef3c9456544d10d343c562af0165485c809a780520b8e1fb5d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live.x86_64.iso.sig",
-                                "sha256": "b9220dae9d56e82d0f64098919166ff0b5c0eb410c8829b42c1c2c0a6fd68012"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live.x86_64.iso.sig",
+                                "sha256": "7d0c1da7ae7e67c242a78bc8bfc5954262da85e54650426a3d9f7b8e44dbca9a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live-kernel-x86_64.sig",
-                                "sha256": "19a12d3b6287560362eb762c52610b7a8e371ba74ed96bd758fa15098480b623"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live-kernel-x86_64.sig",
+                                "sha256": "e031357b2e3b7fa0347ce56279eb66b1cda50046307969e801e326787ca5ad6b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "52adf78740bdbeca9fe9f222e29d1c74070fbd64e4843a8e03aff3759b13da7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "71a3b5da83e8c35eec8d534adee60749d2cea500cbcb55e463f211f9160b9eb8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "f8848580c0fcf6af85805ea47c6fdbf2ab383fe8d4baea28a5ab0a912621113a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "892b31e1a5f1aaab064e853881d8b17ee97a44ba0cf6d3df35da0229febd8eb3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "20a13e3b324a0692ae63e0749b1c55734d2590760439cdaefdc5c9349eb26472",
-                                "uncompressed-sha256": "16a91382697587dc527d283cd387be7644ad30714a24b885193aae39599beafa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "caf84fb77ccbd9d2d113c103b8d5c21b42fa3d5f8c4b4a23a9086532ca9c5857",
+                                "uncompressed-sha256": "dccec3e31818cdaa0bf74cb3a0db9fe4a803b01424e529183ecf8062bddb36e6"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "c3ac282267e0973ad7a327f0082bc2360e27412d93d268d451bf5f8a4452adbf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "0681b8d3fcd74f4236fb225bafa95e4fb1784a93ceb1d2fc4df19e63ab3cf433"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "30a1dd323429c358b8c71c30a4de9d1bcbafe6fd8f1924178fb52d9edaa7d140",
-                                "uncompressed-sha256": "3c20f9d7876cd5cfd8f2b57c58e01c716b04118248d22f3cb661e9d962c7a159"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "bafa17960c13e84e33a340e23594f6e2c84e7a3fe716206f05ff5635dcec65ad",
+                                "uncompressed-sha256": "c3c49720032e86a33bcfbc48c1c798f9a016aa44c410d4f44fb06a6026f0df7d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "54ad5e381fc63fe559328223252beca5f885e3903622ec1a164843cabe7d50e7",
-                                "uncompressed-sha256": "b4d805aa8b4f9479ddf208e7e9e29010c7879954afb982a29e0e854f4fed51a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "06118c2198991e9a519fdd38230d37a725a98cec014869874a3fa063e9459bc0",
+                                "uncompressed-sha256": "71bb389a25ff00fc3aca8c197a5a87126ac827b3abbd3b793195978b2021a009"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "9596c3ae97edf234c51bb3b23156076ac59af2c5940842a0caf109e505c83e92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "41be2d5d1c425d21f889bb442d674356ac920355114dac97889b9a67a2d5be5a"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "b4a418479a6a0cbc47d2492bd7fee9d07d9950be5e728ba026937838d3791526"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "b175ec5559a9969bcac405d7cc3f875c55c36adbf9353f7c2f6938db92ad204c"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "ae7e2917f4ae540c7d91c47b63fec9d37f86b8a986fb9a611102f9ae74aab5b5",
-                                "uncompressed-sha256": "dd8701d598fdd5296dded9cb01c7cf04f07e2f05429e4e9b3b41c6d435308bbe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "d106d8d33bbb517cb57af3536f2b88e13ee9279ec08de3cb1ea6c5ce624f238c",
+                                "uncompressed-sha256": "9a203e54bed94d595a5627c1aaa929f3e3cb321dde63250f756cc1cdf910b6b6"
                             }
                         }
                     }
@@ -494,100 +494,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0ebcf3e68c324e723"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-01e159458c67b1825"
                         },
                         "ap-east-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-091e2960e1ea97d5b"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0980e529488b34ad3"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-00b7b17898c7cf7cd"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0afae1e2c44c9712f"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-05b2832e81ef7ee28"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-06a16d9844543971d"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-054a4adff598188af"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-07790ca7ce0efa8ce"
                         },
                         "ap-south-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-07dee4bcb67a0df59"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-04b222f33f023864a"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0b2a20704ed7ffe5b"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-02b221ffd4bca4196"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-03f4c84f93c7bd28b"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-06f9a164a4925d883"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-04a5a8cf6118c88c1"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-05b8d7d7b6d841c7a"
                         },
                         "ca-central-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0b2b5bf3d428487f3"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-045a89be5be4b0830"
                         },
                         "eu-central-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-07cd2445397e76f0a"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-03f90299db11e77cc"
                         },
                         "eu-north-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0804131510fb6ffff"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0df897825696c23a2"
                         },
                         "eu-south-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-090e372d14fceb7be"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-03d5c4e2a723f8276"
                         },
                         "eu-west-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-03798764699e60de1"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0ddc59a3e5bc7711b"
                         },
                         "eu-west-2": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0245858872f8cfd1d"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0c260d18f52ebbcc5"
                         },
                         "eu-west-3": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0400b1410bebdd61a"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-013383cec6a4ded80"
                         },
                         "me-south-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-057f222bd8adf0f41"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0f0e7020403c85aae"
                         },
                         "sa-east-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-01d9837e2302484e2"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-01d1019652542a55d"
                         },
                         "us-east-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0845e1add6eb33715"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-080a10e999cd4cdd7"
                         },
                         "us-east-2": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0229aa4214e845178"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-08cc589f66a2ae782"
                         },
                         "us-west-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0257adb1dd653b930"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-08108451e9aeb16ae"
                         },
                         "us-west-2": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0784fab64863eca70"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0372ece5a40f941ad"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-36-20220618-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220703-2-1-gcp-x86-64"
                 }
             }
         }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-06-21T14:08:34Z"
+    "last-modified": "2022-07-06T10:25:19Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "36.20220522.3.0",
+      "version": "36.20220605.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "36.20220605.3.0",
+      "version": "36.20220618.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1655823600,
+          "start_epoch": 1657116000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-06-21T14:08:35Z"
+    "last-modified": "2022-07-06T10:25:20Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "36.20220605.2.0",
+      "version": "36.20220618.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "36.20220618.2.0",
+      "version": "36.20220703.2.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1655823600,
+          "start_epoch": 1657116000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @cverna via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).