### PR TITLE
Roll out stable 36.20220806.3.0, testing 36.20220820.2.0, next 36.20220820.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-08-09T19:24:30Z",
-        "generator": "fedora-coreos-stream-generator v0.2.7"
+        "last-modified": "2022-08-23T20:09:19Z",
+        "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "e32f3cbbf4531d3bf55f113908f3d99f2dafb5c97e8e19934a90568747196dd5",
-                                "uncompressed-sha256": "fd2d0fc4edc378c47572a6d0652d03bcff1b98a3694fe518d981bcf1a0d3dbb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "2b5028a50b9fca39a6c7abf470f699fc6e8a6ad797c1297ee424d6462be117ef",
+                                "uncompressed-sha256": "30a59388c9d66a5e61b00d53cf9a7c8e41c4ac9d9f94012335d8a36bc2f7a023"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "66be0108ffdbdec27c48ea13ad507d5c3317f2216e5edae9bbc635916e766b7d",
-                                "uncompressed-sha256": "e3a897283d04ad10564e454d1cc5de46c50ec7d0666349bf28736798ad87052f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "70c85f06af6f8a6143d7d0b424fc0e891085fc804b2bf5ae5378b538a255927b",
+                                "uncompressed-sha256": "9ae0a31eadf7a685eb14c7102ec5571909c37cd7828e2dc9d927ad0667dd38e3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-live.aarch64.iso.sig",
-                                "sha256": "fd782ceb6171215bea83bbf4b87f6aabeb183e67329f258508964e1a099c93fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-live.aarch64.iso.sig",
+                                "sha256": "54350877f0c1fa72d50804f3630c05afb064a5af26a62c15f3b360991ef532cc"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-live-kernel-aarch64.sig",
-                                "sha256": "4da34179a23797b370977134e9323a97ea061862dc09030ba494c9598a96a922"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-live-kernel-aarch64.sig",
+                                "sha256": "fd78e3253466ca4e2243b13ba81fb6283442d665e914c2911cd07330a9a054c9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-live-initramfs.aarch64.img.sig",
-                                "sha256": "914aaab02295b5b9388480b335db8c384967892376589cb7635c57c34fd36217"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "6f9e3868d1efcbc195e119bc0668e21938946ee7232af5249f0c3c9c54c2d9ff"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-live-rootfs.aarch64.img.sig",
-                                "sha256": "a03c7f4cda6062c458612f5b40489e32ad12cdccd2bf6838119539e31358fffe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "cbe458ad83d03f337cf628349c4d9a1ff1b2567183ae4f4433ec54e28061e7ac"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-metal.aarch64.raw.xz.sig",
-                                "sha256": "1e7f0849f8052b5846d239b968bcf3f3048c06c29b90e82c65d49d3e47684f27",
-                                "uncompressed-sha256": "eb849fa252238a0ce29e9ca65e97dcb9a14b33fafd87dec17123d3da01d5f23c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "7131b89a74eda470ba8bb1d74e5aad16ca4bb6ac765795f6e03e7157ae3bd9f6",
+                                "uncompressed-sha256": "a7eb409b3d71958a3951a40d7f41de33b0a64e4ac165bc9cdd7bf7d92ac50f4a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "7b04c4b2c0445b025038b5e1b42b1bebe35f7dbcc782194c6aafda50b770b62a",
-                                "uncompressed-sha256": "82ceda18ab3e33064c70f95e36b48b8e88bf60da5df4668fe7c68a6969d6190f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "5c4a06e1214dad0657918f9b02ee4758bf89da3444f76e97b51dda48b2c4736c",
+                                "uncompressed-sha256": "df29e926a36920a00384868f3daeab9ca5546a5da9dd59ada12a74d5bdcf11ed"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/aarch64/fedora-coreos-36.20220806.1.2-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "b79731d40faca6fcd23c4e8002ebe780329ab4da3c6dc3c40a411611477da5cc",
-                                "uncompressed-sha256": "6efcc91b2651429c5265258bbbb14a4efee94267f3a9a6dcc492416322d207d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "56d32afcd1a56eb6e1114c867379ea3b9178b337b277ce299cea2aa6d1e2da5a",
+                                "uncompressed-sha256": "2a8791ea4592e44aa4902bdbddeeb0dfb83160128788376d4dc241984e5ccd04"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0f8d46dbdaa43bf11"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0c5209a18e500ea69"
                         },
                         "ap-east-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0d474ad3d792d3bd5"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-05db4d71da18de96c"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0e6e8edf0e008cb04"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-09f904483ae6f89b8"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-060b074cd7aba20b1"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0643208255f81d34c"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0e4633bb75374054e"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-012cfe4df0b6b85c8"
                         },
                         "ap-south-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-01ff89761ca15cf6b"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-063b1316475f91966"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-02cc435c1578253f6"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0cf7b5c7b752fbe7f"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-04a7b4c5bf8ac403f"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0868517fd7b0bc7ec"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-00d94027139261f6d"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0f4e7f6a3aedf136a"
                         },
                         "ca-central-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-064e2169708764d90"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-03e84909db236a3ea"
                         },
                         "eu-central-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0cfef20a03960f368"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-05fdbd9bc5d7c7e05"
                         },
                         "eu-north-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-06b64ba0802fe632f"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-03d38ab6eb38c58c3"
                         },
                         "eu-south-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0b53a1e1785f43655"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-055158fdb395049f5"
                         },
                         "eu-west-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-09fd02b6d65b7f01c"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0ef3ba34d86b2238d"
                         },
                         "eu-west-2": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0fdd197f3232c5f8c"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0406a782827ce15c1"
                         },
                         "eu-west-3": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-017e4228e3a4f0dab"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0f61107332373bf5f"
                         },
                         "me-south-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-07fc2d336206f8670"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-04f8e3b777627ac7b"
                         },
                         "sa-east-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0be6d5887c44f817e"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-03bca08507c986741"
                         },
                         "us-east-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-00f120e7ea40d440a"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0358ad2db266a2ce9"
                         },
                         "us-east-2": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-02639c6340fe607b2"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0625591af321e3a35"
                         },
                         "us-west-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0194e76c014e51470"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-00b96db2a59557700"
                         },
                         "us-west-2": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-039f0f51c00ef9a79"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0ce1a772d95138355"
                         }
                     }
                 }
@@ -190,85 +190,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "b4ec6635e759880768f25e63d933db0684e95f05f0d526ba0d7a21770d0b05d9",
-                                "uncompressed-sha256": "905397f5f92a0324de9b6c216307eb423c77f9fb5871b9bfca2ecd99301955c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "8d02008e59c8adc3c70ea1a733d2cc187cbe465900388118d03683bcc86b9c47",
+                                "uncompressed-sha256": "c0820ef389ff7bfaa9ec823bb3dbbd889a8cefe589dfa5b0d855e6382dcd1cfa"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-metal4k.s390x.raw.xz.sig",
-                                "sha256": "c0252749a05e5f9e519158c9557249537a5b6bb542579cf2c28be10ee1b04ab7",
-                                "uncompressed-sha256": "28a1e2021d0cf283979f4636ea2c3c19b628fa4b046b423a462aafe53142669a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "457b3ddf3076125b50071716686504e5f09064e907106fb766219b3d036cd42c",
+                                "uncompressed-sha256": "f882dbe2edc19268723759ff007c19c28567e2cdb994570edacc98bd7339eb7a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-live.s390x.iso.sig",
-                                "sha256": "6cf21cf9f6993fe860316c3dba7f8ef87b22b1fe555753d4bd317d75307522f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-live.s390x.iso.sig",
+                                "sha256": "fb8aaeabf0e74e711ea3ef89609c6daf0c4db325235883368f4e6cbccf1d24d4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-live-kernel-s390x.sig",
-                                "sha256": "e65218e3ff6f77e90432d45833a78e575d36e2bc27428ab40484523b1c583c30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-live-kernel-s390x.sig",
+                                "sha256": "d17160937e8a5062a451c7e161825048233408bb3b96d4d688f22f234afdb50e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-live-initramfs.s390x.img.sig",
-                                "sha256": "5dca9112ef6c90b82c142b36104a436ef8a3580e84090104ecd36027be00eab7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "fe5a87c8c75f39a335eefe1a2fe6c1879122428b70379a4d00d9a94637279dbe"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-live-rootfs.s390x.img.sig",
-                                "sha256": "f410284bc38373b51f25d623cf3520f2e4629268cd70eefa2604d59693479454"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "75b5bfe35abb6695d4fe98b18d096a9ddd0081da0b9f7fe139bba4d4aae2f3af"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-metal.s390x.raw.xz.sig",
-                                "sha256": "bcb94c4d3317f3e75143dcd2021cf955b454f782caad50a91beecabb05ec24bc",
-                                "uncompressed-sha256": "ae4efc94539360b0d7ea54bbee7900730098385e3726905ea46ccd2234ff3007"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "4926bbbd5c0f747413211941d1721bc310aaded252ed8cf54e028d72b71ce1af",
+                                "uncompressed-sha256": "9de385a09c4fa9eea41476356091dfd41f2a5bfd4c32f34699e23807240800f5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "b31064012f6267648ab524a9291a5d23947c4cc4a2e9b6469ef29b0905b6fda9",
-                                "uncompressed-sha256": "6deecdbf7a01de9eab25bd9e6c792b46d6dc39212a4cc5f78622374e62c705e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "18d8b0c60dab6301cf51dbf35a0a005a903db32f90c31ac2ebbeaff693ca04aa",
+                                "uncompressed-sha256": "66f5b27ba8d8be6825fe211b2b4164706608de5b00d53ef91ba881ce21d09643"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/s390x/fedora-coreos-36.20220806.1.2-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "f8fbc73f515822135073977f3c49af2f256924502aed64cc5c07ac2a18955d77",
-                                "uncompressed-sha256": "7fde7a9e48ec6b800ccf443586f877fa496af89985ef1949d1d266c00ca1d86b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "350ddaadd77cf2c35ac7ad3aaff4ff24725ebf98e070b996449fd296f1d28741",
+                                "uncompressed-sha256": "13077ea9b329a6dfe55c6f3fa2fd8e5ba5bebb1582d615412433a109cc41755c"
                             }
                         }
                     }
@@ -279,225 +279,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "3df86a02dfb8a94ae4d2c00c29828ee7273a00d53f45210bc31778b9e497d667",
-                                "uncompressed-sha256": "663fee76502602c8e800290575fde027362d4fe4ef37bfd08c6c6514c46450bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "34c48158147bcfc62e94e6046e44dd181f2f259c7a0a1756f722038392bb46a1",
+                                "uncompressed-sha256": "74eeefbf4eeb6b6af5e7e2f5c462dcc28d65ee2214634c09141ea46a8ad83916"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "99ce60404432fc0063463a5592bfa5f84a57e71947c8937e0b9e662e2734e19b",
-                                "uncompressed-sha256": "8ac905c4b6b9189ff45c191258f24a7d5ca047617b1bc75d474956d690f9cc8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "e955205a2afdc52e073f0cd761a291c1a4929de5a6480718b0fdad44891cdbd4",
+                                "uncompressed-sha256": "d16ab722ee5404b372057b767686533e27fd5772c96ec26a58c16708f63af373"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-azure.x86_64.vhd.xz.sig",
-                                "sha256": "fe02e9dd0e9ee249e981d7bdbb4095c2e9b286d4e6cc2c02fa046514ad0cad21",
-                                "uncompressed-sha256": "2902b09f9a1187fb500afb8e0eb9ab660da14e99689a07b077f3cda8f8fb22a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "9e434713e1a3a5cb2020607f08f250a5dcfb32fb5b7560def0896df27e0be4b4",
+                                "uncompressed-sha256": "69bf76d64dbe9fd9f6f34f333897e8c10e0b0fdf4c46eee2dfb7720f7ae1d0f4"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "ee12932d7cf4a05591c0e17eb307a43898648d0b2d9e8fd70839b52ad5aad1c4",
-                                "uncompressed-sha256": "483b20ffa329da603641c21b2ae844631692bd51c5a953e98c3697792ee19e79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "16caa7a891b1b5686d65db4aa2eda235d6dcc3930d97fad438abf59eda1947f0",
+                                "uncompressed-sha256": "171095e4148f7a90da6731428d83fed529c50ba6316693ebc94ff110a806d39d"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "94026a3bba68f13a49318c794202eafc2cac0d99364c29e2cef3c97c5d721f9e",
-                                "uncompressed-sha256": "6bb47aabf36c3020cc4d5328fd0066565b230494bac000038b53231670abc48d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "4d7cce68f6923f5c1deb976b4d80b35fbb44d31a0912d747cad9f3c269c0efd2",
+                                "uncompressed-sha256": "a4e7e79490d6e06974cee9fb73545fc4f2054fe998f95f7bbf25610529eecf3c"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "87263f31581a57ad09ea9092a1c693febd9240bded4bf4f5413bccb8a02a8671",
-                                "uncompressed-sha256": "e55579e059ff54ea1e0981fdedd3ff52975e62ac542da4b6d83ba22b58fed3b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "c9ed83f86c94e778d6c9f65cd935e09950be959fad21340d11333162a9645131",
+                                "uncompressed-sha256": "0d77e0604dfeeba2ac39e71033226b42e1bf6f8f42f18528cfbf9cf9b2dba0a1"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-gcp.x86_64.tar.gz.sig",
-                                "sha256": "845145fb031f6bfa126470e07a0d835ae79b3a1613d2390dd8982e348549ba54",
-                                "uncompressed-sha256": "9db9ae08fba9a18407c7da713510f7be4b6b8d5ab6ae0a2fe6f2ce93fcc4d929"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "8945a0afd39eb7ff9ef821df88a18eb820915884c16f5cf1bb2e388cdb062821",
+                                "uncompressed-sha256": "e383d77c9c60ea4be2df6ccf1c903742582fe2d4a4716126e0eed1b2a11f8760"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "4475dc3a79976390f28d185e14834ace3d70675d339d39d75eb9b0bb1b400a36",
-                                "uncompressed-sha256": "774f4e13bf0da7bc880d6635dae7bf006ffbdff9d888ea81df4d266f146a76ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "b6a4a64da46e32c0628397a0ca49328c829fc6fd6b78abd1675a97bfab536691",
+                                "uncompressed-sha256": "426b1a03003f7525e396531c66437b0aeb9a4a259c1d929cf760916729308dce"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "cc3b6c62296b929e72f8ab179e402674f23c6e39e07674f52f8b089e1404644b",
-                                "uncompressed-sha256": "ce229527966d6057ab879130d8fefcd006a5b2f4b9f49a6977c95768434d2c44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "536428b0b926bb5d32a9df8987a2f027f1731133e3a0f8091b7e709008652db7",
+                                "uncompressed-sha256": "4ba9d97ee306d20c78003b200581abacc2120a5aadf7b6396ab8a2fa1ef5dd13"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-live.x86_64.iso.sig",
-                                "sha256": "22f926294717f134d087aaebcd57ee263c91839648217857182b5719b61568ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-live.x86_64.iso.sig",
+                                "sha256": "b1b8bfca616f033823154043821ac70735a3edb66e2a9e83abd72f512a37dafd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-live-kernel-x86_64.sig",
-                                "sha256": "1d5ca9c4dcd29bcab564e5326f10a31d2ed1eee4e8f53225f775ccd69edb2abb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-live-kernel-x86_64.sig",
+                                "sha256": "cbb8198d864e4a9830cacf7a19992a6712fd61607bd92684967a0b913b7f5a6c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-live-initramfs.x86_64.img.sig",
-                                "sha256": "fc0cc05ceb818413428e3e9a8559b5d1a45d9aeb1cac3d331d57b00dbad4d6ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "3ede954e9360e31f8b523ef6d371d4163beff55e33728162f3c09ad9bdcf8613"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-live-rootfs.x86_64.img.sig",
-                                "sha256": "f1d2895385ef3d079f3aec7ba55cc0112d507a165fcd0658adf5c9390ce08992"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "921531b3584bd646c3c2e97c2cad4c650df0155781d76c7a28e532694ec2c939"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-metal.x86_64.raw.xz.sig",
-                                "sha256": "a303465b6537aa42da02598f7695e858b975cdaab9beca406606701cfc1ab686",
-                                "uncompressed-sha256": "3a3b55c7aa8094cdf00c7d55d75c417cea384499a523aea2a2fa87e3c7787ecb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "3368562c9e7900bb72514528650ce9af93747c212dbdaf6e828be9667b07e02e",
+                                "uncompressed-sha256": "3bbc80537d8ca6a9b9c7a4cfe321977528c1f308ba1dbb18db2ebe27ead906c4"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-nutanix.x86_64.qcow2.sig",
-                                "sha256": "da3e0818ec57336c576111bb33639b7850e21ed81ef5be8879ad69d9df0f4c4d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "8f659b27e05a0085f75dd5aba044d796ed95595377ce621f74dcf702a6104e24"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "825588acc00477125ef2ad6a908e00a2033be69e2a2f56a3414750020d924851",
-                                "uncompressed-sha256": "3ec1cd9dbcccd394d45ef325918626b7333c93affe1b75a234324615f34a175f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "a5cacb23fb5ed4b7da8d5bc96cf6a3901f4d387090e5477096681adc036a176a",
+                                "uncompressed-sha256": "7b1786d68e57abb923b4fabfd6c24cdc946008d40d61c3733151cbe6c05a2e34"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "a30f0b40d5c2a623df62da8d1c8d34f8aa8ea93735b046d72554c83c6c4e0ad4",
-                                "uncompressed-sha256": "ef005767a46d89267ebdafa6bdf0de42ee946592a1411edb83bc6d8eb8f9ca0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "05240a5c85c6d6fe7d642566b54a698a67ac16097597fda5a3ca5c8c2bd1c542",
+                                "uncompressed-sha256": "f4083c99ef008308e6c18d5e2d6d46506d9ca380e4c0655a768dac237446efdf"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-virtualbox.x86_64.ova.sig",
-                                "sha256": "c6a6bf54196c4f332dc000a3f10cb038edc5147877ae97d30e37d689de19e2c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "7b1775615dcfc89ecd38050d91e2ee1b3a469a82a7c1edb24aa4a448539ec7ec"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-vmware.x86_64.ova.sig",
-                                "sha256": "558d59e8a4a1974e92be73e785fce14e6807d2204a544e49288304d3d3f3a063"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "60f8e1caed338e82cdcffeb104622d03c073ed52144812953fb2b2820f9509b0"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220806.1.2/x86_64/fedora-coreos-36.20220806.1.2-vultr.x86_64.raw.xz.sig",
-                                "sha256": "c85d0bf80811e08a34db167c5f11dc8067ce34c57fe91c56179db4db53a256fc",
-                                "uncompressed-sha256": "62cb280ffe98368dfd1d0867d747d3d369577a9b1253733776d5701da8285029"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "b706ba5589ffa85e53282e63f0d5c7d3ce533e39ca345c6bdc01c5d993887362",
+                                "uncompressed-sha256": "f5e156837fc05085c6b1170e5ae03808760c441f8ea12a9cb744f5c4e6b5671b"
                             }
                         }
                     }
@@ -507,100 +507,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0cdc15e3be12f60da"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-094250c3719f8db39"
                         },
                         "ap-east-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0fb80c75be5698885"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0e107e5dd5dc3449c"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-06435cad47baad2fe"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0c69e806dfa248c5f"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-06b01633efa8bf6f5"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-048981990816d091c"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-091323eee1ac634c9"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0dd4d7b65672a142c"
                         },
                         "ap-south-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0d9fdd36fd42604c9"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-003c8b5da6743d73a"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0d73132400e87b88b"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-09870490569bcdbb3"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-01ef51c6763abe1e3"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-017721186043bca07"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0e177d6fbf442c3e6"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0c1f6d9e0f449c6c5"
                         },
                         "ca-central-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0edeba61d7f1a73de"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-058b63c148e2bf034"
                         },
                         "eu-central-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-03ebe1902cf8ae39a"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0530fd6d024ee3693"
                         },
                         "eu-north-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0e8d026337a9431b8"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0f049ed235dc67d9f"
                         },
                         "eu-south-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-03ef81ef48ee1dfb8"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-01ce21354cea4f1e5"
                         },
                         "eu-west-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0534ab9e3efc26647"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-01366a961cd4cb073"
                         },
                         "eu-west-2": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0ec973a6310de452d"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-087801be084a89a18"
                         },
                         "eu-west-3": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-02c33e1cfc5c6c119"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0dc98fc442e14ee10"
                         },
                         "me-south-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-01ff27185c77b9da9"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0b7c54a8e6b2f63f4"
                         },
                         "sa-east-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-08ce12bcffb190f56"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-025d501a383e513f1"
                         },
                         "us-east-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0d792ded469a992fe"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0143d6b5ccb7f466e"
                         },
                         "us-east-2": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0f45e24db820ce5ea"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0ddf6fbe0d3986dbd"
                         },
                         "us-west-1": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-0c8cc32893f7b90f6"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0a7e3849bc1dc5a16"
                         },
                         "us-west-2": {
-                            "release": "36.20220806.1.2",
-                            "image": "ami-05fc87c508a80e18c"
+                            "release": "36.20220820.1.0",
+                            "image": "ami-0511d197921db0a54"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220806.1.2",
+                    "release": "36.20220820.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-36-20220806-1-2-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220820-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,92 +1,92 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-08-09T19:24:27Z",
-        "generator": "fedora-coreos-stream-generator v0.2.7"
+        "last-modified": "2022-08-23T20:09:15Z",
+        "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "993d117052017c588951ba77283b56aebea47e74539f89c932325799bfd0cec3",
-                                "uncompressed-sha256": "76ccadc05cf3a422b89031e15003ac7d0691a8ed893ace7d31485718888f51bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "67262f6716355e3ddc08248c8426aba6b134da855d423108b300d4275ba759ed",
+                                "uncompressed-sha256": "ba411b026e590a5f0e5476775a07d3b76cef8a36f9e805e19a9826b902967080"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "4544cffe9d7d92c19b43bf279ee3682c00ace38383300c07d4b17299109cfa75",
-                                "uncompressed-sha256": "919ae4cbeb25b5a60f4a5a88c41dd1ab988f8939c0010bde99d68d0c2b7e5903"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "430f58fbccad838fbe40f5e26471f5254d84c134656b92de725d5f3cb49c9ac2",
+                                "uncompressed-sha256": "4bbc2f9dafa87abe9ad2863d564ae9b0a2d7841b2bc4eb4b45fde904a5dffd46"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-live.aarch64.iso.sig",
-                                "sha256": "4b8d55524c17eb398ebb7f9e3a50e1b2556403225928cdc3e7f63e7dd85dafb2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-live.aarch64.iso.sig",
+                                "sha256": "8e5aeaec81ec9afae039c5f54fedd1f59bd14b4a9f9eb86695b42097afc199bf"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-live-kernel-aarch64.sig",
-                                "sha256": "63d9b9c93536aae9d07bf3031e0a259624c1cfbd6391a15cc7a0fcfad504b9d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-live-kernel-aarch64.sig",
+                                "sha256": "4da34179a23797b370977134e9323a97ea061862dc09030ba494c9598a96a922"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "ce8cae6add4e17019ecb354d18f99180946196f072c870070cc3cc1b86a3a9f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "8959d228ec4b5b595b4a4261d13a604fef20ead1777cb451f04f29b64f380f02"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "cef799f9fa6ae3e6001b71f6e069d50eb3d8ab4cd6a61327a76c5b24be548578"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "1a5a84769ec96c5d75730ecd02f589e16f98034c4418cd89b2bcaa556593265d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "130949671b1eeb09a5713d0cfe569a5acdf53bd9cf9594aeae81acbbb148025b",
-                                "uncompressed-sha256": "121eb6f8e79c7ef25c2a067cabcc97f3e8706ae14aac0f35e23f216397e3e7a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "7f00aca412642d469c1c77a8316d6fb48ce4209abd0bb60312345f276a0ac8aa",
+                                "uncompressed-sha256": "5ecff1ee6cd2197c59dac2f1ec5041671b1991a972f8e53c99debcbd7ce50f18"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "646ecdef8b90fc5b06d0fbf2c57082cb023c518442f18c7f8a71a6deb1e2602b",
-                                "uncompressed-sha256": "1ff7d09156b7b577d68a1366fa425791a4362ed063bd087ff5c06e975e8aa038"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "7c64f5902e7ad1a51ed47968ff6cc41d9d343a1bea5ff3f0c28d6ad131083a9b",
+                                "uncompressed-sha256": "b883c49a2bf53120fc5fe6bee56c13e338503b647e5a8fd3bdedc7f522595e86"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/aarch64/fedora-coreos-36.20220723.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "e66762fc6ce0b5f5c67bca4f0aedc9a07b94b71371a2c40c1848cd83173c94a5",
-                                "uncompressed-sha256": "778c0da7ff25047964e0e4b61a6beaf7f5a41ba53f08a5d25920880ac5faf2de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "13e27d291a9a69f5e87ef7c47b27601c4ca40ce2bf3a6fb7487e0f33867b7125",
+                                "uncompressed-sha256": "42a92660b2adb795c077591fd3f4b792784f0f9041feda435094b2a677f2d02a"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0fe52ff142e4253d0"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-0a7a989a13e2d9e88"
                         },
                         "ap-east-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-07457c7d258957a89"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-02da21b321ac3545d"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0a8762fd61756e8ae"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-0534d1ca6c3d08c52"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-09eb86129708dbeae"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-04a12712a6c6c884e"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-081f284dbd2284d42"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-05887e8369c284621"
                         },
                         "ap-south-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0140cdda1ddd65427"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-0bdfb876076c8d81f"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-08ff95818b5684857"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-059f22308f97030f9"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0e1d8761cf3339626"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-06a016a2e7b22912c"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0888c9401b96cf218"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-0c5cffc8de29cc762"
                         },
                         "ca-central-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-07fe232adb0d80a1e"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-063d189663705795b"
                         },
                         "eu-central-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0e8946b97649daefb"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-092b0067d0c32af64"
                         },
                         "eu-north-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-01a49553f68186db9"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-0718686aaf78105a5"
                         },
                         "eu-south-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-019dffa1be8cf3a4c"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-06ee62beb006b3dd2"
                         },
                         "eu-west-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-08d4a3fc229597073"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-08cc094c465e3f482"
                         },
                         "eu-west-2": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-05cb310dbdf5159c1"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-0bce777f1560e6467"
                         },
                         "eu-west-3": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0269a9cd7ab196b61"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-04756327c0adafc58"
                         },
                         "me-south-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0d99f71afca309770"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-025c55d3777480f4b"
                         },
                         "sa-east-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-05023d5e3837c3c8a"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-041996e2bd4e36778"
                         },
                         "us-east-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-03e618b1cad25042f"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-05d80f942bd0ea9c6"
                         },
                         "us-east-2": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0ba1f50ea68d6f51d"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-038092397577b695a"
                         },
                         "us-west-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-008f7fedd22f6fd5a"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-038a9aaf5b5444d1d"
                         },
                         "us-west-2": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0ece1ca3079e2d7d7"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-020dcac64c6911e89"
                         }
                     }
                 }
@@ -190,85 +190,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "54888a2aa2a66cc4e3e884d2e1b418fb9661e79660dbd796ae470ed30599761b",
-                                "uncompressed-sha256": "d43df669d3e52e69471ef861d328a1ddefa48e2607e7c9ccf63ce4eccdf90e92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "35500986f6263cd319fd3b6233008716bc3b491e2d11d48466dec70998221bb9",
+                                "uncompressed-sha256": "c89f35e1573db497ddb2e2c9ded28b1f34677df8c83f77d15b33024cb24c0f4b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "4f9b19cb816b447eecd5108e04890c7de8f463ab3f2b6c2a6617c9be4c28fdf6",
-                                "uncompressed-sha256": "fd149ef69c263e2958ec41023f0a258154b5d9c6478fc5b389506b9d4899fc00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "2ff6caa929cfdc7b2c7420367ad99eac60d0f7776127071837bb1f80e2b9e58a",
+                                "uncompressed-sha256": "7d1d89b45b1dfff13046424ee2f97677b1ea5edeb4ae3ce943026c2147ef5ae5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-live.s390x.iso.sig",
-                                "sha256": "f4bad09ef867d1d979421aea42afc5a08218f9a6663106624a0b17a9f25e5678"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-live.s390x.iso.sig",
+                                "sha256": "e3b7e274c3ea2ee3e1eb13ed9e093503ad748aa3a1c6f56dcb653e7ef5d7595b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-live-kernel-s390x.sig",
-                                "sha256": "9acd61a7c5c12a8854bc4ff34c6fb02f3f85ee3ff9c0846ed286034c0fbaaeb3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-live-kernel-s390x.sig",
+                                "sha256": "e65218e3ff6f77e90432d45833a78e575d36e2bc27428ab40484523b1c583c30"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "7f5e4c82fef5f6158d02f385dc85983cef8c09ea3a7d029e789b2829dfeaf00b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "00d76762996bb77ac468408b88895ed495a80268f77b96a2fd507352e1824cfa"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "81bd9c407640ac748fe4f3bdc20e70e34cac8aa76161ca6bb45f5a869dbe808a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "e12d6f943bbc7edbe6a653134df9d78eeed9e41503cedbd7e77f205a29ec02c4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "0045fdb1332e3d96a7eff161f70862bda3fec3606dcac8c9731e719f59d65d9c",
-                                "uncompressed-sha256": "d47fc349039adb1ad173004535c64ec5cc28a31c5b7c584870476ae7e4770703"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "16e03ff4942a40d1e07d3d35ef8370e33c5a6aa93babf360b2a7bc13c6704c4f",
+                                "uncompressed-sha256": "f247bc3aab73b2ea6443f4154678ef69cfbf5375799598378f75d42f68471954"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "078e79e46a2b985dc5874812a0c2ae364cb3f2f3a5c139f9d9aa61aeca23cc1e",
-                                "uncompressed-sha256": "e1ab4cd103dc7d5377780a59b9ca720b7328347fe44726e8509fcc57fe1b5230"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "ffd7bf1db5af5bd26da8dc8aefc445dc2e2be0f0ee331220506d6296e31f667a",
+                                "uncompressed-sha256": "34668d1efce54960d5dce50498df1d570cc1eeab52b9bdb003ea4894ca76c004"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/s390x/fedora-coreos-36.20220723.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "c9987c232df882fe128cad877c385455395e5f9a2624d986dc405e8e0c07e147",
-                                "uncompressed-sha256": "d98513662968e141b7ee0de376dbc74afe505d4326a42c450ff4b895f6b7d5d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "59084bf3303247af86f7b8aecda9894df9f298133ed036eeb56897fc584a54e3",
+                                "uncompressed-sha256": "7cad7f203fc41431ae561205e9623101304a3b565527035b3ef59c029eb9d33c"
                             }
                         }
                     }
@@ -279,225 +279,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "d4ac8cc6697f42914c84b60be21b04fc813a0cc80dc37223b353c12d97b26ee6",
-                                "uncompressed-sha256": "05d5f89b0fe6cb67e5e30fddc1bbf0515444794b3d09058b7db0a898c3390732"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "4983e3f55246f457f97f96be09dc07d9620b82e031ea0c5f42d4ae662856d3dc",
+                                "uncompressed-sha256": "6bfbb7756f18adb079f576cac3670af76ee4bea93cd948073815064814a31b93"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "811055233530eda815dd6b85c350f516492a823a972fd7bcb0e3c06383f7c0ca",
-                                "uncompressed-sha256": "462cb744d0e72a5a85ca4182591e939d6782ce952ebefc3a92742eca2ff932b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "94d4dfb25c7e9f706b795c4eead393564456f2b6c415e6b103eb676c72567419",
+                                "uncompressed-sha256": "d111a134d1be84f278e9a3f46b8d5ce4f069c67cd3e47ea2ffd4de47d4765fb4"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "e3a36abefb47e848aca25ed1c71d16045e17c50fbf48a451d97f0fe6b9d2cb03",
-                                "uncompressed-sha256": "5536dfee93406122869b9faf8b45646e5844124b356f84a0a0c003c13d93d20f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "94715bb03d679af00dd61fbf4b1fe5bf9773bf156d50fe9346793cb90ef8d693",
+                                "uncompressed-sha256": "8f7224dc1eee5b3771b9f12600f9101d72ffa096b68782f04a3231b230111605"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "8baa0e2409461f1aa5bfbf4aaaff4d344b11712a37ba409e2f56ebccddf896dd",
-                                "uncompressed-sha256": "e5a7ec66f2c347aa4d670e09df8e8d69e4f930455bdc8511253c88a3fc1f901e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "99711231a609f939251260a5eef47e1599aa2d6051b165dfedf024eb4e266e36",
+                                "uncompressed-sha256": "6b9e42da92829bcac02c15f8fda9c1cabbd481f5034c1755e9af9449cac1e292"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "781b1cef11086c400ea52df94cf8eb9989565173f251cbcc35e90f8b9cb714be",
-                                "uncompressed-sha256": "953e0be155d43ec865182757a940fe1fd00468a0948b48f443c2b0d920610962"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "ec0c65cb309b020d2ae8ac3b40249d53ff8471a2ed718a04049673996561098b",
+                                "uncompressed-sha256": "5ba6235ed3b0f853d34be26df1a9f15f5d09e686b3fa93292aa8584ae6fae21a"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "71882fb6e4c0ee7456e387522a3464c15835c8e263d2ff35d99d244b42de150d",
-                                "uncompressed-sha256": "f521276df143494dec7634aae6486e86b866829148b1a3baa9856fae0df05b2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "65da04185bc91686725b4a0920c5278212958bdf7dedca09727426159912a355",
+                                "uncompressed-sha256": "3648a5cf7e137911dcdf8fa989ec34bedee50ca62b81c689a13fcdb77019f222"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "d3da628e1245aa6dd76fd473f7563828d05462f172008ad84265eb91ad3ee124",
-                                "uncompressed-sha256": "107c8e6100a4bd337238a358223be32ced7e424c0517227de112ad3b4e454988"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "cdefc3929a0cadc8c0c980de4763ba37eee8e9f29b27f62dc2e86c8f8bc6fff5",
+                                "uncompressed-sha256": "10f9600aaf907ae393761737f32998e52270cb17882025d38cb5ee5eb7441c7b"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "d71e681c5f221fcd9a1e75fef721fe2a368b7d004475ef328a47db06edd33128",
-                                "uncompressed-sha256": "c045c280beec8be47c304feb511064fc0aa9b74db8fe5d7c6db5064be2a75199"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "69e22653fce7be30c343e10602c9038f477d41f31c73fba46df38a9be431b6a9",
+                                "uncompressed-sha256": "e25e53edd9e63a925654442126821807496e4b049368bc8840d01fe08ce8b5dc"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "0392e8090d071ba0e0687ee3dfaf7302cebaf8e5c97ecf3c6a41497a85730ccd",
-                                "uncompressed-sha256": "fe1e18bd44dbb96bca4fe17b06f9416505f5db660a4f8d1d155e93f3ab89e016"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "8d5fd9c82c71e5fdab53e3365853d7db6522045e300ff7ac8425b862435e83d9",
+                                "uncompressed-sha256": "8e1d7e5eb1934e8e13799f6b89cd5d2bd396ac06357b7502c7ae14a8efa40aab"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-live.x86_64.iso.sig",
-                                "sha256": "8153de5017005d48139fcd9123b3b566c8ed74c78d0cdc4d097daf31b666e328"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-live.x86_64.iso.sig",
+                                "sha256": "b87d29f1af8c7b6a9aa326ef6e44d4992c73d6a9124bd5f3617a9f6e2445d83c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-live-kernel-x86_64.sig",
-                                "sha256": "38640a1e99cd2e0e0e9576638f2cd11fa254c4a7a543cd3eaa0c156762444558"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-live-kernel-x86_64.sig",
+                                "sha256": "1d5ca9c4dcd29bcab564e5326f10a31d2ed1eee4e8f53225f775ccd69edb2abb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "f0e89b393420727652f728bb7ead125e5ae2469528e22ca292124577c83d7385"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "6cce2b161b5e1403fa5e2047397f926ea04935d10a0cf19e405aa8c87ac3cb44"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "2672ca5608facb0bcfe98ed6e96eef5c7f38f88e01baa4e2a7642761cff9c1e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "6e31b872ad5c0338fee627ce65e6c5ac73d5b1f6a2ef8697ac39acf4587a0c2a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "e8407874183c382382dec40a951f97134a85c6b8cb7f4dd41615613813d2803d",
-                                "uncompressed-sha256": "9050947238c4db5057952916cd5df8b61138bd6f09ba160f76c696abb8b2bd23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "f180af371e9e9abfe1a1ff5275272ea7f12b0d88818a6824cf0ac8ce66c8f61e",
+                                "uncompressed-sha256": "9f19d51bbd7f9655127a47b16ae15e487a22a0376dc61327c7258779e3c70a4d"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "4b5c3f6b89cf3f4a23a5c640a9e939c16446c8ab338cb37e4f47c880b411f1c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "83e4f02be66c872fb7693f4a993ae1443940c758bd112b0593b8ff3e6d85579e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "4706b8ba811ffa0f3e04ac6e4b7767b524b624feaa83d02599388ce39c7edb5e",
-                                "uncompressed-sha256": "f283720a23cf7c3a31d6d8df2331ee4cd855a559e6141b61149b8666576e1f11"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "e90dbeb07a72b3967b3f04d3e608f779414c6b91e784ca6efbb6912bae599a8b",
+                                "uncompressed-sha256": "3d4ceba91b135a207b52ba4c2a9f9b109a9ca71866ad28a41dd237861590737d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "5d24bbc536fac409d21da1c8de5d71b72c25e0079cd871ac49020555af382fb7",
-                                "uncompressed-sha256": "7c2f3cb4d033d318ef3eb548251063c608022ca8593bb4e354e6608cfdafaaa2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "c35812a758332b23e36d2dc99e0c17696510848b8281de4b7461bbbe3f7a3aff",
+                                "uncompressed-sha256": "d89b30f306f9d85c06726b247eda5ad28aa16dc3247ccfea847e832e989cdb18"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "d0ae8818634a0e1fe2f306aa9062b5338635d8d886789384ac40ab83a65ee44d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "705176b5d228086fde4f37d2ca284031e7e647130c019d9af1bcda4b5c977977"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "833fa537eb2095d95af74c2b3f1cca7719e109f6fecbfc9b45c967ce9afadc27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "292c8aa68a7f5ace90b50850f84b75380ff19e7ea9e5424a15e1f464fb47d7fa"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220723.3.1/x86_64/fedora-coreos-36.20220723.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "1e9e37a77a3157a3aa0c5fdcf040b5c17118d4d7c6cab9c135a41e9e61357d4e",
-                                "uncompressed-sha256": "1d0116cbb19645c5b4a47053da0fc971be21f2c7f9688f72406dc2136303f84f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "248a9bda0a561e5ecca89bf1202ed4ae066ea70b201dfd6d5aeabe6c262f49ac",
+                                "uncompressed-sha256": "325d55bb49694e78e77eb4f32be4f88d9637750ad8fe4b177fcebeacf97c1a53"
                             }
                         }
                     }
@@ -507,100 +507,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0b46530958895bb5e"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-00357ec5761960b3e"
                         },
                         "ap-east-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0c17157cfdc11e89e"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-0e48f4b6445257d68"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0e83e7bb8e2e46120"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-0751fc30588737011"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0ad22697170f295bd"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-07d1c02605912844b"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0a624d480f97cac75"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-0e8df0b271c1c44e4"
                         },
                         "ap-south-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-04cea480107bcad88"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-0751d8d05323f29c9"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-02b5b3b00caae983e"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-0ff5c08957821d8ee"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0bf40dbaa56903323"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-0189b204908e0491c"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0d5941390d899cd3e"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-06a3151f78a23d6b2"
                         },
                         "ca-central-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0d72521810f718efd"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-047c0f7fb1b02abf6"
                         },
                         "eu-central-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0d604afe1ac3ce5dc"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-033df2be481167d82"
                         },
                         "eu-north-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-088253c4d0feda8c4"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-0c18194fcabba9dde"
                         },
                         "eu-south-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0d991209fe0527ebe"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-0c94747851f309d91"
                         },
                         "eu-west-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-063c37796b12937ed"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-0d5786e119e8fe3d1"
                         },
                         "eu-west-2": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0c645bc951e47b74e"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-0fd240b1c485a927a"
                         },
                         "eu-west-3": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0642e4624ebe4e4ac"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-08332602eb656068f"
                         },
                         "me-south-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-05e35384596a8cae8"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-0af5b5d87ac4c6318"
                         },
                         "sa-east-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0cd3a896cc796b955"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-06d7b4025d0212613"
                         },
                         "us-east-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-04f5bfe37e5d3a7b1"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-0e4e77ff127ccd4a1"
                         },
                         "us-east-2": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-08658218b24784245"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-05633c5e35fcd05c9"
                         },
                         "us-west-1": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-09b132163d40fc122"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-0ca77d2d64383a8bc"
                         },
                         "us-west-2": {
-                            "release": "36.20220723.3.1",
-                            "image": "ami-0c856d27d072f70c6"
+                            "release": "36.20220806.3.0",
+                            "image": "ami-0daba47d691950cd1"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220723.3.1",
+                    "release": "36.20220806.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-36-20220723-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220806-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-08-09T19:24:28Z",
-        "generator": "fedora-coreos-stream-generator v0.2.7"
+        "last-modified": "2022-08-23T20:09:17Z",
+        "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "d67366aaaeb8857aeb4b41aabdb79133441ba9b10a10a74dd017e294f463454d",
-                                "uncompressed-sha256": "cf76c0a90d76daf19164c830e647b2e319a8581daf6622ab883d1bf23bbe2160"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "0daa6713485a14a203ca7791de5812580167669bf36b93964c9ecbad4683dcd3",
+                                "uncompressed-sha256": "0fc73e09992932f6969314c044917570e884e35c2143bb4bb1bf9a8e4c93d6d5"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "f0a394ecc6c00b6a621d948e9ae689e3e2f461678ca81544d8622111d2cb1275",
-                                "uncompressed-sha256": "df55bff023b5feaeac3800a64c7e2001cbfd60e020fe965613b757f179c5f402"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "1e7888b133df7bdc619716e80aa78a472a9897655fbf3018a46b2aee46ffdb44",
+                                "uncompressed-sha256": "c01a043bfcc6bfb778a8d62d420179bfb160543f22d978dc634490424ebab45b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-live.aarch64.iso.sig",
-                                "sha256": "3489934ebbcb4890851409adb595618f68c6d38248af7a10755d13d7e48cffa3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-live.aarch64.iso.sig",
+                                "sha256": "29854ab27438a5fe0baf78bf70a83b487e2a309ef6fe156f85a6710efe6cbf66"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-live-kernel-aarch64.sig",
-                                "sha256": "4da34179a23797b370977134e9323a97ea061862dc09030ba494c9598a96a922"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-live-kernel-aarch64.sig",
+                                "sha256": "fd78e3253466ca4e2243b13ba81fb6283442d665e914c2911cd07330a9a054c9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "bd3e3bb7dfd94e68eba13f1ee247e72e6340114bcaa4917d10221f52406f2e57"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "46387ca6ac5661baa5cf63851c90993f786c527ead6e1b858b494aa35fba9773"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "05c9c64f46d7e60de63bb888aeaa4d43226f70cf6fa73ebda4d64efdbb9e5654"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "eef960142507875996f60a3fe78b70396687c963bbad48c4383d68f0e15c21c0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "01eb30cc635bd89a275f90af38e44abd26dfda570250311050d2b83a682fddcb",
-                                "uncompressed-sha256": "cf8ea3c8d3a37294da7040ea42d048f3be0f08f18b3375a79f62f49dfe44dcb0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "ab42091d127036259ea91cbb219c629751e8d5745c7a34218d6c6c5ef282e364",
+                                "uncompressed-sha256": "2194d09332d80e4569f82e302c11773143377356fe38c9ab442a62e3cb46967d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "6f98b3e67da76f70236bdb38a9f474b050bc084f6a113418414931881c6ccdd0",
-                                "uncompressed-sha256": "a6ad8f76e761414d3e205976ad8fb80e70d2aefbcf5b03a32d34ffd26df14be1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "a613c2f4169edf68bcbf63e2a64885b219ecf9410e09619224a9025b97303652",
+                                "uncompressed-sha256": "c7f1d63ac7d4158c29ef54e984ed49023c111288ee21038c183d54f0c6faa92a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/aarch64/fedora-coreos-36.20220806.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "cd28884e765f981f4e2846af64594e4a46adacae0a9fbf6e157c03185e8ce615",
-                                "uncompressed-sha256": "5f70d8a413cdf0a646c069e0fb4888853a1d3ceec780ea5b7225be8f6e8fb0fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "0157f62c1e110ecccabbf4e2b1880cfd3bcb10454918642df45ed84796a246e9",
+                                "uncompressed-sha256": "2ee1af114e88432533a15180cb3772e06f3775b35aa071ba33c730d55e935ce3"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-00fcafe6797228970"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-0aa29c4772bfd6ac9"
                         },
                         "ap-east-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0a50957f8cf2e18fc"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-057ecba6f7e06f1f8"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0c2274fe41f4b5060"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-07f63697fa1a8541a"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0b94fe6bff1b75971"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-0f73f600dbfa3a771"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-07a5abcd9ed05d0ea"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-0e59e512e7b2bd0e5"
                         },
                         "ap-south-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-04b7c090bbb29de08"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-0fc55f18f616b2f67"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-01e31913342815e9b"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-0a59034e6c5cd1214"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-02235f156c76a003d"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-0bed1fe2cb0ba5207"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0777ac4aa76cbf4d3"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-02c2c6184bfae3b42"
                         },
                         "ca-central-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0e22dc21409a3cc6a"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-03181621dead7b4fa"
                         },
                         "eu-central-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0a2fed03cb7f10f32"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-09a48cd00c41206ed"
                         },
                         "eu-north-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0e302c2077a7107ac"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-07ca44a06be07ac0f"
                         },
                         "eu-south-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-062ed2b0b529de0d0"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-02888d2f3df5f2181"
                         },
                         "eu-west-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-097c7c7fe6ff1d514"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-06e4a5d6a2c5ed8c7"
                         },
                         "eu-west-2": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-049e952275cbcea94"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-00445b2dd814fed7a"
                         },
                         "eu-west-3": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-009a333e7b4f5005f"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-079c15a658a936d45"
                         },
                         "me-south-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-09efa59d26fc328f6"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-0557833e3929c2457"
                         },
                         "sa-east-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0fcf139c68d4353b3"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-03dac8d11bd155dce"
                         },
                         "us-east-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0303ae2ca2620ac0e"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-055f8d9763e1fb4d7"
                         },
                         "us-east-2": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0c1403e6193f43c73"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-06cc69aa8311555bf"
                         },
                         "us-west-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-00a82f7b1ced3a2ac"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-062b2a2f58fdaf72f"
                         },
                         "us-west-2": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0a339b0a2979cfc28"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-0c99e01f5814ee6cb"
                         }
                     }
                 }
@@ -190,85 +190,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "0939605ad846dbdc3775ab6258f096e875cc583a579015fed8c449670ec260e0",
-                                "uncompressed-sha256": "606cf059c375bfb14d66b479931157e967238158ce0316ea9bea1dc206671e79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "4b2cca3500df06917533c4012a887b4dabc1e03c1cd094955ec0633a09b5d668",
+                                "uncompressed-sha256": "258e61745083c74763ac8f3760b2acfd1067e3fbe4434c636d37b4a9d20f7254"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "fde003da2071aabbc153069405adae646d4f1775350a335966f9ee2d3a2fbbaf",
-                                "uncompressed-sha256": "c5917fb82b972bd9d4bbb8648f42ea77c4dda206385e296a6a7f0120981d56b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "93bc1548598198742161791af2ee9f9af5a6a578d9e375f72c80808eba237581",
+                                "uncompressed-sha256": "19a2e328da8e6bc5d15aefa1a820efe9b30dd0359c09d9269404cf75c09c6b1b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-live.s390x.iso.sig",
-                                "sha256": "3c3af1d96a96a4a02b49213fcad1a76d865235539c525802c5428e0f46c81bf6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-live.s390x.iso.sig",
+                                "sha256": "fb8aac18de64542e69a57f7d7705017ccd0fd471ef50eabbaa48ce67c12a7fd3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-live-kernel-s390x.sig",
-                                "sha256": "e65218e3ff6f77e90432d45833a78e575d36e2bc27428ab40484523b1c583c30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-live-kernel-s390x.sig",
+                                "sha256": "d17160937e8a5062a451c7e161825048233408bb3b96d4d688f22f234afdb50e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "bd1f8c35f063d1b42bfb70235f73529c1fe6d7799d4a4630b08cbd168af8b78b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "4a99b21f6af304c0cc3c4ec67efe77c7bd5fae8d0a73c1efb092551745ff0079"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "437c8faff5f4c40568c474e587c98ff574f29d0fa81fe64386d4d1e2292bdcea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "add27cad0d85067c655b7688be5b76f6bdc267f8560e0f12b9de801956a8dff3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "4c3fc24c79e08db773b9410dfe8bea5bc3215c5a2a8306cbfcc35d4f37d2062d",
-                                "uncompressed-sha256": "b53e4b267845fe43dbb315342eeafbd40e3762f290e24de1c06507b0f7034d23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "e2ce4b59530373a02ed293bbc0be068b4979997dedb91f09df190d51fb47708f",
+                                "uncompressed-sha256": "90f3e0060a6f85ee90e2e764004a9be3ff50003bab40534a51e0a060e4a2ac7b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "16125b7ff9114477ad0eadd29d515a2062e36fb934b4c6be1f0551824ba95885",
-                                "uncompressed-sha256": "32daab21f61f731ba0afa37048e0ad9fb6e17674aa006a9ccdc3f87385c43f60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "a65851bd9dd166e9ff5031f6ee7e421031eeef594e40a3f173f7434f07ab5fb3",
+                                "uncompressed-sha256": "b0bd4bfec7a92caebed58526d97d74a5cd353254e2cea47bb87385f8fb57d9d7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/s390x/fedora-coreos-36.20220806.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "2689080367bebeb924e8989bd180fe5f2607330fdf0914a881770c0847a0b485",
-                                "uncompressed-sha256": "8a6f4d0aca568f73d45fe6122df30c2a476afe4f9848c1e4414f2bbc9f050085"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "4c9464382be1a4db2699544eb8faa2c64a2572e41e72dd77004301193115223a",
+                                "uncompressed-sha256": "f6e9f19c251e60ad999c34449e8fc4b032af31a5dc79f8f990beb13c957e65e1"
                             }
                         }
                     }
@@ -279,225 +279,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "9c78a0c8d1d4f9f93f53260561f7fe2a7a5fa356b42f8fd2f391f63ba2e98e14",
-                                "uncompressed-sha256": "640cc11db706cf2fcd6adcf593a12050002dc32228efa37ce0629ca8dbae39e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "74f1b6546c14889c7a4122ac6ec29fa262278eabf2789b21605fff12c5d4f096",
+                                "uncompressed-sha256": "8dabfa46135fc96da413360c958e6c1e71210a479218de2c7599938995a290c9"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "f05b125cbe7bcea068548d90e1feaf4465ab691a389bc4d8058ee5a43266d196",
-                                "uncompressed-sha256": "784e7f5fb55fda16674d6ed81e73cb4379778b532804ea04f7a5317323da1631"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "39dfd820ac59c6a85b6e79e877f6d44ebae784affd1d27cd0810b4325c76321f",
+                                "uncompressed-sha256": "fcf722d5da3592e855fb8750561f08235feb5dbc59eea073edc5ba5e438ad038"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "095c94929ef7de26e6b0192c3f68f3ee532b5b999009ca5ee75275fab3bc59ff",
-                                "uncompressed-sha256": "97f2207a7c4b737cae6961fde567141e5cd1cc7cc59cef16a00a5a9ac7fc5f44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "43d0526314e843ff4b91dfa5e4765444ab08d44c9263672c0ed7685c85c7b8d1",
+                                "uncompressed-sha256": "4ed5932a2c38e5b9beb420f0f19eaf1fe91b651769cdb12aae835e675431617b"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "992b1618e2774ae5bacacc9432752bc8e653175dc8fde8dfc8e68ee2e4de6483",
-                                "uncompressed-sha256": "08b695084804f3b51ee3797d27cab0f20f3ca96f1a306876d1688a296413e6e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "6557ef266ce1a8a68e9503d09732992ff7b1436056da39f803913ef555422319",
+                                "uncompressed-sha256": "6e73f31e1ee91aca14535a2ece14f0434b0a016f70d599f391e62ce4ecd0d7f7"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "5e78f1d19fff470888a4e37dee9d7e4cd9809024ce149ba5fb9d247565f681c5",
-                                "uncompressed-sha256": "95f2729808ea46b7c2bd38cab51ae852d92781c4e6ba6b0d9d7da64990de51c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "244db878eef0cc829b089ec8003cb44076061045992fec609f01754b9fb1c3b7",
+                                "uncompressed-sha256": "237d39fcd1bdc2ce1537f91145e92a6240e1ac607570f8665b299221946ab061"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "e96ec72d869c62583333cd081a3cc4f4037f177ac1bbeeaab08e828e4c76668d",
-                                "uncompressed-sha256": "aa1bb231b3e11dc21dc14d7222b5558983fc2a76d027f78dd3042f7134589883"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "472d79d646289bd4e68f264e952ac978a8df71ba49c759ae9699301730954caf",
+                                "uncompressed-sha256": "f3c03f1951f492f4be9c451a9933db73ef7b01dd14c46091daa26dd790106411"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "f5a7b18d042a5e9a70c1f633a4ec84c246f8f281027b28966f79a7374896339e",
-                                "uncompressed-sha256": "549c58043d3a2ad23c17839698a4b2b2197ac81b8161b2a8bc38abab3ccaedbf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "eab21f062cf74d111f186d843c3a51494446347bf7a792052a5f723e408d6c9b",
+                                "uncompressed-sha256": "43c84415438ed3722eaa587303100941b4d80821de51dfca7fa0586303d8ec28"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a57e89204d398b7421dbe64240cbd963ec00e5941cb8174330efe644604ca9ec",
-                                "uncompressed-sha256": "0771ce8a2a97b1281188651c9d65a7c1d818d303134dabf6fcdbadabf04953ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "2ec5a1db4e5fa808f9a4fd14539649f0876d48b631212bef9806c048593fcfe3",
+                                "uncompressed-sha256": "836b48ad2873e2e8f8eeed200caf16613cb972265044d7ec66c61e893fda9d4b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "489ca1627c8288c1d61650a34383b37cee8cf79fac157d547439e6c52df2d842",
-                                "uncompressed-sha256": "4a616b61900046b66f55fc3eaca131c7067a171aa071dd15a59ddcbd43f12607"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "46feae75c1dcd1bb28ee22019ab7814f7946d6d358e49c8c5e880d8832a12ceb",
+                                "uncompressed-sha256": "55198172598c28520a63141fed3f475f48d82253beb53031716433f38a8bae8a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-live.x86_64.iso.sig",
-                                "sha256": "f9c835f72dfc1aa79883dd44dd9f801fd8a588b5a1042fdd5b4fdfa0787a2786"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-live.x86_64.iso.sig",
+                                "sha256": "264b2bd02867719d63e0d50588435063f57d42d26d94f004f206bc64839a8299"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-live-kernel-x86_64.sig",
-                                "sha256": "1d5ca9c4dcd29bcab564e5326f10a31d2ed1eee4e8f53225f775ccd69edb2abb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-live-kernel-x86_64.sig",
+                                "sha256": "cbb8198d864e4a9830cacf7a19992a6712fd61607bd92684967a0b913b7f5a6c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "fe927e4def169a801109b2502bb559eb4ce5cdc550e1dd051b0a0051765716cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "da89cc4e90aebcaec2b733e526582220a1e54e1677f2063b70ef8b27ca4fb97a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "cb303487107204ab95b5ddca482ca232512eb74885e4c0c8f1235cbe0854a166"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "26723ef421204b865a4a04584a7167bcfa7741aeb7bc4348230370a446a4c6df"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "d38f4ca209a519a4ef99603d20bcb5b2fcbb0759ec707828ef8f5ff42f289b91",
-                                "uncompressed-sha256": "e66bc44ce86d33d60adb4992d233e84b9284d78bd925245c852c181693851ce5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "b6a3c8f9795ebb71ec5a1549015b5ff4794422c9e0941c394102bbb81aa6f4b8",
+                                "uncompressed-sha256": "3edaa090e0c9d68acb12b05bf1d7f113e2d73c7c3fe831e41a032ee2c3cbf253"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "89a2235fbb24c31ad52fe33c12c91dee10292b9097c64ebc701e19823a662e58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "fb78681adff081ad3175ce4df484d8c9a79d8db51705b86537387da1871ed9fe"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "997be748db04e44f61836168c98d8cec9b34cb9ddcf2e312804ad12eb640649c",
-                                "uncompressed-sha256": "3bea3f94eb4a6c329151a0a5aeef5564f30cfda0710153a1bf69063ba36ed166"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "fb124a7f44a5fb156d7a742e93c5bdbc6d4212521bb957ecce3ee9400789b06d",
+                                "uncompressed-sha256": "4bdcd1b3854214d4dc246b421a2176b330d9ed1303775d0e4eca95663da16860"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "4cc10f7a5b2734121430e4cbccf688dd3ba31cd41412525231d0fda17583a17b",
-                                "uncompressed-sha256": "cf3099ba30b57e70a27436460dd4710f0e4b61da146cdcabb75d45fcb46303b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e735ccd685b4fc8582b83a251dbbd37810f1683264305e2d72e8168f0b26fab7",
+                                "uncompressed-sha256": "a9f6f3df70d0c0e9716c41f9a7c141643421497a1f635465c30b8988f4a810b5"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "d2c1f79e3aef418562c684cac640a4fe9609a121dae119e641a06974b4229f13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "7034f07141b8872b5a41ca5f2cbd25ab74d879fff0b48fa2453907ee900c3685"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "88bc0885dc8713ca418703c733f74f0774b1e3d34e1d133daab90b2cb8122ecf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "aa5804e3467856f539ec770b6f3e2fd715c305f4dedb8d66a230966757fab4e5"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220806.2.0/x86_64/fedora-coreos-36.20220806.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "3eeaec0b078655c94fb423f44455285e28ebeb06e262eab0444d2697a8803451",
-                                "uncompressed-sha256": "e2c509e46ee909cb6d035dc1104c4d02c125b52755b2105e9dea11b3b7e25c87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "01758fca2b79fc82f2b785fa8d38e37c82334de6b7dd9e0ce19b37cd6ae94227",
+                                "uncompressed-sha256": "67b8d3060675294b7871e4b1c8d26643986c622544fddbb822aace952fefc9fa"
                             }
                         }
                     }
@@ -507,100 +507,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-09cf9c92ed6cbe398"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-074c021670e46d7b7"
                         },
                         "ap-east-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0ec7069084a0bcd8d"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-03b5f725e3061c65c"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0070a1e6061fe0c3f"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-073e77035e0525114"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0e03bf04ed3636323"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-0b0d9924d093472f4"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-09c5cfb1b4bfbccd3"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-0672acb1a03792911"
                         },
                         "ap-south-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-08f35e463c848f4cf"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-0280e855ddbd0df43"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0f6e0f4a01d45304b"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-0174d25def780003c"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-004c758889470dbe7"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-0099b6040d122865c"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-03d16fddc72d7d369"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-034c16631564d95cc"
                         },
                         "ca-central-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0b87a2f510d38c474"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-0422b706da93bf9d3"
                         },
                         "eu-central-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-096c9287412a65e1e"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-02272ccec09d81b35"
                         },
                         "eu-north-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0aae89ca5d455b5de"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-0e4b352c6b70deb5b"
                         },
                         "eu-south-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0e6e4a18982697fcd"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-04b861777f45a9f39"
                         },
                         "eu-west-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-07a6b243652bdc3d5"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-07deb5921d5a2c411"
                         },
                         "eu-west-2": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0dabc8244bda9dee6"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-0c607e850b5ba119e"
                         },
                         "eu-west-3": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0a89ab4c3ec353e8c"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-0bb400c590f4da0b7"
                         },
                         "me-south-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0fb9a07f09536a6d5"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-0e31b6127afd908db"
                         },
                         "sa-east-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-03b3250900d327eac"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-086fc9aae209b8cff"
                         },
                         "us-east-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-039dd128ae976e409"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-080680b3e616a6d82"
                         },
                         "us-east-2": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-00f4d897304389f97"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-08d969c83ade88942"
                         },
                         "us-west-1": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0510ae74c08593118"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-0a6a5ab91477296b7"
                         },
                         "us-west-2": {
-                            "release": "36.20220806.2.0",
-                            "image": "ami-0f446c6ef1e4ab82a"
+                            "release": "36.20220820.2.0",
+                            "image": "ami-019d8ff961278aee9"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220806.2.0",
+                    "release": "36.20220820.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-36-20220806-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220820-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-08-09T19:24:30Z"
+    "last-modified": "2022-08-23T20:09:20Z"
   },
   "releases": [
     {
@@ -53,7 +53,7 @@
       }
     },
     {
-      "version": "36.20220723.1.2",
+      "version": "36.20220806.1.2",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -61,11 +61,11 @@
       }
     },
     {
-      "version": "36.20220806.1.2",
+      "version": "36.20220820.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1660140000,
+          "start_epoch": 1661349600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-08-09T19:24:28Z"
+    "last-modified": "2022-08-23T20:09:16Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "36.20220716.3.1",
+      "version": "36.20220723.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "36.20220723.3.1",
+      "version": "36.20220806.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1660140000,
+          "start_epoch": 1661349600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-08-09T19:24:29Z"
+    "last-modified": "2022-08-23T20:09:18Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "36.20220723.2.2",
+      "version": "36.20220806.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "36.20220806.2.0",
+      "version": "36.20220820.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1660140000,
+          "start_epoch": 1661349600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).