### PR TITLE
Roll out stable 36.20220716.3.1, testing 36.20220723.2.2, next 36.20220723.1.2

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-07-19T13:47:56Z",
-        "generator": "fedora-coreos-stream-generator v0.2.6"
+        "last-modified": "2022-07-26T22:48:22Z",
+        "generator": "fedora-coreos-stream-generator v0.2.7"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "7c380eec256f0ea69c8209f896ba6b75aefe48fd46f605c87bca5eafaea62c9e",
-                                "uncompressed-sha256": "52241c62175a94dfd8ada23780b76a1dc8506f3aea695fb089befc414692f959"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "b740be65f51bdfd91aef74f2493cdfa412da556a9b668dfb259a75b244dd7a4b",
+                                "uncompressed-sha256": "df3aa6b5346954cb7e2769b356b9739d413a5e6153ad1a9d4e88f543198b18aa"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "e4f6e2e1ab8b7e7aa14ebd27d2ef71591b28e48b80734519435e56822c756df3",
-                                "uncompressed-sha256": "6e74f694fd44126613e33ebabd5becb8f2285aea954e8eafea9a368785cfb644"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "102ab72bce785ed8b10ecccb25f0ea04c081c5b490b357e2fa9ed1d824b88a5b",
+                                "uncompressed-sha256": "3ce53724571265e27d70271eaeba88a7b9872b84b44ec5013f62b164094253eb"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-live.aarch64.iso.sig",
-                                "sha256": "7e5d378498f0e888d248bed4b716d75abab520f22925384ecf2b6068bb15c1ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-live.aarch64.iso.sig",
+                                "sha256": "0bbc5ace92839ddbc6b22d63bebdb7372e237c6405507812fb7db2ec21aaa0cc"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-live-kernel-aarch64.sig",
-                                "sha256": "a5c1fa086cd43caba102bf1c8590055b01d1ab0c78901992dac654bcf1cfcf7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-live-kernel-aarch64.sig",
+                                "sha256": "63d9b9c93536aae9d07bf3031e0a259624c1cfbd6391a15cc7a0fcfad504b9d2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "0207cb35ddccc0277fb0e750879121ecb771fe90e1659388a89e4e79c2412745"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-live-initramfs.aarch64.img.sig",
+                                "sha256": "60c12017db3554c65df44aa4c6586ab2579f0f65ba69911bc2fc3cf65d97d1c4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "1a4a8f06104c106b7f7a7f32683a767384d5fe427dd5a7cba4367dea6d78278e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-live-rootfs.aarch64.img.sig",
+                                "sha256": "444138c7f367c9e1068fe15a7281bd86dcfa3c81d340b59d8c752266e74455f1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "34bdcb349c506903f95abcb7b63e97aa7f1576348f62437037be8d92f2cecaf4",
-                                "uncompressed-sha256": "60408222f01093027b5d28590de86874693459dae1925aa9672667c3cc1fc18e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-metal.aarch64.raw.xz.sig",
+                                "sha256": "0e8ecb4d72be52699724ee7925531edf1fb098f709b7bd56c589790775433c59",
+                                "uncompressed-sha256": "72122c8d842998cbe627d275ede528acfa8b043548ce2e466a7e9de2ffe352cb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "26ce6a1924b4f69ebb8746b7f0370b04ae6313c0642217e8f6f58068a6cdd961",
-                                "uncompressed-sha256": "fd38f6800d14aa22362bbd02189d1ed5a7ef551126a55604ecba53c03d8fb9d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "19a991ad303554c3ecb2972be4495cc14cb4e9a898faff117b11540008fc75b3",
+                                "uncompressed-sha256": "f0c8d551ec5ec80aa7eabe5ce5615fc2ce91f8c09db1994d208321cedea61afb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/aarch64/fedora-coreos-36.20220716.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "52f042df8be04c9974f0855f3a73eb2c0638918af03f435b86638e96b7e0169f",
-                                "uncompressed-sha256": "b19b84abfd656781f3b94403e4cf416a361bb5f4c281d842356aaeabafd383e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "95fb84d1bdf55dc8814aa0b4cd5071e526ebeb6e24c1bdfa5a57fd0355fb14f7",
+                                "uncompressed-sha256": "f7fbb4038993f5844b61c74d22ef71c03bed31c0bc90ea2d2bf91f357c20e791"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0566b898066ded7cb"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0903aaeceea870d22"
                         },
                         "ap-east-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0cef124a08e99d59e"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-057287fa8276fdc20"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0845e811d62a3ca87"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-03b50757aa7be6449"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0038161e582b72f7d"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-03c7e70c420e7fd8d"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-057471b11aebe6931"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0521a5575bad5e83d"
                         },
                         "ap-south-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0a87333fec3964b56"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-05a4fb27f7b0b2bc6"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-068e6305c7f85ed60"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0c6c48b8f39d1d8dd"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0bfca76a3755dde28"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-003eb1cf3a3c71d6c"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-01ffe8d9cbd707fd4"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0e12d54f8fd68ee8e"
                         },
                         "ca-central-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0f70c099186d45e56"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0dae9de8a9dcd2e9d"
                         },
                         "eu-central-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0c1c0b41c1ede3bd8"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-01030410ee9cbc086"
                         },
                         "eu-north-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-04e216a129c28e551"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-05ba2d43c02013067"
                         },
                         "eu-south-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-007a6b523ad9b89f9"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-03ab46074a1af1ea2"
                         },
                         "eu-west-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0b486c015498e2fe3"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-02c31b435f3941e5f"
                         },
                         "eu-west-2": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0681c8c9abaf8ec9b"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-043326b6355e073d2"
                         },
                         "eu-west-3": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0d26d4e69a3c5c52a"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0bed580ea5e44842a"
                         },
                         "me-south-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0cf4208d757739e56"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-01982a2855773ec29"
                         },
                         "sa-east-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-05e46c41d6529b2eb"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0e7c9526f78c82c15"
                         },
                         "us-east-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-09b8eefbdba4fbff8"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0d229cf2ee64e7752"
                         },
                         "us-east-2": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0eb9ab25b33cc7a60"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0e99e4c2ca19237d8"
                         },
                         "us-west-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0bee6f226cede448f"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0482905b9da9c54fe"
                         },
                         "us-west-2": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-02e90c2bbb4d2d367"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-00184cdbdfa05c0b7"
                         }
                     }
                 }
@@ -190,72 +190,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "d0bd43ecd1abb6fde7ec2c5c765609b983860f9f72d33c4253a5b3644f0e7afa",
-                                "uncompressed-sha256": "f144192651a52bce1ce5d3671b11db5214f13a77cbc8be00d7f7caf29668580e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "790a6cc93e383a4dfe4f54b887d0b09924310f1bf091085c516cd534c16aa564",
+                                "uncompressed-sha256": "cd43984dac9add3e5cb5b08473102021b45cd2514ce6687f4794b8066ebeba20"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "30ac74e9532e50342619323f499b713ded74052459370f0506a38c87268a06f4",
-                                "uncompressed-sha256": "eef454f26bb8ae33efa9a1e989684358773cc00b974057f51272c5dba53b5ac5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-metal4k.s390x.raw.xz.sig",
+                                "sha256": "97be9a19df6abd51e2dd7ca9cca8233604f7b77e324adefe65e159a13e27018d",
+                                "uncompressed-sha256": "962b89580211f1d5d964c91421f4973e4d4b047e2d2dcf50a1c91d7f4c120534"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-live.s390x.iso.sig",
-                                "sha256": "ee0c8ef852571d52dfb89391433ce090991776f2644c9e61cb9ce906d86fff46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-live.s390x.iso.sig",
+                                "sha256": "0f03b85610607aa896ea9b16d92e0d3ebe604c848c1abd5e5fd748de0325fb44"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-live-kernel-s390x.sig",
-                                "sha256": "1917ea368be5acc97b062330a4d13111517b357d8dbbb277215716da1a8b0a92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-live-kernel-s390x.sig",
+                                "sha256": "9acd61a7c5c12a8854bc4ff34c6fb02f3f85ee3ff9c0846ed286034c0fbaaeb3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "4ed335e8f83e6d67d1b4eedde1e6669b6ad0702bfddee4b6a68ed54840a2904b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-live-initramfs.s390x.img.sig",
+                                "sha256": "bb7c3aa7c3ce99432c8f9d2f181b5c31ec613fc7ccb29def10d036c1fccabb88"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "a9e7babee44b298d0dfceb2dcf6cd07d7ebbec0b80c82817bb79987e6d76a6cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-live-rootfs.s390x.img.sig",
+                                "sha256": "0f1fb94269e310f69a27467e1e3844f658beae97d28f5a6e920dd7b93fd0b3a8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "37d85d082dd1c3e4855b41e92d6a1eead0aa9d3698ed35c860975765831d1888",
-                                "uncompressed-sha256": "69bbf9f20531a8d3ed8c77c0c25eab8d32d3d550b2485740123b904677689c57"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-metal.s390x.raw.xz.sig",
+                                "sha256": "c47b5cc3da02c4e7bbc793d7d282dcf5a58d05c198b9a59266455303b17ce535",
+                                "uncompressed-sha256": "b56de65dfae6b79ecb354916dd84cb0b87fcbeb1dfd6157226c0f009a3ed8ac7"
+                            }
+                        }
+                    }
+                },
+                "openstack": {
+                    "release": "36.20220723.1.2",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "38a468bf572934ab69dc24c18fe3732582e5581eb08fd39d295f2121b1c61954",
+                                "uncompressed-sha256": "2dfdd115cf4e0a9dab20905a3cfc359f47fa1a0e8f778930f17552751d77badd"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/s390x/fedora-coreos-36.20220716.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "4ffbbf96625836ddf96391c87d31c8e1e419e9346115f20335477067f3d3c149",
-                                "uncompressed-sha256": "ce850427b92085c25e621c63a97ffa3ee082d3aaa3f21496cf9f8b4ab474c138"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "be2ce924d806c7261e2218aec9fa2bac9dbc903bd40147883723e5084c71d535",
+                                "uncompressed-sha256": "28b0bcbb4b68518f54af2b8f721bf6c93d3d699cc807b235a16008e0a5a1ed77"
                             }
                         }
                     }
@@ -266,225 +279,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "5413d95356cd5cafd2d3313eda6b2b22bbf783218725b4575178d8a4d29ad38e",
-                                "uncompressed-sha256": "2d2b7375557377efd8290fd9da61138781a3de717b533b17bd9d53ac86d3c447"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "a93c5261ea1d3811ccbe160bd09794c526f9eca5f5ffa856e4f7501e476c4f6b",
+                                "uncompressed-sha256": "02c46afd13fe55224ec7bff30bb4705ecc9f4a3bd0b2045aa83ae48600a765fb"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "9304d31805145701c4dc376a1e2677daa9c3dce9dcf860ed4f3ce223a36d8880",
-                                "uncompressed-sha256": "c403ed9f9943b11ceca83d5bf58e506c8ae2568fb0b37639aaf38c4d68393fe0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "0b8d2ed4f71efb906ee89e60a43d0121171843a652e9b90d7edf051e75105bd1",
+                                "uncompressed-sha256": "c4ddb596fd19b817773cfd229774e1f4eae33075eda3d59a04a5cafd4e07f95f"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "13d21fef2e7df21038cf6bb57c43e649dc101f1fd3ef71564c21b2bf8b2bb4af",
-                                "uncompressed-sha256": "b5684ebd09c0fae66f2e22186840cd4557ce30e847b8db259b419ed1e373f472"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "0a11e364c10d9550fcf679c79aa74ac87f8b3976e267d4b63cbaea9dbb1620c1",
+                                "uncompressed-sha256": "dc81466cdfd6799f2ba24849cf3788464ebdc0b1e89dcf53770f235f13e68768"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "cc62edb4a7e2a389e94ffa7e5f711ea6c787b7a3021179065096f53b61aec8e3",
-                                "uncompressed-sha256": "956cb1054376219d469efc405930e86fdd56212188954558b8364e39af00e2a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "b4f34d4e3ffd84fc92becb479c3cd353c16fbd77e76eed21a1ce3516382a7838",
+                                "uncompressed-sha256": "ce07202a702985f308522f80b398ac23836592593eaecb1f9e4f265974ac22e9"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "50df1fe9d756f616bdf6c64d666dfe5eb0731a1fccc758e86b4bc15a90c47d99",
-                                "uncompressed-sha256": "6db85d7341de93d84884ca8c986bf63397e352031a3b10b9ef7cfd4b7129ccc7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "bf28038cb8a7682e11ed2f9fdd7eea1363cee055ba25d46389aa83bae16980cd",
+                                "uncompressed-sha256": "802e8693d316c96a1bc1494a15c8108a1cb1cb9ee6a63b31b088d242fa6aaa4c"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "e644fd04ede46a4864753618763b9d244c4b61354096c35a13eeca3a222f2a0c",
-                                "uncompressed-sha256": "71092163c50b38ea3277b13086a9ee70ab88e1a0d6dad43bee9078b52704d8b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "30464fb0762fcabccf1b0991a189ca8d62e449081d0f3e480fadd8bc0b1848e2",
+                                "uncompressed-sha256": "a790b21ceb74c9d41d9d3682b4de497172b3ece9c16af73249da694d01d12184"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "01c5e15bbe3b6dfc4140b649d76cdfced6c003fd155d1352cb796287b0aa086c",
-                                "uncompressed-sha256": "dbe4b3e88484156e1819d5a6ec0c2820e44b92d02da0904ece776cdbc0661fa1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "c1ad5a219c1cd0c385ecad7af6c17eeff8f75a1aae0406764c3c08b0e73e173c",
+                                "uncompressed-sha256": "a72fb2a1e6ad59851d06b98ebf2e3930a96af7e8a45ecf6f776e92c0840e2b6e"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "8b0838d9182c7682f7c56c06325ce0e75d7d0500da0bc5fae6c571d12b5764e5",
-                                "uncompressed-sha256": "78532f91d39a4ee557fdd27a4a4666d0504222d7370e7fe57fe50e1cacbbd864"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "861aa5839fb276d8d43a8d4d012b48f410eccfc7b887b820e156400d0a5a0d47",
+                                "uncompressed-sha256": "59b04957dfa766d657f1716ec482b741527844f354c9dc59a52d2d3917dbd0dc"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "77f164ca822d7895f8d94e7cda0000efddf1ae0d8e9b7f9bc7b6b84e5daae6c2",
-                                "uncompressed-sha256": "6d13e9b5e60bc45929c83f19244fdf7d24b9dfd319fce7ffd45fb3fcb22eba8d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "2a93f09b8179ee64f915af75e5b23a4917d28ad8765bc8124c887afb4f1eed2a",
+                                "uncompressed-sha256": "a08d26de880cd1cf6516b666b5f344ff5293ec3656a272e9b5d6fa9e6893e897"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-live.x86_64.iso.sig",
-                                "sha256": "b1948d86a04bd81181b50a7156dd31333da52258f6e6ef34af4d32a389a7a2c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-live.x86_64.iso.sig",
+                                "sha256": "68f046222dd4559b7d041477c065c86705dbe3ac9848e2409ad7d4cfc943b93a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-live-kernel-x86_64.sig",
-                                "sha256": "a834a9a7230b3efaab2362ebc5b3733bacbc320b145989fa9f70c0d3dd3d996e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-live-kernel-x86_64.sig",
+                                "sha256": "38640a1e99cd2e0e0e9576638f2cd11fa254c4a7a543cd3eaa0c156762444558"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "dcea50ad89ba5da2e99317e9b21d3a3a928109d818c93f8de3539e0e111f6957"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "307354ca4b037df3d00cdbaaca43ba9c3cf4ddfe07f6d8b401843b08df70ed47"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "d4de4a38139b5e76c3e7f06b467a84c983f5495ae1a283467c802d5ac295f6f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-live-rootfs.x86_64.img.sig",
+                                "sha256": "9cc84e1cd8bc65b8b349c7defdb83f185d48f60b6ce4b3f53f18652ce67cb72a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "71e4bb54cee53d6e526e6b6d0b1935f065f6ae05d95169cd9bab0f320da72da4",
-                                "uncompressed-sha256": "7ef4878de208446c9c6724b4b9565c6e779958739820d7f9e7208c9af27fa7f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "62029dd26b795dda81a727ae49b6a1bd1405dbc5d3eb4d6b64055265f2bf87ef",
+                                "uncompressed-sha256": "663ff7e16d94311bdf99c670d1ec69bb78441d38e2f966b9a9bc47e387973e21"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "4485316db3e4d81c9c5ed9eaf192a294d5125678b5074dc2f9fc5dbb4d9da64c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-nutanix.x86_64.qcow2.sig",
+                                "sha256": "1984f10c6ffc5596a3ff1192c1f6489953c37f6ad67f615c5c556773cda6a5dc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "7faaa28ae3a699c06741cab08025a2a7b321a484ae2faed516b5039650b391cb",
-                                "uncompressed-sha256": "aa41309358fc82c9489df8364aaf56168b841c79f15df31520c498223a99b77e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "55460b6e2a98e881beb8657790c21bcaef3ec348280d8b530eb1cb1f1e4ebefa",
+                                "uncompressed-sha256": "f7327bd1723695170e306b7013666f4987d40acc8f4ee1cf38b1c0b461074716"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "eb44301a9ec9eaba0fdca6384bc1ad1f4a4d1911beade5e6a54dcd38f4e6e7f9",
-                                "uncompressed-sha256": "f26b22e39e40a554df6edda14a7846e192c132f1dcb152aaa3758ce2bc46b1f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "890a09b5f4203edf4a064d035f3052559c87f71f4e4f9967e9b767742f063562",
+                                "uncompressed-sha256": "f620e9bdaa1da7e3393d3e4d06dc1a5ddb2b5f76d4b67632371082bf9044109b"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "b2573ad290c1346d80a14c7739a7c93d0ca97026ac82de0d1eb1ca17aee7d03a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-virtualbox.x86_64.ova.sig",
+                                "sha256": "43df60317932febc31d94537c59b5ab5ad3480a83fb1e9bfd4202f4de4451395"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "f784b9436bf5cd6466ffb1bb58dc145482514f6b956b8496474879cc9a0e627c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-vmware.x86_64.ova.sig",
+                                "sha256": "e03f9172210de89eb7f87bf4e8c9dd574533a476f18c3f99c021ce202c392e97"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220716.1.0/x86_64/fedora-coreos-36.20220716.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "2e7679b918bab9051b858f60c2dc94832c7aa6a578893c02293e0c1aa4b75ded",
-                                "uncompressed-sha256": "354eddd258a70ccd6e7c474d25236db0b1468f177a299223fc0b3907093bd475"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-vultr.x86_64.raw.xz.sig",
+                                "sha256": "5b400f7d2ace8c73fc8befd8416a016dd61de7bc02dc57054ca0ac8ba3a8c633",
+                                "uncompressed-sha256": "8b73601f8a159daa3277b94b0f0be6c98eb7af5c4d3f863d7555a170890134bb"
                             }
                         }
                     }
@@ -494,100 +507,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0a9b5bf49e0115779"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0528076b3547ed257"
                         },
                         "ap-east-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0066e9f09d28b7911"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0a24302b9734c2be5"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-01ce7adac307e6f33"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-088ce60a942a1c07f"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0e247c82d71cdce58"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0e74d627f3055527b"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-025629a32cfd1b0c6"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-09fccf1af632e7c19"
                         },
                         "ap-south-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-05747da1db7c922e3"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0e7e4f888921b8def"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0786647be8876afa8"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-00feba79daa14910e"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0180db27fa11c3203"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0b3f9efe58a3ddef1"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-018ea642acbe42496"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0ac421816ffdfd53a"
                         },
                         "ca-central-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-088d8ba49e15cf749"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0710d7b5d5104a4ab"
                         },
                         "eu-central-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-09599b910e6f96624"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0d5f8dc76a16b97bc"
                         },
                         "eu-north-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0ced9d20134507f1c"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0be8bac3d938a2410"
                         },
                         "eu-south-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0ee1e7fe3f5f79a95"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0ce69b1a986dee829"
                         },
                         "eu-west-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-029cf97beb6c31788"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-087b442ba44d18859"
                         },
                         "eu-west-2": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0f18855c7456c8d17"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-075262fa2ed7feb66"
                         },
                         "eu-west-3": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0d689abf6a7314c1e"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0b1c12effe7b94a17"
                         },
                         "me-south-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0876fa6e78a650036"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-051c8cb0f69c84b62"
                         },
                         "sa-east-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0a12142d0e54a1dd8"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-07af3bb89598b7d4b"
                         },
                         "us-east-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0c74e1e4b273281ee"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-067f17e4e2a284a29"
                         },
                         "us-east-2": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-02378d85c1717ea4a"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-08d81dbfb668e3122"
                         },
                         "us-west-1": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-08dea0a6798908243"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-0cb968cee64a7e899"
                         },
                         "us-west-2": {
-                            "release": "36.20220716.1.0",
-                            "image": "ami-0f3cd04558f2ed8b7"
+                            "release": "36.20220723.1.2",
+                            "image": "ami-081110f5271a559b5"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220716.1.0",
+                    "release": "36.20220723.1.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-36-20220716-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220723-1-2-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,92 +1,92 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-07-19T13:47:54Z",
-        "generator": "fedora-coreos-stream-generator v0.2.6"
+        "last-modified": "2022-07-26T22:48:18Z",
+        "generator": "fedora-coreos-stream-generator v0.2.7"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "b08f6883284dc39021e359430b2b6c622a132120a484b12a0c715c75c1bc0707",
-                                "uncompressed-sha256": "36bacbe5f43fdb1c78537ca34067e39449305a7b47961a744a450c0ab1145205"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "50114b48c259917cc23e761e840ead7b198de329885ae0f21f7221debab5826a",
+                                "uncompressed-sha256": "a0221aca5415844ef67cee7a41130c4be23af82a62ed32ea045be623a20466d5"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "f0e06afea934aade896b7884d81d15d850e6871da73e8f557d2aa67a1833428e",
-                                "uncompressed-sha256": "4c448f5a62369e71f18e50e61af0790d0a766432edf7382daeeb58405cddba27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "d7d28f92c131049efcd816973e4048d4dfb00ae129cc947e1a9fa544d2195c08",
+                                "uncompressed-sha256": "3aa96a4dd18d4b37d74114eea3bd2e51ee8f88fa3e82282f642b093d6ffa1965"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-live.aarch64.iso.sig",
-                                "sha256": "516ab0517464c429cf674f6c7d6777d485b5d7110ceedb3436ee98b953c2b971"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-live.aarch64.iso.sig",
+                                "sha256": "8361b662d2f8da93cf02b1c4fba76b63e080b74bd01525ce735adab153557804"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-live-kernel-aarch64.sig",
-                                "sha256": "850152289a68aea396c4f422a4570165680f3cf27dc7a956fbf5bedb98e8b12f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-live-kernel-aarch64.sig",
+                                "sha256": "a5c1fa086cd43caba102bf1c8590055b01d1ab0c78901992dac654bcf1cfcf7a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "c31971ecc474bb64aef2e24152ae0fbe8b5715e43b939a1f4a856b70de44772f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "1bc72e1261524faad57ab97ce9b3244b66585bb63e57bb83589f963a9ad91c08"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "8c27368731b91af0a360d0ca59c47a7cf1879eb0bfa13661956166fd2cee32ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "710f5164a844d56d116ab95fe3456863a95a424cfcf5dbe6007ce0a2842fa3d1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "741d8e2a6874f54e118e31186920105374ac076881b509cee4e9ea954f249fb8",
-                                "uncompressed-sha256": "7bb41d7ac13239ed6f1cde0e6768f3c596f07b9ae9291c15ab0068c80a417cfd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "1552bb0275e0ec60e36288220c4900fafabf120f3f2fac0cf9b30f0a65012966",
+                                "uncompressed-sha256": "af4db59f39010580b8ed6a215530f6821a5eaf72254b2bb5bb3dcb6889435641"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "8ab29d40118b435804e25d252f9b76ebd03f7105ce85acfb2f301964c041c073",
-                                "uncompressed-sha256": "263757b4d2a749ce788abf5ab35876273bd89234b9b4d7fd3b84e32f35fad543"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c2cf06ffc32f58387e2ac9dff5e6a1396c026957f29ec24797be8c8d8cd30014",
+                                "uncompressed-sha256": "3f6fd939a9424f7c845357f26edc19cf2de1ea6ad893994291c26f321e216469"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/aarch64/fedora-coreos-36.20220703.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "c1f8bbb7d505f408850dbaddd8a2cbce7734aa374fa3a6e517a6a1262d30d1ec",
-                                "uncompressed-sha256": "55cd450db24836fec609133a0a272b64b22b39d81d3208a68d9243a30f2d24ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "69c705576af157a7e9ba82eae9e17f9d5bebed2f563ffb0beda4cf2510a209e1",
+                                "uncompressed-sha256": "74ec86d5ef2cc6539a255822ccf3acd2aa9dc8bdfeef0d724fd9ca587f401dec"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-05e3083cf74e81feb"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-09458e29a8edb9f55"
                         },
                         "ap-east-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0de389d25ea098539"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-0902e1fef48a3c3f6"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0f389e7387e922099"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-064f3aa9a186f7a4a"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0f02a040d81a44e81"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-021fa9153efc5603d"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0dc44dc1ca07b2ff9"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-0cddbc17fccfc0d68"
                         },
                         "ap-south-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0d475174aac20a920"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-092111d625e4a5972"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-021eecee02fc7031d"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-062c310291b474c18"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0736352efabcdc01a"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-016e9546ea3fe3fa3"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-024e9c24770ed2a81"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-0ea417ecc87b47805"
                         },
                         "ca-central-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0de714704d92f9060"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-00f884f01aae093f6"
                         },
                         "eu-central-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0a1929603fa4698f3"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-01fbd1f8b9d81c085"
                         },
                         "eu-north-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0f795c6cda869fc46"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-03a71754c9726edd6"
                         },
                         "eu-south-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0cf2f1b88580f2cfa"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-07e93e7de1cf4952e"
                         },
                         "eu-west-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0f461d8a1bff4b991"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-07fefbe9a7f1ab216"
                         },
                         "eu-west-2": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-07606dea895cbb99c"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-04db5ecc5c11ee46a"
                         },
                         "eu-west-3": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0ed0b97323ca6a402"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-02eda8fb651ff5278"
                         },
                         "me-south-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-09088fb7cfbd2551c"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-07aa996711bdcab9c"
                         },
                         "sa-east-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0ba6665ea83a3bd59"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-0cb2e1800f821f5f6"
                         },
                         "us-east-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0a806811c54e44c95"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-0d5d573cf24d48189"
                         },
                         "us-east-2": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0e81280fb1ae694cd"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-0a340df91ed606210"
                         },
                         "us-west-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-003fbfa680c7cb41d"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-0e743824c54556f34"
                         },
                         "us-west-2": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-04ffca676f27ac2c8"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-010f9efc48c5acbfc"
                         }
                     }
                 }
@@ -190,72 +190,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "8e3d3c0f2892f6f9bb033950ba74b2e3160341e92fb0a8556214c44fbf55161b",
-                                "uncompressed-sha256": "a653622a0047c19466f92186d130fc4c7c752039661907c2dda4a95739f5c8b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "eabcc0c8b7b2905e83107c05f7f4dbb6ab67bb114f2bee329c80d6f52fe3394c",
+                                "uncompressed-sha256": "8371aa07cb7529d7c69628ae1176ef622f1c44c4021485fc35611a1cbf32065c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "e727fa787f70a5b510a327cbe18fea05e9d6216df5db13b3d23da3ad0b855073",
-                                "uncompressed-sha256": "ff7aeefe7f96b5e80ed084e2e7389fda2244d0f2f382355687bfae81990fe612"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "42e405fbef76e9b2d1d2e13731860b1ccc04419b39e8d529098072ee226335da",
+                                "uncompressed-sha256": "7dfa8330cd5ab5564832959332a34d772e02540a792f88864dc6c372d359a3b7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-live.s390x.iso.sig",
-                                "sha256": "541a0af3aaa773528483bc6541efa436f66f316a3ce0a9bdd9ef26fc8609c430"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-live.s390x.iso.sig",
+                                "sha256": "5a73582778ac61e56c8af4b3e22d356f022528f731c97d921c7d8deeef61c738"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-live-kernel-s390x.sig",
-                                "sha256": "8b468ae0ad9a39f31d59b897bc49638e3790adc83f725a608b56b1b2fd830b8d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-live-kernel-s390x.sig",
+                                "sha256": "1917ea368be5acc97b062330a4d13111517b357d8dbbb277215716da1a8b0a92"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "91773303eb9dd4f3930b2c8b1548241f080b80c1d213e6e51abe037342c2e416"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "f05ae880ef9562a5abf9cc98b3baa972ad6b5bb4a06ed177fa854e2a4e540dde"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "d0f0200fbcb75b83f8b59ff02e662586836fbc77e3b6f95a29deb656a6097d99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "4b68f855eb0eb491f9b73c8ff8ef390d139a8b391ca6c5d059302fadbb532d52"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "caace7b49e5ed73a65aff5271b6331efd45799d89c7dba91f4f499c7cc712466",
-                                "uncompressed-sha256": "0f39a84efc673b42fbb45cc9c5409280a3b52e240e1c911958d6ec38e8f769e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "7e6c96f55b5c3d96e2a2602f0198447baec1c378331162df87625c8aa42decd3",
+                                "uncompressed-sha256": "18657e786f837a87d88b1baf803bd5edb7f299c3cd7d09259ca408792d7e0ab5"
+                            }
+                        }
+                    }
+                },
+                "openstack": {
+                    "release": "36.20220716.3.1",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "4ae22a8888369ecfacdb4dec007cdef054329e07fed3c235a817c6eddfcfec12",
+                                "uncompressed-sha256": "7fc5551bf19ab648c935877beb6557abe9f22612cd9585207a9bb59ea3e0da4d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/s390x/fedora-coreos-36.20220703.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "e624eb6ade2e0a21f5541a13350214f7ec5a42704989ba1cac45866a608c3514",
-                                "uncompressed-sha256": "f3d7c98ace760b0730ef35290e348104dc858676f54339fef9c94ed4d3c93263"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "7a50ba125a25896d4ed726e71f54f63df16d841846d884d5fc10d7d4c58710e0",
+                                "uncompressed-sha256": "1f842ca7c509c56d50d3aafbfdfd3c7ffd535190f29a1ac72cf9c24e7498e3b9"
                             }
                         }
                     }
@@ -266,225 +279,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "f890123ca7d6f1028154275c816693fa6190306d0415c6b22c185fd835478232",
-                                "uncompressed-sha256": "cf10adfb475893e0d01665780eae4d91d41d5d4a7abe5cfce6407ab682fcf5d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "968702458ed501af66adc2b33d3fdd56e402cb9408865b59430c7250eb70acf7",
+                                "uncompressed-sha256": "97880477b9d352b314bfb6149f72d9780d2f3c1e6d21770dc5fe854faa2cc733"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "4907664c27993d8c48fd73c5d17524485ecfee24638908cdaf5874cfd538bdf7",
-                                "uncompressed-sha256": "09b518b88c231241209f5867b1576554877a74dbaa9d34d59b71b4d37d139ff6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "6b6ec4bbd4a6b2c6bbd160680d2f8057d18cdb7e6d79b3f7dec53f984b511c47",
+                                "uncompressed-sha256": "e03843f960b790f051c24c480e1a0c09807d6cc92eb0bac8f2b0855a3885de3a"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "3f9b5251f8f9b7c747771ef92075b27cc21b92efb6dbccc9d22d63f53d2d78a3",
-                                "uncompressed-sha256": "e40eea3e2bccc169195e576a543a6a2d0d56d2c87dcf121e6be7d69e2b927b3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "503ffe8a800da60ab36cfd8b7e3336c80bc2e788943c4e8c3ed31203976f513d",
+                                "uncompressed-sha256": "db5f10dfe79fecf8e11da9d8d2bd198cee78fbc84b1b3e909ec31102fa520641"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "1ac74ae43cd026545bbcc175e751c2f59e85c4879ef04c2d4b28a837c3713edf",
-                                "uncompressed-sha256": "68dd4bfe8f11599bb4e2b65ad77914b27928ccae10dac9de0339e2309e57fb92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "33c0914dc5548393a0e974ef0839ef871e02cfe269ea67a310cd7fc5995d59fa",
+                                "uncompressed-sha256": "68cc46879aaca35f13b20a68ca3e057cdf61ef0844776c10239e27c924326b4e"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "ddbcb7a14019820e70d9cafea69a5ffa8097929f6e41d2a4f29dd344610e539c",
-                                "uncompressed-sha256": "f0bb3c7edef4bd398f30f337453e2140b01ce2cd4531d6459c8ca415c509389f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "cecfe4f408a75d7fcfa52e880bd708e294612f42c51119fde72205c88842081d",
+                                "uncompressed-sha256": "ec1583d6b3844b2b0e95150f8dbfbed8228f90efa721b0a0a6ca6ff080b3a8a6"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "0ef36265d12cf4cfcab67160b45606c7821fbf6e9e3d135e457a463481e15ff8",
-                                "uncompressed-sha256": "1a54ef0d60f2a2c891ea2e45423cc4566172159b330f5b1f8c325a3941d5839f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "8364411d8886e0cffb2dd25819d82733ec894ad6ada62bad33b779f7b90f8666",
+                                "uncompressed-sha256": "cafe173b28bbb33289d59966f172fe7c436551d06d03c6095d70e43820a6c07d"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "b65d0c60d4a070fec2f04dd64191b1dfc2537d87a0f3f403b36c3287bdb96b20",
-                                "uncompressed-sha256": "cf7383f8e0d21f08199823be31a969dbae54aab6ce78c8c965d73ee59afc8f65"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "6b892f8d8768d1f11111886dbbbb3f387c0f50263cb72a14b7e85199c04c977f",
+                                "uncompressed-sha256": "da516d9b6c8de0414d31dca97fdc2236e209872b7e3fcc33ebd33fe15e03a75a"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "28537a6f786d81408b4e48fc96d90e9b8aeba74e91493baa86edebc21fe50a66",
-                                "uncompressed-sha256": "91fb1ea84b7863aa27d75a21cddc5ec53763d304f7fc3084678fcdedfe8fe4ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "69c8de5fd0a85f1a4085ebb9cd0c1b0bff54d7ecb6a8a2ac100fb82030ee6616",
+                                "uncompressed-sha256": "e2e154a800f6e1edcb9a297ff3cf2c3ab3888373039644dcb1db9a4c55ad8c87"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "c3dee26f2a9c9a61920215d5d7a67ba6672b125d7f4252476d89603bf2a1d4db",
-                                "uncompressed-sha256": "ba2dccfac35fffef884042ff2495ad899d2344599410ca069f01d61ff25174d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "52da283f1d76ed74e79ba9812fcf4bae009914ee7fde44f3b474ae30243db04c",
+                                "uncompressed-sha256": "7f3b40affa16a9f3f69aefdd48189f479c365067f2507e08bce393efbda8beb1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-live.x86_64.iso.sig",
-                                "sha256": "64b98af1e2a0dd86dbc0d5c6ebf9e3b0d7eb390087debb17eeee0ac3f9ee1797"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-live.x86_64.iso.sig",
+                                "sha256": "ba6e27a66f9553de2bb0cf0952ca031171a0dc66514a3ec10590b3158394879e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-live-kernel-x86_64.sig",
-                                "sha256": "e031357b2e3b7fa0347ce56279eb66b1cda50046307969e801e326787ca5ad6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-live-kernel-x86_64.sig",
+                                "sha256": "a834a9a7230b3efaab2362ebc5b3733bacbc320b145989fa9f70c0d3dd3d996e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "bb519af0d2c4fb84210d92abadafca3eb4ebe1de51d2a741405952e9603c1c87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "ead9fd86dbdbac1076c4e9fd9a6c6dd83bdfa89ba2a74935ddccd9249ae7a21f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "228c874349364ea2358c63fa3945340ca7c8ebcc2c7aee325ca9db4e3b566dd1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "668e093bc441eb0945ba7bb5e8ac5bfcf880fbc6bd909386e442f813b8f551b9"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "7d5bd81271758a365f0199577ee3e1ec2c364362080410d6c09a04aaf91bb462",
-                                "uncompressed-sha256": "fa30fd736b7f92b2f20bb121fee22af8f1c71b69b5c0850332f5d8c81ab05533"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "fe7e2084522eea78047279327e6d5de8b97d80f1cfda43e47a5d64c2e330e0a6",
+                                "uncompressed-sha256": "cc9a610392a8f59ab9bd8679853868bcc52c99e8c8d5a7965e50458197781286"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "740b47b75f56e8dcc1a1d56d4a0fe6b4c60c526fd30688cc6bd45f9398cf658d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "81cd04f462eecd212b1d05a2909f21a01203403c8b7a932be2c5bef851bd1df3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "1711ee12ddcd48ee84f17645d541bf3b27c9e37eec5ac40e98f305fae442fa0c",
-                                "uncompressed-sha256": "74c91e2422ff3527e031ed84493aea5306c9489840d45f4fd4441795557646a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "065e483f74f101197ce9856dde4eb0ba8fd48d45b62204529694949d90371069",
+                                "uncompressed-sha256": "f9c4309ee7a86161927fe16003fbb8cd8fe66343a186c8cbe7220f5963b1ee12"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e3e7d6ae18d07b5aeac96edaccc2a91a9085826b65dd1e7ec5185c7f1b123edb",
-                                "uncompressed-sha256": "b194b060135fb852391b5056404b46d472ec5855ce0002f0260b75818eed3858"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e2393cbe8e3add8bf9bcfb367a4f6fdb6291ae8b87ae903d494261ce5ec5d5fa",
+                                "uncompressed-sha256": "f169ff86f0db885fe3c261a2783f68466fcc99c9c9f55e611367dd2ba2f2f24d"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "383bd7608b27b09552095cf37b4cc826324f2270bef26378912de97544af2102"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "422baee330339715be0e7a5e7a7ca6299e7e046e89dd416d5fa70853ee46aa23"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "e98d6672f61d09a35787ab6e5ab340c0a7abc98734cf8b54e81163334678bec8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "e448b601ee2a67cfabfcc27bf413bf29efc44c679930b5c117fe7460f2547930"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220703.3.1/x86_64/fedora-coreos-36.20220703.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "ab54aeba65ea9e22049703d7e77c79374a8bd687c114f674eba44a2920e0d726",
-                                "uncompressed-sha256": "b7564eac176f53f0869e3bb957b4f863b781f8443c86516ba59b14bf95f745b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "0a361b854c60b9144e70b65140c742c34ee04272af2af878ea6afa3e75624e42",
+                                "uncompressed-sha256": "9931df0523823ffd576a5075e16c354ab9e5e57041f7dc2d9a47d56e780c1f42"
                             }
                         }
                     }
@@ -494,100 +507,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0b5e91ef0fa980b56"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-0df263b11352f2940"
                         },
                         "ap-east-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0431df7b20a0adeda"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-0c6776eeba7f76262"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-04719e5a7207e382e"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-0c7a551d1824a8cda"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0e40862f51bb06d04"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-0a970a8d871e85c4a"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-048db68fef45eb525"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-05e26ff1441ff95d2"
                         },
                         "ap-south-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0106e6add8d83be86"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-05e0a92b92b01fbe5"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-08ed7c48d2602fc5d"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-07e57b7002b52eca5"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-08fd0c85867f4410e"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-0aff2ba00bcd6adf5"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-02af4f68acd5acae3"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-00df2f3705e6b882b"
                         },
                         "ca-central-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0120dc98318ce86dc"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-00d6571dc7548fc03"
                         },
                         "eu-central-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0ca07e058d989c5f7"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-0037cfd83bf77778c"
                         },
                         "eu-north-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0665027e7604eaeed"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-042d15dee4c643d65"
                         },
                         "eu-south-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0d490e05047124adf"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-088f96a19b2e94d0e"
                         },
                         "eu-west-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0c6f1ee16f8cc67a3"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-03625cea0b495eede"
                         },
                         "eu-west-2": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-04e9b60626149bf2c"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-0001c9b25b9ca6731"
                         },
                         "eu-west-3": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0fefd9c3306faedfb"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-000d4f5e28902476d"
                         },
                         "me-south-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-050f3ce379aa285a1"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-02664b3c387db55e8"
                         },
                         "sa-east-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0545092bde4b8846c"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-083be92a06ed2729a"
                         },
                         "us-east-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-015620f6c802f8e8c"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-03929f88dfb4b1c1c"
                         },
                         "us-east-2": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0e4d3929423bf7d23"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-022b6f47cedd241ad"
                         },
                         "us-west-1": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-01cf1aeb299f767f9"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-06e1fb9c118f0a557"
                         },
                         "us-west-2": {
-                            "release": "36.20220703.3.1",
-                            "image": "ami-0e64a65554048cb62"
+                            "release": "36.20220716.3.1",
+                            "image": "ami-064b01edffc8550de"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220703.3.1",
+                    "release": "36.20220716.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-36-20220703-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220716-3-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-07-19T13:47:55Z",
-        "generator": "fedora-coreos-stream-generator v0.2.6"
+        "last-modified": "2022-07-26T22:48:20Z",
+        "generator": "fedora-coreos-stream-generator v0.2.7"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "3f405300c122f34a6db948865ed84e1383a01d11ad7e26b5c51806a66c800c8d",
-                                "uncompressed-sha256": "3a36d7d8025267e5b9b2077c73ed187113a8e5c6a35510ea94192706f0f90cd8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "bbea346c12328368de4d28c620f40817bfca0b818cab508abcc8803b25b93caf",
+                                "uncompressed-sha256": "7747cba4610a5ff3036f8148c5ca7d9fd33df9fb79650f94391cf3777069869a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "f61c09cd7e024968871c0addbb15a4154b55edac2656dd33bb8b18dc79c9e797",
-                                "uncompressed-sha256": "b6dd6b24c56ce8b29276d69c278e1fbaf01594ed0af8ae805d88d2384a0706a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "05736b127acc090ccaa31e9d3d4c67cbb65f4b7af7e8fca5fb2cc148858a71cb",
+                                "uncompressed-sha256": "791218b25ad6a8aa9ffc61237c669bbba473ee0848134aef6866ad8c27d69999"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-live.aarch64.iso.sig",
-                                "sha256": "7e6dfa599b9db74e9474d2e8ab81260ab7b441276d7a9fbb2c44960f53168852"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-live.aarch64.iso.sig",
+                                "sha256": "d0170ed9ca0640ef4d41e2e7601edca469be06b6e2bb8fb6fae085f206b3fa60"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-live-kernel-aarch64.sig",
-                                "sha256": "a5c1fa086cd43caba102bf1c8590055b01d1ab0c78901992dac654bcf1cfcf7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-live-kernel-aarch64.sig",
+                                "sha256": "63d9b9c93536aae9d07bf3031e0a259624c1cfbd6391a15cc7a0fcfad504b9d2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "459aa0278457450c5dcbd9f859a0c7d2eb3a747a981dbfdfbe613657b33084b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-live-initramfs.aarch64.img.sig",
+                                "sha256": "baa12fa5858a1bf6f16ff6c91ead32629504751e0b62b4fde2ce9f74a24cdd4a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "81f0bdf36f39cdc7d9cce191dc55efad2de158287bda9dd3bda23ba22d7a66e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-live-rootfs.aarch64.img.sig",
+                                "sha256": "cc1004a2eeae428f73b4c0e69a8ac1abefc21f3822720d24f57564bab5f73102"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "0d02add1384b51e5efb9499c86c79a0b9da432cd15a565f2dfc0c66022a771a3",
-                                "uncompressed-sha256": "c8647cf06cac8e80fd1a2914112c48ca881940a0df464e5a37556f4aff6d5982"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-metal.aarch64.raw.xz.sig",
+                                "sha256": "23ec681091a5ec05f4faab6cef058e084b8fb61b30306b2f6759dde55268f384",
+                                "uncompressed-sha256": "5e749c07d1ea45546c1acca55fd2af1f860725545e4213b133cf1d42e5f21acc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "609a5ecd2e1cc7b9060e3e1028d42ae0fbf057360ec879be3b99695895e41b75",
-                                "uncompressed-sha256": "be1e64c246f4c2a16682bbb0248b777652d53e0b477fa45e2b5c006e96c011a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "969d6744fa8168435d21b6f6b63f2c864e65b30927e23c0dab0b4bea984f547c",
+                                "uncompressed-sha256": "d28579a58b7dcb4bc74d7765f7e46496a96305939af6b3cd17a36a866d0f9201"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/aarch64/fedora-coreos-36.20220716.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "97fe572229b9e5f25d75ed2d43e4150454386da244a055546d5bb1600ba1c71d",
-                                "uncompressed-sha256": "c08bdbedf582ded89e15283c86eb102354e209de2ab70984c68810a21c38c0be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "f12f1a787e0672468fb87bb3635fdfa5e290a7a5355e292f67152736a238665a",
+                                "uncompressed-sha256": "c2df2afad03a05ff4e3cf9256098234b35b6467533cd6b7e67c89a18b0e45568"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-08d2ab14015c33f4f"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-06ee88d676c66e832"
                         },
                         "ap-east-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-06d2e1214268c78a4"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0c1c8d95d544be3ab"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-0b2e371d0c54c8d1f"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0201f7d58bd73d8f7"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-0d4249dd45c847793"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-05f982af0b18e4b67"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-09d8ff35aa39d00f1"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0e267b8ce5a40287e"
                         },
                         "ap-south-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-0d4c3f9e5310cb662"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-04a77deb15d5b09ef"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-050ff7fe648fd7803"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-03c66bd8e315c9ec2"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-0afbf2507be1f0ef9"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0770df2f7c8d91a08"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-08a132f26ccbcfcce"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0fc26c6ddd120091f"
                         },
                         "ca-central-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-007d5a9c5a395978f"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-08f312e982099dc40"
                         },
                         "eu-central-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-04dbbb30b7c121c35"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-03c7aa75790e2eceb"
                         },
                         "eu-north-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-0999661925b86e5cb"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-08f73070eeb195d77"
                         },
                         "eu-south-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-00a1240e822fef732"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0da33069dd996783b"
                         },
                         "eu-west-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-0a03a790ff6e2179b"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0b253d9af04244faa"
                         },
                         "eu-west-2": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-0bfef56a72a63c64d"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-06c67bc086547744a"
                         },
                         "eu-west-3": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-009a2627470eb6984"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-00a5ece55cd0b0e2d"
                         },
                         "me-south-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-0fd489d5acfbb0632"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0905daf5ef9b15c03"
                         },
                         "sa-east-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-0e6daff66777a5190"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-07ceaeabe0a5aa8c7"
                         },
                         "us-east-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-07849fc0ef3d9b939"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0749ebc5c99d6c42b"
                         },
                         "us-east-2": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-0e35f8d7893df0da1"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0931d1c16893fe3a3"
                         },
                         "us-west-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-0bf1ec582adfaba5b"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0f25f357ba30ba9b7"
                         },
                         "us-west-2": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-09c336fe47d2178b1"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0da792e71f66f171c"
                         }
                     }
                 }
@@ -190,72 +190,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "b198415552644cdefa2e61978108fd1c13f6f284dcf77981d5a8a217e83f05a2",
-                                "uncompressed-sha256": "ef4b76ba6dbef2261573572fce9d1a536ab8aa4376c76a0b2219fd13b3c21b0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "a2324d1d0b47a20177df7dd9a4d0a2015bca6a01af40abb4c2f7eb93f1a3d0dc",
+                                "uncompressed-sha256": "05295967e94be65c28d3d7a59f26696c2fde3c6bfc0979cd6c51d4d823c009bf"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "2607f0a829013f1f9dde9418857fe294ba3703332d25b335db3e5e1d11c43491",
-                                "uncompressed-sha256": "33dc985ce63f8ed89427feb1fff7bed80b251ccf24c51424dae4ba29b4d58a57"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-metal4k.s390x.raw.xz.sig",
+                                "sha256": "b6c73ad70f92d6eb8e7fc5b9b241d5716ba75749f6e7964c2cf39d02f1285e46",
+                                "uncompressed-sha256": "dc10b74b4d6fdfa355ef38323e9eada47ff14547f3f3d4efe4f1391af2b95d76"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-live.s390x.iso.sig",
-                                "sha256": "4cab3182343e4e4ac5da420c032bfa12f08668e5490f6cbaf14afb8a48edeb78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-live.s390x.iso.sig",
+                                "sha256": "a964824ceaf6eb6f0b8f66b01f4fb69ffbb74a8399d8af64977f8b413b3f379f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-live-kernel-s390x.sig",
-                                "sha256": "1917ea368be5acc97b062330a4d13111517b357d8dbbb277215716da1a8b0a92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-live-kernel-s390x.sig",
+                                "sha256": "9acd61a7c5c12a8854bc4ff34c6fb02f3f85ee3ff9c0846ed286034c0fbaaeb3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "a8a33af0e1ac00d6c9b56f99e1d6452e6b9169fd98b2ab5c5c767fd0f8e925e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-live-initramfs.s390x.img.sig",
+                                "sha256": "d1168e503e174fa014d6d59a8d8cec448d9d42bfa846e5e9a2d733c4f829cb8a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "37de76267848f67e3554c177f2c2e0db7010898310cb20c172e1ae014b31bcb7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-live-rootfs.s390x.img.sig",
+                                "sha256": "5344642fec86a03bce2f546b24dd0a7e4462001e4daa35b31368f27a247fbca7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "036c16b3100bf90c78dabc34a7ba98db8e6fd53e0fe8ce4ad300365348abf431",
-                                "uncompressed-sha256": "86ee82dbdd77d0ed2a0613b23dea56bf66432f4bd6e638aa714e1fddbcabf056"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-metal.s390x.raw.xz.sig",
+                                "sha256": "85d1bd51989a67d97ba092a2d3f0c4f04e32e9cee9466b4c30ffcbd4d3c5f4bf",
+                                "uncompressed-sha256": "4ba56de9277ff33571f65cf0f527cc718d246be567c072be9b42751b1f444883"
+                            }
+                        }
+                    }
+                },
+                "openstack": {
+                    "release": "36.20220723.2.2",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "f8e3ae39e9aedc83fa89e84fd731f72e6eaa5e046a13837e7a429e9b56e44aec",
+                                "uncompressed-sha256": "b8bb375ff84836f21c7f552ef28523f396d3145edc394f3fe0479412f3a731c5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/s390x/fedora-coreos-36.20220716.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "e01b5972a72ab3dee1d9131d5aa68b37bba6cb3c434c50cffd044f841529b265",
-                                "uncompressed-sha256": "57d866a90e6f614431d178cb6ad6d95805805cfd7e5737daf7ce16db6c46e7ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "a5be12555759a6b3feab24efc70a60958faa24a437c518bef69965af168d8ddd",
+                                "uncompressed-sha256": "1d03c786dd488e459423c64c85103ed2e534337c2671588111acbc249e74ddbc"
                             }
                         }
                     }
@@ -266,225 +279,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "40f84786979d18c6b4cfb8366b00557c45e3916478bac1dbc3bbffd55978622d",
-                                "uncompressed-sha256": "c9d21d9b57b74b127e66d489f592893e5b68fd7b95e9c3463925ef8ea6cfe09a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "85d98e4e0f0e8572a3a577f5d872b761dccefb69ef226cf48cdc1d849bf30045",
+                                "uncompressed-sha256": "55bbdd8d27c81f3efb7321aa00b5fb14924a8b6d63b221e329c745eb1656b29b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "a52f497928e93737c80e58a35e6d44a1cb8113435ae2df1fa586a1e155f951c0",
-                                "uncompressed-sha256": "81bbe4ea567f3e0e14d76f929e0a3cdaa6a94d738534fe3cba6350aae86d5eda"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "926bbd0f389ab927e03d348e60eabd6f5c5e36187408dd4102f6cfb7a08fb945",
+                                "uncompressed-sha256": "83102b339a055d2a04bd9c8a95ee966aecb778b1f30d537a708bf3bf0fa7501e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "ac79cbcbd0fb50904da54c6cb3634d4b35221e0b1a5356f9b51dc06825329699",
-                                "uncompressed-sha256": "ddea80dbd583673132e73c6c62f971b3712dd85ed74247e2f5dfe88b6c04b7f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "a0c04be1266a079f813e47c2dd22215a4d369092a2990dbe4b2879f00740a258",
+                                "uncompressed-sha256": "ebfa66c937a3448accffc2f76eb8b862eb7eb934bb89909e9daba9eabae95447"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "8d30a1e1f9551e5043fbebe4ab45ce66d5a424257a01129fa8ae329c9ba472f6",
-                                "uncompressed-sha256": "0d20d7ecdbff3aa8d20f588721530ae67c8ebb67d7feea9000ab8e29ab8cf567"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "7cb35593a9f8db09b3760b1474c6e5140421fd9b7578a816377865ee17829756",
+                                "uncompressed-sha256": "6761fd17349badb514b02ed7a7eb6a9cd3cef331b504a565d265db772fa0a364"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "92ada5912275d1d0783218fb1a039c894750fa121d11eaf8fa135249924c70a7",
-                                "uncompressed-sha256": "0da369bb856a33a4e2f2d29892e29670a7e790cb79efbf3d2293e2f839cfa42f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "c9c9883a946be181f8eea8b229b0702fc5b111067716a946e33b63af01cbf058",
+                                "uncompressed-sha256": "74ed60c6b99a73eb298e3bf671cb44971d67f945dbb5eff7477d6316874c3bb8"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "bf1d9e09b2ae0ae77ff79358b409e0e22fb9626d8a73220700429dc8c4b13a64",
-                                "uncompressed-sha256": "bdb7e3c31e2957714df6a2f3f7278dd6848646ab3e5f719220b1e608d4d53bd8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "81af608a75a812779b804b1972081101c51c574bf32c694c64d15957df8f34d6",
+                                "uncompressed-sha256": "9ac592f2102650d8da1c7124c7bea0880777bd2f35b8edcd62ba4372c01e290e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "f8bb6e98a1187691262a007b345a6946156b5e0a8127e1b418be65f803b13731",
-                                "uncompressed-sha256": "833ad4e55963dd8801f3bd5d0c59a5b46276810a9e18f4d954f6afcbc2098d4d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "b990a9591e0a6b26f588f09519dc462e169a38219074a7a839772ea8f915dd21",
+                                "uncompressed-sha256": "4b4de028ff127fed1a1d04f3bee70b9cc858f0298ca0de3ac895be0525cf83c8"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "d07f24a670ac7eb389145ce956be1186260babd82bb44ac52592e24b4afc2c33",
-                                "uncompressed-sha256": "79f248ee87ae842ae4e7cc8cbb8989496ddf6698233a41c5d896de57d36f2840"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "6aa96f4f38b9cbab8a06ffaf05d6b2f6e326282947203de5257b8be9649b1204",
+                                "uncompressed-sha256": "94cff39c9638b48f7d7457c9236a790e035056e186ce142484c4456a57668635"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "61bbe0421bde06d14bdade288b3cebfdcdb3c965259c11ffc0bf050c7e47961c",
-                                "uncompressed-sha256": "a05ee5cddac855724a40526fca9c977fd53384dc9a8ec27ba886163e45c1b3ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "26f6c67414f8741f49c676d8b170df6fad3d8bc5b053930a892c46c59a4ec6ee",
+                                "uncompressed-sha256": "ea2eadb2e458fe9cb6461db02bdac80aa8d87807babb997561f9397b23dbf987"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-live.x86_64.iso.sig",
-                                "sha256": "4eea451d19d50a17cd3c955b285e5ae9ae7724e26d7c0d189c0fa3266d3b728b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-live.x86_64.iso.sig",
+                                "sha256": "984207aafe1b5e17545c2794150e299310c41c3f5036b94a353ef5628cb75435"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-live-kernel-x86_64.sig",
-                                "sha256": "a834a9a7230b3efaab2362ebc5b3733bacbc320b145989fa9f70c0d3dd3d996e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-live-kernel-x86_64.sig",
+                                "sha256": "38640a1e99cd2e0e0e9576638f2cd11fa254c4a7a543cd3eaa0c156762444558"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "df7c7938af95c64a5e12e1bb6e1e47e4528b3fe783c9f74b3001743b57fc2138"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "ead76ecc91b2b5ae55ecee72f92f675361c3168a90046409d21e11a9f2cb8fc0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "af37d04f2cef79a0461bb565cf5ac7d00eded386160c7e85d899e90a337f758c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-live-rootfs.x86_64.img.sig",
+                                "sha256": "d607f0006cc2d43ca45ef9ec31650585b513537292fc4ac8eb56225566d6a9b8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "29717528be7c1ddb5b0869e877c2efc3958ffc96908ab5096ce7c8b04f77526c",
-                                "uncompressed-sha256": "6bfd9d76f57e6a5326d856c8e70166ab05f035c848cf729d376b2c5e30d8b4bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "09367fa285504f0b862ac9a105c23c64ead8142e2738426d1edd208bc4b33210",
+                                "uncompressed-sha256": "81b704558c5a2cd08907cfc32e22d8043b72e5b664c4c4bd9d9c362f12c6794a"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "83bf8122b353bb28cc8230df80db2305fcefabd5e749cbf61dc2502249d5fd91"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-nutanix.x86_64.qcow2.sig",
+                                "sha256": "e5b2999a48459c76b882f633de175fa973d4677560c7beb6a16a778926f7b910"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "8fbccbb40ea445d3db11922270df4d2050c0658eaff1e88cd47c2d408643a6aa",
-                                "uncompressed-sha256": "354b4b86ae076a3c92975eb94cb8c8b1106e6f5c75fe343bb659e33461c67c79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "0a88272d945c363f8fb3ee7e5d3feb3fb73c56f7c3871352ac870d9290e2ca06",
+                                "uncompressed-sha256": "cefbf8df33b0c76bad57c5da5470cd15ef0a128af1026becfc43ab557bebec90"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "8f4e49fdfc0801166995e7d59b855f58c7637e358d222714ca8e6538d4d4f967",
-                                "uncompressed-sha256": "c3a3b6d7251c81e63452f001924cc2ea5b587ea6825ee6cc259c7d37ca0d32aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "4bd175e80220c7e5a811774b0e7c69d97e18081160480bb4787d69b6549e2aba",
+                                "uncompressed-sha256": "66dfe3e79b8a287697e47ba2a3e2d32c37a49fd8fc4be6c9c16d3977e9a58b10"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "f89d82be4ecfb79b7a1acaa9765ca85acf459e2473daf9dc85e7e5bdd4fd039c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-virtualbox.x86_64.ova.sig",
+                                "sha256": "4491f4aa322fcad4aecb27ffb78f3627264e8e945475d8c910db4be915e2d483"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "1b9486708d0ce757b0dd9b1d1838de75fdc09e94c4fb91a495610c9797191d2a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-vmware.x86_64.ova.sig",
+                                "sha256": "7b68b41c85c9c0bc977739a3806091f37269a3e8a853038f40d943e0d799aa28"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220716.2.0/x86_64/fedora-coreos-36.20220716.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "104c3f3c58a68cccb08f668b53dc5d152b3217d9c01800cf5fa6f0a732f2352c",
-                                "uncompressed-sha256": "ab85c89135fa2079564fb97c1f708bd9b0902a94d405dbcb2c7aa3203ed985e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-vultr.x86_64.raw.xz.sig",
+                                "sha256": "df264167f892628d6b1889cd60fd59987eb0b3000603dca182e8f2eea8ba0cba",
+                                "uncompressed-sha256": "6989b12ae8dd6558bca910c251b4e0931a14dc96786d58b4799175885e3cce05"
                             }
                         }
                     }
@@ -494,100 +507,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-0b40381a3a5450dc1"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0d28867c8a56bc703"
                         },
                         "ap-east-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-09518eb8aab050646"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-000c2759722a4457e"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-0b8b28fc9f0ac7ddc"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-06ebaf9b0286785b0"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-03f89a9c52d4abec5"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0dced6de4ccb7611b"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-0a580668115471cbc"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0a57010b15bb428c5"
                         },
                         "ap-south-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-08234322811c2d498"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0a9d587833d996851"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-08e381fe66748e0c1"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0f7d7405d1a0763e8"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-0c696c03950a21047"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-09e19481df8a37106"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-09255128563b01033"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0e0f586fef3024904"
                         },
                         "ca-central-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-093c1a0c380a9517c"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-036e25bbd6ba26e8d"
                         },
                         "eu-central-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-052c59a20c5a7255d"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0019bd3eab0b18103"
                         },
                         "eu-north-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-0d1aa47d1b1d117dc"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-046ab3819b80b052f"
                         },
                         "eu-south-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-08cf2da48812133c8"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-00476b01ff6719ca5"
                         },
                         "eu-west-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-052c97eff5501b2ae"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-03101ea32651fa810"
                         },
                         "eu-west-2": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-0eb1cf425317edf12"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0a792ebef3147a2da"
                         },
                         "eu-west-3": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-000988de1420e4579"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-050139aa5a5c4f1e6"
                         },
                         "me-south-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-0fc28dde43073c031"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0b7e77ca1c5fa9db5"
                         },
                         "sa-east-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-0aee2278cf797c88d"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0ccab6e489bef88b6"
                         },
                         "us-east-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-02aed71d0fe218f64"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-068df0b4ca626835d"
                         },
                         "us-east-2": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-06e0c744f58b27214"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0873ef85b9569a3bf"
                         },
                         "us-west-1": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-03cd485c3ff1b633e"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-0c7afb2d2687a40f3"
                         },
                         "us-west-2": {
-                            "release": "36.20220716.2.0",
-                            "image": "ami-049093cc187682429"
+                            "release": "36.20220723.2.2",
+                            "image": "ami-043807f24066dbd87"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220716.2.0",
+                    "release": "36.20220723.2.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-36-20220716-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220723-2-2-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-07-19T13:47:56Z"
+    "last-modified": "2022-07-26T22:48:23Z"
   },
   "releases": [
     {
@@ -53,7 +53,7 @@
       }
     },
     {
-      "version": "36.20220703.1.1",
+      "version": "36.20220716.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -61,11 +61,11 @@
       }
     },
     {
-      "version": "36.20220716.1.0",
+      "version": "36.20220723.1.2",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1658242800,
+          "start_epoch": 1658926800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-07-19T13:47:55Z"
+    "last-modified": "2022-07-26T22:48:19Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "36.20220618.3.1",
+      "version": "36.20220703.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "36.20220703.3.1",
+      "version": "36.20220716.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1658242800,
+          "start_epoch": 1658926800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-07-19T13:47:55Z"
+    "last-modified": "2022-07-26T22:48:21Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "36.20220703.2.1",
+      "version": "36.20220716.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "36.20220716.2.0",
+      "version": "36.20220723.2.2",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1658242800,
+          "start_epoch": 1658926800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @gursewak1997 via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).