### PR TITLE
Roll out stable 36.20220723.3.1, testing 36.20220806.2.0, next 36.20220806.1.2

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-07-26T22:48:22Z",
+        "last-modified": "2022-08-09T19:24:30Z",
         "generator": "fedora-coreos-stream-generator v0.2.7"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "b740be65f51bdfd91aef74f2493cdfa412da556a9b668dfb259a75b244dd7a4b",
-                                "uncompressed-sha256": "df3aa6b5346954cb7e2769b356b9739d413a5e6153ad1a9d4e88f543198b18aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "e32f3cbbf4531d3bf55f113908f3d99f2dafb5c97e8e19934a90568747196dd5",
+                                "uncompressed-sha256": "fd2d0fc4edc378c47572a6d0652d03bcff1b98a3694fe518d981bcf1a0d3dbb8"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "102ab72bce785ed8b10ecccb25f0ea04c081c5b490b357e2fa9ed1d824b88a5b",
-                                "uncompressed-sha256": "3ce53724571265e27d70271eaeba88a7b9872b84b44ec5013f62b164094253eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "66be0108ffdbdec27c48ea13ad507d5c3317f2216e5edae9bbc635916e766b7d",
+                                "uncompressed-sha256": "e3a897283d04ad10564e454d1cc5de46c50ec7d0666349bf28736798ad87052f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-live.aarch64.iso.sig",
-                                "sha256": "0bbc5ace92839ddbc6b22d63bebdb7372e237c6405507812fb7db2ec21aaa0cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-live.aarch64.iso.sig",
+                                "sha256": "fd782ceb6171215bea83bbf4b87f6aabeb183e67329f258508964e1a099c93fc"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-live-kernel-aarch64.sig",
-                                "sha256": "63d9b9c93536aae9d07bf3031e0a259624c1cfbd6391a15cc7a0fcfad504b9d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-live-kernel-aarch64.sig",
+                                "sha256": "4da34179a23797b370977134e9323a97ea061862dc09030ba494c9598a96a922"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-live-initramfs.aarch64.img.sig",
-                                "sha256": "60c12017db3554c65df44aa4c6586ab2579f0f65ba69911bc2fc3cf65d97d1c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-live-initramfs.aarch64.img.sig",
+                                "sha256": "914aaab02295b5b9388480b335db8c384967892376589cb7635c57c34fd36217"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-live-rootfs.aarch64.img.sig",
-                                "sha256": "444138c7f367c9e1068fe15a7281bd86dcfa3c81d340b59d8c752266e74455f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-live-rootfs.aarch64.img.sig",
+                                "sha256": "a03c7f4cda6062c458612f5b40489e32ad12cdccd2bf6838119539e31358fffe"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-metal.aarch64.raw.xz.sig",
-                                "sha256": "0e8ecb4d72be52699724ee7925531edf1fb098f709b7bd56c589790775433c59",
-                                "uncompressed-sha256": "72122c8d842998cbe627d275ede528acfa8b043548ce2e466a7e9de2ffe352cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-metal.aarch64.raw.xz.sig",
+                                "sha256": "1e7f0849f8052b5846d239b968bcf3f3048c06c29b90e82c65d49d3e47684f27",
+                                "uncompressed-sha256": "eb849fa252238a0ce29e9ca65e97dcb9a14b33fafd87dec17123d3da01d5f23c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "19a991ad303554c3ecb2972be4495cc14cb4e9a898faff117b11540008fc75b3",
-                                "uncompressed-sha256": "f0c8d551ec5ec80aa7eabe5ce5615fc2ce91f8c09db1994d208321cedea61afb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "7b04c4b2c0445b025038b5e1b42b1bebe35f7dbcc782194c6aafda50b770b62a",
+                                "uncompressed-sha256": "82ceda18ab3e33064c70f95e36b48b8e88bf60da5df4668fe7c68a6969d6190f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/aarch64/fedora-coreos-36.20220723.1.2-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "95fb84d1bdf55dc8814aa0b4cd5071e526ebeb6e24c1bdfa5a57fd0355fb14f7",
-                                "uncompressed-sha256": "f7fbb4038993f5844b61c74d22ef71c03bed31c0bc90ea2d2bf91f357c20e791"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "b79731d40faca6fcd23c4e8002ebe780329ab4da3c6dc3c40a411611477da5cc",
+                                "uncompressed-sha256": "6efcc91b2651429c5265258bbbb14a4efee94267f3a9a6dcc492416322d207d5"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0903aaeceea870d22"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0f8d46dbdaa43bf11"
                         },
                         "ap-east-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-057287fa8276fdc20"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0d474ad3d792d3bd5"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-03b50757aa7be6449"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0e6e8edf0e008cb04"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-03c7e70c420e7fd8d"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-060b074cd7aba20b1"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0521a5575bad5e83d"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0e4633bb75374054e"
                         },
                         "ap-south-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-05a4fb27f7b0b2bc6"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-01ff89761ca15cf6b"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0c6c48b8f39d1d8dd"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-02cc435c1578253f6"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-003eb1cf3a3c71d6c"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-04a7b4c5bf8ac403f"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0e12d54f8fd68ee8e"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-00d94027139261f6d"
                         },
                         "ca-central-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0dae9de8a9dcd2e9d"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-064e2169708764d90"
                         },
                         "eu-central-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-01030410ee9cbc086"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0cfef20a03960f368"
                         },
                         "eu-north-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-05ba2d43c02013067"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-06b64ba0802fe632f"
                         },
                         "eu-south-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-03ab46074a1af1ea2"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0b53a1e1785f43655"
                         },
                         "eu-west-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-02c31b435f3941e5f"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-09fd02b6d65b7f01c"
                         },
                         "eu-west-2": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-043326b6355e073d2"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0fdd197f3232c5f8c"
                         },
                         "eu-west-3": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0bed580ea5e44842a"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-017e4228e3a4f0dab"
                         },
                         "me-south-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-01982a2855773ec29"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-07fc2d336206f8670"
                         },
                         "sa-east-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0e7c9526f78c82c15"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0be6d5887c44f817e"
                         },
                         "us-east-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0d229cf2ee64e7752"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-00f120e7ea40d440a"
                         },
                         "us-east-2": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0e99e4c2ca19237d8"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-02639c6340fe607b2"
                         },
                         "us-west-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0482905b9da9c54fe"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0194e76c014e51470"
                         },
                         "us-west-2": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-00184cdbdfa05c0b7"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-039f0f51c00ef9a79"
                         }
                     }
                 }
@@ -190,85 +190,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "790a6cc93e383a4dfe4f54b887d0b09924310f1bf091085c516cd534c16aa564",
-                                "uncompressed-sha256": "cd43984dac9add3e5cb5b08473102021b45cd2514ce6687f4794b8066ebeba20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "b4ec6635e759880768f25e63d933db0684e95f05f0d526ba0d7a21770d0b05d9",
+                                "uncompressed-sha256": "905397f5f92a0324de9b6c216307eb423c77f9fb5871b9bfca2ecd99301955c2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-metal4k.s390x.raw.xz.sig",
-                                "sha256": "97be9a19df6abd51e2dd7ca9cca8233604f7b77e324adefe65e159a13e27018d",
-                                "uncompressed-sha256": "962b89580211f1d5d964c91421f4973e4d4b047e2d2dcf50a1c91d7f4c120534"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-metal4k.s390x.raw.xz.sig",
+                                "sha256": "c0252749a05e5f9e519158c9557249537a5b6bb542579cf2c28be10ee1b04ab7",
+                                "uncompressed-sha256": "28a1e2021d0cf283979f4636ea2c3c19b628fa4b046b423a462aafe53142669a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-live.s390x.iso.sig",
-                                "sha256": "0f03b85610607aa896ea9b16d92e0d3ebe604c848c1abd5e5fd748de0325fb44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-live.s390x.iso.sig",
+                                "sha256": "6cf21cf9f6993fe860316c3dba7f8ef87b22b1fe555753d4bd317d75307522f3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-live-kernel-s390x.sig",
-                                "sha256": "9acd61a7c5c12a8854bc4ff34c6fb02f3f85ee3ff9c0846ed286034c0fbaaeb3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-live-kernel-s390x.sig",
+                                "sha256": "e65218e3ff6f77e90432d45833a78e575d36e2bc27428ab40484523b1c583c30"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-live-initramfs.s390x.img.sig",
-                                "sha256": "bb7c3aa7c3ce99432c8f9d2f181b5c31ec613fc7ccb29def10d036c1fccabb88"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-live-initramfs.s390x.img.sig",
+                                "sha256": "5dca9112ef6c90b82c142b36104a436ef8a3580e84090104ecd36027be00eab7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-live-rootfs.s390x.img.sig",
-                                "sha256": "0f1fb94269e310f69a27467e1e3844f658beae97d28f5a6e920dd7b93fd0b3a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-live-rootfs.s390x.img.sig",
+                                "sha256": "f410284bc38373b51f25d623cf3520f2e4629268cd70eefa2604d59693479454"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-metal.s390x.raw.xz.sig",
-                                "sha256": "c47b5cc3da02c4e7bbc793d7d282dcf5a58d05c198b9a59266455303b17ce535",
-                                "uncompressed-sha256": "b56de65dfae6b79ecb354916dd84cb0b87fcbeb1dfd6157226c0f009a3ed8ac7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-metal.s390x.raw.xz.sig",
+                                "sha256": "bcb94c4d3317f3e75143dcd2021cf955b454f782caad50a91beecabb05ec24bc",
+                                "uncompressed-sha256": "ae4efc94539360b0d7ea54bbee7900730098385e3726905ea46ccd2234ff3007"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "38a468bf572934ab69dc24c18fe3732582e5581eb08fd39d295f2121b1c61954",
-                                "uncompressed-sha256": "2dfdd115cf4e0a9dab20905a3cfc359f47fa1a0e8f778930f17552751d77badd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "b31064012f6267648ab524a9291a5d23947c4cc4a2e9b6469ef29b0905b6fda9",
+                                "uncompressed-sha256": "6deecdbf7a01de9eab25bd9e6c792b46d6dc39212a4cc5f78622374e62c705e5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/s390x/fedora-coreos-36.20220723.1.2-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "be2ce924d806c7261e2218aec9fa2bac9dbc903bd40147883723e5084c71d535",
-                                "uncompressed-sha256": "28b0bcbb4b68518f54af2b8f721bf6c93d3d699cc807b235a16008e0a5a1ed77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "f8fbc73f515822135073977f3c49af2f256924502aed64cc5c07ac2a18955d77",
+                                "uncompressed-sha256": "7fde7a9e48ec6b800ccf443586f877fa496af89985ef1949d1d266c00ca1d86b"
                             }
                         }
                     }
@@ -279,225 +279,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "a93c5261ea1d3811ccbe160bd09794c526f9eca5f5ffa856e4f7501e476c4f6b",
-                                "uncompressed-sha256": "02c46afd13fe55224ec7bff30bb4705ecc9f4a3bd0b2045aa83ae48600a765fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "3df86a02dfb8a94ae4d2c00c29828ee7273a00d53f45210bc31778b9e497d667",
+                                "uncompressed-sha256": "663fee76502602c8e800290575fde027362d4fe4ef37bfd08c6c6514c46450bb"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "0b8d2ed4f71efb906ee89e60a43d0121171843a652e9b90d7edf051e75105bd1",
-                                "uncompressed-sha256": "c4ddb596fd19b817773cfd229774e1f4eae33075eda3d59a04a5cafd4e07f95f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "99ce60404432fc0063463a5592bfa5f84a57e71947c8937e0b9e662e2734e19b",
+                                "uncompressed-sha256": "8ac905c4b6b9189ff45c191258f24a7d5ca047617b1bc75d474956d690f9cc8c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-azure.x86_64.vhd.xz.sig",
-                                "sha256": "0a11e364c10d9550fcf679c79aa74ac87f8b3976e267d4b63cbaea9dbb1620c1",
-                                "uncompressed-sha256": "dc81466cdfd6799f2ba24849cf3788464ebdc0b1e89dcf53770f235f13e68768"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "fe02e9dd0e9ee249e981d7bdbb4095c2e9b286d4e6cc2c02fa046514ad0cad21",
+                                "uncompressed-sha256": "2902b09f9a1187fb500afb8e0eb9ab660da14e99689a07b077f3cda8f8fb22a3"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "b4f34d4e3ffd84fc92becb479c3cd353c16fbd77e76eed21a1ce3516382a7838",
-                                "uncompressed-sha256": "ce07202a702985f308522f80b398ac23836592593eaecb1f9e4f265974ac22e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "ee12932d7cf4a05591c0e17eb307a43898648d0b2d9e8fd70839b52ad5aad1c4",
+                                "uncompressed-sha256": "483b20ffa329da603641c21b2ae844631692bd51c5a953e98c3697792ee19e79"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "bf28038cb8a7682e11ed2f9fdd7eea1363cee055ba25d46389aa83bae16980cd",
-                                "uncompressed-sha256": "802e8693d316c96a1bc1494a15c8108a1cb1cb9ee6a63b31b088d242fa6aaa4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "94026a3bba68f13a49318c794202eafc2cac0d99364c29e2cef3c97c5d721f9e",
+                                "uncompressed-sha256": "6bb47aabf36c3020cc4d5328fd0066565b230494bac000038b53231670abc48d"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "30464fb0762fcabccf1b0991a189ca8d62e449081d0f3e480fadd8bc0b1848e2",
-                                "uncompressed-sha256": "a790b21ceb74c9d41d9d3682b4de497172b3ece9c16af73249da694d01d12184"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "87263f31581a57ad09ea9092a1c693febd9240bded4bf4f5413bccb8a02a8671",
+                                "uncompressed-sha256": "e55579e059ff54ea1e0981fdedd3ff52975e62ac542da4b6d83ba22b58fed3b6"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-gcp.x86_64.tar.gz.sig",
-                                "sha256": "c1ad5a219c1cd0c385ecad7af6c17eeff8f75a1aae0406764c3c08b0e73e173c",
-                                "uncompressed-sha256": "a72fb2a1e6ad59851d06b98ebf2e3930a96af7e8a45ecf6f776e92c0840e2b6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "845145fb031f6bfa126470e07a0d835ae79b3a1613d2390dd8982e348549ba54",
+                                "uncompressed-sha256": "9db9ae08fba9a18407c7da713510f7be4b6b8d5ab6ae0a2fe6f2ce93fcc4d929"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "861aa5839fb276d8d43a8d4d012b48f410eccfc7b887b820e156400d0a5a0d47",
-                                "uncompressed-sha256": "59b04957dfa766d657f1716ec482b741527844f354c9dc59a52d2d3917dbd0dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4475dc3a79976390f28d185e14834ace3d70675d339d39d75eb9b0bb1b400a36",
+                                "uncompressed-sha256": "774f4e13bf0da7bc880d6635dae7bf006ffbdff9d888ea81df4d266f146a76ea"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "2a93f09b8179ee64f915af75e5b23a4917d28ad8765bc8124c887afb4f1eed2a",
-                                "uncompressed-sha256": "a08d26de880cd1cf6516b666b5f344ff5293ec3656a272e9b5d6fa9e6893e897"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "cc3b6c62296b929e72f8ab179e402674f23c6e39e07674f52f8b089e1404644b",
+                                "uncompressed-sha256": "ce229527966d6057ab879130d8fefcd006a5b2f4b9f49a6977c95768434d2c44"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-live.x86_64.iso.sig",
-                                "sha256": "68f046222dd4559b7d041477c065c86705dbe3ac9848e2409ad7d4cfc943b93a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-live.x86_64.iso.sig",
+                                "sha256": "22f926294717f134d087aaebcd57ee263c91839648217857182b5719b61568ff"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-live-kernel-x86_64.sig",
-                                "sha256": "38640a1e99cd2e0e0e9576638f2cd11fa254c4a7a543cd3eaa0c156762444558"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-live-kernel-x86_64.sig",
+                                "sha256": "1d5ca9c4dcd29bcab564e5326f10a31d2ed1eee4e8f53225f775ccd69edb2abb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-live-initramfs.x86_64.img.sig",
-                                "sha256": "307354ca4b037df3d00cdbaaca43ba9c3cf4ddfe07f6d8b401843b08df70ed47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "fc0cc05ceb818413428e3e9a8559b5d1a45d9aeb1cac3d331d57b00dbad4d6ac"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-live-rootfs.x86_64.img.sig",
-                                "sha256": "9cc84e1cd8bc65b8b349c7defdb83f185d48f60b6ce4b3f53f18652ce67cb72a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-live-rootfs.x86_64.img.sig",
+                                "sha256": "f1d2895385ef3d079f3aec7ba55cc0112d507a165fcd0658adf5c9390ce08992"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-metal.x86_64.raw.xz.sig",
-                                "sha256": "62029dd26b795dda81a727ae49b6a1bd1405dbc5d3eb4d6b64055265f2bf87ef",
-                                "uncompressed-sha256": "663ff7e16d94311bdf99c670d1ec69bb78441d38e2f966b9a9bc47e387973e21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "a303465b6537aa42da02598f7695e858b975cdaab9beca406606701cfc1ab686",
+                                "uncompressed-sha256": "3a3b55c7aa8094cdf00c7d55d75c417cea384499a523aea2a2fa87e3c7787ecb"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-nutanix.x86_64.qcow2.sig",
-                                "sha256": "1984f10c6ffc5596a3ff1192c1f6489953c37f6ad67f615c5c556773cda6a5dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-nutanix.x86_64.qcow2.sig",
+                                "sha256": "da3e0818ec57336c576111bb33639b7850e21ed81ef5be8879ad69d9df0f4c4d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "55460b6e2a98e881beb8657790c21bcaef3ec348280d8b530eb1cb1f1e4ebefa",
-                                "uncompressed-sha256": "f7327bd1723695170e306b7013666f4987d40acc8f4ee1cf38b1c0b461074716"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "825588acc00477125ef2ad6a908e00a2033be69e2a2f56a3414750020d924851",
+                                "uncompressed-sha256": "3ec1cd9dbcccd394d45ef325918626b7333c93affe1b75a234324615f34a175f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "890a09b5f4203edf4a064d035f3052559c87f71f4e4f9967e9b767742f063562",
-                                "uncompressed-sha256": "f620e9bdaa1da7e3393d3e4d06dc1a5ddb2b5f76d4b67632371082bf9044109b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "a30f0b40d5c2a623df62da8d1c8d34f8aa8ea93735b046d72554c83c6c4e0ad4",
+                                "uncompressed-sha256": "ef005767a46d89267ebdafa6bdf0de42ee946592a1411edb83bc6d8eb8f9ca0d"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-virtualbox.x86_64.ova.sig",
-                                "sha256": "43df60317932febc31d94537c59b5ab5ad3480a83fb1e9bfd4202f4de4451395"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-virtualbox.x86_64.ova.sig",
+                                "sha256": "c6a6bf54196c4f332dc000a3f10cb038edc5147877ae97d30e37d689de19e2c2"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-vmware.x86_64.ova.sig",
-                                "sha256": "e03f9172210de89eb7f87bf4e8c9dd574533a476f18c3f99c021ce202c392e97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-vmware.x86_64.ova.sig",
+                                "sha256": "558d59e8a4a1974e92be73e785fce14e6807d2204a544e49288304d3d3f3a063"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220723.1.2/x86_64/fedora-coreos-36.20220723.1.2-vultr.x86_64.raw.xz.sig",
-                                "sha256": "5b400f7d2ace8c73fc8befd8416a016dd61de7bc02dc57054ca0ac8ba3a8c633",
-                                "uncompressed-sha256": "8b73601f8a159daa3277b94b0f0be6c98eb7af5c4d3f863d7555a170890134bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-vultr.x86_64.raw.xz.sig",
+                                "sha256": "c85d0bf80811e08a34db167c5f11dc8067ce34c57fe91c56179db4db53a256fc",
+                                "uncompressed-sha256": "62cb280ffe98368dfd1d0867d747d3d369577a9b1253733776d5701da8285029"
                             }
                         }
                     }
@@ -507,100 +507,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0528076b3547ed257"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0cdc15e3be12f60da"
                         },
                         "ap-east-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0a24302b9734c2be5"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0fb80c75be5698885"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-088ce60a942a1c07f"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-06435cad47baad2fe"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0e74d627f3055527b"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-06b01633efa8bf6f5"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-09fccf1af632e7c19"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-091323eee1ac634c9"
                         },
                         "ap-south-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0e7e4f888921b8def"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0d9fdd36fd42604c9"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-00feba79daa14910e"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0d73132400e87b88b"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0b3f9efe58a3ddef1"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-01ef51c6763abe1e3"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0ac421816ffdfd53a"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0e177d6fbf442c3e6"
                         },
                         "ca-central-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0710d7b5d5104a4ab"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0edeba61d7f1a73de"
                         },
                         "eu-central-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0d5f8dc76a16b97bc"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-03ebe1902cf8ae39a"
                         },
                         "eu-north-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0be8bac3d938a2410"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0e8d026337a9431b8"
                         },
                         "eu-south-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0ce69b1a986dee829"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-03ef81ef48ee1dfb8"
                         },
                         "eu-west-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-087b442ba44d18859"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0534ab9e3efc26647"
                         },
                         "eu-west-2": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-075262fa2ed7feb66"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0ec973a6310de452d"
                         },
                         "eu-west-3": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0b1c12effe7b94a17"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-02c33e1cfc5c6c119"
                         },
                         "me-south-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-051c8cb0f69c84b62"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-01ff27185c77b9da9"
                         },
                         "sa-east-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-07af3bb89598b7d4b"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-08ce12bcffb190f56"
                         },
                         "us-east-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-067f17e4e2a284a29"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0d792ded469a992fe"
                         },
                         "us-east-2": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-08d81dbfb668e3122"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0f45e24db820ce5ea"
                         },
                         "us-west-1": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-0cb968cee64a7e899"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-0c8cc32893f7b90f6"
                         },
                         "us-west-2": {
-                            "release": "36.20220723.1.2",
-                            "image": "ami-081110f5271a559b5"
+                            "release": "36.20220806.1.2",
+                            "image": "ami-05fc87c508a80e18c"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220723.1.2",
+                    "release": "36.20220806.1.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-36-20220723-1-2-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220806-1-2-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,92 +1,92 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-07-26T22:48:18Z",
+        "last-modified": "2022-08-09T19:24:27Z",
         "generator": "fedora-coreos-stream-generator v0.2.7"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "50114b48c259917cc23e761e840ead7b198de329885ae0f21f7221debab5826a",
-                                "uncompressed-sha256": "a0221aca5415844ef67cee7a41130c4be23af82a62ed32ea045be623a20466d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "993d117052017c588951ba77283b56aebea47e74539f89c932325799bfd0cec3",
+                                "uncompressed-sha256": "76ccadc05cf3a422b89031e15003ac7d0691a8ed893ace7d31485718888f51bb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "d7d28f92c131049efcd816973e4048d4dfb00ae129cc947e1a9fa544d2195c08",
-                                "uncompressed-sha256": "3aa96a4dd18d4b37d74114eea3bd2e51ee8f88fa3e82282f642b093d6ffa1965"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "4544cffe9d7d92c19b43bf279ee3682c00ace38383300c07d4b17299109cfa75",
+                                "uncompressed-sha256": "919ae4cbeb25b5a60f4a5a88c41dd1ab988f8939c0010bde99d68d0c2b7e5903"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-live.aarch64.iso.sig",
-                                "sha256": "8361b662d2f8da93cf02b1c4fba76b63e080b74bd01525ce735adab153557804"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-live.aarch64.iso.sig",
+                                "sha256": "4b8d55524c17eb398ebb7f9e3a50e1b2556403225928cdc3e7f63e7dd85dafb2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-live-kernel-aarch64.sig",
-                                "sha256": "a5c1fa086cd43caba102bf1c8590055b01d1ab0c78901992dac654bcf1cfcf7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-live-kernel-aarch64.sig",
+                                "sha256": "63d9b9c93536aae9d07bf3031e0a259624c1cfbd6391a15cc7a0fcfad504b9d2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "1bc72e1261524faad57ab97ce9b3244b66585bb63e57bb83589f963a9ad91c08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "ce8cae6add4e17019ecb354d18f99180946196f072c870070cc3cc1b86a3a9f0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "710f5164a844d56d116ab95fe3456863a95a424cfcf5dbe6007ce0a2842fa3d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "cef799f9fa6ae3e6001b71f6e069d50eb3d8ab4cd6a61327a76c5b24be548578"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "1552bb0275e0ec60e36288220c4900fafabf120f3f2fac0cf9b30f0a65012966",
-                                "uncompressed-sha256": "af4db59f39010580b8ed6a215530f6821a5eaf72254b2bb5bb3dcb6889435641"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "130949671b1eeb09a5713d0cfe569a5acdf53bd9cf9594aeae81acbbb148025b",
+                                "uncompressed-sha256": "121eb6f8e79c7ef25c2a067cabcc97f3e8706ae14aac0f35e23f216397e3e7a6"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "c2cf06ffc32f58387e2ac9dff5e6a1396c026957f29ec24797be8c8d8cd30014",
-                                "uncompressed-sha256": "3f6fd939a9424f7c845357f26edc19cf2de1ea6ad893994291c26f321e216469"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "646ecdef8b90fc5b06d0fbf2c57082cb023c518442f18c7f8a71a6deb1e2602b",
+                                "uncompressed-sha256": "1ff7d09156b7b577d68a1366fa425791a4362ed063bd087ff5c06e975e8aa038"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/aarch64/fedora-coreos-36.20220716.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "69c705576af157a7e9ba82eae9e17f9d5bebed2f563ffb0beda4cf2510a209e1",
-                                "uncompressed-sha256": "74ec86d5ef2cc6539a255822ccf3acd2aa9dc8bdfeef0d724fd9ca587f401dec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "e66762fc6ce0b5f5c67bca4f0aedc9a07b94b71371a2c40c1848cd83173c94a5",
+                                "uncompressed-sha256": "778c0da7ff25047964e0e4b61a6beaf7f5a41ba53f08a5d25920880ac5faf2de"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-09458e29a8edb9f55"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0fe52ff142e4253d0"
                         },
                         "ap-east-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-0902e1fef48a3c3f6"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-07457c7d258957a89"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-064f3aa9a186f7a4a"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0a8762fd61756e8ae"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-021fa9153efc5603d"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-09eb86129708dbeae"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-0cddbc17fccfc0d68"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-081f284dbd2284d42"
                         },
                         "ap-south-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-092111d625e4a5972"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0140cdda1ddd65427"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-062c310291b474c18"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-08ff95818b5684857"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-016e9546ea3fe3fa3"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0e1d8761cf3339626"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-0ea417ecc87b47805"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0888c9401b96cf218"
                         },
                         "ca-central-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-00f884f01aae093f6"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-07fe232adb0d80a1e"
                         },
                         "eu-central-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-01fbd1f8b9d81c085"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0e8946b97649daefb"
                         },
                         "eu-north-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-03a71754c9726edd6"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-01a49553f68186db9"
                         },
                         "eu-south-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-07e93e7de1cf4952e"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-019dffa1be8cf3a4c"
                         },
                         "eu-west-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-07fefbe9a7f1ab216"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-08d4a3fc229597073"
                         },
                         "eu-west-2": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-04db5ecc5c11ee46a"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-05cb310dbdf5159c1"
                         },
                         "eu-west-3": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-02eda8fb651ff5278"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0269a9cd7ab196b61"
                         },
                         "me-south-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-07aa996711bdcab9c"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0d99f71afca309770"
                         },
                         "sa-east-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-0cb2e1800f821f5f6"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-05023d5e3837c3c8a"
                         },
                         "us-east-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-0d5d573cf24d48189"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-03e618b1cad25042f"
                         },
                         "us-east-2": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-0a340df91ed606210"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0ba1f50ea68d6f51d"
                         },
                         "us-west-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-0e743824c54556f34"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-008f7fedd22f6fd5a"
                         },
                         "us-west-2": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-010f9efc48c5acbfc"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0ece1ca3079e2d7d7"
                         }
                     }
                 }
@@ -190,85 +190,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "eabcc0c8b7b2905e83107c05f7f4dbb6ab67bb114f2bee329c80d6f52fe3394c",
-                                "uncompressed-sha256": "8371aa07cb7529d7c69628ae1176ef622f1c44c4021485fc35611a1cbf32065c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "54888a2aa2a66cc4e3e884d2e1b418fb9661e79660dbd796ae470ed30599761b",
+                                "uncompressed-sha256": "d43df669d3e52e69471ef861d328a1ddefa48e2607e7c9ccf63ce4eccdf90e92"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "42e405fbef76e9b2d1d2e13731860b1ccc04419b39e8d529098072ee226335da",
-                                "uncompressed-sha256": "7dfa8330cd5ab5564832959332a34d772e02540a792f88864dc6c372d359a3b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "4f9b19cb816b447eecd5108e04890c7de8f463ab3f2b6c2a6617c9be4c28fdf6",
+                                "uncompressed-sha256": "fd149ef69c263e2958ec41023f0a258154b5d9c6478fc5b389506b9d4899fc00"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-live.s390x.iso.sig",
-                                "sha256": "5a73582778ac61e56c8af4b3e22d356f022528f731c97d921c7d8deeef61c738"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-live.s390x.iso.sig",
+                                "sha256": "f4bad09ef867d1d979421aea42afc5a08218f9a6663106624a0b17a9f25e5678"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-live-kernel-s390x.sig",
-                                "sha256": "1917ea368be5acc97b062330a4d13111517b357d8dbbb277215716da1a8b0a92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-live-kernel-s390x.sig",
+                                "sha256": "9acd61a7c5c12a8854bc4ff34c6fb02f3f85ee3ff9c0846ed286034c0fbaaeb3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "f05ae880ef9562a5abf9cc98b3baa972ad6b5bb4a06ed177fa854e2a4e540dde"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "7f5e4c82fef5f6158d02f385dc85983cef8c09ea3a7d029e789b2829dfeaf00b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "4b68f855eb0eb491f9b73c8ff8ef390d139a8b391ca6c5d059302fadbb532d52"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "81bd9c407640ac748fe4f3bdc20e70e34cac8aa76161ca6bb45f5a869dbe808a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "7e6c96f55b5c3d96e2a2602f0198447baec1c378331162df87625c8aa42decd3",
-                                "uncompressed-sha256": "18657e786f837a87d88b1baf803bd5edb7f299c3cd7d09259ca408792d7e0ab5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "0045fdb1332e3d96a7eff161f70862bda3fec3606dcac8c9731e719f59d65d9c",
+                                "uncompressed-sha256": "d47fc349039adb1ad173004535c64ec5cc28a31c5b7c584870476ae7e4770703"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "4ae22a8888369ecfacdb4dec007cdef054329e07fed3c235a817c6eddfcfec12",
-                                "uncompressed-sha256": "7fc5551bf19ab648c935877beb6557abe9f22612cd9585207a9bb59ea3e0da4d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "078e79e46a2b985dc5874812a0c2ae364cb3f2f3a5c139f9d9aa61aeca23cc1e",
+                                "uncompressed-sha256": "e1ab4cd103dc7d5377780a59b9ca720b7328347fe44726e8509fcc57fe1b5230"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/s390x/fedora-coreos-36.20220716.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "7a50ba125a25896d4ed726e71f54f63df16d841846d884d5fc10d7d4c58710e0",
-                                "uncompressed-sha256": "1f842ca7c509c56d50d3aafbfdfd3c7ffd535190f29a1ac72cf9c24e7498e3b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "c9987c232df882fe128cad877c385455395e5f9a2624d986dc405e8e0c07e147",
+                                "uncompressed-sha256": "d98513662968e141b7ee0de376dbc74afe505d4326a42c450ff4b895f6b7d5d4"
                             }
                         }
                     }
@@ -279,225 +279,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "968702458ed501af66adc2b33d3fdd56e402cb9408865b59430c7250eb70acf7",
-                                "uncompressed-sha256": "97880477b9d352b314bfb6149f72d9780d2f3c1e6d21770dc5fe854faa2cc733"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d4ac8cc6697f42914c84b60be21b04fc813a0cc80dc37223b353c12d97b26ee6",
+                                "uncompressed-sha256": "05d5f89b0fe6cb67e5e30fddc1bbf0515444794b3d09058b7db0a898c3390732"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "6b6ec4bbd4a6b2c6bbd160680d2f8057d18cdb7e6d79b3f7dec53f984b511c47",
-                                "uncompressed-sha256": "e03843f960b790f051c24c480e1a0c09807d6cc92eb0bac8f2b0855a3885de3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "811055233530eda815dd6b85c350f516492a823a972fd7bcb0e3c06383f7c0ca",
+                                "uncompressed-sha256": "462cb744d0e72a5a85ca4182591e939d6782ce952ebefc3a92742eca2ff932b8"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "503ffe8a800da60ab36cfd8b7e3336c80bc2e788943c4e8c3ed31203976f513d",
-                                "uncompressed-sha256": "db5f10dfe79fecf8e11da9d8d2bd198cee78fbc84b1b3e909ec31102fa520641"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e3a36abefb47e848aca25ed1c71d16045e17c50fbf48a451d97f0fe6b9d2cb03",
+                                "uncompressed-sha256": "5536dfee93406122869b9faf8b45646e5844124b356f84a0a0c003c13d93d20f"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "33c0914dc5548393a0e974ef0839ef871e02cfe269ea67a310cd7fc5995d59fa",
-                                "uncompressed-sha256": "68cc46879aaca35f13b20a68ca3e057cdf61ef0844776c10239e27c924326b4e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "8baa0e2409461f1aa5bfbf4aaaff4d344b11712a37ba409e2f56ebccddf896dd",
+                                "uncompressed-sha256": "e5a7ec66f2c347aa4d670e09df8e8d69e4f930455bdc8511253c88a3fc1f901e"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "cecfe4f408a75d7fcfa52e880bd708e294612f42c51119fde72205c88842081d",
-                                "uncompressed-sha256": "ec1583d6b3844b2b0e95150f8dbfbed8228f90efa721b0a0a6ca6ff080b3a8a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "781b1cef11086c400ea52df94cf8eb9989565173f251cbcc35e90f8b9cb714be",
+                                "uncompressed-sha256": "953e0be155d43ec865182757a940fe1fd00468a0948b48f443c2b0d920610962"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "8364411d8886e0cffb2dd25819d82733ec894ad6ada62bad33b779f7b90f8666",
-                                "uncompressed-sha256": "cafe173b28bbb33289d59966f172fe7c436551d06d03c6095d70e43820a6c07d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "71882fb6e4c0ee7456e387522a3464c15835c8e263d2ff35d99d244b42de150d",
+                                "uncompressed-sha256": "f521276df143494dec7634aae6486e86b866829148b1a3baa9856fae0df05b2d"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "6b892f8d8768d1f11111886dbbbb3f387c0f50263cb72a14b7e85199c04c977f",
-                                "uncompressed-sha256": "da516d9b6c8de0414d31dca97fdc2236e209872b7e3fcc33ebd33fe15e03a75a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "d3da628e1245aa6dd76fd473f7563828d05462f172008ad84265eb91ad3ee124",
+                                "uncompressed-sha256": "107c8e6100a4bd337238a358223be32ced7e424c0517227de112ad3b4e454988"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "69c8de5fd0a85f1a4085ebb9cd0c1b0bff54d7ecb6a8a2ac100fb82030ee6616",
-                                "uncompressed-sha256": "e2e154a800f6e1edcb9a297ff3cf2c3ab3888373039644dcb1db9a4c55ad8c87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "d71e681c5f221fcd9a1e75fef721fe2a368b7d004475ef328a47db06edd33128",
+                                "uncompressed-sha256": "c045c280beec8be47c304feb511064fc0aa9b74db8fe5d7c6db5064be2a75199"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "52da283f1d76ed74e79ba9812fcf4bae009914ee7fde44f3b474ae30243db04c",
-                                "uncompressed-sha256": "7f3b40affa16a9f3f69aefdd48189f479c365067f2507e08bce393efbda8beb1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "0392e8090d071ba0e0687ee3dfaf7302cebaf8e5c97ecf3c6a41497a85730ccd",
+                                "uncompressed-sha256": "fe1e18bd44dbb96bca4fe17b06f9416505f5db660a4f8d1d155e93f3ab89e016"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-live.x86_64.iso.sig",
-                                "sha256": "ba6e27a66f9553de2bb0cf0952ca031171a0dc66514a3ec10590b3158394879e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-live.x86_64.iso.sig",
+                                "sha256": "8153de5017005d48139fcd9123b3b566c8ed74c78d0cdc4d097daf31b666e328"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-live-kernel-x86_64.sig",
-                                "sha256": "a834a9a7230b3efaab2362ebc5b3733bacbc320b145989fa9f70c0d3dd3d996e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-live-kernel-x86_64.sig",
+                                "sha256": "38640a1e99cd2e0e0e9576638f2cd11fa254c4a7a543cd3eaa0c156762444558"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "ead9fd86dbdbac1076c4e9fd9a6c6dd83bdfa89ba2a74935ddccd9249ae7a21f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "f0e89b393420727652f728bb7ead125e5ae2469528e22ca292124577c83d7385"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "668e093bc441eb0945ba7bb5e8ac5bfcf880fbc6bd909386e442f813b8f551b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "2672ca5608facb0bcfe98ed6e96eef5c7f38f88e01baa4e2a7642761cff9c1e3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "fe7e2084522eea78047279327e6d5de8b97d80f1cfda43e47a5d64c2e330e0a6",
-                                "uncompressed-sha256": "cc9a610392a8f59ab9bd8679853868bcc52c99e8c8d5a7965e50458197781286"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "e8407874183c382382dec40a951f97134a85c6b8cb7f4dd41615613813d2803d",
+                                "uncompressed-sha256": "9050947238c4db5057952916cd5df8b61138bd6f09ba160f76c696abb8b2bd23"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "81cd04f462eecd212b1d05a2909f21a01203403c8b7a932be2c5bef851bd1df3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "4b5c3f6b89cf3f4a23a5c640a9e939c16446c8ab338cb37e4f47c880b411f1c3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "065e483f74f101197ce9856dde4eb0ba8fd48d45b62204529694949d90371069",
-                                "uncompressed-sha256": "f9c4309ee7a86161927fe16003fbb8cd8fe66343a186c8cbe7220f5963b1ee12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "4706b8ba811ffa0f3e04ac6e4b7767b524b624feaa83d02599388ce39c7edb5e",
+                                "uncompressed-sha256": "f283720a23cf7c3a31d6d8df2331ee4cd855a559e6141b61149b8666576e1f11"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e2393cbe8e3add8bf9bcfb367a4f6fdb6291ae8b87ae903d494261ce5ec5d5fa",
-                                "uncompressed-sha256": "f169ff86f0db885fe3c261a2783f68466fcc99c9c9f55e611367dd2ba2f2f24d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "5d24bbc536fac409d21da1c8de5d71b72c25e0079cd871ac49020555af382fb7",
+                                "uncompressed-sha256": "7c2f3cb4d033d318ef3eb548251063c608022ca8593bb4e354e6608cfdafaaa2"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "422baee330339715be0e7a5e7a7ca6299e7e046e89dd416d5fa70853ee46aa23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "d0ae8818634a0e1fe2f306aa9062b5338635d8d886789384ac40ab83a65ee44d"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "e448b601ee2a67cfabfcc27bf413bf29efc44c679930b5c117fe7460f2547930"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "833fa537eb2095d95af74c2b3f1cca7719e109f6fecbfc9b45c967ce9afadc27"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220716.3.1/x86_64/fedora-coreos-36.20220716.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "0a361b854c60b9144e70b65140c742c34ee04272af2af878ea6afa3e75624e42",
-                                "uncompressed-sha256": "9931df0523823ffd576a5075e16c354ab9e5e57041f7dc2d9a47d56e780c1f42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "1e9e37a77a3157a3aa0c5fdcf040b5c17118d4d7c6cab9c135a41e9e61357d4e",
+                                "uncompressed-sha256": "1d0116cbb19645c5b4a47053da0fc971be21f2c7f9688f72406dc2136303f84f"
                             }
                         }
                     }
@@ -507,100 +507,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-0df263b11352f2940"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0b46530958895bb5e"
                         },
                         "ap-east-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-0c6776eeba7f76262"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0c17157cfdc11e89e"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-0c7a551d1824a8cda"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0e83e7bb8e2e46120"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-0a970a8d871e85c4a"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0ad22697170f295bd"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-05e26ff1441ff95d2"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0a624d480f97cac75"
                         },
                         "ap-south-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-05e0a92b92b01fbe5"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-04cea480107bcad88"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-07e57b7002b52eca5"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-02b5b3b00caae983e"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-0aff2ba00bcd6adf5"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0bf40dbaa56903323"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-00df2f3705e6b882b"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0d5941390d899cd3e"
                         },
                         "ca-central-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-00d6571dc7548fc03"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0d72521810f718efd"
                         },
                         "eu-central-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-0037cfd83bf77778c"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0d604afe1ac3ce5dc"
                         },
                         "eu-north-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-042d15dee4c643d65"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-088253c4d0feda8c4"
                         },
                         "eu-south-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-088f96a19b2e94d0e"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0d991209fe0527ebe"
                         },
                         "eu-west-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-03625cea0b495eede"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-063c37796b12937ed"
                         },
                         "eu-west-2": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-0001c9b25b9ca6731"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0c645bc951e47b74e"
                         },
                         "eu-west-3": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-000d4f5e28902476d"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0642e4624ebe4e4ac"
                         },
                         "me-south-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-02664b3c387db55e8"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-05e35384596a8cae8"
                         },
                         "sa-east-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-083be92a06ed2729a"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0cd3a896cc796b955"
                         },
                         "us-east-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-03929f88dfb4b1c1c"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-04f5bfe37e5d3a7b1"
                         },
                         "us-east-2": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-022b6f47cedd241ad"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-08658218b24784245"
                         },
                         "us-west-1": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-06e1fb9c118f0a557"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-09b132163d40fc122"
                         },
                         "us-west-2": {
-                            "release": "36.20220716.3.1",
-                            "image": "ami-064b01edffc8550de"
+                            "release": "36.20220723.3.1",
+                            "image": "ami-0c856d27d072f70c6"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220716.3.1",
+                    "release": "36.20220723.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-36-20220716-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220723-3-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-07-26T22:48:20Z",
+        "last-modified": "2022-08-09T19:24:28Z",
         "generator": "fedora-coreos-stream-generator v0.2.7"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "bbea346c12328368de4d28c620f40817bfca0b818cab508abcc8803b25b93caf",
-                                "uncompressed-sha256": "7747cba4610a5ff3036f8148c5ca7d9fd33df9fb79650f94391cf3777069869a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "d67366aaaeb8857aeb4b41aabdb79133441ba9b10a10a74dd017e294f463454d",
+                                "uncompressed-sha256": "cf76c0a90d76daf19164c830e647b2e319a8581daf6622ab883d1bf23bbe2160"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "05736b127acc090ccaa31e9d3d4c67cbb65f4b7af7e8fca5fb2cc148858a71cb",
-                                "uncompressed-sha256": "791218b25ad6a8aa9ffc61237c669bbba473ee0848134aef6866ad8c27d69999"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "f0a394ecc6c00b6a621d948e9ae689e3e2f461678ca81544d8622111d2cb1275",
+                                "uncompressed-sha256": "df55bff023b5feaeac3800a64c7e2001cbfd60e020fe965613b757f179c5f402"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-live.aarch64.iso.sig",
-                                "sha256": "d0170ed9ca0640ef4d41e2e7601edca469be06b6e2bb8fb6fae085f206b3fa60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-live.aarch64.iso.sig",
+                                "sha256": "3489934ebbcb4890851409adb595618f68c6d38248af7a10755d13d7e48cffa3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-live-kernel-aarch64.sig",
-                                "sha256": "63d9b9c93536aae9d07bf3031e0a259624c1cfbd6391a15cc7a0fcfad504b9d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-live-kernel-aarch64.sig",
+                                "sha256": "4da34179a23797b370977134e9323a97ea061862dc09030ba494c9598a96a922"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-live-initramfs.aarch64.img.sig",
-                                "sha256": "baa12fa5858a1bf6f16ff6c91ead32629504751e0b62b4fde2ce9f74a24cdd4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "bd3e3bb7dfd94e68eba13f1ee247e72e6340114bcaa4917d10221f52406f2e57"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-live-rootfs.aarch64.img.sig",
-                                "sha256": "cc1004a2eeae428f73b4c0e69a8ac1abefc21f3822720d24f57564bab5f73102"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "05c9c64f46d7e60de63bb888aeaa4d43226f70cf6fa73ebda4d64efdbb9e5654"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-metal.aarch64.raw.xz.sig",
-                                "sha256": "23ec681091a5ec05f4faab6cef058e084b8fb61b30306b2f6759dde55268f384",
-                                "uncompressed-sha256": "5e749c07d1ea45546c1acca55fd2af1f860725545e4213b133cf1d42e5f21acc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "01eb30cc635bd89a275f90af38e44abd26dfda570250311050d2b83a682fddcb",
+                                "uncompressed-sha256": "cf8ea3c8d3a37294da7040ea42d048f3be0f08f18b3375a79f62f49dfe44dcb0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "969d6744fa8168435d21b6f6b63f2c864e65b30927e23c0dab0b4bea984f547c",
-                                "uncompressed-sha256": "d28579a58b7dcb4bc74d7765f7e46496a96305939af6b3cd17a36a866d0f9201"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "6f98b3e67da76f70236bdb38a9f474b050bc084f6a113418414931881c6ccdd0",
+                                "uncompressed-sha256": "a6ad8f76e761414d3e205976ad8fb80e70d2aefbcf5b03a32d34ffd26df14be1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/aarch64/fedora-coreos-36.20220723.2.2-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "f12f1a787e0672468fb87bb3635fdfa5e290a7a5355e292f67152736a238665a",
-                                "uncompressed-sha256": "c2df2afad03a05ff4e3cf9256098234b35b6467533cd6b7e67c89a18b0e45568"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "cd28884e765f981f4e2846af64594e4a46adacae0a9fbf6e157c03185e8ce615",
+                                "uncompressed-sha256": "5f70d8a413cdf0a646c069e0fb4888853a1d3ceec780ea5b7225be8f6e8fb0fc"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-06ee88d676c66e832"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-00fcafe6797228970"
                         },
                         "ap-east-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0c1c8d95d544be3ab"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0a50957f8cf2e18fc"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0201f7d58bd73d8f7"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0c2274fe41f4b5060"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-05f982af0b18e4b67"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0b94fe6bff1b75971"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0e267b8ce5a40287e"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-07a5abcd9ed05d0ea"
                         },
                         "ap-south-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-04a77deb15d5b09ef"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-04b7c090bbb29de08"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-03c66bd8e315c9ec2"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-01e31913342815e9b"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0770df2f7c8d91a08"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-02235f156c76a003d"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0fc26c6ddd120091f"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0777ac4aa76cbf4d3"
                         },
                         "ca-central-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-08f312e982099dc40"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0e22dc21409a3cc6a"
                         },
                         "eu-central-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-03c7aa75790e2eceb"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0a2fed03cb7f10f32"
                         },
                         "eu-north-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-08f73070eeb195d77"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0e302c2077a7107ac"
                         },
                         "eu-south-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0da33069dd996783b"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-062ed2b0b529de0d0"
                         },
                         "eu-west-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0b253d9af04244faa"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-097c7c7fe6ff1d514"
                         },
                         "eu-west-2": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-06c67bc086547744a"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-049e952275cbcea94"
                         },
                         "eu-west-3": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-00a5ece55cd0b0e2d"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-009a333e7b4f5005f"
                         },
                         "me-south-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0905daf5ef9b15c03"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-09efa59d26fc328f6"
                         },
                         "sa-east-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-07ceaeabe0a5aa8c7"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0fcf139c68d4353b3"
                         },
                         "us-east-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0749ebc5c99d6c42b"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0303ae2ca2620ac0e"
                         },
                         "us-east-2": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0931d1c16893fe3a3"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0c1403e6193f43c73"
                         },
                         "us-west-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0f25f357ba30ba9b7"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-00a82f7b1ced3a2ac"
                         },
                         "us-west-2": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0da792e71f66f171c"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0a339b0a2979cfc28"
                         }
                     }
                 }
@@ -190,85 +190,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "a2324d1d0b47a20177df7dd9a4d0a2015bca6a01af40abb4c2f7eb93f1a3d0dc",
-                                "uncompressed-sha256": "05295967e94be65c28d3d7a59f26696c2fde3c6bfc0979cd6c51d4d823c009bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "0939605ad846dbdc3775ab6258f096e875cc583a579015fed8c449670ec260e0",
+                                "uncompressed-sha256": "606cf059c375bfb14d66b479931157e967238158ce0316ea9bea1dc206671e79"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-metal4k.s390x.raw.xz.sig",
-                                "sha256": "b6c73ad70f92d6eb8e7fc5b9b241d5716ba75749f6e7964c2cf39d02f1285e46",
-                                "uncompressed-sha256": "dc10b74b4d6fdfa355ef38323e9eada47ff14547f3f3d4efe4f1391af2b95d76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "fde003da2071aabbc153069405adae646d4f1775350a335966f9ee2d3a2fbbaf",
+                                "uncompressed-sha256": "c5917fb82b972bd9d4bbb8648f42ea77c4dda206385e296a6a7f0120981d56b1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-live.s390x.iso.sig",
-                                "sha256": "a964824ceaf6eb6f0b8f66b01f4fb69ffbb74a8399d8af64977f8b413b3f379f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-live.s390x.iso.sig",
+                                "sha256": "3c3af1d96a96a4a02b49213fcad1a76d865235539c525802c5428e0f46c81bf6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-live-kernel-s390x.sig",
-                                "sha256": "9acd61a7c5c12a8854bc4ff34c6fb02f3f85ee3ff9c0846ed286034c0fbaaeb3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-live-kernel-s390x.sig",
+                                "sha256": "e65218e3ff6f77e90432d45833a78e575d36e2bc27428ab40484523b1c583c30"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-live-initramfs.s390x.img.sig",
-                                "sha256": "d1168e503e174fa014d6d59a8d8cec448d9d42bfa846e5e9a2d733c4f829cb8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "bd1f8c35f063d1b42bfb70235f73529c1fe6d7799d4a4630b08cbd168af8b78b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-live-rootfs.s390x.img.sig",
-                                "sha256": "5344642fec86a03bce2f546b24dd0a7e4462001e4daa35b31368f27a247fbca7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "437c8faff5f4c40568c474e587c98ff574f29d0fa81fe64386d4d1e2292bdcea"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-metal.s390x.raw.xz.sig",
-                                "sha256": "85d1bd51989a67d97ba092a2d3f0c4f04e32e9cee9466b4c30ffcbd4d3c5f4bf",
-                                "uncompressed-sha256": "4ba56de9277ff33571f65cf0f527cc718d246be567c072be9b42751b1f444883"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "4c3fc24c79e08db773b9410dfe8bea5bc3215c5a2a8306cbfcc35d4f37d2062d",
+                                "uncompressed-sha256": "b53e4b267845fe43dbb315342eeafbd40e3762f290e24de1c06507b0f7034d23"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "f8e3ae39e9aedc83fa89e84fd731f72e6eaa5e046a13837e7a429e9b56e44aec",
-                                "uncompressed-sha256": "b8bb375ff84836f21c7f552ef28523f396d3145edc394f3fe0479412f3a731c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "16125b7ff9114477ad0eadd29d515a2062e36fb934b4c6be1f0551824ba95885",
+                                "uncompressed-sha256": "32daab21f61f731ba0afa37048e0ad9fb6e17674aa006a9ccdc3f87385c43f60"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/s390x/fedora-coreos-36.20220723.2.2-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "a5be12555759a6b3feab24efc70a60958faa24a437c518bef69965af168d8ddd",
-                                "uncompressed-sha256": "1d03c786dd488e459423c64c85103ed2e534337c2671588111acbc249e74ddbc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "2689080367bebeb924e8989bd180fe5f2607330fdf0914a881770c0847a0b485",
+                                "uncompressed-sha256": "8a6f4d0aca568f73d45fe6122df30c2a476afe4f9848c1e4414f2bbc9f050085"
                             }
                         }
                     }
@@ -279,225 +279,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "85d98e4e0f0e8572a3a577f5d872b761dccefb69ef226cf48cdc1d849bf30045",
-                                "uncompressed-sha256": "55bbdd8d27c81f3efb7321aa00b5fb14924a8b6d63b221e329c745eb1656b29b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "9c78a0c8d1d4f9f93f53260561f7fe2a7a5fa356b42f8fd2f391f63ba2e98e14",
+                                "uncompressed-sha256": "640cc11db706cf2fcd6adcf593a12050002dc32228efa37ce0629ca8dbae39e3"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "926bbd0f389ab927e03d348e60eabd6f5c5e36187408dd4102f6cfb7a08fb945",
-                                "uncompressed-sha256": "83102b339a055d2a04bd9c8a95ee966aecb778b1f30d537a708bf3bf0fa7501e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "f05b125cbe7bcea068548d90e1feaf4465ab691a389bc4d8058ee5a43266d196",
+                                "uncompressed-sha256": "784e7f5fb55fda16674d6ed81e73cb4379778b532804ea04f7a5317323da1631"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-azure.x86_64.vhd.xz.sig",
-                                "sha256": "a0c04be1266a079f813e47c2dd22215a4d369092a2990dbe4b2879f00740a258",
-                                "uncompressed-sha256": "ebfa66c937a3448accffc2f76eb8b862eb7eb934bb89909e9daba9eabae95447"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "095c94929ef7de26e6b0192c3f68f3ee532b5b999009ca5ee75275fab3bc59ff",
+                                "uncompressed-sha256": "97f2207a7c4b737cae6961fde567141e5cd1cc7cc59cef16a00a5a9ac7fc5f44"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "7cb35593a9f8db09b3760b1474c6e5140421fd9b7578a816377865ee17829756",
-                                "uncompressed-sha256": "6761fd17349badb514b02ed7a7eb6a9cd3cef331b504a565d265db772fa0a364"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "992b1618e2774ae5bacacc9432752bc8e653175dc8fde8dfc8e68ee2e4de6483",
+                                "uncompressed-sha256": "08b695084804f3b51ee3797d27cab0f20f3ca96f1a306876d1688a296413e6e7"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c9c9883a946be181f8eea8b229b0702fc5b111067716a946e33b63af01cbf058",
-                                "uncompressed-sha256": "74ed60c6b99a73eb298e3bf671cb44971d67f945dbb5eff7477d6316874c3bb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "5e78f1d19fff470888a4e37dee9d7e4cd9809024ce149ba5fb9d247565f681c5",
+                                "uncompressed-sha256": "95f2729808ea46b7c2bd38cab51ae852d92781c4e6ba6b0d9d7da64990de51c4"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "81af608a75a812779b804b1972081101c51c574bf32c694c64d15957df8f34d6",
-                                "uncompressed-sha256": "9ac592f2102650d8da1c7124c7bea0880777bd2f35b8edcd62ba4372c01e290e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e96ec72d869c62583333cd081a3cc4f4037f177ac1bbeeaab08e828e4c76668d",
+                                "uncompressed-sha256": "aa1bb231b3e11dc21dc14d7222b5558983fc2a76d027f78dd3042f7134589883"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-gcp.x86_64.tar.gz.sig",
-                                "sha256": "b990a9591e0a6b26f588f09519dc462e169a38219074a7a839772ea8f915dd21",
-                                "uncompressed-sha256": "4b4de028ff127fed1a1d04f3bee70b9cc858f0298ca0de3ac895be0525cf83c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f5a7b18d042a5e9a70c1f633a4ec84c246f8f281027b28966f79a7374896339e",
+                                "uncompressed-sha256": "549c58043d3a2ad23c17839698a4b2b2197ac81b8161b2a8bc38abab3ccaedbf"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "6aa96f4f38b9cbab8a06ffaf05d6b2f6e326282947203de5257b8be9649b1204",
-                                "uncompressed-sha256": "94cff39c9638b48f7d7457c9236a790e035056e186ce142484c4456a57668635"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "a57e89204d398b7421dbe64240cbd963ec00e5941cb8174330efe644604ca9ec",
+                                "uncompressed-sha256": "0771ce8a2a97b1281188651c9d65a7c1d818d303134dabf6fcdbadabf04953ff"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "26f6c67414f8741f49c676d8b170df6fad3d8bc5b053930a892c46c59a4ec6ee",
-                                "uncompressed-sha256": "ea2eadb2e458fe9cb6461db02bdac80aa8d87807babb997561f9397b23dbf987"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "489ca1627c8288c1d61650a34383b37cee8cf79fac157d547439e6c52df2d842",
+                                "uncompressed-sha256": "4a616b61900046b66f55fc3eaca131c7067a171aa071dd15a59ddcbd43f12607"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-live.x86_64.iso.sig",
-                                "sha256": "984207aafe1b5e17545c2794150e299310c41c3f5036b94a353ef5628cb75435"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-live.x86_64.iso.sig",
+                                "sha256": "f9c835f72dfc1aa79883dd44dd9f801fd8a588b5a1042fdd5b4fdfa0787a2786"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-live-kernel-x86_64.sig",
-                                "sha256": "38640a1e99cd2e0e0e9576638f2cd11fa254c4a7a543cd3eaa0c156762444558"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-live-kernel-x86_64.sig",
+                                "sha256": "1d5ca9c4dcd29bcab564e5326f10a31d2ed1eee4e8f53225f775ccd69edb2abb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-live-initramfs.x86_64.img.sig",
-                                "sha256": "ead76ecc91b2b5ae55ecee72f92f675361c3168a90046409d21e11a9f2cb8fc0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "fe927e4def169a801109b2502bb559eb4ce5cdc550e1dd051b0a0051765716cc"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-live-rootfs.x86_64.img.sig",
-                                "sha256": "d607f0006cc2d43ca45ef9ec31650585b513537292fc4ac8eb56225566d6a9b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "cb303487107204ab95b5ddca482ca232512eb74885e4c0c8f1235cbe0854a166"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-metal.x86_64.raw.xz.sig",
-                                "sha256": "09367fa285504f0b862ac9a105c23c64ead8142e2738426d1edd208bc4b33210",
-                                "uncompressed-sha256": "81b704558c5a2cd08907cfc32e22d8043b72e5b664c4c4bd9d9c362f12c6794a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "d38f4ca209a519a4ef99603d20bcb5b2fcbb0759ec707828ef8f5ff42f289b91",
+                                "uncompressed-sha256": "e66bc44ce86d33d60adb4992d233e84b9284d78bd925245c852c181693851ce5"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-nutanix.x86_64.qcow2.sig",
-                                "sha256": "e5b2999a48459c76b882f633de175fa973d4677560c7beb6a16a778926f7b910"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "89a2235fbb24c31ad52fe33c12c91dee10292b9097c64ebc701e19823a662e58"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "0a88272d945c363f8fb3ee7e5d3feb3fb73c56f7c3871352ac870d9290e2ca06",
-                                "uncompressed-sha256": "cefbf8df33b0c76bad57c5da5470cd15ef0a128af1026becfc43ab557bebec90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "997be748db04e44f61836168c98d8cec9b34cb9ddcf2e312804ad12eb640649c",
+                                "uncompressed-sha256": "3bea3f94eb4a6c329151a0a5aeef5564f30cfda0710153a1bf69063ba36ed166"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "4bd175e80220c7e5a811774b0e7c69d97e18081160480bb4787d69b6549e2aba",
-                                "uncompressed-sha256": "66dfe3e79b8a287697e47ba2a3e2d32c37a49fd8fc4be6c9c16d3977e9a58b10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "4cc10f7a5b2734121430e4cbccf688dd3ba31cd41412525231d0fda17583a17b",
+                                "uncompressed-sha256": "cf3099ba30b57e70a27436460dd4710f0e4b61da146cdcabb75d45fcb46303b2"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-virtualbox.x86_64.ova.sig",
-                                "sha256": "4491f4aa322fcad4aecb27ffb78f3627264e8e945475d8c910db4be915e2d483"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "d2c1f79e3aef418562c684cac640a4fe9609a121dae119e641a06974b4229f13"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-vmware.x86_64.ova.sig",
-                                "sha256": "7b68b41c85c9c0bc977739a3806091f37269a3e8a853038f40d943e0d799aa28"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "88bc0885dc8713ca418703c733f74f0774b1e3d34e1d133daab90b2cb8122ecf"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220723.2.2/x86_64/fedora-coreos-36.20220723.2.2-vultr.x86_64.raw.xz.sig",
-                                "sha256": "df264167f892628d6b1889cd60fd59987eb0b3000603dca182e8f2eea8ba0cba",
-                                "uncompressed-sha256": "6989b12ae8dd6558bca910c251b4e0931a14dc96786d58b4799175885e3cce05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "3eeaec0b078655c94fb423f44455285e28ebeb06e262eab0444d2697a8803451",
+                                "uncompressed-sha256": "e2c509e46ee909cb6d035dc1104c4d02c125b52755b2105e9dea11b3b7e25c87"
                             }
                         }
                     }
@@ -507,100 +507,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0d28867c8a56bc703"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-09cf9c92ed6cbe398"
                         },
                         "ap-east-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-000c2759722a4457e"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0ec7069084a0bcd8d"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-06ebaf9b0286785b0"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0070a1e6061fe0c3f"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0dced6de4ccb7611b"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0e03bf04ed3636323"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0a57010b15bb428c5"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-09c5cfb1b4bfbccd3"
                         },
                         "ap-south-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0a9d587833d996851"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-08f35e463c848f4cf"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0f7d7405d1a0763e8"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0f6e0f4a01d45304b"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-09e19481df8a37106"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-004c758889470dbe7"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0e0f586fef3024904"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-03d16fddc72d7d369"
                         },
                         "ca-central-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-036e25bbd6ba26e8d"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0b87a2f510d38c474"
                         },
                         "eu-central-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0019bd3eab0b18103"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-096c9287412a65e1e"
                         },
                         "eu-north-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-046ab3819b80b052f"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0aae89ca5d455b5de"
                         },
                         "eu-south-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-00476b01ff6719ca5"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0e6e4a18982697fcd"
                         },
                         "eu-west-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-03101ea32651fa810"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-07a6b243652bdc3d5"
                         },
                         "eu-west-2": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0a792ebef3147a2da"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0dabc8244bda9dee6"
                         },
                         "eu-west-3": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-050139aa5a5c4f1e6"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0a89ab4c3ec353e8c"
                         },
                         "me-south-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0b7e77ca1c5fa9db5"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0fb9a07f09536a6d5"
                         },
                         "sa-east-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0ccab6e489bef88b6"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-03b3250900d327eac"
                         },
                         "us-east-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-068df0b4ca626835d"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-039dd128ae976e409"
                         },
                         "us-east-2": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0873ef85b9569a3bf"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-00f4d897304389f97"
                         },
                         "us-west-1": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-0c7afb2d2687a40f3"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0510ae74c08593118"
                         },
                         "us-west-2": {
-                            "release": "36.20220723.2.2",
-                            "image": "ami-043807f24066dbd87"
+                            "release": "36.20220806.2.0",
+                            "image": "ami-0f446c6ef1e4ab82a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220723.2.2",
+                    "release": "36.20220806.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-36-20220723-2-2-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220806-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-07-26T22:48:23Z"
+    "last-modified": "2022-08-09T19:24:30Z"
   },
   "releases": [
     {
@@ -53,7 +53,7 @@
       }
     },
     {
-      "version": "36.20220716.1.0",
+      "version": "36.20220723.1.2",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -61,11 +61,11 @@
       }
     },
     {
-      "version": "36.20220723.1.2",
+      "version": "36.20220806.1.2",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1658926800,
+          "start_epoch": 1660140000,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-07-26T22:48:19Z"
+    "last-modified": "2022-08-09T19:24:28Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "36.20220703.3.1",
+      "version": "36.20220716.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "36.20220716.3.1",
+      "version": "36.20220723.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1658926800,
+          "start_epoch": 1660140000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-07-26T22:48:21Z"
+    "last-modified": "2022-08-09T19:24:29Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "36.20220716.2.0",
+      "version": "36.20220723.2.2",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "36.20220723.2.2",
+      "version": "36.20220806.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1658926800,
+          "start_epoch": 1660140000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).