### PR TITLE
Roll out stable 36.20220618.3.1, testing 36.20220703.2.1, next 36.20220703.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-06-21T14:08:35Z",
+        "last-modified": "2022-07-06T16:19:25Z",
         "generator": "fedora-coreos-stream-generator v0.2.6"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "2155605836562ce6f4d061ae015a5afbfe198df33d93f2c24294f8daa9985039",
-                                "uncompressed-sha256": "dfddd5b2b77479a29a132da4e50190316cd6f01f7d46010bb4fb5a046d2f3600"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "73a3483f3ea61e30d4d32ca016e2fc626d7827268215035e6b713a5a8e0ced45",
+                                "uncompressed-sha256": "703d71ce10a43c2db7eaed19d1c11c9a024a1b41563c761068796bcc6c17ab2f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "27bf1ecd1eb4d3bdad00d0dc03c75c71c8f1c72983ebbb8fc45c422767dd4bab",
-                                "uncompressed-sha256": "28ac62adb81af3e28de6e5164787756fc758be05e48d93e21b5491608e88af27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "c74ef2e30bdd53a3269968d4eb828db574ffaf48fde73839244c349407d484e3",
+                                "uncompressed-sha256": "bbfadaf4f613093ad569fa32b8535b37cdee632dc879ceebb1bf9c42cba752d8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-live.aarch64.iso.sig",
-                                "sha256": "887f09668d8e052e4c3d09ae61cad3e75d31c0c3d23fa7a1d6b7248a2a031d44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-live.aarch64.iso.sig",
+                                "sha256": "3f0fa015cbe7c106f8b3364b00ca9290ae31073d51a149a221992a670490ace0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-live-kernel-aarch64.sig",
-                                "sha256": "fce2ccc1f09cef7709cb75274adc015836baf9e78d094335fd803252dc8c9622"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-live-kernel-aarch64.sig",
+                                "sha256": "850152289a68aea396c4f422a4570165680f3cf27dc7a956fbf5bedb98e8b12f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "7813fa94969b00ecb7e67e111a7ddce3fd86a475dc9c9c8d6840bedad54cf900"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "244daaa1d0d70c356e0b16ffc87ca5da6269fde0b3987fb332ba168bd2bc8232"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "fa9ffa43c3f2daaa7ddb8ef394f9018b3bf05df321c63f6aff3f8ccfd024cbb0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "372f04d8c39b0c041e5912ed9c9c5205c6b3156930ed7ace2dcea849b3f925a6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "81a69b103465de74a32aef4688025b80a8aa36ef52994668347a01dee4af1bfa",
-                                "uncompressed-sha256": "3562e47f62a3eb87aec29d734fca71382772eb89a85e8c1214a35d8598856c1b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "5fdf9481fed6b8b1f6ecefc4cf9a0bea7c4ac515f4f65950e0fd0f0962bc2167",
+                                "uncompressed-sha256": "baeae66f35395cca659aeb8cccc91a780ebbc2909bdd991f12765c66e6576393"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "4ac5e84a179f715d8f8c27357ceb602a42c1b4ec7f1ba8ea4e85ab05fa28ea7f",
-                                "uncompressed-sha256": "0296e4809a4708be2e90acd961220f51baf77fd896fe5d4047369352c16625c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "1f560517f621f753ee96d1bc806109205ecae2259e708292f1207922e06d954d",
+                                "uncompressed-sha256": "183dd9a52a758c4a1edce9722353f42b53a1ab33b632ec813d3f050ab93834c5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/aarch64/fedora-coreos-36.20220618.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "169ab06bc18df19baed53a01c199d5841102f6becf9abe9963e466fc41755d90",
-                                "uncompressed-sha256": "5b1a088bc7d85270f14300c2408ea5d0b3fb583f04a4ea6b9e7de1e6f212faf6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "97df01e3dc28abf6eec9c1144ffc3ea31b562cf1d3106554b4bc3dde1db40ede",
+                                "uncompressed-sha256": "824ec87689ce94c19a1cdf68c4b63531f4fe5aca4f33bf38d03240348d197171"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0b2f50b3ff2739730"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-06c590d4294e8e93a"
                         },
                         "ap-east-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-007c797c4c080f192"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-0953d161250dcff64"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0c8d6feff411e0a15"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-0561004044c59ddb3"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0c0ddac9056648276"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-01fccee8199d85e85"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-01b8faa44f8778e48"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-01f6030434483a295"
                         },
                         "ap-south-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-042d381bfde69b0b8"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-0199898262a8c41bd"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0ca3a741fe901cbf5"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-058887511cdddfd9f"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0f99b634cf5273908"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-066c2c1ef133fffdb"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-04d13b22a3a7ec426"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-0f4f7e26ee35f8d53"
                         },
                         "ca-central-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0b81e9efd4c4815ae"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-03cc031b5a3f3355a"
                         },
                         "eu-central-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0c37f96064ba7eb42"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-060c3f106c583419e"
                         },
                         "eu-north-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-080dec3474bac79d7"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-03055ae47c664e692"
                         },
                         "eu-south-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0f625ffba9fcb0ba3"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-0ea38626dbfb1fa63"
                         },
                         "eu-west-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-091a8e1debd3670d8"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-07e1e28b423b70936"
                         },
                         "eu-west-2": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-08cb292e01e98c716"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-0f1b486dea6924c0a"
                         },
                         "eu-west-3": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-01bcc1241531fe926"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-03a9bf2e57b9cc7cd"
                         },
                         "me-south-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0b91da8d40dc31a3e"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-091fda7d3ab9b6059"
                         },
                         "sa-east-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0448cdb1c7b8c0ebb"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-00345453a327650e3"
                         },
                         "us-east-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0a1dde2fd7d4c7755"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-0ec2d4943325e5540"
                         },
                         "us-east-2": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0fa9407136ca1170d"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-0883fdccf06437677"
                         },
                         "us-west-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-08c48869c1accaed4"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-068f7082d6bcc74f7"
                         },
                         "us-west-2": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-09b11a31a25c9cec2"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-070f308599005e24a"
                         }
                     }
                 }
@@ -190,72 +190,72 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "92251197017fd4d7afd3dd58bb15774dc7b7c90d725d30dfa3df222a0f0bd264",
-                                "uncompressed-sha256": "4d5845004edc38e020c0f100d3e09cbdc84d5eb614b0f6896d8de43b0933a7a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "9d5d4742eef56cdc514c740dd75401af2b36c17b25e6969cc966eb6713c8e2c4",
+                                "uncompressed-sha256": "737d08dd0407b199f0f67dc614ffec748497fa012602d834d499bfcff8ad06a8"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "db21a7f02590eb122e7913b30b3a1a9e4c8f8bb9c8ab4804898ee077c7711c6a",
-                                "uncompressed-sha256": "586a6d34254052af84f282736e1a616aa51887a269ef7e4bbbcf5cc046ae4fc3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "23cd6bc0bb0b7132d45ba80febffdac32fb8c73a14f0e10c9e62011471d2f56a",
+                                "uncompressed-sha256": "6d1826c1d7666a6408cc9bd7efb015c592ccb00ac88ad7c3bde6f10c15c8659c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-live.s390x.iso.sig",
-                                "sha256": "5f23572deda12ba86b3078c541828172887845dbc0c4fe621127780f4ad53be6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-live.s390x.iso.sig",
+                                "sha256": "e4293243727345f2c5886dae072e355cbcc102227b0d984f7bad01eae8c3e060"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-live-kernel-s390x.sig",
-                                "sha256": "bba8bd387bf722cc6feea585eae2037b071296a4622f18c51fd7138e886d78c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-live-kernel-s390x.sig",
+                                "sha256": "8b468ae0ad9a39f31d59b897bc49638e3790adc83f725a608b56b1b2fd830b8d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "be90bbac3b1093e1f0de1c7d96287a09991f9546f38b16ca49b7800108bd8fab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "2a1cecdac24d4b4e578c5880812a5a56b706a8ebfe14f18bf6faeb0f6b92377d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "dc13ec0866fec3117af044ff3eab06a7ed4771346e84aa0b5fd0b3fe6bd88e9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "5da283a3beea22b08626e74f566f7e3bbe5e22320f20f35523281950ccd6ea84"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "4156a8492bd83c64bd2983c63807f05544b0d8dd5cc92f5971d45369d7e3b2a5",
-                                "uncompressed-sha256": "0c52a19f7b0a017e251dd66b5daf693906e7fbbe7d3acdab6f7625953e785473"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "c330597994087299a22e3c547fdcecc114c8d0f51f01065386d35bcd02f9cb7d",
+                                "uncompressed-sha256": "46ea13a53d6b5b67d82c3cdf0019eed949a4d214f78f1624a6d866276f4c9b87"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/s390x/fedora-coreos-36.20220618.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "2d005de7f0d5a4f7cc38966bea2f14e55624894b5c7ba2a7838431bd34b07e37",
-                                "uncompressed-sha256": "a109bb605f16afb7734d077ed196fcf25fb59d7aa4ee3389f61f70c47453750b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "5ccabfe20583c572d7ad0f56642eebf81571b2ed1013d55f9f8f07876c9fb29a",
+                                "uncompressed-sha256": "cca0d210f95d53e51a57c50f18f93fb54530c66a89b62e219164bcd54b6edca9"
                             }
                         }
                     }
@@ -266,225 +266,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "c44586a9ee5de97f2896ffda65c70ce5759731172692e4003a8c6b57f5b2fb6e",
-                                "uncompressed-sha256": "7ea1dc85bcb508c74ad021e5617645b0dca5f37b1659626ff0ff4c0435a86609"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "61c0f7c07e5efadf44fe31cdca9dcbcb2d7f8c9edb4bc4a211d3da097e98d0e9",
+                                "uncompressed-sha256": "dfc201819009bf9e5a15b9ce00a3163db9370e1f9d160dad4b331ccf0f582441"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "962ff411aa37231a13dad291bad956601fb1e5755c9588a0ebfb86e50655f908",
-                                "uncompressed-sha256": "1e4274c50a45b0c6ca0674833a3a103061f8a200f850f5e7e569d5b922dfdd8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "1e87ce7218e1ef01298d2f3c636afc040196cf7bbc2490b549c7c96b4068140c",
+                                "uncompressed-sha256": "e4cc5c1ffce3dea66deaf9cd11733090b5f69a69be6869f57572eb284f280490"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "2b413ebd3a453fbfb8b19abbf7f74f48b9d80ab2a74e6f0d5de7e61da8b18844",
-                                "uncompressed-sha256": "b3af628a80743e6abe21bdb5206c7194141c4e87e546c62309dcb22481c234ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "3fae3d700c6e095f864907ddb9a100dfd875a52e3083cec1ab8472f2bd8e58a6",
+                                "uncompressed-sha256": "7c6a91ed26b80665ec22e05f51d4fb4bd8c16a61a09054ad62298ae6bd751372"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "94256ba98cb1d8f5d6c295dbd0a65bcb5a671ccb2abd12e44337d40498d101ec",
-                                "uncompressed-sha256": "6de51653a6c3d4ec1e90a5e41e90e1cba9147e793b1744e236977d67b6a0729c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "67441ecb6664901799f37fe826d067663acd571ef1bca63bf2b467e795a299dd",
+                                "uncompressed-sha256": "e1474702ab2a804734772240e0ddf0f93ab4a2622362fa8d7857ae0871c5fd13"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "4a9096a9cf0905ffe3b976de16b495419805db592cae6b644d0b3bed7f32ebea",
-                                "uncompressed-sha256": "ee731371859189bcb168e3c5015880d7ead979606e670f6bbe108e939cbc3a63"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "8908681c09148c35e58759729feeb82665fdbe1f83f6c73c04eae1da2223b4f8",
+                                "uncompressed-sha256": "a6916c84568f87157a1b3df78620114fa922c597b8ef045360512266e310affc"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "1f311eaeaa73d6e597768b9fef3b9926e41cb024037a0990b6fa266186e30010",
-                                "uncompressed-sha256": "daaca1cf469fc6c128d0be96a92aff2083f00c131a0e7a31bc557553a75cf7a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "be98de7bf74dc0fc2491c7dff31d15ebc99bd0a1aebe0b1cfb9e13cbd97c52c6",
+                                "uncompressed-sha256": "d1d37a3e124224e7f24d39335ccfb13a1f049ab08f86dc5683b675ef11ade786"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "d2d789f799a9caffd722cbafb883691856e396c57b20f043f1ec389380849e48",
-                                "uncompressed-sha256": "6ac5a6e4da1fa0702aa6ec0ebb8458f9846f728c1974c50aaea0b6e6629033f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "64939298d82e766395abbba47eb1f8114fcc90d068b153e5c6445c12ea3164be",
+                                "uncompressed-sha256": "42c318f958edbd67d08c434f89f927e8d9ec2f6879db85fdfabb253f25c8851b"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "d1a6a55cb9abf63c52a283bf2264a6deaf7231818debe5a33a2f8dcc72d1d999",
-                                "uncompressed-sha256": "808c5d0c65bb2da313cf0229c23e30a3b671a044aa778117edae5a17de9cd4f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "f6ae67b4e8b5fca4ddd749579583c52e56a5729979efee7c4ca93bffaa05285a",
+                                "uncompressed-sha256": "dbac3805eb99a351fc076500a87063c55c84c877a140b6b1fc449cce8e4ba6a2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "c2a89e887aeec04ad9bd114015eaca5a1622b3d39dfec8b274bf2d133c807221",
-                                "uncompressed-sha256": "36ffb0130ef4f547b4e38bc3ee9abfe96b120dc72e3ffb8919306f47b4a4dacd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "68adff5e10aad778deaf51365ce2a88798a63d3277e0dc1170f913fd76a5e808",
+                                "uncompressed-sha256": "2f28230f58f63935f216bed38b044d0cf11cfbb6f4cab733d00cd74fe0434fda"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-live.x86_64.iso.sig",
-                                "sha256": "bc14006fc8bbf9f0c80a2c130cfdecea2ad51192e1ee7e68acadfcc116981cb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-live.x86_64.iso.sig",
+                                "sha256": "5a1753566c1bb2081ca1433ea4dedc52c7857b6a70e14d3e4d0337cc2a42d786"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-live-kernel-x86_64.sig",
-                                "sha256": "19a12d3b6287560362eb762c52610b7a8e371ba74ed96bd758fa15098480b623"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-live-kernel-x86_64.sig",
+                                "sha256": "e031357b2e3b7fa0347ce56279eb66b1cda50046307969e801e326787ca5ad6b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "bff1b7bc83d5234a1c77e5b23c8a189286fa6a3851b76956afd6f2d839067d63"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "b6d5ad5d756674dbeb3c59872a57c7ad36a2b6822884a604013d3b3427aed731"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "3f669ea02f9a544fc8c48313e87f6e8ced937bedf0b2d9bc837711b1c4d7885f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "542bfac747d844408f6b4aa3e593d9b8017c3228e396e7f1ea6fe7384dbbceba"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "82bdc7c1f20dbf90acbdede8451baac14cac3e48286fae3c9616b3ccd4dc9fda",
-                                "uncompressed-sha256": "c9795a73833b22fef284cecf94edd616ab7523132b10610d353cd5b595ba7447"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "b4093d7b439991b29a942035b0041132dfb3f803fab67440a69c8110a096110e",
+                                "uncompressed-sha256": "c6f6cb411af8bf710f4a789099aef9de8462747aaa5b9a9a55734436def6fcba"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "36d82ad8c6d673b375988cab63abe8bb04e94a00cb2fa405b2998b96178e4fdc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "43521f76f25a00866872b52cfb15fb147716f12b3f78cf557c4580bd3d90eb3e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "1cd890912396e96c5404c5755dec199ad545d0c1e1031217135f4e86029c39c4",
-                                "uncompressed-sha256": "f03086a68f8c63b0e6c6cd1f0cf8fe9e6b757eb8d3b883965522315541e3106f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "0925957df68cccb777b7320e86d950be9b06debff96aadbf1b35fcc71fdc5129",
+                                "uncompressed-sha256": "810baec76db3a2edc648a1b5976c36e76bf478a80694b79f9ddcc5ffebca29b7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "96549cc75e1213fd378ec4df4d0acdcaa563bd46daff2fc5811371fdb77bf85d",
-                                "uncompressed-sha256": "9a8fe296d9fc39f92f1da66bff039021ba46741a4264dc5d559fcf8ff72c951e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "6f554fade6fd1ab60116aed2a0e9907d7dae803e9c70200bdc770233fb6b61ba",
+                                "uncompressed-sha256": "e085583fce6a3b6bdf3a20072ba6db14d706be64a9b7bda0d18c0e9845fefc2c"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "2b3258316c6fe65b29152030718cb16afacbbbd7f9159d8b620b26073bf4a123"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "d9d3984bc9fd0144fb1cf20f2a7b96221ccfc761fef64482b24561f33afea5a6"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "5969e2ceaaf28e31082ae9264bfea05c1595404f1eda2d49ced38e1735759514"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "4c86ef56f078e95a4e3b18b6f3e1f7ad502b4381969ad3e4b89b7286f8fef157"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220618.1.1/x86_64/fedora-coreos-36.20220618.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "074c0c52c43188a8d27a1f4a8684e3b85a3993b4da3ccfd7a216c5bca23ebcf5",
-                                "uncompressed-sha256": "9a474588241e217b444bb706308f170891872e4fd376d38b0d14b89b0f70be34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "dad0c3f3e02c3882817ef77f2e144da56b57349bd6748336ed9094b1ace1a53c",
+                                "uncompressed-sha256": "cf2af8e9cb78902eff0d9149020feed24ac4eced03707273c6b7e69096669579"
                             }
                         }
                     }
@@ -494,100 +494,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-07778f57b1ba6296f"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-039ba10d1576b1463"
                         },
                         "ap-east-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-08b9519e0c3b2bc03"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-0f317596ddedfe9b0"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-02c6760e842541f3d"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-0707e6d89bcb5a283"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0735805e41624ff07"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-0fec13ab3e3bbbadf"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0b9a5eeffa87628f5"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-01d386d40535d2a49"
                         },
                         "ap-south-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0f39fbcd7acb94626"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-00fad82babea043b6"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-08033e7263b637b63"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-0bc6636bc8534157c"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-02c0152021c9cc9f3"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-0a7d359c79025ca40"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-03072d3b22cb8148a"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-0c378e75b1a0de63a"
                         },
                         "ca-central-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0469e0d96acd3538f"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-040f9a0734fa1d7f5"
                         },
                         "eu-central-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0794e72dea892abc3"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-02641c6e7e68346e1"
                         },
                         "eu-north-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-06c7465f423b24f1f"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-0183c1f556e75fe90"
                         },
                         "eu-south-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-007f872a9381f27f1"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-0cc941a57f5b4a3c0"
                         },
                         "eu-west-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-068292feac2a7a377"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-067d027c0395e99fe"
                         },
                         "eu-west-2": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-02ef7e302306fe917"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-05c1dbf28384b5cef"
                         },
                         "eu-west-3": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-059d610712a3c2e2c"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-094b86bb8e742794b"
                         },
                         "me-south-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0a0bc752da571045b"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-0120d8079286774a2"
                         },
                         "sa-east-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-03ceb3c8972fe2fac"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-0994888467c040390"
                         },
                         "us-east-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0649961a33f15a398"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-09baf5faabf7a21e5"
                         },
                         "us-east-2": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0ba3699c77cbff059"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-0b35125609696e4d5"
                         },
                         "us-west-1": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0c21b32937718e45f"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-00c413f33d80a1952"
                         },
                         "us-west-2": {
-                            "release": "36.20220618.1.1",
-                            "image": "ami-0e1ecd943f9ad7993"
+                            "release": "36.20220703.1.1",
+                            "image": "ami-05cb6a74532081ac2"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220618.1.1",
+                    "release": "36.20220703.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-36-20220618-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220703-1-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,92 +1,92 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-06-21T14:08:33Z",
+        "last-modified": "2022-07-06T16:19:23Z",
         "generator": "fedora-coreos-stream-generator v0.2.6"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "0489fc927fc6792210ce56923b3da91251844df86bc9aed66cd56cefce95246b",
-                                "uncompressed-sha256": "2ef3f840961682bc9b49e3a2830c9b5e3a2ba4b187755daab105e04b21e2717c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "cf8b082a4b67e7be0e1e0926e970b39c3be8644445f32093fbd67a939ea73082",
+                                "uncompressed-sha256": "72d8c3448c28aaafd3aecc36bc982bc9eb118d08be804ca35875deeacd79d464"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "2037937e69c5e9715eff42924df0fb63763c0da13ce7239ac3104bbf77b69bad",
-                                "uncompressed-sha256": "5ed618ad26349445e4416c14b5e8e4baef78f803e8c3127648ff132900427331"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "efee10b610f054836d64906b924e62373ab92729f57b35eeb585afd8cad17c6d",
+                                "uncompressed-sha256": "88f4f3655e4c2198bc3370edabeac4aad57c8f32a630fc3c5d30167d21a01e8b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live.aarch64.iso.sig",
-                                "sha256": "b5d90aceaf0e0eed585877cd033f2447f6cb8dcff32283253393cec88e6ffcf5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live.aarch64.iso.sig",
+                                "sha256": "b1cf82b51c40f5ea319eb8651ab092ec3588de4ec817a12fbafe5b01fa399d98"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live-kernel-aarch64.sig",
-                                "sha256": "d43703f0f6eefa6ebc26dde5fde0252da632a847392904d5e2348dc215ce6fb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live-kernel-aarch64.sig",
+                                "sha256": "fce2ccc1f09cef7709cb75274adc015836baf9e78d094335fd803252dc8c9622"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "7ac56ff4bd16d08eb6022043b3e72773f68768e6b1693a2719f394aba8af0325"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "b8f180244a8eda6098c17cb3ce2296f9a97c1871651248e9e7b2e4b314bd5624"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "eb0a59d06b3103fbfa4b4aa659a14696b2454fc1910676d73a19ed1290568003"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "9dffddfb3cbb89828305e9aa8d1c4f8d422752d379f4254e6b35683d9e741e7d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "f43e282eb104649c2d8aed9bdb825a7921efc1374536659562b7bed17353fc4e",
-                                "uncompressed-sha256": "fe569075ff24fcf5ee1a70ab29f5692e249d5f70e012200519396e1021b66e50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "d792a2e8826e47726cf899bbc9e4a8fc6ad0eaf0f3935b929cc9302927554ac2",
+                                "uncompressed-sha256": "8e3027a954da11be7cd868933e0759a201cae11335c70ea97eb88163bf15a53c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "241c235aa0377986f3d837939ade017456938e3e93cfdf1419bd59ef28438d81",
-                                "uncompressed-sha256": "b4d6a77f2a2b7b92c991d753aad6ae3010ed648b06104dc1d6ad14c4c29ee8bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "434c283a81a5a104953f9f69c38593ef25ed488e78ced68c24b9b099afcd7408",
+                                "uncompressed-sha256": "01ab79135ed3e1bd98405803f076de75edd008266b38bee7d3555f0195cc5c16"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/aarch64/fedora-coreos-36.20220605.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "c2a953b7e5a4f4f1f4c21dd489a352854eb204b176b5386fe4fe46ae1dd8be9d",
-                                "uncompressed-sha256": "9842087452d55c51578661875a1c2d96e148b00d8804f3e11e2f98ccfd486b07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "cc9aaa639313cf772fd0c2699da1cd8edd71510d8ae7621dee584384018df0a7",
+                                "uncompressed-sha256": "7072b7fd699c82b04ad1346aa04e32dfab41fd38ad2e2437fd2e69affb9ae037"
                             }
                         }
                     }
@@ -96,319 +96,395 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-01c169e432b991a52"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0e8ae97c082d002f6"
                         },
                         "ap-east-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-037b9425f78e223e4"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0365a794f16c7744a"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-063ae04d36383ed0b"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0ae6e0422a215e2e3"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-092914ed089113f9e"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-065cea2b66a8f4d6e"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0ff7fc919b81ad551"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-089d98530667bc354"
                         },
                         "ap-south-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0691078078f5737f5"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0bd3b92d9440cd31c"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0930b69cf736a0937"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0e44b29d45d2ee9b5"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0a11e4d49c5df91c5"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0be993005e99d16f5"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-05b330f432a7a5366"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-01ec571f2bbf28114"
                         },
                         "ca-central-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0de4d555ad68dca90"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-033ad50458df19b0a"
                         },
                         "eu-central-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-00f6a0df93b7d1a4b"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0fdf3419612fd2dc0"
                         },
                         "eu-north-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-07f7f3dc3f68ca381"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-09c108728ab6242c8"
                         },
                         "eu-south-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0a81cb2f749a3becc"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0e2c5901cac0fefe6"
                         },
                         "eu-west-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0f39059f7774198af"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-069ee8919bb018aab"
                         },
                         "eu-west-2": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0d8f7464bc9110031"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-016aa50c449a0b2f0"
                         },
                         "eu-west-3": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-064db7b365f7a9760"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0b481a7e699ce9c89"
                         },
                         "me-south-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-010f06d1a90f46985"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0ec748c557eabbfc6"
                         },
                         "sa-east-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-066d590f75fac95f0"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-054481f90e8d45a40"
                         },
                         "us-east-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-099d6b9b1339fa083"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0c0ab89211e0767d6"
                         },
                         "us-east-2": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-09e2300f99c1530dc"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-03350b9dae604191f"
                         },
                         "us-west-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-07cf4694ad649a069"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-012f10df6179bfe22"
                         },
                         "us-west-2": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-010f881571730769f"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-05fac706885df7ead"
                         }
                     }
                 }
             }
         },
-        "x86_64": {
+        "s390x": {
             "artifacts": {
-                "aliyun": {
-                    "release": "36.20220605.3.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "99c1516f99f89f84c476aa327651c9b63ea0409e8c9ab1f171931ee8c80228c8",
-                                "uncompressed-sha256": "006efc926af451261f76ecb8cbf3f9cec16e583973dbd0fcfd1be7b8ea6a78c0"
-                            }
-                        }
-                    }
-                },
-                "aws": {
-                    "release": "36.20220605.3.0",
-                    "formats": {
-                        "vmdk.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "cf0f467255303f89b6ba61ad9b1c1bb546a4dd026aba8af5c97b54cc63694106",
-                                "uncompressed-sha256": "a030f4b55e585ff695ce3a24e96b763a1e117724dad52627d95d4f99ddbfb774"
-                            }
-                        }
-                    }
-                },
-                "azure": {
-                    "release": "36.20220605.3.0",
-                    "formats": {
-                        "vhd.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "4c5a42cb635cf4691b7107caddd08eeb6e039af4cf8f76f7f2e216fb55ad364d",
-                                "uncompressed-sha256": "2c5eb4a2060e3e547cc1103a4ed5857a819fab9f44b726151d3ca42ac2c419b8"
-                            }
-                        }
-                    }
-                },
-                "azurestack": {
-                    "release": "36.20220605.3.0",
-                    "formats": {
-                        "vhd.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "06d94d70eb6474d59131184f645f0ca5f7e613a90aeb2f90e9aed80d73b00a36",
-                                "uncompressed-sha256": "0c750ba56a562061d301d435a587d30c728e050cb357db9e6139ef811bb70cc4"
-                            }
-                        }
-                    }
-                },
-                "digitalocean": {
-                    "release": "36.20220605.3.0",
-                    "formats": {
-                        "qcow2.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "048ca51487cab906187a4c2d0f5e1439e3db3da8e9d6e3a92cde32854a86fd8e",
-                                "uncompressed-sha256": "5cb234af18911989c579561d8e829d2fc8cc3f8014e2be04c4c6babbb9535903"
-                            }
-                        }
-                    }
-                },
-                "exoscale": {
-                    "release": "36.20220605.3.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "e41d201cc6812f44836afb18e4623f433a5b5e65c6e27fa38629f09e9d54a224",
-                                "uncompressed-sha256": "27f0fda33e1f0883faae2f89447cddaa63013f1ef231e772b42c8d3f333967d3"
-                            }
-                        }
-                    }
-                },
-                "gcp": {
-                    "release": "36.20220605.3.0",
-                    "formats": {
-                        "tar.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "cd715f3d2daa501ee7af98e1ca11d09320b709bc4fe0f9e3c51e40d9bb5d71bc",
-                                "uncompressed-sha256": "90e4908cfd7e582ce5a3d02dfd4bede34934ea443bc09895a34bffbdb0ee1754"
-                            }
-                        }
-                    }
-                },
                 "ibmcloud": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a92442a998d805382929edb77725c0baa187f72a8eef20b03b3ec67ca0589df3",
-                                "uncompressed-sha256": "a4dd9def33468abbe08bf5363da5aaa9e8fa9ad83c560c74c2343938f18169eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "f6365ce14e95dc895b0d2ff54e62e62051a72db9d5883b8b1c859d619800c53d",
+                                "uncompressed-sha256": "8875e84c8a498fa5197bbc39b4894372c7cdd9138663906e0e2ea64a0e6fedd6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "dbc755e0bfd7414a7accfed88c21184a072f6ea8eacf82aa461ca39f279fac98",
-                                "uncompressed-sha256": "805d77570c82b796cfa83af3548053a86f208ce5506e59a7b0ba526d8b948667"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "39b8a1d08986fd8785952c2370f174c88df0167b7391e5bdce2bde2bcf3c63ac",
+                                "uncompressed-sha256": "ce84b2032433bfa90eb133cd8ef144f5b6265daff66890b10704e4394e628449"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live.x86_64.iso.sig",
-                                "sha256": "66941312564cb6b3de1ea536aa162a5ee747a4668faecde88fa38bc668df1100"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live.s390x.iso.sig",
+                                "sha256": "caff6c12eec2e6dfbaa207f6da005b3343f3bfb9be4601d6c2a4e6610e14a2e9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live-kernel-x86_64.sig",
-                                "sha256": "ac47aa3d1a21b5665f885f3c85c9b3b9d4bca6f7dd94c38c016f10c735b48d0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live-kernel-s390x.sig",
+                                "sha256": "bba8bd387bf722cc6feea585eae2037b071296a4622f18c51fd7138e886d78c7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "2cbda89fa398ce9aa085492c291f83aacb8ed22f7e3c019c69ae10b03e0231f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "f092a82256b3445576f743de7ce47858b76c567d1cce33bac88427916ffe0ed0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "e133a47f03d063ea90540dfe8401182b0f089c1bf2b170d2dae63c5433410f6d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "abd1f507a018d880e069144f65b824f7eed2373dcef570659e184887aac9f4f9"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f09b9b2735cf69fcaf3a52ff8f8658aefb19bcaea2768a13824ec6735686552e",
-                                "uncompressed-sha256": "f8aed4a84e81f47a30c694e1e6dcb28a0e1653de39aad24eda17e532d68c5fce"
-                            }
-                        }
-                    }
-                },
-                "nutanix": {
-                    "release": "36.20220605.3.0",
-                    "formats": {
-                        "qcow2": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "fa4a316641c77cff0086b39779e9d62d8496821da34c10c72e2f278e3a2cfdd7"
-                            }
-                        }
-                    }
-                },
-                "openstack": {
-                    "release": "36.20220605.3.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "7dda9700e5b4e6c15a8c81520a3613ac31105d61ad03e88ed265ba463c55f98c",
-                                "uncompressed-sha256": "e27205919b098a8f443296e7b0d6afbdd5a9f2cbdf389446f760e41f216c25fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "647c2cdb8117f36a98b8743cacb85e4f6efef49d79e6be3080cbe0253e446be8",
+                                "uncompressed-sha256": "cd0a261135306caacc7091cab3a32b276d02dd580f6169e090c37623a58c017a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "21a1c0f408ca8817e0a4e969828ccabf26e8db121ee5a48dd191e9525ec16c90",
-                                "uncompressed-sha256": "c135a76958f093ab7d5c72d5ef8ad7ac4347caccec01e0998092a6a42061a4b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "74b5c35e46a41d32a50e2c9abae3b862f6ee84a61a8ede0825604ed85f2eafbf",
+                                "uncompressed-sha256": "ace8ffe45f2cff27417163bbce35019aca54d5fa7c41538eaa34b71dce4825d0"
+                            }
+                        }
+                    }
+                }
+            },
+            "images": {}
+        },
+        "x86_64": {
+            "artifacts": {
+                "aliyun": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "655fd7ca5b33fa10687b0f16b2dbcd0b8475ea71ba9ac76dd91fe4608a272e26",
+                                "uncompressed-sha256": "d861bfc6ffe1aa247d7d6279f17618cee85cbbf140302d41b71b841e76617d70"
+                            }
+                        }
+                    }
+                },
+                "aws": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "vmdk.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "6a0a0bd38289f4d51708b6cffd9f9718cb1542e85d97a81244f3f734a9616152",
+                                "uncompressed-sha256": "077b7928d855fb26712fcbabc90ff5fd6a635f1d71616777db3f960bddb7fdc4"
+                            }
+                        }
+                    }
+                },
+                "azure": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "f5ffda1a68f26b6512e4e035bd79e772803afc3e6a9baa7cf507d5a641838a94",
+                                "uncompressed-sha256": "b0cb9a782926cb55e85d503b0ef7e715091783c168cf7963dcac74efc7f3f70e"
+                            }
+                        }
+                    }
+                },
+                "azurestack": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "34cf287e75c3e6a435332678a47db99b3b341d82989020103d5dc911cf03099b",
+                                "uncompressed-sha256": "42feb8ac932b8005cae6d3878c0d25f16c5838d5704635a0c5c382ad5a10ecd6"
+                            }
+                        }
+                    }
+                },
+                "digitalocean": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "qcow2.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "d199503afeddd9bcbca6cf3ce22a44379c2de4945f9632ed273d68868c884baf",
+                                "uncompressed-sha256": "25d7212c03f86bc279bf8aa062ea86d17cb80b5073988465bb35ae131679dc4d"
+                            }
+                        }
+                    }
+                },
+                "exoscale": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "82e90fbae9a885f5023da7552a5ac7a6354b53919cb8de096f7b892801484717",
+                                "uncompressed-sha256": "bc4f74276e1d774ca7e3f2fbac40cb6c0287b2461756319090e80746bd885b4d"
+                            }
+                        }
+                    }
+                },
+                "gcp": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "tar.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "c91de9dc1441c80ec1e22ed78d100e22c13ed4c64835eb1615d7ca8ec3d70828",
+                                "uncompressed-sha256": "1c376dd49e570eb76724f79caa2b4dc0c3df41b5c55a819f5913951673eb5916"
+                            }
+                        }
+                    }
+                },
+                "ibmcloud": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "2ef74c2c6a9cd4fd5b14b9fcb3c22695335f7b8846106d55b7ac34093b8a512d",
+                                "uncompressed-sha256": "9856a0fbfad6ecebd8b10b62a96b380755819be6671e07897686a47b04100d30"
+                            }
+                        }
+                    }
+                },
+                "metal": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "4k.raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "f737ce150651f639a87b2206b8b81464b446d6b72a767b3bdfe83d190655c2ab",
+                                "uncompressed-sha256": "9288a525dd249699944515ecf4f919d6b415fef9d893e070814241acf7c1cb25"
+                            }
+                        },
+                        "iso": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live.x86_64.iso.sig",
+                                "sha256": "4fcda251b318f006aac823dc0954747361ef2723ddd1a35c1c5caeb911c5eae5"
+                            }
+                        },
+                        "pxe": {
+                            "kernel": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live-kernel-x86_64.sig",
+                                "sha256": "19a12d3b6287560362eb762c52610b7a8e371ba74ed96bd758fa15098480b623"
+                            },
+                            "initramfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "890adf70fcb615c78857af3de1fa7aef607f3579d8c8f1385ec4c0439bb7bbde"
+                            },
+                            "rootfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "18b52ac0a4b3dde3a094e66616dde90a710e2e720338c520dfd3700cd55f1706"
+                            }
+                        },
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "c0369a7bc36de121771c6d3b10e6c6bdb0f37e62fa78023578e869dc33db03f0",
+                                "uncompressed-sha256": "26612eb86a6b9bede28399725fce6b1678d0605e7401b045faca0fb878c320af"
+                            }
+                        }
+                    }
+                },
+                "nutanix": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "qcow2": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "00c53804428700bba6924caf0724c1854d99ea7768a26fda1d45e555f7c78694"
+                            }
+                        }
+                    }
+                },
+                "openstack": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "71c0624a90d0993b39c2a1f4bae4fa4e5d6554da0b4c6bc53022094202f29db0",
+                                "uncompressed-sha256": "a766aea069f3c5ff491822a23b0b0ca11e10e956871adb8c9912540e759290c8"
+                            }
+                        }
+                    }
+                },
+                "qemu": {
+                    "release": "36.20220618.3.1",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "dfe190390d1e4e751f8b3978b15a466744022db1801673614744886b38d498cc",
+                                "uncompressed-sha256": "62c05da2208b8af3f9a7ddf6e4632ef6f7fc252a6b76ae2a452341f05e6e1733"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "d582f891288a4b29a615f80c18bc94fac6025611318cc2b2149dc1dbfcc7814c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "cf4ba506f271b50d437af59f50bbf6b4ed05de97d3d9eeaaf30496087364a34b"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "1d6be531b1cf30e0657a6b9749de4be067fefecaa7f443d919040028eba28698"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "e02faf1a1f5c86f7a9b49853ab6b8a56e551b918a4ce2502bae5362a0fbe131f"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220605.3.0/x86_64/fedora-coreos-36.20220605.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "3877ed1a9ee0a46a81e6e7993a9d24b8a78d90d4de6b5ab22d58d80df95ae029",
-                                "uncompressed-sha256": "9316b5dbae47e36ea8c00d6383f68d72dd63bb007cedb8299f2fee074409c1cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "126f02f7e8e28bc8064592512bdf5856b920df40ec921ffdbb43433f0c2ba93c",
+                                "uncompressed-sha256": "19bd19d4849fe518694f10c5f7dd6b528098af19278d5b62f65b6797a63b8ca6"
                             }
                         }
                     }
@@ -418,100 +494,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0082386ed3c7bde94"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-077d2db1977a340f8"
                         },
                         "ap-east-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-071cdcba4d2279084"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-03394caca36940099"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-03c92db560f4f9f7b"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0b52486c2645b8763"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0f1e8a2a7b1acbf11"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0f8550fb21d2c5e9c"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-01ecd2d463f524375"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-030a1e8c9dc52b0c0"
                         },
                         "ap-south-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-07d493c6cc836d651"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-03123403cd0acb925"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0998769d3c22cdbdc"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0af9b6899c022fee5"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0f3545edc9142ccc2"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-01f43ca3c433c7f04"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0320015d4da80708d"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0f17e539211213f82"
                         },
                         "ca-central-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-03fce3c5b2103e866"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-09b6fced48017dcaf"
                         },
                         "eu-central-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0432542ca6340bbc6"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-013c43dc5efbab770"
                         },
                         "eu-north-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0826206f35baa28a6"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0582fcca2f226ba2b"
                         },
                         "eu-south-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0acdd9d8ecd732ac5"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0eb34462bc63428aa"
                         },
                         "eu-west-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-04dc67d11375529d9"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0ae9b5e521f641134"
                         },
                         "eu-west-2": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-03f56d07a739aa94c"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-05ef2120b391eab14"
                         },
                         "eu-west-3": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0e572f0bb71f173fb"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-027f69d71b0500c6a"
                         },
                         "me-south-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0bc60ec5e634a73c9"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0a03687bab4df2238"
                         },
                         "sa-east-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-00d284737e8fc2edb"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0c78ce635c2a22bf6"
                         },
                         "us-east-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0d604208402ac04e1"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-09268db52299b7bb4"
                         },
                         "us-east-2": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0f70a909636c5fd14"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0b537df7f00f60dfd"
                         },
                         "us-west-1": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-0286b6e1ea4e62caf"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-08875bfe9a15c7361"
                         },
                         "us-west-2": {
-                            "release": "36.20220605.3.0",
-                            "image": "ami-098f3c5f1a8e640f3"
+                            "release": "36.20220618.3.1",
+                            "image": "ami-0f1f42acc3476dc19"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220605.3.0",
+                    "release": "36.20220618.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-36-20220605-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220618-3-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-06-21T14:08:34Z",
+        "last-modified": "2022-07-06T16:19:24Z",
         "generator": "fedora-coreos-stream-generator v0.2.6"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "11eeb75ce55503abb40d8e7641ecf2fcd24e3a1831602c3e5bc469e6b25d5634",
-                                "uncompressed-sha256": "22297d2269add0538ae5747f1d7e2f7ef6e986afa604c5b599e3dfb483a723cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "96f6c1412348bd0df752197a2dcf0c70c35177f8e314a9913bcb2944bae150a0",
+                                "uncompressed-sha256": "a70ce44fc5993eb2232779c76c05529562d0c56033b2eee7caec464793acd218"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "e437bbacf7eaa06a4640e03db6386138ab7eb9fe4ea714664d35ab3f6a393dff",
-                                "uncompressed-sha256": "12933ded07e01a34f817b560229f0dae46279514368f49557a417699aa5bab2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "43d6a435a3c94add4b56e0a0ab6f9e83ae1a6ae02af44b4432f5eed1405c5296",
+                                "uncompressed-sha256": "da8b34192d6707a397ac5e3a0e4789d81d4caefcbabea3250ceaf77d6821313e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live.aarch64.iso.sig",
-                                "sha256": "54094ae0e43c894608785fde7d4935a5427f5bc4091327f147d3510133239904"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live.aarch64.iso.sig",
+                                "sha256": "09da685c6e9ee6297fa23eb17b6681f26782edbc059a1a1e853f1cc0bfc364e3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live-kernel-aarch64.sig",
-                                "sha256": "fce2ccc1f09cef7709cb75274adc015836baf9e78d094335fd803252dc8c9622"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live-kernel-aarch64.sig",
+                                "sha256": "850152289a68aea396c4f422a4570165680f3cf27dc7a956fbf5bedb98e8b12f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "5b42598a7afe9fc766337532212c0763d702c42414377d4d062ac328f4e1d34a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "04d665437233a33fa2cd9ccbf22032331fe71e9fd30ea3049df59cbd3d597187"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "3aed0281ffc1b1c04cc982a05711c945896e48e74b57c3ec04f2f7f622d8f19c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "c0afbd9f3845666944b1eaa7b5c14c6a7503c494f9faa8f8bff87125b6fbabf2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "bc5fec383a9919cd8c8813e9788a0d826c5432f417d5133e0bb9b40356aca3ca",
-                                "uncompressed-sha256": "5c4c0389c5fab9eb0395b063c836d86d74463e8c89590e1cf9a9c7b23fe01564"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "cb29cff457dcf2a145df928a2ce8456777db5a409602da0a65419b6d4b142155",
+                                "uncompressed-sha256": "bc669207bf407f3a34953e20888309035cf0ffd480efb8157f294e4b49caa941"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "eec36f7c6f91e215ba369a25eb30bd613e151cef650434e4e65351ac181a4426",
-                                "uncompressed-sha256": "31745f7fddc77b3307c166f72e6810d56edc3b9ff5cc34a3923ee0173cd87cca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "db0c214738bef555658edcb5fd35cfbb1fc9b660462deab947540ab7fd80de84",
+                                "uncompressed-sha256": "52b36e7a507d6ebc9031968aaf405bf4075aa581806731cc0236792a5c26eef6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/aarch64/fedora-coreos-36.20220618.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "9b876cf1491655ec7f03d5be7e50d0c547a83d7a0736a1195016c8562395054b",
-                                "uncompressed-sha256": "f04f8c0e83a47e738ea0df158f638e8c199864e2483dc16c97832ce5194d7c29"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "65bf42b023e82c31475ea37afa7bd6706fb25748a7deedc1bc76a0b7fad4c7c8",
+                                "uncompressed-sha256": "57e74a440e2bd8c8d867c94fb58d097811e4166c733985f77913a5784c86c755"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-01e394f80d32f1d57"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0ac32b388d381d383"
                         },
                         "ap-east-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-050bbac0e88eab075"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-04549f80f1c154904"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0216c60ef9911f8c1"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0dc232786d5a0edf9"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0f4771fae51ea57fd"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-03e1d54e2275c56e8"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0c2a92a0c0ae706e1"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-07f9110893d77ba04"
                         },
                         "ap-south-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0c0f5ccae08caa9d5"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0cb90c19a3036f24e"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0bd3ed3356771771c"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-01b03ab6bbe851e78"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0905e0e9bb8a66fd4"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0e0ca26c365a9f919"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-07a2bdc2f6ca5b47f"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0982cb61ca7d2f35a"
                         },
                         "ca-central-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0fbda341c2f5b2083"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-096d9357bc2501430"
                         },
                         "eu-central-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0aeaef9c3e766d55c"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0b5512b7425d20bb7"
                         },
                         "eu-north-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0ba8d8a6a968616d1"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0cfca40446c0d0807"
                         },
                         "eu-south-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-00e5e8c7289ade7e8"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0f26ed10adf72b64b"
                         },
                         "eu-west-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0f23bfb81936997b4"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-08d67f452581957a9"
                         },
                         "eu-west-2": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0aaffca81ca29bb1e"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-02ecf0467a9370b95"
                         },
                         "eu-west-3": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-07be9fc3b804fb136"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-04b780f75c31db697"
                         },
                         "me-south-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-002285e5433bbe52b"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-04218e475837e432c"
                         },
                         "sa-east-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0b93af9197de2e4be"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0c98706f0ccc4480d"
                         },
                         "us-east-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-01498eb06dac3520a"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-029e44a6a9d76e4d1"
                         },
                         "us-east-2": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-06750517062b27156"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-01cec8422dbfe7fb3"
                         },
                         "us-west-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0c0c4b06511ab929d"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0eb97ff18a670d856"
                         },
                         "us-west-2": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-02a5976e743cbf8eb"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0690f706e41ffae7f"
                         }
                     }
                 }
@@ -190,72 +190,72 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "505643eb16180c292db3a409fe491d943b292914cb46c3e2c53c61957de6fbbb",
-                                "uncompressed-sha256": "c3a1fb7087d7be9125d9307d6bab7b142be0f3ca5b6073a5e0d488b99ceeec53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "4199493100f2a5277bda997de8794f0a5ac83e8beaaa511ed0a7891faa421cb9",
+                                "uncompressed-sha256": "cbee3f66efa5e6e609abdc17ded6c067199372c97f6555a2e0d594f7b40230c7"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "fd0706770b76ad9b150899437f9779979e3b9185d007752dfdc68cf8449c7ca4",
-                                "uncompressed-sha256": "2c0485156a35203f5191df7d65d7588708570e00687c1dc0e14d45fdcea4dda8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "e53ed3faee46b197a48d6a80dc9996ecec76f6fcbf00fcf85900f79d1c0efd23",
+                                "uncompressed-sha256": "df4e51bf0c4960c06d28e6e1d109b382b34aef31c63d90be8c41bdf97efee883"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live.s390x.iso.sig",
-                                "sha256": "27e8369bc1be3171fc459a769aca3ab39b71ae8c82f7bd10c1228f5242ad66ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live.s390x.iso.sig",
+                                "sha256": "8cabf48de51443fc3d1bc92201214d59e8147695e42555b263569cafd8c2c9a3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live-kernel-s390x.sig",
-                                "sha256": "bba8bd387bf722cc6feea585eae2037b071296a4622f18c51fd7138e886d78c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live-kernel-s390x.sig",
+                                "sha256": "8b468ae0ad9a39f31d59b897bc49638e3790adc83f725a608b56b1b2fd830b8d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "df97a9223e847123ba5c1d43f61393d0f30a83245bfcd2782b9387f71e0963c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "3007ea5dded487f2a2a72e15f6c1c5dd53c4e68cb6b4411eb21929d1556a4d8e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "360c93aeeb5610e497ba8d49911a3ab90070d17d3696c09caa534f389cc1c7c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "3367c701d5d52475d0bae177d85712eacb04323ff5af7bc1aadeb69e0dee4703"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "4751f71846a076b3c6a2a2569ad67f3fe67d08c6059b1a82bd8e3362950d5f7b",
-                                "uncompressed-sha256": "72cd06f6579e6377cd0d32506b6d1f97edac9aa1eb0d3b62d57f3616054fc123"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "b73b6a825cb2cad725ebf60eb7195d473169adb35c72c7e6d25739be1a4e3a30",
+                                "uncompressed-sha256": "0f0410d1026e7b8dfc63b437e106eaf4be1c3664317197df3b7ae95bc8b0cd60"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/s390x/fedora-coreos-36.20220618.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "bf2d6ca9ff66671ac48e276dd6d7143f3db4980298e4e00f77001072f4460c36",
-                                "uncompressed-sha256": "8f039b8af8d2718f467f8598f7b9b02905353f4fd198b5d00f68c60b8d7e1705"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "357d71763962803a0299ceb9d7bc7a39186bc013da5878bc51ca12ac43140b3c",
+                                "uncompressed-sha256": "e4631ff1a1f2b13f146b16dc24674e33172a7eda80c8ab913b67bc76fd8a74a9"
                             }
                         }
                     }
@@ -266,225 +266,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "b754af10ee9480bce5cdd0c684f0a34f0ab8a322d384932c2d200d64f70826e4",
-                                "uncompressed-sha256": "9878778af173dc10b27aaa455172c1be660dcf1dc3f3bc9b56690c81dbffb609"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "4a2c7544b0e0354576e00ee8b2225573bcf47d454a8411ba7b539c2a8627d580",
+                                "uncompressed-sha256": "7f6e62a3d4047cdacfb307057584bd4e58b77e5ef61d44176eb7a03be832cda0"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "383a471e4a17f0c049f7d67e0b8652308a291754d470b5f0782f7dfae7d00bd7",
-                                "uncompressed-sha256": "1cca3cc80da6425eca9fc5ef3a6e3c6f9f464d2c6622902f8a6cd75b924cb900"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "95957c1cdc1b3936a9df63764afe2766939ceeec096e33cac88b89d8b49f528a",
+                                "uncompressed-sha256": "068f19b77e39eaee449029362189ec15b87d4fb1231d316527637c2871dddf81"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "e887c6d37649019981de880d1999430c9bb56d8998828ce10a159a69371b6c3e",
-                                "uncompressed-sha256": "bf37c3214aa8ad68a25f7f5e634683b1dcb700a9c0cb9949b19a7bffeb239478"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "edd698de2f7a2b02e77cf15e3745a8627c1af68e7920b91a036ad95f762f0d72",
+                                "uncompressed-sha256": "cb9d9a12486444e57f16e564ba8abe9e0d84aebc2efe543838ea0adad79c6547"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "c17939ea926a133c7127c2241fb56aba7e7edd7a70feedf969141a64f516b247",
-                                "uncompressed-sha256": "cfd496c7f4d65dc89c726d9f0a1f702dd86fb49b9097bdf062ea3d87f0865569"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "125d40c8668f27a695e5ab0c55816810afc0567ef46d308bbccf1cdce2bbef52",
+                                "uncompressed-sha256": "7e5bbecdb38b83ca7087da8bfa29dd08b6647cd6083ab06dfd9981910c2d7af2"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "aa19136a082f062bf1d9b0cd956b13cd6be5ef3af26472dd3e7ca272e95b1b3d",
-                                "uncompressed-sha256": "ca938d88b87a6c655df3efee0c95ea70015fda5df5b5308f2a793c3cbf16d066"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "8a3a2696d7ae5135a7d90651ddc6cf2d2ca3d9c2e9ad215ff340721ed58ea725",
+                                "uncompressed-sha256": "1739c8c26f106a2c3ea5af78af2d5790d26fc50dcc72ed1dc2b9440682e105cc"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "8e5cae785eebbc9afeb7512be459bcde0d76fa138b6307621d86579bf7681472",
-                                "uncompressed-sha256": "d7f210419d1cf5be9252b29095f2b2e7fe6e92aa553388c01379ccd65ba715c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "7622d93d7a604cdacaa355db03b313cb0a52161e9317f6cc9a5a17130002984a",
+                                "uncompressed-sha256": "8822909fd1102f4483f35a85661be7e694878c7fbe646dfda535ac6a8872dfba"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "ee78d7612bd472affd6189d5cf2130ac436f158b94b18401c49bc082206eea93",
-                                "uncompressed-sha256": "0609a01cb4b8509b7f916c037569fe68b554ddca57e38ac3eaeab7bd7361d584"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "d72d408d27351e376e1841de3cdd06b18bb92b5a0d4f139528eb7d17de4a35fa",
+                                "uncompressed-sha256": "b9cc788e732584b94090c14b253315159359e4609338f744ac202b820fc5c270"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "157cf2ea46bdd6e2a2866c18fefedbf2b78219bc7a3ab552ddd55692f53ddd76",
-                                "uncompressed-sha256": "402b28934bf3252ecb24b7031fcb6092a7c18bf21ebd600c2d2204c4c90e2090"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "77476765424cc89e062488dfa2023cbc282df0d5c185ca02cfbc8b50dbdca80f",
+                                "uncompressed-sha256": "ddb71543c44efc2b00a460e9eabbc4f1bcd6adcb24000f9615fc944db0ccec4e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "59ed361ab7f410140780929878a80610f0dc34a8d03a2b0c18c97c6c1e3d12e5",
-                                "uncompressed-sha256": "ba437f6c240dca68d705b738a35c51aafd3309880f2e279a8ca0300cee564b8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "7977843eafcb349f39c82942973335c1431c2c64ebb96ff6a84215d0fc57a6d8",
+                                "uncompressed-sha256": "c250350fc7716bef3c9456544d10d343c562af0165485c809a780520b8e1fb5d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live.x86_64.iso.sig",
-                                "sha256": "b9220dae9d56e82d0f64098919166ff0b5c0eb410c8829b42c1c2c0a6fd68012"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live.x86_64.iso.sig",
+                                "sha256": "7d0c1da7ae7e67c242a78bc8bfc5954262da85e54650426a3d9f7b8e44dbca9a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live-kernel-x86_64.sig",
-                                "sha256": "19a12d3b6287560362eb762c52610b7a8e371ba74ed96bd758fa15098480b623"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live-kernel-x86_64.sig",
+                                "sha256": "e031357b2e3b7fa0347ce56279eb66b1cda50046307969e801e326787ca5ad6b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "52adf78740bdbeca9fe9f222e29d1c74070fbd64e4843a8e03aff3759b13da7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "71a3b5da83e8c35eec8d534adee60749d2cea500cbcb55e463f211f9160b9eb8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "f8848580c0fcf6af85805ea47c6fdbf2ab383fe8d4baea28a5ab0a912621113a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "892b31e1a5f1aaab064e853881d8b17ee97a44ba0cf6d3df35da0229febd8eb3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "20a13e3b324a0692ae63e0749b1c55734d2590760439cdaefdc5c9349eb26472",
-                                "uncompressed-sha256": "16a91382697587dc527d283cd387be7644ad30714a24b885193aae39599beafa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "caf84fb77ccbd9d2d113c103b8d5c21b42fa3d5f8c4b4a23a9086532ca9c5857",
+                                "uncompressed-sha256": "dccec3e31818cdaa0bf74cb3a0db9fe4a803b01424e529183ecf8062bddb36e6"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "c3ac282267e0973ad7a327f0082bc2360e27412d93d268d451bf5f8a4452adbf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "0681b8d3fcd74f4236fb225bafa95e4fb1784a93ceb1d2fc4df19e63ab3cf433"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "30a1dd323429c358b8c71c30a4de9d1bcbafe6fd8f1924178fb52d9edaa7d140",
-                                "uncompressed-sha256": "3c20f9d7876cd5cfd8f2b57c58e01c716b04118248d22f3cb661e9d962c7a159"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "bafa17960c13e84e33a340e23594f6e2c84e7a3fe716206f05ff5635dcec65ad",
+                                "uncompressed-sha256": "c3c49720032e86a33bcfbc48c1c798f9a016aa44c410d4f44fb06a6026f0df7d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "54ad5e381fc63fe559328223252beca5f885e3903622ec1a164843cabe7d50e7",
-                                "uncompressed-sha256": "b4d805aa8b4f9479ddf208e7e9e29010c7879954afb982a29e0e854f4fed51a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "06118c2198991e9a519fdd38230d37a725a98cec014869874a3fa063e9459bc0",
+                                "uncompressed-sha256": "71bb389a25ff00fc3aca8c197a5a87126ac827b3abbd3b793195978b2021a009"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "9596c3ae97edf234c51bb3b23156076ac59af2c5940842a0caf109e505c83e92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "41be2d5d1c425d21f889bb442d674356ac920355114dac97889b9a67a2d5be5a"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "b4a418479a6a0cbc47d2492bd7fee9d07d9950be5e728ba026937838d3791526"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "b175ec5559a9969bcac405d7cc3f875c55c36adbf9353f7c2f6938db92ad204c"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220618.2.0/x86_64/fedora-coreos-36.20220618.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "ae7e2917f4ae540c7d91c47b63fec9d37f86b8a986fb9a611102f9ae74aab5b5",
-                                "uncompressed-sha256": "dd8701d598fdd5296dded9cb01c7cf04f07e2f05429e4e9b3b41c6d435308bbe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "d106d8d33bbb517cb57af3536f2b88e13ee9279ec08de3cb1ea6c5ce624f238c",
+                                "uncompressed-sha256": "9a203e54bed94d595a5627c1aaa929f3e3cb321dde63250f756cc1cdf910b6b6"
                             }
                         }
                     }
@@ -494,100 +494,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0ebcf3e68c324e723"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-01e159458c67b1825"
                         },
                         "ap-east-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-091e2960e1ea97d5b"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0980e529488b34ad3"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-00b7b17898c7cf7cd"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0afae1e2c44c9712f"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-05b2832e81ef7ee28"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-06a16d9844543971d"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-054a4adff598188af"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-07790ca7ce0efa8ce"
                         },
                         "ap-south-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-07dee4bcb67a0df59"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-04b222f33f023864a"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0b2a20704ed7ffe5b"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-02b221ffd4bca4196"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-03f4c84f93c7bd28b"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-06f9a164a4925d883"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-04a5a8cf6118c88c1"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-05b8d7d7b6d841c7a"
                         },
                         "ca-central-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0b2b5bf3d428487f3"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-045a89be5be4b0830"
                         },
                         "eu-central-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-07cd2445397e76f0a"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-03f90299db11e77cc"
                         },
                         "eu-north-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0804131510fb6ffff"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0df897825696c23a2"
                         },
                         "eu-south-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-090e372d14fceb7be"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-03d5c4e2a723f8276"
                         },
                         "eu-west-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-03798764699e60de1"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0ddc59a3e5bc7711b"
                         },
                         "eu-west-2": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0245858872f8cfd1d"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0c260d18f52ebbcc5"
                         },
                         "eu-west-3": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0400b1410bebdd61a"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-013383cec6a4ded80"
                         },
                         "me-south-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-057f222bd8adf0f41"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0f0e7020403c85aae"
                         },
                         "sa-east-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-01d9837e2302484e2"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-01d1019652542a55d"
                         },
                         "us-east-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0845e1add6eb33715"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-080a10e999cd4cdd7"
                         },
                         "us-east-2": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0229aa4214e845178"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-08cc589f66a2ae782"
                         },
                         "us-west-1": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0257adb1dd653b930"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-08108451e9aeb16ae"
                         },
                         "us-west-2": {
-                            "release": "36.20220618.2.0",
-                            "image": "ami-0784fab64863eca70"
+                            "release": "36.20220703.2.1",
+                            "image": "ami-0372ece5a40f941ad"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220618.2.0",
+                    "release": "36.20220703.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-36-20220618-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220703-2-1-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-06-21T14:08:36Z"
+    "last-modified": "2022-07-06T16:19:26Z"
   },
   "releases": [
     {
@@ -53,7 +53,7 @@
       }
     },
     {
-      "version": "36.20220605.1.0",
+      "version": "36.20220618.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -61,11 +61,11 @@
       }
     },
     {
-      "version": "36.20220618.1.1",
+      "version": "36.20220703.1.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1655823600,
+          "start_epoch": 1657126800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-06-21T14:08:34Z"
+    "last-modified": "2022-07-06T16:19:24Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "36.20220522.3.0",
+      "version": "36.20220605.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "36.20220605.3.0",
+      "version": "36.20220618.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1655823600,
+          "start_epoch": 1657126800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-06-21T14:08:35Z"
+    "last-modified": "2022-07-06T16:19:25Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "36.20220605.2.0",
+      "version": "36.20220618.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "36.20220618.2.0",
+      "version": "36.20220703.2.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1655823600,
+          "start_epoch": 1657126800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @cverna via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).