### PR TITLE
Roll out stable 36.20220703.3.1, testing 36.20220716.2.0, next 36.20220716.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-07-06T16:19:25Z",
+        "last-modified": "2022-07-19T13:47:56Z",
         "generator": "fedora-coreos-stream-generator v0.2.6"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "73a3483f3ea61e30d4d32ca016e2fc626d7827268215035e6b713a5a8e0ced45",
-                                "uncompressed-sha256": "703d71ce10a43c2db7eaed19d1c11c9a024a1b41563c761068796bcc6c17ab2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "7c380eec256f0ea69c8209f896ba6b75aefe48fd46f605c87bca5eafaea62c9e",
+                                "uncompressed-sha256": "52241c62175a94dfd8ada23780b76a1dc8506f3aea695fb089befc414692f959"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "c74ef2e30bdd53a3269968d4eb828db574ffaf48fde73839244c349407d484e3",
-                                "uncompressed-sha256": "bbfadaf4f613093ad569fa32b8535b37cdee632dc879ceebb1bf9c42cba752d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "e4f6e2e1ab8b7e7aa14ebd27d2ef71591b28e48b80734519435e56822c756df3",
+                                "uncompressed-sha256": "6e74f694fd44126613e33ebabd5becb8f2285aea954e8eafea9a368785cfb644"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-live.aarch64.iso.sig",
-                                "sha256": "3f0fa015cbe7c106f8b3364b00ca9290ae31073d51a149a221992a670490ace0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-live.aarch64.iso.sig",
+                                "sha256": "7e5d378498f0e888d248bed4b716d75abab520f22925384ecf2b6068bb15c1ed"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-live-kernel-aarch64.sig",
-                                "sha256": "850152289a68aea396c4f422a4570165680f3cf27dc7a956fbf5bedb98e8b12f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-live-kernel-aarch64.sig",
+                                "sha256": "a5c1fa086cd43caba102bf1c8590055b01d1ab0c78901992dac654bcf1cfcf7a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "244daaa1d0d70c356e0b16ffc87ca5da6269fde0b3987fb332ba168bd2bc8232"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "0207cb35ddccc0277fb0e750879121ecb771fe90e1659388a89e4e79c2412745"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "372f04d8c39b0c041e5912ed9c9c5205c6b3156930ed7ace2dcea849b3f925a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "1a4a8f06104c106b7f7a7f32683a767384d5fe427dd5a7cba4367dea6d78278e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "5fdf9481fed6b8b1f6ecefc4cf9a0bea7c4ac515f4f65950e0fd0f0962bc2167",
-                                "uncompressed-sha256": "baeae66f35395cca659aeb8cccc91a780ebbc2909bdd991f12765c66e6576393"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "34bdcb349c506903f95abcb7b63e97aa7f1576348f62437037be8d92f2cecaf4",
+                                "uncompressed-sha256": "60408222f01093027b5d28590de86874693459dae1925aa9672667c3cc1fc18e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "1f560517f621f753ee96d1bc806109205ecae2259e708292f1207922e06d954d",
-                                "uncompressed-sha256": "183dd9a52a758c4a1edce9722353f42b53a1ab33b632ec813d3f050ab93834c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "26ce6a1924b4f69ebb8746b7f0370b04ae6313c0642217e8f6f58068a6cdd961",
+                                "uncompressed-sha256": "fd38f6800d14aa22362bbd02189d1ed5a7ef551126a55604ecba53c03d8fb9d3"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/aarch64/fedora-coreos-36.20220703.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "97df01e3dc28abf6eec9c1144ffc3ea31b562cf1d3106554b4bc3dde1db40ede",
-                                "uncompressed-sha256": "824ec87689ce94c19a1cdf68c4b63531f4fe5aca4f33bf38d03240348d197171"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "52f042df8be04c9974f0855f3a73eb2c0638918af03f435b86638e96b7e0169f",
+                                "uncompressed-sha256": "b19b84abfd656781f3b94403e4cf416a361bb5f4c281d842356aaeabafd383e7"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-06c590d4294e8e93a"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0566b898066ded7cb"
                         },
                         "ap-east-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-0953d161250dcff64"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0cef124a08e99d59e"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-0561004044c59ddb3"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0845e811d62a3ca87"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-01fccee8199d85e85"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0038161e582b72f7d"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-01f6030434483a295"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-057471b11aebe6931"
                         },
                         "ap-south-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-0199898262a8c41bd"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0a87333fec3964b56"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-058887511cdddfd9f"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-068e6305c7f85ed60"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-066c2c1ef133fffdb"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0bfca76a3755dde28"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-0f4f7e26ee35f8d53"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-01ffe8d9cbd707fd4"
                         },
                         "ca-central-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-03cc031b5a3f3355a"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0f70c099186d45e56"
                         },
                         "eu-central-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-060c3f106c583419e"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0c1c0b41c1ede3bd8"
                         },
                         "eu-north-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-03055ae47c664e692"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-04e216a129c28e551"
                         },
                         "eu-south-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-0ea38626dbfb1fa63"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-007a6b523ad9b89f9"
                         },
                         "eu-west-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-07e1e28b423b70936"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0b486c015498e2fe3"
                         },
                         "eu-west-2": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-0f1b486dea6924c0a"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0681c8c9abaf8ec9b"
                         },
                         "eu-west-3": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-03a9bf2e57b9cc7cd"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0d26d4e69a3c5c52a"
                         },
                         "me-south-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-091fda7d3ab9b6059"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0cf4208d757739e56"
                         },
                         "sa-east-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-00345453a327650e3"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-05e46c41d6529b2eb"
                         },
                         "us-east-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-0ec2d4943325e5540"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-09b8eefbdba4fbff8"
                         },
                         "us-east-2": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-0883fdccf06437677"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0eb9ab25b33cc7a60"
                         },
                         "us-west-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-068f7082d6bcc74f7"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0bee6f226cede448f"
                         },
                         "us-west-2": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-070f308599005e24a"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-02e90c2bbb4d2d367"
                         }
                     }
                 }
@@ -190,72 +190,72 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "9d5d4742eef56cdc514c740dd75401af2b36c17b25e6969cc966eb6713c8e2c4",
-                                "uncompressed-sha256": "737d08dd0407b199f0f67dc614ffec748497fa012602d834d499bfcff8ad06a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "d0bd43ecd1abb6fde7ec2c5c765609b983860f9f72d33c4253a5b3644f0e7afa",
+                                "uncompressed-sha256": "f144192651a52bce1ce5d3671b11db5214f13a77cbc8be00d7f7caf29668580e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "23cd6bc0bb0b7132d45ba80febffdac32fb8c73a14f0e10c9e62011471d2f56a",
-                                "uncompressed-sha256": "6d1826c1d7666a6408cc9bd7efb015c592ccb00ac88ad7c3bde6f10c15c8659c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "30ac74e9532e50342619323f499b713ded74052459370f0506a38c87268a06f4",
+                                "uncompressed-sha256": "eef454f26bb8ae33efa9a1e989684358773cc00b974057f51272c5dba53b5ac5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-live.s390x.iso.sig",
-                                "sha256": "e4293243727345f2c5886dae072e355cbcc102227b0d984f7bad01eae8c3e060"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-live.s390x.iso.sig",
+                                "sha256": "ee0c8ef852571d52dfb89391433ce090991776f2644c9e61cb9ce906d86fff46"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-live-kernel-s390x.sig",
-                                "sha256": "8b468ae0ad9a39f31d59b897bc49638e3790adc83f725a608b56b1b2fd830b8d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-live-kernel-s390x.sig",
+                                "sha256": "1917ea368be5acc97b062330a4d13111517b357d8dbbb277215716da1a8b0a92"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "2a1cecdac24d4b4e578c5880812a5a56b706a8ebfe14f18bf6faeb0f6b92377d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "4ed335e8f83e6d67d1b4eedde1e6669b6ad0702bfddee4b6a68ed54840a2904b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "5da283a3beea22b08626e74f566f7e3bbe5e22320f20f35523281950ccd6ea84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "a9e7babee44b298d0dfceb2dcf6cd07d7ebbec0b80c82817bb79987e6d76a6cc"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "c330597994087299a22e3c547fdcecc114c8d0f51f01065386d35bcd02f9cb7d",
-                                "uncompressed-sha256": "46ea13a53d6b5b67d82c3cdf0019eed949a4d214f78f1624a6d866276f4c9b87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "37d85d082dd1c3e4855b41e92d6a1eead0aa9d3698ed35c860975765831d1888",
+                                "uncompressed-sha256": "69bbf9f20531a8d3ed8c77c0c25eab8d32d3d550b2485740123b904677689c57"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/s390x/fedora-coreos-36.20220703.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "5ccabfe20583c572d7ad0f56642eebf81571b2ed1013d55f9f8f07876c9fb29a",
-                                "uncompressed-sha256": "cca0d210f95d53e51a57c50f18f93fb54530c66a89b62e219164bcd54b6edca9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "4ffbbf96625836ddf96391c87d31c8e1e419e9346115f20335477067f3d3c149",
+                                "uncompressed-sha256": "ce850427b92085c25e621c63a97ffa3ee082d3aaa3f21496cf9f8b4ab474c138"
                             }
                         }
                     }
@@ -266,225 +266,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "61c0f7c07e5efadf44fe31cdca9dcbcb2d7f8c9edb4bc4a211d3da097e98d0e9",
-                                "uncompressed-sha256": "dfc201819009bf9e5a15b9ce00a3163db9370e1f9d160dad4b331ccf0f582441"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "5413d95356cd5cafd2d3313eda6b2b22bbf783218725b4575178d8a4d29ad38e",
+                                "uncompressed-sha256": "2d2b7375557377efd8290fd9da61138781a3de717b533b17bd9d53ac86d3c447"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "1e87ce7218e1ef01298d2f3c636afc040196cf7bbc2490b549c7c96b4068140c",
-                                "uncompressed-sha256": "e4cc5c1ffce3dea66deaf9cd11733090b5f69a69be6869f57572eb284f280490"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "9304d31805145701c4dc376a1e2677daa9c3dce9dcf860ed4f3ce223a36d8880",
+                                "uncompressed-sha256": "c403ed9f9943b11ceca83d5bf58e506c8ae2568fb0b37639aaf38c4d68393fe0"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "3fae3d700c6e095f864907ddb9a100dfd875a52e3083cec1ab8472f2bd8e58a6",
-                                "uncompressed-sha256": "7c6a91ed26b80665ec22e05f51d4fb4bd8c16a61a09054ad62298ae6bd751372"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "13d21fef2e7df21038cf6bb57c43e649dc101f1fd3ef71564c21b2bf8b2bb4af",
+                                "uncompressed-sha256": "b5684ebd09c0fae66f2e22186840cd4557ce30e847b8db259b419ed1e373f472"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "67441ecb6664901799f37fe826d067663acd571ef1bca63bf2b467e795a299dd",
-                                "uncompressed-sha256": "e1474702ab2a804734772240e0ddf0f93ab4a2622362fa8d7857ae0871c5fd13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "cc62edb4a7e2a389e94ffa7e5f711ea6c787b7a3021179065096f53b61aec8e3",
+                                "uncompressed-sha256": "956cb1054376219d469efc405930e86fdd56212188954558b8364e39af00e2a7"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "8908681c09148c35e58759729feeb82665fdbe1f83f6c73c04eae1da2223b4f8",
-                                "uncompressed-sha256": "a6916c84568f87157a1b3df78620114fa922c597b8ef045360512266e310affc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "50df1fe9d756f616bdf6c64d666dfe5eb0731a1fccc758e86b4bc15a90c47d99",
+                                "uncompressed-sha256": "6db85d7341de93d84884ca8c986bf63397e352031a3b10b9ef7cfd4b7129ccc7"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "be98de7bf74dc0fc2491c7dff31d15ebc99bd0a1aebe0b1cfb9e13cbd97c52c6",
-                                "uncompressed-sha256": "d1d37a3e124224e7f24d39335ccfb13a1f049ab08f86dc5683b675ef11ade786"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e644fd04ede46a4864753618763b9d244c4b61354096c35a13eeca3a222f2a0c",
+                                "uncompressed-sha256": "71092163c50b38ea3277b13086a9ee70ab88e1a0d6dad43bee9078b52704d8b1"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "64939298d82e766395abbba47eb1f8114fcc90d068b153e5c6445c12ea3164be",
-                                "uncompressed-sha256": "42c318f958edbd67d08c434f89f927e8d9ec2f6879db85fdfabb253f25c8851b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "01c5e15bbe3b6dfc4140b649d76cdfced6c003fd155d1352cb796287b0aa086c",
+                                "uncompressed-sha256": "dbe4b3e88484156e1819d5a6ec0c2820e44b92d02da0904ece776cdbc0661fa1"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "f6ae67b4e8b5fca4ddd749579583c52e56a5729979efee7c4ca93bffaa05285a",
-                                "uncompressed-sha256": "dbac3805eb99a351fc076500a87063c55c84c877a140b6b1fc449cce8e4ba6a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "8b0838d9182c7682f7c56c06325ce0e75d7d0500da0bc5fae6c571d12b5764e5",
+                                "uncompressed-sha256": "78532f91d39a4ee557fdd27a4a4666d0504222d7370e7fe57fe50e1cacbbd864"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "68adff5e10aad778deaf51365ce2a88798a63d3277e0dc1170f913fd76a5e808",
-                                "uncompressed-sha256": "2f28230f58f63935f216bed38b044d0cf11cfbb6f4cab733d00cd74fe0434fda"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "77f164ca822d7895f8d94e7cda0000efddf1ae0d8e9b7f9bc7b6b84e5daae6c2",
+                                "uncompressed-sha256": "6d13e9b5e60bc45929c83f19244fdf7d24b9dfd319fce7ffd45fb3fcb22eba8d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-live.x86_64.iso.sig",
-                                "sha256": "5a1753566c1bb2081ca1433ea4dedc52c7857b6a70e14d3e4d0337cc2a42d786"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-live.x86_64.iso.sig",
+                                "sha256": "b1948d86a04bd81181b50a7156dd31333da52258f6e6ef34af4d32a389a7a2c8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-live-kernel-x86_64.sig",
-                                "sha256": "e031357b2e3b7fa0347ce56279eb66b1cda50046307969e801e326787ca5ad6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-live-kernel-x86_64.sig",
+                                "sha256": "a834a9a7230b3efaab2362ebc5b3733bacbc320b145989fa9f70c0d3dd3d996e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "b6d5ad5d756674dbeb3c59872a57c7ad36a2b6822884a604013d3b3427aed731"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "dcea50ad89ba5da2e99317e9b21d3a3a928109d818c93f8de3539e0e111f6957"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "542bfac747d844408f6b4aa3e593d9b8017c3228e396e7f1ea6fe7384dbbceba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "d4de4a38139b5e76c3e7f06b467a84c983f5495ae1a283467c802d5ac295f6f5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "b4093d7b439991b29a942035b0041132dfb3f803fab67440a69c8110a096110e",
-                                "uncompressed-sha256": "c6f6cb411af8bf710f4a789099aef9de8462747aaa5b9a9a55734436def6fcba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "71e4bb54cee53d6e526e6b6d0b1935f065f6ae05d95169cd9bab0f320da72da4",
+                                "uncompressed-sha256": "7ef4878de208446c9c6724b4b9565c6e779958739820d7f9e7208c9af27fa7f3"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "43521f76f25a00866872b52cfb15fb147716f12b3f78cf557c4580bd3d90eb3e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "4485316db3e4d81c9c5ed9eaf192a294d5125678b5074dc2f9fc5dbb4d9da64c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "0925957df68cccb777b7320e86d950be9b06debff96aadbf1b35fcc71fdc5129",
-                                "uncompressed-sha256": "810baec76db3a2edc648a1b5976c36e76bf478a80694b79f9ddcc5ffebca29b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "7faaa28ae3a699c06741cab08025a2a7b321a484ae2faed516b5039650b391cb",
+                                "uncompressed-sha256": "aa41309358fc82c9489df8364aaf56168b841c79f15df31520c498223a99b77e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "6f554fade6fd1ab60116aed2a0e9907d7dae803e9c70200bdc770233fb6b61ba",
-                                "uncompressed-sha256": "e085583fce6a3b6bdf3a20072ba6db14d706be64a9b7bda0d18c0e9845fefc2c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "eb44301a9ec9eaba0fdca6384bc1ad1f4a4d1911beade5e6a54dcd38f4e6e7f9",
+                                "uncompressed-sha256": "f26b22e39e40a554df6edda14a7846e192c132f1dcb152aaa3758ce2bc46b1f1"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "d9d3984bc9fd0144fb1cf20f2a7b96221ccfc761fef64482b24561f33afea5a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "b2573ad290c1346d80a14c7739a7c93d0ca97026ac82de0d1eb1ca17aee7d03a"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "4c86ef56f078e95a4e3b18b6f3e1f7ad502b4381969ad3e4b89b7286f8fef157"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "f784b9436bf5cd6466ffb1bb58dc145482514f6b956b8496474879cc9a0e627c"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220703.1.1/x86_64/fedora-coreos-36.20220703.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "dad0c3f3e02c3882817ef77f2e144da56b57349bd6748336ed9094b1ace1a53c",
-                                "uncompressed-sha256": "cf2af8e9cb78902eff0d9149020feed24ac4eced03707273c6b7e69096669579"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "2e7679b918bab9051b858f60c2dc94832c7aa6a578893c02293e0c1aa4b75ded",
+                                "uncompressed-sha256": "354eddd258a70ccd6e7c474d25236db0b1468f177a299223fc0b3907093bd475"
                             }
                         }
                     }
@@ -494,100 +494,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-039ba10d1576b1463"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0a9b5bf49e0115779"
                         },
                         "ap-east-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-0f317596ddedfe9b0"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0066e9f09d28b7911"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-0707e6d89bcb5a283"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-01ce7adac307e6f33"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-0fec13ab3e3bbbadf"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0e247c82d71cdce58"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-01d386d40535d2a49"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-025629a32cfd1b0c6"
                         },
                         "ap-south-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-00fad82babea043b6"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-05747da1db7c922e3"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-0bc6636bc8534157c"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0786647be8876afa8"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-0a7d359c79025ca40"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0180db27fa11c3203"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-0c378e75b1a0de63a"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-018ea642acbe42496"
                         },
                         "ca-central-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-040f9a0734fa1d7f5"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-088d8ba49e15cf749"
                         },
                         "eu-central-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-02641c6e7e68346e1"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-09599b910e6f96624"
                         },
                         "eu-north-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-0183c1f556e75fe90"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0ced9d20134507f1c"
                         },
                         "eu-south-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-0cc941a57f5b4a3c0"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0ee1e7fe3f5f79a95"
                         },
                         "eu-west-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-067d027c0395e99fe"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-029cf97beb6c31788"
                         },
                         "eu-west-2": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-05c1dbf28384b5cef"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0f18855c7456c8d17"
                         },
                         "eu-west-3": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-094b86bb8e742794b"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0d689abf6a7314c1e"
                         },
                         "me-south-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-0120d8079286774a2"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0876fa6e78a650036"
                         },
                         "sa-east-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-0994888467c040390"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0a12142d0e54a1dd8"
                         },
                         "us-east-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-09baf5faabf7a21e5"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0c74e1e4b273281ee"
                         },
                         "us-east-2": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-0b35125609696e4d5"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-02378d85c1717ea4a"
                         },
                         "us-west-1": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-00c413f33d80a1952"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-08dea0a6798908243"
                         },
                         "us-west-2": {
-                            "release": "36.20220703.1.1",
-                            "image": "ami-05cb6a74532081ac2"
+                            "release": "36.20220716.1.0",
+                            "image": "ami-0f3cd04558f2ed8b7"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220703.1.1",
+                    "release": "36.20220716.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-36-20220703-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220716-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,92 +1,92 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-07-06T16:19:23Z",
+        "last-modified": "2022-07-19T13:47:54Z",
         "generator": "fedora-coreos-stream-generator v0.2.6"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "cf8b082a4b67e7be0e1e0926e970b39c3be8644445f32093fbd67a939ea73082",
-                                "uncompressed-sha256": "72d8c3448c28aaafd3aecc36bc982bc9eb118d08be804ca35875deeacd79d464"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "b08f6883284dc39021e359430b2b6c622a132120a484b12a0c715c75c1bc0707",
+                                "uncompressed-sha256": "36bacbe5f43fdb1c78537ca34067e39449305a7b47961a744a450c0ab1145205"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "efee10b610f054836d64906b924e62373ab92729f57b35eeb585afd8cad17c6d",
-                                "uncompressed-sha256": "88f4f3655e4c2198bc3370edabeac4aad57c8f32a630fc3c5d30167d21a01e8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "f0e06afea934aade896b7884d81d15d850e6871da73e8f557d2aa67a1833428e",
+                                "uncompressed-sha256": "4c448f5a62369e71f18e50e61af0790d0a766432edf7382daeeb58405cddba27"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live.aarch64.iso.sig",
-                                "sha256": "b1cf82b51c40f5ea319eb8651ab092ec3588de4ec817a12fbafe5b01fa399d98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-live.aarch64.iso.sig",
+                                "sha256": "516ab0517464c429cf674f6c7d6777d485b5d7110ceedb3436ee98b953c2b971"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live-kernel-aarch64.sig",
-                                "sha256": "fce2ccc1f09cef7709cb75274adc015836baf9e78d094335fd803252dc8c9622"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-live-kernel-aarch64.sig",
+                                "sha256": "850152289a68aea396c4f422a4570165680f3cf27dc7a956fbf5bedb98e8b12f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "b8f180244a8eda6098c17cb3ce2296f9a97c1871651248e9e7b2e4b314bd5624"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "c31971ecc474bb64aef2e24152ae0fbe8b5715e43b939a1f4a856b70de44772f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "9dffddfb3cbb89828305e9aa8d1c4f8d422752d379f4254e6b35683d9e741e7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "8c27368731b91af0a360d0ca59c47a7cf1879eb0bfa13661956166fd2cee32ec"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "d792a2e8826e47726cf899bbc9e4a8fc6ad0eaf0f3935b929cc9302927554ac2",
-                                "uncompressed-sha256": "8e3027a954da11be7cd868933e0759a201cae11335c70ea97eb88163bf15a53c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "741d8e2a6874f54e118e31186920105374ac076881b509cee4e9ea954f249fb8",
+                                "uncompressed-sha256": "7bb41d7ac13239ed6f1cde0e6768f3c596f07b9ae9291c15ab0068c80a417cfd"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "434c283a81a5a104953f9f69c38593ef25ed488e78ced68c24b9b099afcd7408",
-                                "uncompressed-sha256": "01ab79135ed3e1bd98405803f076de75edd008266b38bee7d3555f0195cc5c16"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "8ab29d40118b435804e25d252f9b76ebd03f7105ce85acfb2f301964c041c073",
+                                "uncompressed-sha256": "263757b4d2a749ce788abf5ab35876273bd89234b9b4d7fd3b84e32f35fad543"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/aarch64/fedora-coreos-36.20220618.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "cc9aaa639313cf772fd0c2699da1cd8edd71510d8ae7621dee584384018df0a7",
-                                "uncompressed-sha256": "7072b7fd699c82b04ad1346aa04e32dfab41fd38ad2e2437fd2e69affb9ae037"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "c1f8bbb7d505f408850dbaddd8a2cbce7734aa374fa3a6e517a6a1262d30d1ec",
+                                "uncompressed-sha256": "55cd450db24836fec609133a0a272b64b22b39d81d3208a68d9243a30f2d24ea"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0e8ae97c082d002f6"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-05e3083cf74e81feb"
                         },
                         "ap-east-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0365a794f16c7744a"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0de389d25ea098539"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0ae6e0422a215e2e3"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0f389e7387e922099"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-065cea2b66a8f4d6e"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0f02a040d81a44e81"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-089d98530667bc354"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0dc44dc1ca07b2ff9"
                         },
                         "ap-south-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0bd3b92d9440cd31c"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0d475174aac20a920"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0e44b29d45d2ee9b5"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-021eecee02fc7031d"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0be993005e99d16f5"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0736352efabcdc01a"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-01ec571f2bbf28114"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-024e9c24770ed2a81"
                         },
                         "ca-central-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-033ad50458df19b0a"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0de714704d92f9060"
                         },
                         "eu-central-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0fdf3419612fd2dc0"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0a1929603fa4698f3"
                         },
                         "eu-north-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-09c108728ab6242c8"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0f795c6cda869fc46"
                         },
                         "eu-south-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0e2c5901cac0fefe6"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0cf2f1b88580f2cfa"
                         },
                         "eu-west-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-069ee8919bb018aab"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0f461d8a1bff4b991"
                         },
                         "eu-west-2": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-016aa50c449a0b2f0"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-07606dea895cbb99c"
                         },
                         "eu-west-3": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0b481a7e699ce9c89"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0ed0b97323ca6a402"
                         },
                         "me-south-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0ec748c557eabbfc6"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-09088fb7cfbd2551c"
                         },
                         "sa-east-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-054481f90e8d45a40"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0ba6665ea83a3bd59"
                         },
                         "us-east-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0c0ab89211e0767d6"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0a806811c54e44c95"
                         },
                         "us-east-2": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-03350b9dae604191f"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0e81280fb1ae694cd"
                         },
                         "us-west-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-012f10df6179bfe22"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-003fbfa680c7cb41d"
                         },
                         "us-west-2": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-05fac706885df7ead"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-04ffca676f27ac2c8"
                         }
                     }
                 }
@@ -190,72 +190,72 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "f6365ce14e95dc895b0d2ff54e62e62051a72db9d5883b8b1c859d619800c53d",
-                                "uncompressed-sha256": "8875e84c8a498fa5197bbc39b4894372c7cdd9138663906e0e2ea64a0e6fedd6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "8e3d3c0f2892f6f9bb033950ba74b2e3160341e92fb0a8556214c44fbf55161b",
+                                "uncompressed-sha256": "a653622a0047c19466f92186d130fc4c7c752039661907c2dda4a95739f5c8b3"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "39b8a1d08986fd8785952c2370f174c88df0167b7391e5bdce2bde2bcf3c63ac",
-                                "uncompressed-sha256": "ce84b2032433bfa90eb133cd8ef144f5b6265daff66890b10704e4394e628449"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "e727fa787f70a5b510a327cbe18fea05e9d6216df5db13b3d23da3ad0b855073",
+                                "uncompressed-sha256": "ff7aeefe7f96b5e80ed084e2e7389fda2244d0f2f382355687bfae81990fe612"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live.s390x.iso.sig",
-                                "sha256": "caff6c12eec2e6dfbaa207f6da005b3343f3bfb9be4601d6c2a4e6610e14a2e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-live.s390x.iso.sig",
+                                "sha256": "541a0af3aaa773528483bc6541efa436f66f316a3ce0a9bdd9ef26fc8609c430"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live-kernel-s390x.sig",
-                                "sha256": "bba8bd387bf722cc6feea585eae2037b071296a4622f18c51fd7138e886d78c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-live-kernel-s390x.sig",
+                                "sha256": "8b468ae0ad9a39f31d59b897bc49638e3790adc83f725a608b56b1b2fd830b8d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "f092a82256b3445576f743de7ce47858b76c567d1cce33bac88427916ffe0ed0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "91773303eb9dd4f3930b2c8b1548241f080b80c1d213e6e51abe037342c2e416"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "abd1f507a018d880e069144f65b824f7eed2373dcef570659e184887aac9f4f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "d0f0200fbcb75b83f8b59ff02e662586836fbc77e3b6f95a29deb656a6097d99"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "647c2cdb8117f36a98b8743cacb85e4f6efef49d79e6be3080cbe0253e446be8",
-                                "uncompressed-sha256": "cd0a261135306caacc7091cab3a32b276d02dd580f6169e090c37623a58c017a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "caace7b49e5ed73a65aff5271b6331efd45799d89c7dba91f4f499c7cc712466",
+                                "uncompressed-sha256": "0f39a84efc673b42fbb45cc9c5409280a3b52e240e1c911958d6ec38e8f769e9"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/s390x/fedora-coreos-36.20220618.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "74b5c35e46a41d32a50e2c9abae3b862f6ee84a61a8ede0825604ed85f2eafbf",
-                                "uncompressed-sha256": "ace8ffe45f2cff27417163bbce35019aca54d5fa7c41538eaa34b71dce4825d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "e624eb6ade2e0a21f5541a13350214f7ec5a42704989ba1cac45866a608c3514",
+                                "uncompressed-sha256": "f3d7c98ace760b0730ef35290e348104dc858676f54339fef9c94ed4d3c93263"
                             }
                         }
                     }
@@ -266,225 +266,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "655fd7ca5b33fa10687b0f16b2dbcd0b8475ea71ba9ac76dd91fe4608a272e26",
-                                "uncompressed-sha256": "d861bfc6ffe1aa247d7d6279f17618cee85cbbf140302d41b71b841e76617d70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "f890123ca7d6f1028154275c816693fa6190306d0415c6b22c185fd835478232",
+                                "uncompressed-sha256": "cf10adfb475893e0d01665780eae4d91d41d5d4a7abe5cfce6407ab682fcf5d4"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "6a0a0bd38289f4d51708b6cffd9f9718cb1542e85d97a81244f3f734a9616152",
-                                "uncompressed-sha256": "077b7928d855fb26712fcbabc90ff5fd6a635f1d71616777db3f960bddb7fdc4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "4907664c27993d8c48fd73c5d17524485ecfee24638908cdaf5874cfd538bdf7",
+                                "uncompressed-sha256": "09b518b88c231241209f5867b1576554877a74dbaa9d34d59b71b4d37d139ff6"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "f5ffda1a68f26b6512e4e035bd79e772803afc3e6a9baa7cf507d5a641838a94",
-                                "uncompressed-sha256": "b0cb9a782926cb55e85d503b0ef7e715091783c168cf7963dcac74efc7f3f70e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "3f9b5251f8f9b7c747771ef92075b27cc21b92efb6dbccc9d22d63f53d2d78a3",
+                                "uncompressed-sha256": "e40eea3e2bccc169195e576a543a6a2d0d56d2c87dcf121e6be7d69e2b927b3f"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "34cf287e75c3e6a435332678a47db99b3b341d82989020103d5dc911cf03099b",
-                                "uncompressed-sha256": "42feb8ac932b8005cae6d3878c0d25f16c5838d5704635a0c5c382ad5a10ecd6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "1ac74ae43cd026545bbcc175e751c2f59e85c4879ef04c2d4b28a837c3713edf",
+                                "uncompressed-sha256": "68dd4bfe8f11599bb4e2b65ad77914b27928ccae10dac9de0339e2309e57fb92"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "d199503afeddd9bcbca6cf3ce22a44379c2de4945f9632ed273d68868c884baf",
-                                "uncompressed-sha256": "25d7212c03f86bc279bf8aa062ea86d17cb80b5073988465bb35ae131679dc4d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "ddbcb7a14019820e70d9cafea69a5ffa8097929f6e41d2a4f29dd344610e539c",
+                                "uncompressed-sha256": "f0bb3c7edef4bd398f30f337453e2140b01ce2cd4531d6459c8ca415c509389f"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "82e90fbae9a885f5023da7552a5ac7a6354b53919cb8de096f7b892801484717",
-                                "uncompressed-sha256": "bc4f74276e1d774ca7e3f2fbac40cb6c0287b2461756319090e80746bd885b4d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "0ef36265d12cf4cfcab67160b45606c7821fbf6e9e3d135e457a463481e15ff8",
+                                "uncompressed-sha256": "1a54ef0d60f2a2c891ea2e45423cc4566172159b330f5b1f8c325a3941d5839f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "c91de9dc1441c80ec1e22ed78d100e22c13ed4c64835eb1615d7ca8ec3d70828",
-                                "uncompressed-sha256": "1c376dd49e570eb76724f79caa2b4dc0c3df41b5c55a819f5913951673eb5916"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "b65d0c60d4a070fec2f04dd64191b1dfc2537d87a0f3f403b36c3287bdb96b20",
+                                "uncompressed-sha256": "cf7383f8e0d21f08199823be31a969dbae54aab6ce78c8c965d73ee59afc8f65"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "2ef74c2c6a9cd4fd5b14b9fcb3c22695335f7b8846106d55b7ac34093b8a512d",
-                                "uncompressed-sha256": "9856a0fbfad6ecebd8b10b62a96b380755819be6671e07897686a47b04100d30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "28537a6f786d81408b4e48fc96d90e9b8aeba74e91493baa86edebc21fe50a66",
+                                "uncompressed-sha256": "91fb1ea84b7863aa27d75a21cddc5ec53763d304f7fc3084678fcdedfe8fe4ad"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "f737ce150651f639a87b2206b8b81464b446d6b72a767b3bdfe83d190655c2ab",
-                                "uncompressed-sha256": "9288a525dd249699944515ecf4f919d6b415fef9d893e070814241acf7c1cb25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "c3dee26f2a9c9a61920215d5d7a67ba6672b125d7f4252476d89603bf2a1d4db",
+                                "uncompressed-sha256": "ba2dccfac35fffef884042ff2495ad899d2344599410ca069f01d61ff25174d9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live.x86_64.iso.sig",
-                                "sha256": "4fcda251b318f006aac823dc0954747361ef2723ddd1a35c1c5caeb911c5eae5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-live.x86_64.iso.sig",
+                                "sha256": "64b98af1e2a0dd86dbc0d5c6ebf9e3b0d7eb390087debb17eeee0ac3f9ee1797"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live-kernel-x86_64.sig",
-                                "sha256": "19a12d3b6287560362eb762c52610b7a8e371ba74ed96bd758fa15098480b623"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-live-kernel-x86_64.sig",
+                                "sha256": "e031357b2e3b7fa0347ce56279eb66b1cda50046307969e801e326787ca5ad6b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "890adf70fcb615c78857af3de1fa7aef607f3579d8c8f1385ec4c0439bb7bbde"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "bb519af0d2c4fb84210d92abadafca3eb4ebe1de51d2a741405952e9603c1c87"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "18b52ac0a4b3dde3a094e66616dde90a710e2e720338c520dfd3700cd55f1706"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "228c874349364ea2358c63fa3945340ca7c8ebcc2c7aee325ca9db4e3b566dd1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "c0369a7bc36de121771c6d3b10e6c6bdb0f37e62fa78023578e869dc33db03f0",
-                                "uncompressed-sha256": "26612eb86a6b9bede28399725fce6b1678d0605e7401b045faca0fb878c320af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "7d5bd81271758a365f0199577ee3e1ec2c364362080410d6c09a04aaf91bb462",
+                                "uncompressed-sha256": "fa30fd736b7f92b2f20bb121fee22af8f1c71b69b5c0850332f5d8c81ab05533"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "00c53804428700bba6924caf0724c1854d99ea7768a26fda1d45e555f7c78694"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "740b47b75f56e8dcc1a1d56d4a0fe6b4c60c526fd30688cc6bd45f9398cf658d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "71c0624a90d0993b39c2a1f4bae4fa4e5d6554da0b4c6bc53022094202f29db0",
-                                "uncompressed-sha256": "a766aea069f3c5ff491822a23b0b0ca11e10e956871adb8c9912540e759290c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "1711ee12ddcd48ee84f17645d541bf3b27c9e37eec5ac40e98f305fae442fa0c",
+                                "uncompressed-sha256": "74c91e2422ff3527e031ed84493aea5306c9489840d45f4fd4441795557646a5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "dfe190390d1e4e751f8b3978b15a466744022db1801673614744886b38d498cc",
-                                "uncompressed-sha256": "62c05da2208b8af3f9a7ddf6e4632ef6f7fc252a6b76ae2a452341f05e6e1733"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e3e7d6ae18d07b5aeac96edaccc2a91a9085826b65dd1e7ec5185c7f1b123edb",
+                                "uncompressed-sha256": "b194b060135fb852391b5056404b46d472ec5855ce0002f0260b75818eed3858"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "cf4ba506f271b50d437af59f50bbf6b4ed05de97d3d9eeaaf30496087364a34b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "383bd7608b27b09552095cf37b4cc826324f2270bef26378912de97544af2102"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "e02faf1a1f5c86f7a9b49853ab6b8a56e551b918a4ce2502bae5362a0fbe131f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "e98d6672f61d09a35787ab6e5ab340c0a7abc98734cf8b54e81163334678bec8"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220618.3.1/x86_64/fedora-coreos-36.20220618.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "126f02f7e8e28bc8064592512bdf5856b920df40ec921ffdbb43433f0c2ba93c",
-                                "uncompressed-sha256": "19bd19d4849fe518694f10c5f7dd6b528098af19278d5b62f65b6797a63b8ca6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "ab54aeba65ea9e22049703d7e77c79374a8bd687c114f674eba44a2920e0d726",
+                                "uncompressed-sha256": "b7564eac176f53f0869e3bb957b4f863b781f8443c86516ba59b14bf95f745b2"
                             }
                         }
                     }
@@ -494,100 +494,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-077d2db1977a340f8"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0b5e91ef0fa980b56"
                         },
                         "ap-east-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-03394caca36940099"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0431df7b20a0adeda"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0b52486c2645b8763"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-04719e5a7207e382e"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0f8550fb21d2c5e9c"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0e40862f51bb06d04"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-030a1e8c9dc52b0c0"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-048db68fef45eb525"
                         },
                         "ap-south-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-03123403cd0acb925"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0106e6add8d83be86"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0af9b6899c022fee5"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-08ed7c48d2602fc5d"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-01f43ca3c433c7f04"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-08fd0c85867f4410e"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0f17e539211213f82"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-02af4f68acd5acae3"
                         },
                         "ca-central-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-09b6fced48017dcaf"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0120dc98318ce86dc"
                         },
                         "eu-central-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-013c43dc5efbab770"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0ca07e058d989c5f7"
                         },
                         "eu-north-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0582fcca2f226ba2b"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0665027e7604eaeed"
                         },
                         "eu-south-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0eb34462bc63428aa"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0d490e05047124adf"
                         },
                         "eu-west-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0ae9b5e521f641134"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0c6f1ee16f8cc67a3"
                         },
                         "eu-west-2": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-05ef2120b391eab14"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-04e9b60626149bf2c"
                         },
                         "eu-west-3": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-027f69d71b0500c6a"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0fefd9c3306faedfb"
                         },
                         "me-south-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0a03687bab4df2238"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-050f3ce379aa285a1"
                         },
                         "sa-east-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0c78ce635c2a22bf6"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0545092bde4b8846c"
                         },
                         "us-east-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-09268db52299b7bb4"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-015620f6c802f8e8c"
                         },
                         "us-east-2": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0b537df7f00f60dfd"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0e4d3929423bf7d23"
                         },
                         "us-west-1": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-08875bfe9a15c7361"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-01cf1aeb299f767f9"
                         },
                         "us-west-2": {
-                            "release": "36.20220618.3.1",
-                            "image": "ami-0f1f42acc3476dc19"
+                            "release": "36.20220703.3.1",
+                            "image": "ami-0e64a65554048cb62"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220618.3.1",
+                    "release": "36.20220703.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-36-20220618-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220703-3-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-07-06T16:19:24Z",
+        "last-modified": "2022-07-19T13:47:55Z",
         "generator": "fedora-coreos-stream-generator v0.2.6"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "96f6c1412348bd0df752197a2dcf0c70c35177f8e314a9913bcb2944bae150a0",
-                                "uncompressed-sha256": "a70ce44fc5993eb2232779c76c05529562d0c56033b2eee7caec464793acd218"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "3f405300c122f34a6db948865ed84e1383a01d11ad7e26b5c51806a66c800c8d",
+                                "uncompressed-sha256": "3a36d7d8025267e5b9b2077c73ed187113a8e5c6a35510ea94192706f0f90cd8"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "43d6a435a3c94add4b56e0a0ab6f9e83ae1a6ae02af44b4432f5eed1405c5296",
-                                "uncompressed-sha256": "da8b34192d6707a397ac5e3a0e4789d81d4caefcbabea3250ceaf77d6821313e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "f61c09cd7e024968871c0addbb15a4154b55edac2656dd33bb8b18dc79c9e797",
+                                "uncompressed-sha256": "b6dd6b24c56ce8b29276d69c278e1fbaf01594ed0af8ae805d88d2384a0706a3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live.aarch64.iso.sig",
-                                "sha256": "09da685c6e9ee6297fa23eb17b6681f26782edbc059a1a1e853f1cc0bfc364e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-live.aarch64.iso.sig",
+                                "sha256": "7e6dfa599b9db74e9474d2e8ab81260ab7b441276d7a9fbb2c44960f53168852"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live-kernel-aarch64.sig",
-                                "sha256": "850152289a68aea396c4f422a4570165680f3cf27dc7a956fbf5bedb98e8b12f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-live-kernel-aarch64.sig",
+                                "sha256": "a5c1fa086cd43caba102bf1c8590055b01d1ab0c78901992dac654bcf1cfcf7a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "04d665437233a33fa2cd9ccbf22032331fe71e9fd30ea3049df59cbd3d597187"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "459aa0278457450c5dcbd9f859a0c7d2eb3a747a981dbfdfbe613657b33084b4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "c0afbd9f3845666944b1eaa7b5c14c6a7503c494f9faa8f8bff87125b6fbabf2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "81f0bdf36f39cdc7d9cce191dc55efad2de158287bda9dd3bda23ba22d7a66e7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "cb29cff457dcf2a145df928a2ce8456777db5a409602da0a65419b6d4b142155",
-                                "uncompressed-sha256": "bc669207bf407f3a34953e20888309035cf0ffd480efb8157f294e4b49caa941"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "0d02add1384b51e5efb9499c86c79a0b9da432cd15a565f2dfc0c66022a771a3",
+                                "uncompressed-sha256": "c8647cf06cac8e80fd1a2914112c48ca881940a0df464e5a37556f4aff6d5982"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "db0c214738bef555658edcb5fd35cfbb1fc9b660462deab947540ab7fd80de84",
-                                "uncompressed-sha256": "52b36e7a507d6ebc9031968aaf405bf4075aa581806731cc0236792a5c26eef6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "609a5ecd2e1cc7b9060e3e1028d42ae0fbf057360ec879be3b99695895e41b75",
+                                "uncompressed-sha256": "be1e64c246f4c2a16682bbb0248b777652d53e0b477fa45e2b5c006e96c011a4"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/aarch64/fedora-coreos-36.20220703.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "65bf42b023e82c31475ea37afa7bd6706fb25748a7deedc1bc76a0b7fad4c7c8",
-                                "uncompressed-sha256": "57e74a440e2bd8c8d867c94fb58d097811e4166c733985f77913a5784c86c755"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "97fe572229b9e5f25d75ed2d43e4150454386da244a055546d5bb1600ba1c71d",
+                                "uncompressed-sha256": "c08bdbedf582ded89e15283c86eb102354e209de2ab70984c68810a21c38c0be"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-0ac32b388d381d383"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-08d2ab14015c33f4f"
                         },
                         "ap-east-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-04549f80f1c154904"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-06d2e1214268c78a4"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-0dc232786d5a0edf9"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-0b2e371d0c54c8d1f"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-03e1d54e2275c56e8"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-0d4249dd45c847793"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-07f9110893d77ba04"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-09d8ff35aa39d00f1"
                         },
                         "ap-south-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-0cb90c19a3036f24e"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-0d4c3f9e5310cb662"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-01b03ab6bbe851e78"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-050ff7fe648fd7803"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-0e0ca26c365a9f919"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-0afbf2507be1f0ef9"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-0982cb61ca7d2f35a"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-08a132f26ccbcfcce"
                         },
                         "ca-central-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-096d9357bc2501430"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-007d5a9c5a395978f"
                         },
                         "eu-central-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-0b5512b7425d20bb7"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-04dbbb30b7c121c35"
                         },
                         "eu-north-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-0cfca40446c0d0807"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-0999661925b86e5cb"
                         },
                         "eu-south-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-0f26ed10adf72b64b"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-00a1240e822fef732"
                         },
                         "eu-west-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-08d67f452581957a9"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-0a03a790ff6e2179b"
                         },
                         "eu-west-2": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-02ecf0467a9370b95"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-0bfef56a72a63c64d"
                         },
                         "eu-west-3": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-04b780f75c31db697"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-009a2627470eb6984"
                         },
                         "me-south-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-04218e475837e432c"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-0fd489d5acfbb0632"
                         },
                         "sa-east-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-0c98706f0ccc4480d"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-0e6daff66777a5190"
                         },
                         "us-east-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-029e44a6a9d76e4d1"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-07849fc0ef3d9b939"
                         },
                         "us-east-2": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-01cec8422dbfe7fb3"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-0e35f8d7893df0da1"
                         },
                         "us-west-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-0eb97ff18a670d856"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-0bf1ec582adfaba5b"
                         },
                         "us-west-2": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-0690f706e41ffae7f"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-09c336fe47d2178b1"
                         }
                     }
                 }
@@ -190,72 +190,72 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "4199493100f2a5277bda997de8794f0a5ac83e8beaaa511ed0a7891faa421cb9",
-                                "uncompressed-sha256": "cbee3f66efa5e6e609abdc17ded6c067199372c97f6555a2e0d594f7b40230c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "b198415552644cdefa2e61978108fd1c13f6f284dcf77981d5a8a217e83f05a2",
+                                "uncompressed-sha256": "ef4b76ba6dbef2261573572fce9d1a536ab8aa4376c76a0b2219fd13b3c21b0a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "e53ed3faee46b197a48d6a80dc9996ecec76f6fcbf00fcf85900f79d1c0efd23",
-                                "uncompressed-sha256": "df4e51bf0c4960c06d28e6e1d109b382b34aef31c63d90be8c41bdf97efee883"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "2607f0a829013f1f9dde9418857fe294ba3703332d25b335db3e5e1d11c43491",
+                                "uncompressed-sha256": "33dc985ce63f8ed89427feb1fff7bed80b251ccf24c51424dae4ba29b4d58a57"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live.s390x.iso.sig",
-                                "sha256": "8cabf48de51443fc3d1bc92201214d59e8147695e42555b263569cafd8c2c9a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-live.s390x.iso.sig",
+                                "sha256": "4cab3182343e4e4ac5da420c032bfa12f08668e5490f6cbaf14afb8a48edeb78"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live-kernel-s390x.sig",
-                                "sha256": "8b468ae0ad9a39f31d59b897bc49638e3790adc83f725a608b56b1b2fd830b8d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-live-kernel-s390x.sig",
+                                "sha256": "1917ea368be5acc97b062330a4d13111517b357d8dbbb277215716da1a8b0a92"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "3007ea5dded487f2a2a72e15f6c1c5dd53c4e68cb6b4411eb21929d1556a4d8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "a8a33af0e1ac00d6c9b56f99e1d6452e6b9169fd98b2ab5c5c767fd0f8e925e5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "3367c701d5d52475d0bae177d85712eacb04323ff5af7bc1aadeb69e0dee4703"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "37de76267848f67e3554c177f2c2e0db7010898310cb20c172e1ae014b31bcb7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "b73b6a825cb2cad725ebf60eb7195d473169adb35c72c7e6d25739be1a4e3a30",
-                                "uncompressed-sha256": "0f0410d1026e7b8dfc63b437e106eaf4be1c3664317197df3b7ae95bc8b0cd60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "036c16b3100bf90c78dabc34a7ba98db8e6fd53e0fe8ce4ad300365348abf431",
+                                "uncompressed-sha256": "86ee82dbdd77d0ed2a0613b23dea56bf66432f4bd6e638aa714e1fddbcabf056"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/s390x/fedora-coreos-36.20220703.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "357d71763962803a0299ceb9d7bc7a39186bc013da5878bc51ca12ac43140b3c",
-                                "uncompressed-sha256": "e4631ff1a1f2b13f146b16dc24674e33172a7eda80c8ab913b67bc76fd8a74a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "e01b5972a72ab3dee1d9131d5aa68b37bba6cb3c434c50cffd044f841529b265",
+                                "uncompressed-sha256": "57d866a90e6f614431d178cb6ad6d95805805cfd7e5737daf7ce16db6c46e7ba"
                             }
                         }
                     }
@@ -266,225 +266,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "4a2c7544b0e0354576e00ee8b2225573bcf47d454a8411ba7b539c2a8627d580",
-                                "uncompressed-sha256": "7f6e62a3d4047cdacfb307057584bd4e58b77e5ef61d44176eb7a03be832cda0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "40f84786979d18c6b4cfb8366b00557c45e3916478bac1dbc3bbffd55978622d",
+                                "uncompressed-sha256": "c9d21d9b57b74b127e66d489f592893e5b68fd7b95e9c3463925ef8ea6cfe09a"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "95957c1cdc1b3936a9df63764afe2766939ceeec096e33cac88b89d8b49f528a",
-                                "uncompressed-sha256": "068f19b77e39eaee449029362189ec15b87d4fb1231d316527637c2871dddf81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "a52f497928e93737c80e58a35e6d44a1cb8113435ae2df1fa586a1e155f951c0",
+                                "uncompressed-sha256": "81bbe4ea567f3e0e14d76f929e0a3cdaa6a94d738534fe3cba6350aae86d5eda"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "edd698de2f7a2b02e77cf15e3745a8627c1af68e7920b91a036ad95f762f0d72",
-                                "uncompressed-sha256": "cb9d9a12486444e57f16e564ba8abe9e0d84aebc2efe543838ea0adad79c6547"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "ac79cbcbd0fb50904da54c6cb3634d4b35221e0b1a5356f9b51dc06825329699",
+                                "uncompressed-sha256": "ddea80dbd583673132e73c6c62f971b3712dd85ed74247e2f5dfe88b6c04b7f2"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "125d40c8668f27a695e5ab0c55816810afc0567ef46d308bbccf1cdce2bbef52",
-                                "uncompressed-sha256": "7e5bbecdb38b83ca7087da8bfa29dd08b6647cd6083ab06dfd9981910c2d7af2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "8d30a1e1f9551e5043fbebe4ab45ce66d5a424257a01129fa8ae329c9ba472f6",
+                                "uncompressed-sha256": "0d20d7ecdbff3aa8d20f588721530ae67c8ebb67d7feea9000ab8e29ab8cf567"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "8a3a2696d7ae5135a7d90651ddc6cf2d2ca3d9c2e9ad215ff340721ed58ea725",
-                                "uncompressed-sha256": "1739c8c26f106a2c3ea5af78af2d5790d26fc50dcc72ed1dc2b9440682e105cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "92ada5912275d1d0783218fb1a039c894750fa121d11eaf8fa135249924c70a7",
+                                "uncompressed-sha256": "0da369bb856a33a4e2f2d29892e29670a7e790cb79efbf3d2293e2f839cfa42f"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "7622d93d7a604cdacaa355db03b313cb0a52161e9317f6cc9a5a17130002984a",
-                                "uncompressed-sha256": "8822909fd1102f4483f35a85661be7e694878c7fbe646dfda535ac6a8872dfba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "bf1d9e09b2ae0ae77ff79358b409e0e22fb9626d8a73220700429dc8c4b13a64",
+                                "uncompressed-sha256": "bdb7e3c31e2957714df6a2f3f7278dd6848646ab3e5f719220b1e608d4d53bd8"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "d72d408d27351e376e1841de3cdd06b18bb92b5a0d4f139528eb7d17de4a35fa",
-                                "uncompressed-sha256": "b9cc788e732584b94090c14b253315159359e4609338f744ac202b820fc5c270"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f8bb6e98a1187691262a007b345a6946156b5e0a8127e1b418be65f803b13731",
+                                "uncompressed-sha256": "833ad4e55963dd8801f3bd5d0c59a5b46276810a9e18f4d954f6afcbc2098d4d"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "77476765424cc89e062488dfa2023cbc282df0d5c185ca02cfbc8b50dbdca80f",
-                                "uncompressed-sha256": "ddb71543c44efc2b00a460e9eabbc4f1bcd6adcb24000f9615fc944db0ccec4e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "d07f24a670ac7eb389145ce956be1186260babd82bb44ac52592e24b4afc2c33",
+                                "uncompressed-sha256": "79f248ee87ae842ae4e7cc8cbb8989496ddf6698233a41c5d896de57d36f2840"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "7977843eafcb349f39c82942973335c1431c2c64ebb96ff6a84215d0fc57a6d8",
-                                "uncompressed-sha256": "c250350fc7716bef3c9456544d10d343c562af0165485c809a780520b8e1fb5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "61bbe0421bde06d14bdade288b3cebfdcdb3c965259c11ffc0bf050c7e47961c",
+                                "uncompressed-sha256": "a05ee5cddac855724a40526fca9c977fd53384dc9a8ec27ba886163e45c1b3ac"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live.x86_64.iso.sig",
-                                "sha256": "7d0c1da7ae7e67c242a78bc8bfc5954262da85e54650426a3d9f7b8e44dbca9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-live.x86_64.iso.sig",
+                                "sha256": "4eea451d19d50a17cd3c955b285e5ae9ae7724e26d7c0d189c0fa3266d3b728b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live-kernel-x86_64.sig",
-                                "sha256": "e031357b2e3b7fa0347ce56279eb66b1cda50046307969e801e326787ca5ad6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-live-kernel-x86_64.sig",
+                                "sha256": "a834a9a7230b3efaab2362ebc5b3733bacbc320b145989fa9f70c0d3dd3d996e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "71a3b5da83e8c35eec8d534adee60749d2cea500cbcb55e463f211f9160b9eb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "df7c7938af95c64a5e12e1bb6e1e47e4528b3fe783c9f74b3001743b57fc2138"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "892b31e1a5f1aaab064e853881d8b17ee97a44ba0cf6d3df35da0229febd8eb3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "af37d04f2cef79a0461bb565cf5ac7d00eded386160c7e85d899e90a337f758c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "caf84fb77ccbd9d2d113c103b8d5c21b42fa3d5f8c4b4a23a9086532ca9c5857",
-                                "uncompressed-sha256": "dccec3e31818cdaa0bf74cb3a0db9fe4a803b01424e529183ecf8062bddb36e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "29717528be7c1ddb5b0869e877c2efc3958ffc96908ab5096ce7c8b04f77526c",
+                                "uncompressed-sha256": "6bfd9d76f57e6a5326d856c8e70166ab05f035c848cf729d376b2c5e30d8b4bd"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "0681b8d3fcd74f4236fb225bafa95e4fb1784a93ceb1d2fc4df19e63ab3cf433"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "83bf8122b353bb28cc8230df80db2305fcefabd5e749cbf61dc2502249d5fd91"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "bafa17960c13e84e33a340e23594f6e2c84e7a3fe716206f05ff5635dcec65ad",
-                                "uncompressed-sha256": "c3c49720032e86a33bcfbc48c1c798f9a016aa44c410d4f44fb06a6026f0df7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "8fbccbb40ea445d3db11922270df4d2050c0658eaff1e88cd47c2d408643a6aa",
+                                "uncompressed-sha256": "354b4b86ae076a3c92975eb94cb8c8b1106e6f5c75fe343bb659e33461c67c79"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "06118c2198991e9a519fdd38230d37a725a98cec014869874a3fa063e9459bc0",
-                                "uncompressed-sha256": "71bb389a25ff00fc3aca8c197a5a87126ac827b3abbd3b793195978b2021a009"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "8f4e49fdfc0801166995e7d59b855f58c7637e358d222714ca8e6538d4d4f967",
+                                "uncompressed-sha256": "c3a3b6d7251c81e63452f001924cc2ea5b587ea6825ee6cc259c7d37ca0d32aa"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "41be2d5d1c425d21f889bb442d674356ac920355114dac97889b9a67a2d5be5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "f89d82be4ecfb79b7a1acaa9765ca85acf459e2473daf9dc85e7e5bdd4fd039c"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "b175ec5559a9969bcac405d7cc3f875c55c36adbf9353f7c2f6938db92ad204c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "1b9486708d0ce757b0dd9b1d1838de75fdc09e94c4fb91a495610c9797191d2a"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220703.2.1/x86_64/fedora-coreos-36.20220703.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "d106d8d33bbb517cb57af3536f2b88e13ee9279ec08de3cb1ea6c5ce624f238c",
-                                "uncompressed-sha256": "9a203e54bed94d595a5627c1aaa929f3e3cb321dde63250f756cc1cdf910b6b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "104c3f3c58a68cccb08f668b53dc5d152b3217d9c01800cf5fa6f0a732f2352c",
+                                "uncompressed-sha256": "ab85c89135fa2079564fb97c1f708bd9b0902a94d405dbcb2c7aa3203ed985e8"
                             }
                         }
                     }
@@ -494,100 +494,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-01e159458c67b1825"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-0b40381a3a5450dc1"
                         },
                         "ap-east-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-0980e529488b34ad3"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-09518eb8aab050646"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-0afae1e2c44c9712f"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-0b8b28fc9f0ac7ddc"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-06a16d9844543971d"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-03f89a9c52d4abec5"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-07790ca7ce0efa8ce"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-0a580668115471cbc"
                         },
                         "ap-south-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-04b222f33f023864a"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-08234322811c2d498"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-02b221ffd4bca4196"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-08e381fe66748e0c1"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-06f9a164a4925d883"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-0c696c03950a21047"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-05b8d7d7b6d841c7a"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-09255128563b01033"
                         },
                         "ca-central-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-045a89be5be4b0830"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-093c1a0c380a9517c"
                         },
                         "eu-central-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-03f90299db11e77cc"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-052c59a20c5a7255d"
                         },
                         "eu-north-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-0df897825696c23a2"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-0d1aa47d1b1d117dc"
                         },
                         "eu-south-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-03d5c4e2a723f8276"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-08cf2da48812133c8"
                         },
                         "eu-west-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-0ddc59a3e5bc7711b"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-052c97eff5501b2ae"
                         },
                         "eu-west-2": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-0c260d18f52ebbcc5"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-0eb1cf425317edf12"
                         },
                         "eu-west-3": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-013383cec6a4ded80"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-000988de1420e4579"
                         },
                         "me-south-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-0f0e7020403c85aae"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-0fc28dde43073c031"
                         },
                         "sa-east-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-01d1019652542a55d"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-0aee2278cf797c88d"
                         },
                         "us-east-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-080a10e999cd4cdd7"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-02aed71d0fe218f64"
                         },
                         "us-east-2": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-08cc589f66a2ae782"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-06e0c744f58b27214"
                         },
                         "us-west-1": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-08108451e9aeb16ae"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-03cd485c3ff1b633e"
                         },
                         "us-west-2": {
-                            "release": "36.20220703.2.1",
-                            "image": "ami-0372ece5a40f941ad"
+                            "release": "36.20220716.2.0",
+                            "image": "ami-049093cc187682429"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220703.2.1",
+                    "release": "36.20220716.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-36-20220703-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220716-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-07-06T16:19:26Z"
+    "last-modified": "2022-07-19T13:47:56Z"
   },
   "releases": [
     {
@@ -53,7 +53,7 @@
       }
     },
     {
-      "version": "36.20220618.1.1",
+      "version": "36.20220703.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -61,11 +61,11 @@
       }
     },
     {
-      "version": "36.20220703.1.1",
+      "version": "36.20220716.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1657126800,
+          "start_epoch": 1658242800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-07-06T16:19:24Z"
+    "last-modified": "2022-07-19T13:47:55Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "36.20220605.3.0",
+      "version": "36.20220618.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "36.20220618.3.1",
+      "version": "36.20220703.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1657126800,
+          "start_epoch": 1658242800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-07-06T16:19:25Z"
+    "last-modified": "2022-07-19T13:47:55Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "36.20220618.2.0",
+      "version": "36.20220703.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "36.20220703.2.1",
+      "version": "36.20220716.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1657126800,
+          "start_epoch": 1658242800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @saqibali-2k via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).