### PR TITLE
Roll out stable 36.20220820.3.0, testing 36.20220906.2.0, next 36.20220906.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-08-23T20:09:19Z",
+        "last-modified": "2022-09-07T09:12:53Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "2b5028a50b9fca39a6c7abf470f699fc6e8a6ad797c1297ee424d6462be117ef",
-                                "uncompressed-sha256": "30a59388c9d66a5e61b00d53cf9a7c8e41c4ac9d9f94012335d8a36bc2f7a023"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/aarch64/fedora-coreos-36.20220906.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/aarch64/fedora-coreos-36.20220906.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "8fd41f7c1f31af45bb45a2c6c41bc184bb77f11629aedb360e01d55334e6dac5",
+                                "uncompressed-sha256": "25634757ba0c1af626bc31f314083ea8b6ab47e8738c5bdc0eef50d87e42e0e6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "70c85f06af6f8a6143d7d0b424fc0e891085fc804b2bf5ae5378b538a255927b",
-                                "uncompressed-sha256": "9ae0a31eadf7a685eb14c7102ec5571909c37cd7828e2dc9d927ad0667dd38e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/aarch64/fedora-coreos-36.20220906.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/aarch64/fedora-coreos-36.20220906.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a733eb1176a4e603f4c5a77eea5f3783adf32e63ff8e46ca2b362707db83044b",
+                                "uncompressed-sha256": "929c8942fa3e0c8287e24cc23fbf4dd713c4338bb75c0583e612497c97fe9bcb"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-live.aarch64.iso.sig",
-                                "sha256": "54350877f0c1fa72d50804f3630c05afb064a5af26a62c15f3b360991ef532cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/aarch64/fedora-coreos-36.20220906.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/aarch64/fedora-coreos-36.20220906.1.0-live.aarch64.iso.sig",
+                                "sha256": "eaae73a65783e81ecb3702fe60a0581138dbdb7addf4f177c2f658008f82a529"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-live-kernel-aarch64.sig",
-                                "sha256": "fd78e3253466ca4e2243b13ba81fb6283442d665e914c2911cd07330a9a054c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/aarch64/fedora-coreos-36.20220906.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/aarch64/fedora-coreos-36.20220906.1.0-live-kernel-aarch64.sig",
+                                "sha256": "02fa706427a69e9bf24dfa14e7ecf694c6646293216b38808648134efe65fd47"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "6f9e3868d1efcbc195e119bc0668e21938946ee7232af5249f0c3c9c54c2d9ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/aarch64/fedora-coreos-36.20220906.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/aarch64/fedora-coreos-36.20220906.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "0a487fd3cfe8fa6aacf8fbf29cde2d697bb5b6d88c8012e46ceec656480e92e6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "cbe458ad83d03f337cf628349c4d9a1ff1b2567183ae4f4433ec54e28061e7ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/aarch64/fedora-coreos-36.20220906.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/aarch64/fedora-coreos-36.20220906.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "dab2e54eb904fd6c9f89918f56abcbedbd403a3f6939ae458e88d61fdfa84e6b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "7131b89a74eda470ba8bb1d74e5aad16ca4bb6ac765795f6e03e7157ae3bd9f6",
-                                "uncompressed-sha256": "a7eb409b3d71958a3951a40d7f41de33b0a64e4ac165bc9cdd7bf7d92ac50f4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/aarch64/fedora-coreos-36.20220906.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/aarch64/fedora-coreos-36.20220906.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "6836fe6aa111015d44394e3d8bb5c47cd0e259c6167b1c2a09119d4bef5d9f5d",
+                                "uncompressed-sha256": "e3f710537b08e19fe494b0f60d755df809492e46deb734c050899ef67528861c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "5c4a06e1214dad0657918f9b02ee4758bf89da3444f76e97b51dda48b2c4736c",
-                                "uncompressed-sha256": "df29e926a36920a00384868f3daeab9ca5546a5da9dd59ada12a74d5bdcf11ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/aarch64/fedora-coreos-36.20220906.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/aarch64/fedora-coreos-36.20220906.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "2b9da1ea887ec317097d3d1c706bf3a08d9410da953ae5cc59803f53c07889ca",
+                                "uncompressed-sha256": "c63cceccd0d658e1e6ae3ed4ce3e1e8f5c88e980bce2e5186086961afc1401fd"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/aarch64/fedora-coreos-36.20220820.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "56d32afcd1a56eb6e1114c867379ea3b9178b337b277ce299cea2aa6d1e2da5a",
-                                "uncompressed-sha256": "2a8791ea4592e44aa4902bdbddeeb0dfb83160128788376d4dc241984e5ccd04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/aarch64/fedora-coreos-36.20220906.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/aarch64/fedora-coreos-36.20220906.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "38738456762a1a91ac4917493fa50485d1853a2135139be48892aaa1f32a140d",
+                                "uncompressed-sha256": "23f4bcf4ef5004510753b02de4764d66827448137eb1e37c22afe86da303fe04"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0c5209a18e500ea69"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-02916d8b8a345f474"
                         },
                         "ap-east-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-05db4d71da18de96c"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-026e798be69101055"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-09f904483ae6f89b8"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0370229f4b59c7693"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0643208255f81d34c"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-09aec8eb6c2daae87"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-012cfe4df0b6b85c8"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-07ace372b72d3789c"
                         },
                         "ap-south-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-063b1316475f91966"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-00964d1d089b85dbd"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0cf7b5c7b752fbe7f"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-02468b9804a56a384"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0868517fd7b0bc7ec"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0cc1bd48c1b7c7a00"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0f4e7f6a3aedf136a"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0695e6411aaa9fb30"
                         },
                         "ca-central-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-03e84909db236a3ea"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0055d0441211cbe5d"
                         },
                         "eu-central-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-05fdbd9bc5d7c7e05"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0725bbb7497a50ccd"
                         },
                         "eu-north-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-03d38ab6eb38c58c3"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-063a8fcff1a52185f"
                         },
                         "eu-south-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-055158fdb395049f5"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-039abcd4fb2d596d5"
                         },
                         "eu-west-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0ef3ba34d86b2238d"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0ac96040f6adc3efa"
                         },
                         "eu-west-2": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0406a782827ce15c1"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0e86c6bfa8340ab2b"
                         },
                         "eu-west-3": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0f61107332373bf5f"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-06c67ca00889934d9"
                         },
                         "me-south-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-04f8e3b777627ac7b"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0a263d88f53985e23"
                         },
                         "sa-east-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-03bca08507c986741"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-086c30d6348440948"
                         },
                         "us-east-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0358ad2db266a2ce9"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0985ae2fea7e980da"
                         },
                         "us-east-2": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0625591af321e3a35"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-08deafd2fedfe6c53"
                         },
                         "us-west-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-00b96db2a59557700"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-060222a5706c9f114"
                         },
                         "us-west-2": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0ce1a772d95138355"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-014382b9cdaa49543"
                         }
                     }
                 }
@@ -190,85 +190,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "8d02008e59c8adc3c70ea1a733d2cc187cbe465900388118d03683bcc86b9c47",
-                                "uncompressed-sha256": "c0820ef389ff7bfaa9ec823bb3dbbd889a8cefe589dfa5b0d855e6382dcd1cfa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/s390x/fedora-coreos-36.20220906.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/s390x/fedora-coreos-36.20220906.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "44b69dbb9b8d0e17a7a0853e755c2e8424aac60aad839edeaf098c0d9d26c840",
+                                "uncompressed-sha256": "b73f7c83f39000495b86856452a680b8109cf3d656711a3beec32b54229375a4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "457b3ddf3076125b50071716686504e5f09064e907106fb766219b3d036cd42c",
-                                "uncompressed-sha256": "f882dbe2edc19268723759ff007c19c28567e2cdb994570edacc98bd7339eb7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/s390x/fedora-coreos-36.20220906.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/s390x/fedora-coreos-36.20220906.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "02f0cf61fe175c2b980979078fa0a9113a0cf8211297cd63ef2210a4b3cd1c81",
+                                "uncompressed-sha256": "240a7c471b84fd92df181ef65848007b3f09239418c32885ed4cf00888f808c1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-live.s390x.iso.sig",
-                                "sha256": "fb8aaeabf0e74e711ea3ef89609c6daf0c4db325235883368f4e6cbccf1d24d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/s390x/fedora-coreos-36.20220906.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/s390x/fedora-coreos-36.20220906.1.0-live.s390x.iso.sig",
+                                "sha256": "98d7b57c57b6a44117a1d9d428467560d296afa9fcf2e669273cbefb513052f1"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-live-kernel-s390x.sig",
-                                "sha256": "d17160937e8a5062a451c7e161825048233408bb3b96d4d688f22f234afdb50e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/s390x/fedora-coreos-36.20220906.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/s390x/fedora-coreos-36.20220906.1.0-live-kernel-s390x.sig",
+                                "sha256": "d226a10a5afb66d81cf2f6b78498ad8808fa515779c68e2f8c946582b58c77d7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "fe5a87c8c75f39a335eefe1a2fe6c1879122428b70379a4d00d9a94637279dbe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/s390x/fedora-coreos-36.20220906.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/s390x/fedora-coreos-36.20220906.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "94118854a2220b94536c841e9c6962c2b5c5a8fa46aeb95910891fa1af972352"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "75b5bfe35abb6695d4fe98b18d096a9ddd0081da0b9f7fe139bba4d4aae2f3af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/s390x/fedora-coreos-36.20220906.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/s390x/fedora-coreos-36.20220906.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "c4c448b45229ead635b73c7e4744ebfe418a0164d8abbfa78807e6488c1c6b4d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "4926bbbd5c0f747413211941d1721bc310aaded252ed8cf54e028d72b71ce1af",
-                                "uncompressed-sha256": "9de385a09c4fa9eea41476356091dfd41f2a5bfd4c32f34699e23807240800f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/s390x/fedora-coreos-36.20220906.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/s390x/fedora-coreos-36.20220906.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "87c0879204b42a2ee8ba353a485efdf7d3a104894c7778cd8fd1a27aa3c4adba",
+                                "uncompressed-sha256": "4f8a7e4717ee33c046d591d06fb01835f66ba0b07e5d623ce6d11c4d5d2a0f17"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "18d8b0c60dab6301cf51dbf35a0a005a903db32f90c31ac2ebbeaff693ca04aa",
-                                "uncompressed-sha256": "66f5b27ba8d8be6825fe211b2b4164706608de5b00d53ef91ba881ce21d09643"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/s390x/fedora-coreos-36.20220906.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/s390x/fedora-coreos-36.20220906.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "6f5fd37e90800547ae7df46b1bcd63cda9f8bca17c4ee3bf5305c492e6255b20",
+                                "uncompressed-sha256": "02206831930fa882e516f693e0fd74862b0e80ac7b67fe7e5992668f7b716f9b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/s390x/fedora-coreos-36.20220820.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "350ddaadd77cf2c35ac7ad3aaff4ff24725ebf98e070b996449fd296f1d28741",
-                                "uncompressed-sha256": "13077ea9b329a6dfe55c6f3fa2fd8e5ba5bebb1582d615412433a109cc41755c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/s390x/fedora-coreos-36.20220906.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/s390x/fedora-coreos-36.20220906.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "b871904e5f6b531edc1eee66dd6df0f6bbcda7b4dc1920eb35c9d1307853d1d9",
+                                "uncompressed-sha256": "29f2e0ff38fa3a988839b5e8b2998475863c982bbdcc03d62cb1c0337c2cf938"
                             }
                         }
                     }
@@ -279,225 +279,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "34c48158147bcfc62e94e6046e44dd181f2f259c7a0a1756f722038392bb46a1",
-                                "uncompressed-sha256": "74eeefbf4eeb6b6af5e7e2f5c462dcc28d65ee2214634c09141ea46a8ad83916"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "9d6dd66d61b9ad56985db3ec77856f257c0762960ac54223696efd132d7dc3c3",
+                                "uncompressed-sha256": "ac48203415444a62874a14b7ac6c9a47ebd8c46b86ab9a501e7c9a7012f7d320"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "e955205a2afdc52e073f0cd761a291c1a4929de5a6480718b0fdad44891cdbd4",
-                                "uncompressed-sha256": "d16ab722ee5404b372057b767686533e27fd5772c96ec26a58c16708f63af373"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "bf3180fdcf55ad6312422b8330744755a6b98415c06f177ad1e8721f6c15a26d",
+                                "uncompressed-sha256": "5e1aeb9484514e6f823f53391a2546ba0994a4c8e2048fefa331ecbcf23fd0d7"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "9e434713e1a3a5cb2020607f08f250a5dcfb32fb5b7560def0896df27e0be4b4",
-                                "uncompressed-sha256": "69bf76d64dbe9fd9f6f34f333897e8c10e0b0fdf4c46eee2dfb7720f7ae1d0f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "9adf7a352145db0a24b480a53d03e4ab4a0133004326c6bfaf9a47d827a11422",
+                                "uncompressed-sha256": "4ca97ff2ccf5413918656f021f5079957bae71a265a899bba414705dff9e2170"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "16caa7a891b1b5686d65db4aa2eda235d6dcc3930d97fad438abf59eda1947f0",
-                                "uncompressed-sha256": "171095e4148f7a90da6731428d83fed529c50ba6316693ebc94ff110a806d39d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "4c1bf402ddceee7d300d7db9babd0a555adfeb12e0ba5e9e755fed6e0a96c9d1",
+                                "uncompressed-sha256": "fb4e91f463db001bd87cde85a6cab631e73752a78f48cdca17f307fa89a6e73f"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "4d7cce68f6923f5c1deb976b4d80b35fbb44d31a0912d747cad9f3c269c0efd2",
-                                "uncompressed-sha256": "a4e7e79490d6e06974cee9fb73545fc4f2054fe998f95f7bbf25610529eecf3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "d1e40d2955d98744842aa6d8f2429a2405589714cee3efe7c5713f020101e6bd",
+                                "uncompressed-sha256": "c098c11f5cf55f3f1d51b4053a09c2f6b34c2a2eb4c327b555c6035c0131371a"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "c9ed83f86c94e778d6c9f65cd935e09950be959fad21340d11333162a9645131",
-                                "uncompressed-sha256": "0d77e0604dfeeba2ac39e71033226b42e1bf6f8f42f18528cfbf9cf9b2dba0a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "7aacfe886db0fb838ce2306a8e37a76a4a83082fa0cbcdae638859bcc5607560",
+                                "uncompressed-sha256": "b3ec3df00cd4d3e197b6b2ce081aba6d2e0565ef1223f645a8cecfb003c6e6c6"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "8945a0afd39eb7ff9ef821df88a18eb820915884c16f5cf1bb2e388cdb062821",
-                                "uncompressed-sha256": "e383d77c9c60ea4be2df6ccf1c903742582fe2d4a4716126e0eed1b2a11f8760"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "255d78b20611fa03b1596eaab22b3afceba2da3cefe29d0c570006dcb15a762a",
+                                "uncompressed-sha256": "477636952190f3f40885a9312c60aec3ab865f04d8404049f8fa60e1ee9795cb"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "b6a4a64da46e32c0628397a0ca49328c829fc6fd6b78abd1675a97bfab536691",
-                                "uncompressed-sha256": "426b1a03003f7525e396531c66437b0aeb9a4a259c1d929cf760916729308dce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "9b2a531ddf7594b4494cb469690a51720ad431909ad6d3f39fb0f5ea5674b000",
+                                "uncompressed-sha256": "51da6faa4c6c40a43ca2c3f3150f47f7858a501341ce695512ebccd5e35bebaa"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "536428b0b926bb5d32a9df8987a2f027f1731133e3a0f8091b7e709008652db7",
-                                "uncompressed-sha256": "4ba9d97ee306d20c78003b200581abacc2120a5aadf7b6396ab8a2fa1ef5dd13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "d9dc34543d1edf3254a16f99a8c1a19b2dd8cf4175de339ed061140a9be76bed",
+                                "uncompressed-sha256": "41381b92ecd9283816f39feb027cdac033bcf9212664f290ebd34e8f20244bc8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-live.x86_64.iso.sig",
-                                "sha256": "b1b8bfca616f033823154043821ac70735a3edb66e2a9e83abd72f512a37dafd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-live.x86_64.iso.sig",
+                                "sha256": "2245a7ce0ce8b19f36f8d04974be98473994f1e96907c2d272a5ec9231667c17"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-live-kernel-x86_64.sig",
-                                "sha256": "cbb8198d864e4a9830cacf7a19992a6712fd61607bd92684967a0b913b7f5a6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-live-kernel-x86_64.sig",
+                                "sha256": "ed60ee3dce287f90eef9101aefae1ae0aa6036365ed59df71984321f8c83b6f4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "3ede954e9360e31f8b523ef6d371d4163beff55e33728162f3c09ad9bdcf8613"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "c9e94a3ed0b440545fe849dafa39e148a845cf85fd0e16e585949caaecc0a353"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "921531b3584bd646c3c2e97c2cad4c650df0155781d76c7a28e532694ec2c939"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "e7c65b824dd4c61d2328d403f7ddd321d396e70793d9e6a7f0b41f743d9d2d57"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "3368562c9e7900bb72514528650ce9af93747c212dbdaf6e828be9667b07e02e",
-                                "uncompressed-sha256": "3bbc80537d8ca6a9b9c7a4cfe321977528c1f308ba1dbb18db2ebe27ead906c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "053e3d17389c93124256956a0bfb33349b38827da289752bb7e9f1e7a8b151ea",
+                                "uncompressed-sha256": "e183d69813d1ea7a7f35ca640007ede3aaf144427bb9b1f4a41a2824ee6a2f5a"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "8f659b27e05a0085f75dd5aba044d796ed95595377ce621f74dcf702a6104e24"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "7a7e2cd9444e173c7f2eedbdaef5ec4d060e954be8615b76f3a141d2a17fbdaa"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "a5cacb23fb5ed4b7da8d5bc96cf6a3901f4d387090e5477096681adc036a176a",
-                                "uncompressed-sha256": "7b1786d68e57abb923b4fabfd6c24cdc946008d40d61c3733151cbe6c05a2e34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "62512a93197966adc07ea102e8d463dcc83ae463cc20e5b1aff5821be9313e11",
+                                "uncompressed-sha256": "b176189585e067d99cd75e927421b957af937e7705bcecdf1890ce8f19f88cd5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "05240a5c85c6d6fe7d642566b54a698a67ac16097597fda5a3ca5c8c2bd1c542",
-                                "uncompressed-sha256": "f4083c99ef008308e6c18d5e2d6d46506d9ca380e4c0655a768dac237446efdf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "1a6bac74e5c7856c39b2b554fb3014b86ef9ae6c23818287131d5b8cf64dc26c",
+                                "uncompressed-sha256": "24fbebb81056382415338427d524f74b18c490787dcc823ec603cefc2eff6d6f"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "7b1775615dcfc89ecd38050d91e2ee1b3a469a82a7c1edb24aa4a448539ec7ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "cdc1eadba3a01ba4d9971fc5c5d3db24cccefc30f05575026bf5f27bffb83a06"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "60f8e1caed338e82cdcffeb104622d03c073ed52144812953fb2b2820f9509b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "2a6fb035a24c23cdf619ac5eb52f4c7613b59df4efea140d8cccd825115042b9"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220820.1.0/x86_64/fedora-coreos-36.20220820.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "b706ba5589ffa85e53282e63f0d5c7d3ce533e39ca345c6bdc01c5d993887362",
-                                "uncompressed-sha256": "f5e156837fc05085c6b1170e5ae03808760c441f8ea12a9cb744f5c4e6b5671b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/36.20220906.1.0/x86_64/fedora-coreos-36.20220906.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "c6cec81232515063aa1bcc4c8eb0181d66e7faded4a32a001a4f42e208a476cc",
+                                "uncompressed-sha256": "26526f46f0f5387876df212b48f49abe3e16320296ac8f822f752314a3ea74ff"
                             }
                         }
                     }
@@ -507,100 +507,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-094250c3719f8db39"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0dacc9a2f6b4c4b05"
                         },
                         "ap-east-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0e107e5dd5dc3449c"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0eb24f6f4604541e8"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0c69e806dfa248c5f"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-07c567204da6c93f1"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-048981990816d091c"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-06463dd3dc6ad160e"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0dd4d7b65672a142c"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0d1a2117d15a4f878"
                         },
                         "ap-south-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-003c8b5da6743d73a"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0ac1a1dfbb75a7fd1"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-09870490569bcdbb3"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-08b7ecae4a2d31a4d"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-017721186043bca07"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0a3b140b24a4848a5"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0c1f6d9e0f449c6c5"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-02e82dc75ce776d49"
                         },
                         "ca-central-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-058b63c148e2bf034"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0d27dca8098855516"
                         },
                         "eu-central-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0530fd6d024ee3693"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-05ab79923dbdb7207"
                         },
                         "eu-north-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0f049ed235dc67d9f"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0d5768b9346dd2ca8"
                         },
                         "eu-south-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-01ce21354cea4f1e5"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0c2c0be462d3095d0"
                         },
                         "eu-west-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-01366a961cd4cb073"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-007c049e943dfd09a"
                         },
                         "eu-west-2": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-087801be084a89a18"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-004537ce30fe70840"
                         },
                         "eu-west-3": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0dc98fc442e14ee10"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0bf29b9095531ea6c"
                         },
                         "me-south-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0b7c54a8e6b2f63f4"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-02aacd06cdcae1f6d"
                         },
                         "sa-east-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-025d501a383e513f1"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0398bc2d2df114a9d"
                         },
                         "us-east-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0143d6b5ccb7f466e"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-05f8ce7d1bd1cfd9e"
                         },
                         "us-east-2": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0ddf6fbe0d3986dbd"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0e3e36b4d3b8a782e"
                         },
                         "us-west-1": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0a7e3849bc1dc5a16"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0d37b4d89ca448f84"
                         },
                         "us-west-2": {
-                            "release": "36.20220820.1.0",
-                            "image": "ami-0511d197921db0a54"
+                            "release": "36.20220906.1.0",
+                            "image": "ami-0e9812a8a242597d0"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220820.1.0",
+                    "release": "36.20220906.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-36-20220820-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220906-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,92 +1,92 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-08-23T20:09:15Z",
+        "last-modified": "2022-09-07T09:12:50Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "67262f6716355e3ddc08248c8426aba6b134da855d423108b300d4275ba759ed",
-                                "uncompressed-sha256": "ba411b026e590a5f0e5476775a07d3b76cef8a36f9e805e19a9826b902967080"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "fd4477e9de3f623c537090adf9e1620818973b1db86d07b250340b378752b6c1",
+                                "uncompressed-sha256": "3736de81051da36c566204af2eb239f0ec3f412057450925680c2ca5634935a2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "430f58fbccad838fbe40f5e26471f5254d84c134656b92de725d5f3cb49c9ac2",
-                                "uncompressed-sha256": "4bbc2f9dafa87abe9ad2863d564ae9b0a2d7841b2bc4eb4b45fde904a5dffd46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "1d17dd525adc1a8727f8ff5c3ba0ad6b83d11fbb05bd43cdfc666b3f5a53179e",
+                                "uncompressed-sha256": "9f4ed9a5dee4e0009363ea79c79d784c11cf34fc2c0e4af470b8c6507ef15d69"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-live.aarch64.iso.sig",
-                                "sha256": "8e5aeaec81ec9afae039c5f54fedd1f59bd14b4a9f9eb86695b42097afc199bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-live.aarch64.iso.sig",
+                                "sha256": "305568733acafe4cb420879fb6704874930d54effda40492b364f0db8031fabd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-live-kernel-aarch64.sig",
-                                "sha256": "4da34179a23797b370977134e9323a97ea061862dc09030ba494c9598a96a922"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-live-kernel-aarch64.sig",
+                                "sha256": "fd78e3253466ca4e2243b13ba81fb6283442d665e914c2911cd07330a9a054c9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "8959d228ec4b5b595b4a4261d13a604fef20ead1777cb451f04f29b64f380f02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "18fd3ef389b3d05847008485d673cf277f265955f68063a85767f35a13935b18"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "1a5a84769ec96c5d75730ecd02f589e16f98034c4418cd89b2bcaa556593265d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "a6ed3dd34d9c9f60a1209fbbfa43e7bcbd658eed9bb98e5dea4c8ad4e4cbad63"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "7f00aca412642d469c1c77a8316d6fb48ce4209abd0bb60312345f276a0ac8aa",
-                                "uncompressed-sha256": "5ecff1ee6cd2197c59dac2f1ec5041671b1991a972f8e53c99debcbd7ce50f18"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "ae35530be826af9d84ace0e78380597bd0496d237fbbc1d885d1dcc564e39137",
+                                "uncompressed-sha256": "5aa03b902c5de867c81ac98e28f8f1eba8cb9923d7f8fb2a51ae5b91de7544c2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "7c64f5902e7ad1a51ed47968ff6cc41d9d343a1bea5ff3f0c28d6ad131083a9b",
-                                "uncompressed-sha256": "b883c49a2bf53120fc5fe6bee56c13e338503b647e5a8fd3bdedc7f522595e86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "4357ab3cf5abd01693ef880e17eeb9aa633d752fe8ab6badf761b4316e340ad1",
+                                "uncompressed-sha256": "0dfc04eeda314c30666ce8de9729253d198fea1ca71d5a1eba03192be12380a1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/aarch64/fedora-coreos-36.20220806.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "13e27d291a9a69f5e87ef7c47b27601c4ca40ce2bf3a6fb7487e0f33867b7125",
-                                "uncompressed-sha256": "42a92660b2adb795c077591fd3f4b792784f0f9041feda435094b2a677f2d02a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "d94c42294a510e87fb9260c5b9bdbca434285802b8c378ce86d8e49a03c9e4c7",
+                                "uncompressed-sha256": "9f58ad3fd3ccb979d30382cdf6d48db5405d36a6d8922ed202c1db37c9381831"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-0a7a989a13e2d9e88"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0dd04e7e693b60094"
                         },
                         "ap-east-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-02da21b321ac3545d"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-02b0d7472060a5032"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-0534d1ca6c3d08c52"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-020ae75ca012b328a"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-04a12712a6c6c884e"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0e068630d4765c233"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-05887e8369c284621"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0f43167ad55b9b0d2"
                         },
                         "ap-south-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-0bdfb876076c8d81f"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-026516bccf0a6ab45"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-059f22308f97030f9"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0e77f96b972a72353"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-06a016a2e7b22912c"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0306c4bea6642083a"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-0c5cffc8de29cc762"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0554e7762e94adbbd"
                         },
                         "ca-central-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-063d189663705795b"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0359c22a6bf23cda6"
                         },
                         "eu-central-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-092b0067d0c32af64"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0ee3adbf93a178701"
                         },
                         "eu-north-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-0718686aaf78105a5"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0064b3638b9c0931e"
                         },
                         "eu-south-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-06ee62beb006b3dd2"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-03d5f16e8d524c0fd"
                         },
                         "eu-west-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-08cc094c465e3f482"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0be00bd3a0568226c"
                         },
                         "eu-west-2": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-0bce777f1560e6467"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0663424d1c6664a41"
                         },
                         "eu-west-3": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-04756327c0adafc58"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0eaec7eb7ec99c475"
                         },
                         "me-south-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-025c55d3777480f4b"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0ab0618848ad482c7"
                         },
                         "sa-east-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-041996e2bd4e36778"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0ee1a6cb5b0025e10"
                         },
                         "us-east-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-05d80f942bd0ea9c6"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0e520022b70b9e8f2"
                         },
                         "us-east-2": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-038092397577b695a"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-051d048ac8f03d55e"
                         },
                         "us-west-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-038a9aaf5b5444d1d"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0fd56f9cfbcb40ad1"
                         },
                         "us-west-2": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-020dcac64c6911e89"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-050a32df8495c375f"
                         }
                     }
                 }
@@ -190,85 +190,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "35500986f6263cd319fd3b6233008716bc3b491e2d11d48466dec70998221bb9",
-                                "uncompressed-sha256": "c89f35e1573db497ddb2e2c9ded28b1f34677df8c83f77d15b33024cb24c0f4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "db320892af54b69c0f5336aa1490f1d02f2278c3fa5f7ab158af50c858773953",
+                                "uncompressed-sha256": "4d6116e5bf82d7537f08d412690af28d79822999156e719f9e88b33e3a4cbbf7"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "2ff6caa929cfdc7b2c7420367ad99eac60d0f7776127071837bb1f80e2b9e58a",
-                                "uncompressed-sha256": "7d1d89b45b1dfff13046424ee2f97677b1ea5edeb4ae3ce943026c2147ef5ae5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "4b691fe7e72116b6064781e44b445509118b74b3adbdc7cf05f5e05c13f02500",
+                                "uncompressed-sha256": "157c8c345797fc3500ef1bd55abb7154453e4963d0f69ab14090f8af64c4b775"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-live.s390x.iso.sig",
-                                "sha256": "e3b7e274c3ea2ee3e1eb13ed9e093503ad748aa3a1c6f56dcb653e7ef5d7595b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-live.s390x.iso.sig",
+                                "sha256": "1a51051745ed70e4bc155070934f019d36ee63efbb078fe59cd22be5a43bc274"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-live-kernel-s390x.sig",
-                                "sha256": "e65218e3ff6f77e90432d45833a78e575d36e2bc27428ab40484523b1c583c30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-live-kernel-s390x.sig",
+                                "sha256": "d17160937e8a5062a451c7e161825048233408bb3b96d4d688f22f234afdb50e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "00d76762996bb77ac468408b88895ed495a80268f77b96a2fd507352e1824cfa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "608979f1c592555ec8a7c2794e09141abec73d6730e7a371b9c6969ad8d1d044"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "e12d6f943bbc7edbe6a653134df9d78eeed9e41503cedbd7e77f205a29ec02c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "982904c9c5607883a77d70ecdc6e6e628822bfa5ddd7ebe8ef1f2f51b6ff06aa"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "16e03ff4942a40d1e07d3d35ef8370e33c5a6aa93babf360b2a7bc13c6704c4f",
-                                "uncompressed-sha256": "f247bc3aab73b2ea6443f4154678ef69cfbf5375799598378f75d42f68471954"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "144aadeeae40cc80bfe2cef1054a9f4993178e7357bd8328493e151aecc557e9",
+                                "uncompressed-sha256": "294b8edda412834057f6a9b77bf1c027b24cadf561dee34cebe1962080449cec"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "ffd7bf1db5af5bd26da8dc8aefc445dc2e2be0f0ee331220506d6296e31f667a",
-                                "uncompressed-sha256": "34668d1efce54960d5dce50498df1d570cc1eeab52b9bdb003ea4894ca76c004"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "a3a7d2c8be6979fa2438f8387aaaaffc2c80f3b95f28cbfc20465c6c73446f42",
+                                "uncompressed-sha256": "664d86a8e8864bfc881fd0c8f977c0316eb1cd8158275dfaf6053deb8576992f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/s390x/fedora-coreos-36.20220806.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "59084bf3303247af86f7b8aecda9894df9f298133ed036eeb56897fc584a54e3",
-                                "uncompressed-sha256": "7cad7f203fc41431ae561205e9623101304a3b565527035b3ef59c029eb9d33c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "118968fe3d5425ea54864034f99a46f621b3dd9a1c399e743dc31a395abbe0af",
+                                "uncompressed-sha256": "dba387d6f5d627356770d0615938ff986e4e207c11f7a00ea0523828e77611fc"
                             }
                         }
                     }
@@ -279,225 +279,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "4983e3f55246f457f97f96be09dc07d9620b82e031ea0c5f42d4ae662856d3dc",
-                                "uncompressed-sha256": "6bfbb7756f18adb079f576cac3670af76ee4bea93cd948073815064814a31b93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "0d53cdfe90d0efcc6472b58b39c87c7449658e451ec882b2dce5f20701170823",
+                                "uncompressed-sha256": "d161ca0c63721493b6ed01ef59e5eb043b0dfaab7d3c955af4549a5245454a89"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "94d4dfb25c7e9f706b795c4eead393564456f2b6c415e6b103eb676c72567419",
-                                "uncompressed-sha256": "d111a134d1be84f278e9a3f46b8d5ce4f069c67cd3e47ea2ffd4de47d4765fb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "b4b56d28d882b5fc42c23a3b6f7f2adc21457ced1d2b19cfb5c8fd49bc672d4d",
+                                "uncompressed-sha256": "c04f41c9a1606e77a1dab542e0daa864cab21e6eccfdac8f607036261be4dd46"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "94715bb03d679af00dd61fbf4b1fe5bf9773bf156d50fe9346793cb90ef8d693",
-                                "uncompressed-sha256": "8f7224dc1eee5b3771b9f12600f9101d72ffa096b68782f04a3231b230111605"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "4ff9d7f924c18d20a2e865222d63eb2b70906b2edf966337457995fd3f9a3321",
+                                "uncompressed-sha256": "9b43ad73c77e90974cce242e04889c459ed36bc51791a0504091488d58083809"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "99711231a609f939251260a5eef47e1599aa2d6051b165dfedf024eb4e266e36",
-                                "uncompressed-sha256": "6b9e42da92829bcac02c15f8fda9c1cabbd481f5034c1755e9af9449cac1e292"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "e1cbbe9ef70bceb1fb5098c216c7ef99bfa25f1e583b918e23d217f411adc16c",
+                                "uncompressed-sha256": "aa2d4a707e0e324806736a53e67e684abdeca043e954b91af1a42fbbe80d8929"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "ec0c65cb309b020d2ae8ac3b40249d53ff8471a2ed718a04049673996561098b",
-                                "uncompressed-sha256": "5ba6235ed3b0f853d34be26df1a9f15f5d09e686b3fa93292aa8584ae6fae21a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "3370947ccc6e5c7246b71bd65e8426a7f6c754e068360efd892c74b89b29783c",
+                                "uncompressed-sha256": "7f34e9f8c8723b1c06340f0e7273b02255bd6fe737de1bda0daf36d94fffc05c"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "65da04185bc91686725b4a0920c5278212958bdf7dedca09727426159912a355",
-                                "uncompressed-sha256": "3648a5cf7e137911dcdf8fa989ec34bedee50ca62b81c689a13fcdb77019f222"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "907c206e4441af2a5aabc3601b497e03c74d02b04439715561a3c081a760f2b9",
+                                "uncompressed-sha256": "c6de69fd6366995632753efa218e4ba8c6c38b101cc94a4e98fb8fede9fa5378"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "cdefc3929a0cadc8c0c980de4763ba37eee8e9f29b27f62dc2e86c8f8bc6fff5",
-                                "uncompressed-sha256": "10f9600aaf907ae393761737f32998e52270cb17882025d38cb5ee5eb7441c7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "c2f4367aaa858e729eaaa0501420f123921b39b7612654295da6402ab1c4a722",
+                                "uncompressed-sha256": "71449b12f5f105b785de09d67bd1cb567eb8bccabb624f0f14f89898752390e8"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "69e22653fce7be30c343e10602c9038f477d41f31c73fba46df38a9be431b6a9",
-                                "uncompressed-sha256": "e25e53edd9e63a925654442126821807496e4b049368bc8840d01fe08ce8b5dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "b6768f1b33705131f5e0717b95df4f33b71ce2fbb603e66f27a4df7115399479",
+                                "uncompressed-sha256": "83e76f0c3de9d5621085c37a6f00360398428480e2ebde4ca7f015d15a6bf15a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "8d5fd9c82c71e5fdab53e3365853d7db6522045e300ff7ac8425b862435e83d9",
-                                "uncompressed-sha256": "8e1d7e5eb1934e8e13799f6b89cd5d2bd396ac06357b7502c7ae14a8efa40aab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "dc26389a92944e4f0fe8afe2d41d1d519be47c217c2f485bb5b90356e0ce0bf2",
+                                "uncompressed-sha256": "c3580ae9e1df8c39c933f8f3bf721b1ff3826837fb20ad51c999e3bf13ccaf86"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-live.x86_64.iso.sig",
-                                "sha256": "b87d29f1af8c7b6a9aa326ef6e44d4992c73d6a9124bd5f3617a9f6e2445d83c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-live.x86_64.iso.sig",
+                                "sha256": "8c1668684848a07346ee3f723ae576441f93cabfd7b9fa64a69d9dac396bdbc9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-live-kernel-x86_64.sig",
-                                "sha256": "1d5ca9c4dcd29bcab564e5326f10a31d2ed1eee4e8f53225f775ccd69edb2abb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-live-kernel-x86_64.sig",
+                                "sha256": "cbb8198d864e4a9830cacf7a19992a6712fd61607bd92684967a0b913b7f5a6c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "6cce2b161b5e1403fa5e2047397f926ea04935d10a0cf19e405aa8c87ac3cb44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "85c13d3777e1ddc4d09bfae4f5218699dd21b28a6f8f56fa5229e80202dcded1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "6e31b872ad5c0338fee627ce65e6c5ac73d5b1f6a2ef8697ac39acf4587a0c2a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "427036df6cd2158e343e0b338ba24b2b050d02fb7eeda64ec96177798e29c4ee"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f180af371e9e9abfe1a1ff5275272ea7f12b0d88818a6824cf0ac8ce66c8f61e",
-                                "uncompressed-sha256": "9f19d51bbd7f9655127a47b16ae15e487a22a0376dc61327c7258779e3c70a4d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "d89014a554eb44bdd445995cc97a7a9ee217d6032c9acc9cc620a2944e12301b",
+                                "uncompressed-sha256": "05c5849f458aace92df0bda0d76e859fcc849560c1c4dd519265788bc06f4a24"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "83e4f02be66c872fb7693f4a993ae1443940c758bd112b0593b8ff3e6d85579e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "0589cc8af605944585555138a24934596c32e9c5b181d3bd1ad20f5818f1c1e1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e90dbeb07a72b3967b3f04d3e608f779414c6b91e784ca6efbb6912bae599a8b",
-                                "uncompressed-sha256": "3d4ceba91b135a207b52ba4c2a9f9b109a9ca71866ad28a41dd237861590737d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "e3bc0fa8b0a86afad1d444aff9c5245de10935697625fc7ff1a01343c2ffd821",
+                                "uncompressed-sha256": "8daca8f4ac61840560f82208900057eac0bf36a19ea619e528597a2e0a4629bf"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "c35812a758332b23e36d2dc99e0c17696510848b8281de4b7461bbbe3f7a3aff",
-                                "uncompressed-sha256": "d89b30f306f9d85c06726b247eda5ad28aa16dc3247ccfea847e832e989cdb18"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "3f9cf657e20ea3af7816b4ccc8d703bb3f6d4718de82a258061d08497ddffe3c",
+                                "uncompressed-sha256": "90c8f98235e3c939a888dbd67bebe99a6bfb313feca550866f1ed9e56e5ac364"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "705176b5d228086fde4f37d2ca284031e7e647130c019d9af1bcda4b5c977977"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "864b81e2c23573d98a07bc37d1e0eeffd594e2ac31edecfc6e0c7cbb16037f06"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "292c8aa68a7f5ace90b50850f84b75380ff19e7ea9e5424a15e1f464fb47d7fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "4ff659fab770a4c8166a7b8cb24833d7e63d6ddb6158b648ba6016789af20e69"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220806.3.0/x86_64/fedora-coreos-36.20220806.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "248a9bda0a561e5ecca89bf1202ed4ae066ea70b201dfd6d5aeabe6c262f49ac",
-                                "uncompressed-sha256": "325d55bb49694e78e77eb4f32be4f88d9637750ad8fe4b177fcebeacf97c1a53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "55c7bae6c24b41f151aa7aad5791d664a6148b0a2c1b4c75e284203cbf9205a6",
+                                "uncompressed-sha256": "da9678a63694d91bbc317ceb4f6592ec02a3678e122ed9590861525e97545a40"
                             }
                         }
                     }
@@ -507,100 +507,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-00357ec5761960b3e"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-01ffecfb00820935d"
                         },
                         "ap-east-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-0e48f4b6445257d68"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-035c2146d112f84a9"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-0751fc30588737011"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-07048af161653626f"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-07d1c02605912844b"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0b5e652981c0f6a2a"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-0e8df0b271c1c44e4"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0748ccb19c1ce604b"
                         },
                         "ap-south-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-0751d8d05323f29c9"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-00b1a8c786be1bc01"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-0ff5c08957821d8ee"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-01381e1d7fbaf4734"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-0189b204908e0491c"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-002c5d41dd388096e"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-06a3151f78a23d6b2"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0074a92c8ec5602e3"
                         },
                         "ca-central-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-047c0f7fb1b02abf6"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0e1bda07a5d29db55"
                         },
                         "eu-central-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-033df2be481167d82"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-07298551f92dcb6bb"
                         },
                         "eu-north-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-0c18194fcabba9dde"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0ecced23f715449c3"
                         },
                         "eu-south-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-0c94747851f309d91"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-06d8d7019daabc076"
                         },
                         "eu-west-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-0d5786e119e8fe3d1"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-09a16cf524101e46d"
                         },
                         "eu-west-2": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-0fd240b1c485a927a"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-05b022eade229a660"
                         },
                         "eu-west-3": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-08332602eb656068f"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-04e6d34f953a22746"
                         },
                         "me-south-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-0af5b5d87ac4c6318"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-037b58599758c457a"
                         },
                         "sa-east-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-06d7b4025d0212613"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-06ff7ad679a3936a5"
                         },
                         "us-east-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-0e4e77ff127ccd4a1"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0331ce6a9b2537088"
                         },
                         "us-east-2": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-05633c5e35fcd05c9"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-0e6f4ffb61e585c76"
                         },
                         "us-west-1": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-0ca77d2d64383a8bc"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-04f2a5462112fc48f"
                         },
                         "us-west-2": {
-                            "release": "36.20220806.3.0",
-                            "image": "ami-0daba47d691950cd1"
+                            "release": "36.20220820.3.0",
+                            "image": "ami-02453b490b0fea552"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220806.3.0",
+                    "release": "36.20220820.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-36-20220806-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220820-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-08-23T20:09:17Z",
+        "last-modified": "2022-09-07T09:12:51Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "0daa6713485a14a203ca7791de5812580167669bf36b93964c9ecbad4683dcd3",
-                                "uncompressed-sha256": "0fc73e09992932f6969314c044917570e884e35c2143bb4bb1bf9a8e4c93d6d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "02b6b66f55f033b4d0068086d2d76e3d6efabc49dc05e2c54e98104034ee07cb",
+                                "uncompressed-sha256": "7334ed3b9335fd1a93cc468e18cf6921eb7ab00ee9a2014ef7963e1b047ca161"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "1e7888b133df7bdc619716e80aa78a472a9897655fbf3018a46b2aee46ffdb44",
-                                "uncompressed-sha256": "c01a043bfcc6bfb778a8d62d420179bfb160543f22d978dc634490424ebab45b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "3e667b2f47e39597c0e12147a12561d4fc048a1d9da40d1becf669edd080aae3",
+                                "uncompressed-sha256": "a3474a68b80891b424fddfe8bb64b20476a94446bac0d7ed17c363f6a5a50283"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-live.aarch64.iso.sig",
-                                "sha256": "29854ab27438a5fe0baf78bf70a83b487e2a309ef6fe156f85a6710efe6cbf66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-live.aarch64.iso.sig",
+                                "sha256": "97da63435f84090e90bdd8dc4e9308369bc00096ef57c05505b75a4752360833"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-live-kernel-aarch64.sig",
-                                "sha256": "fd78e3253466ca4e2243b13ba81fb6283442d665e914c2911cd07330a9a054c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-live-kernel-aarch64.sig",
+                                "sha256": "02fa706427a69e9bf24dfa14e7ecf694c6646293216b38808648134efe65fd47"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "46387ca6ac5661baa5cf63851c90993f786c527ead6e1b858b494aa35fba9773"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "7f9dc6ec0c8a78f39220e77947e181381fc58b3067d92dec91d129bf2155787a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "eef960142507875996f60a3fe78b70396687c963bbad48c4383d68f0e15c21c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "0ddd96c9651039c40501b1ffb0d9733191c62a71879cb149da0fcf013971282d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "ab42091d127036259ea91cbb219c629751e8d5745c7a34218d6c6c5ef282e364",
-                                "uncompressed-sha256": "2194d09332d80e4569f82e302c11773143377356fe38c9ab442a62e3cb46967d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "8a9fdf5211107fe1d2b606401e35b6c301f368aed7bac8d53d308fa475f3aec9",
+                                "uncompressed-sha256": "f3094a4eb7a2c95c6c23064ac4fd1dfc5c26b5b58c95ec16b75739624552d883"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "a613c2f4169edf68bcbf63e2a64885b219ecf9410e09619224a9025b97303652",
-                                "uncompressed-sha256": "c7f1d63ac7d4158c29ef54e984ed49023c111288ee21038c183d54f0c6faa92a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "897e82621dfb01dc965d84101a562de4de7f1c3a8a8bcd5719d31c75dd4e79e7",
+                                "uncompressed-sha256": "aadd955f272e6e7c35a09e005b68d53abf894b9107ec98fbd0103324454e0e64"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/aarch64/fedora-coreos-36.20220820.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "0157f62c1e110ecccabbf4e2b1880cfd3bcb10454918642df45ed84796a246e9",
-                                "uncompressed-sha256": "2ee1af114e88432533a15180cb3772e06f3775b35aa071ba33c730d55e935ce3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "4b988acd58490cb91fdb4a7f7dda1af5b671548639c078432b12f8eff7d3ec40",
+                                "uncompressed-sha256": "a9f72888fc8b764f7fb06f191a7ec3cccafea28f52cb7313fdf73942944b1246"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-0aa29c4772bfd6ac9"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0db4fa22f041df4f6"
                         },
                         "ap-east-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-057ecba6f7e06f1f8"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0577f89e86dfa032d"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-07f63697fa1a8541a"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0827938b65ad14315"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-0f73f600dbfa3a771"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0e0daabda610abcc9"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-0e59e512e7b2bd0e5"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0ee5d46b3c850ba8f"
                         },
                         "ap-south-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-0fc55f18f616b2f67"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0055981b36b6583b2"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-0a59034e6c5cd1214"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0203386a06d7a9650"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-0bed1fe2cb0ba5207"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0ece7e95a636fda78"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-02c2c6184bfae3b42"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-03eee21172d716090"
                         },
                         "ca-central-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-03181621dead7b4fa"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0814b6030bc92eefe"
                         },
                         "eu-central-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-09a48cd00c41206ed"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-085e466fdecb1694c"
                         },
                         "eu-north-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-07ca44a06be07ac0f"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-079b7d137524aeb1d"
                         },
                         "eu-south-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-02888d2f3df5f2181"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-061052833e33b470a"
                         },
                         "eu-west-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-06e4a5d6a2c5ed8c7"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0410b484c7dcb001b"
                         },
                         "eu-west-2": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-00445b2dd814fed7a"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-08dd5ad67998566be"
                         },
                         "eu-west-3": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-079c15a658a936d45"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-02f974db08a259338"
                         },
                         "me-south-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-0557833e3929c2457"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-00d9261958b002427"
                         },
                         "sa-east-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-03dac8d11bd155dce"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-071ca062282748956"
                         },
                         "us-east-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-055f8d9763e1fb4d7"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0b5e8e821edf1ec27"
                         },
                         "us-east-2": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-06cc69aa8311555bf"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-06c7aff6ef2c39909"
                         },
                         "us-west-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-062b2a2f58fdaf72f"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-001934f1193bb00bb"
                         },
                         "us-west-2": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-0c99e01f5814ee6cb"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-020d6b4f239711b4e"
                         }
                     }
                 }
@@ -190,85 +190,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "4b2cca3500df06917533c4012a887b4dabc1e03c1cd094955ec0633a09b5d668",
-                                "uncompressed-sha256": "258e61745083c74763ac8f3760b2acfd1067e3fbe4434c636d37b4a9d20f7254"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "244983884c8db2b784d632ad07429c2b6e9afc0fcb286cd01fb52f1fa37d7062",
+                                "uncompressed-sha256": "55fd6ce7ba296b86403aa9b6a7149ae02238d2c79e3f0c657c077f92f59aa7db"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "93bc1548598198742161791af2ee9f9af5a6a578d9e375f72c80808eba237581",
-                                "uncompressed-sha256": "19a2e328da8e6bc5d15aefa1a820efe9b30dd0359c09d9269404cf75c09c6b1b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "5509d1c2a3c6bea7f087b44727842b4f5615aea9cfc95a1cc2f6819cfd478eba",
+                                "uncompressed-sha256": "6ae94cd15d4c29dd54b73ea3c020938b94253e24ae17e123b66343f0525472c9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-live.s390x.iso.sig",
-                                "sha256": "fb8aac18de64542e69a57f7d7705017ccd0fd471ef50eabbaa48ce67c12a7fd3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-live.s390x.iso.sig",
+                                "sha256": "6dd27f08e536759d351ef8d208ef1ff47e1efbeadffd97a0ba5c68fa94b07eba"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-live-kernel-s390x.sig",
-                                "sha256": "d17160937e8a5062a451c7e161825048233408bb3b96d4d688f22f234afdb50e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-live-kernel-s390x.sig",
+                                "sha256": "d226a10a5afb66d81cf2f6b78498ad8808fa515779c68e2f8c946582b58c77d7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "4a99b21f6af304c0cc3c4ec67efe77c7bd5fae8d0a73c1efb092551745ff0079"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "64476c9cfb7835427c2c234e6eaec2091c3bc210632e9d8658ba8d60e16ac8b3"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "add27cad0d85067c655b7688be5b76f6bdc267f8560e0f12b9de801956a8dff3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "cd3a235295c335eee3754e45ad917c3ef644b3971474668a6a5303cdf01afc3f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "e2ce4b59530373a02ed293bbc0be068b4979997dedb91f09df190d51fb47708f",
-                                "uncompressed-sha256": "90f3e0060a6f85ee90e2e764004a9be3ff50003bab40534a51e0a060e4a2ac7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "94e875272c2efde3145e519dd9a65187807a89baf3f91c2482d0b5de31a0db78",
+                                "uncompressed-sha256": "320eb78cf27c8b58d019a3706e78bd391298b214e85295eca46e2e9381690a1c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "a65851bd9dd166e9ff5031f6ee7e421031eeef594e40a3f173f7434f07ab5fb3",
-                                "uncompressed-sha256": "b0bd4bfec7a92caebed58526d97d74a5cd353254e2cea47bb87385f8fb57d9d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "12be57df37afbe15104a365583d3bdbebf589326c6543c4fc4cd386ccb697237",
+                                "uncompressed-sha256": "6d0bca597ad1a7a03b3f2f01639c5ba687a85ccd2dddeedeb20feadf18f7ddf0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/s390x/fedora-coreos-36.20220820.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "4c9464382be1a4db2699544eb8faa2c64a2572e41e72dd77004301193115223a",
-                                "uncompressed-sha256": "f6e9f19c251e60ad999c34449e8fc4b032af31a5dc79f8f990beb13c957e65e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "61ed5144dd38536fde7478adf8037d49c0691505ef1ea6a96d4c147678719e70",
+                                "uncompressed-sha256": "64753bc5a143b43089df1aab551b6e4773b53d859d34e036f7269986ddc82572"
                             }
                         }
                     }
@@ -279,225 +279,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "74f1b6546c14889c7a4122ac6ec29fa262278eabf2789b21605fff12c5d4f096",
-                                "uncompressed-sha256": "8dabfa46135fc96da413360c958e6c1e71210a479218de2c7599938995a290c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "edb25685fea56ea5b2ba043d8784226e3798ec807d85ef4066359e2fcb686850",
+                                "uncompressed-sha256": "67a76223a259e217c4c2165488784698336843f765ee41538046235f8b138946"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "39dfd820ac59c6a85b6e79e877f6d44ebae784affd1d27cd0810b4325c76321f",
-                                "uncompressed-sha256": "fcf722d5da3592e855fb8750561f08235feb5dbc59eea073edc5ba5e438ad038"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "6a6e4180ea757c03b1d91810f52a9c16c3e9a6111af48d5e90c5d1c7ee3bce74",
+                                "uncompressed-sha256": "bc50eb54b2a8f9b36b1d788c260cac20123f024dbcf194b08b30dc6203de6361"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "43d0526314e843ff4b91dfa5e4765444ab08d44c9263672c0ed7685c85c7b8d1",
-                                "uncompressed-sha256": "4ed5932a2c38e5b9beb420f0f19eaf1fe91b651769cdb12aae835e675431617b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "1901195735251c742b1f67a2de1d97b815f8e2fc5fca31b5467056999012935a",
+                                "uncompressed-sha256": "3ec89e86b8c17af1aeab8033508727c9812f21c1df4a64138793adc563ee30cc"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "6557ef266ce1a8a68e9503d09732992ff7b1436056da39f803913ef555422319",
-                                "uncompressed-sha256": "6e73f31e1ee91aca14535a2ece14f0434b0a016f70d599f391e62ce4ecd0d7f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "c129689e52b148d9357330ca37944b591e17639bda64d3148075ce6336a67b63",
+                                "uncompressed-sha256": "6bbb4de2a4fdcd350abb3d44a5929133b2a0523dec77bdfca318056ceef051b1"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "244db878eef0cc829b089ec8003cb44076061045992fec609f01754b9fb1c3b7",
-                                "uncompressed-sha256": "237d39fcd1bdc2ce1537f91145e92a6240e1ac607570f8665b299221946ab061"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "64d29a9f8a98492386b60be9160b0cdaab77ca2412fcb592245f04d0f42cd5d4",
+                                "uncompressed-sha256": "f817fd0dc6a80fed46bddcf77e7062668b23f97f85e912f6dd469d9a1adc1272"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "472d79d646289bd4e68f264e952ac978a8df71ba49c759ae9699301730954caf",
-                                "uncompressed-sha256": "f3c03f1951f492f4be9c451a9933db73ef7b01dd14c46091daa26dd790106411"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "5c2f5362ffe29713f5486ff3d6ba0044248d06b8dc1972b21174d1b90fb684a9",
+                                "uncompressed-sha256": "f1d5768ccf6e06b3cd1abffc9bd2333c14bdaae475dec60c785aad38cafd89cc"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "eab21f062cf74d111f186d843c3a51494446347bf7a792052a5f723e408d6c9b",
-                                "uncompressed-sha256": "43c84415438ed3722eaa587303100941b4d80821de51dfca7fa0586303d8ec28"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "3ac00ca726c10db05a006ae3a987a4c5beccaa0747101bc8b0f02ebfcc12a27d",
+                                "uncompressed-sha256": "9bdd39f508932d967fe3e57d16ba42ff90a70d333f8eb51d577fb8b33e5c5acd"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "2ec5a1db4e5fa808f9a4fd14539649f0876d48b631212bef9806c048593fcfe3",
-                                "uncompressed-sha256": "836b48ad2873e2e8f8eeed200caf16613cb972265044d7ec66c61e893fda9d4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "02bf3aa83ed953f8382c71cc7c0bac85a4b44be673e5ca84bbb6340faeb1a225",
+                                "uncompressed-sha256": "95e2ec8b82468da5c7a0473499d4881709887b2170ad528c3e7dceadbb5ddbcf"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "46feae75c1dcd1bb28ee22019ab7814f7946d6d358e49c8c5e880d8832a12ceb",
-                                "uncompressed-sha256": "55198172598c28520a63141fed3f475f48d82253beb53031716433f38a8bae8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "044883dba021274587b98596fcca97930e984f558336b949f99d95cd3188b0b4",
+                                "uncompressed-sha256": "612ecf1e84e2c11ece12545647e301669af6072bca8351bf9aa0d3ce2b6c3941"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-live.x86_64.iso.sig",
-                                "sha256": "264b2bd02867719d63e0d50588435063f57d42d26d94f004f206bc64839a8299"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-live.x86_64.iso.sig",
+                                "sha256": "19a7d9fd2e521d6fa59138743c4418e91a4c7d0af58c5d1ed3e350e2f0079994"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-live-kernel-x86_64.sig",
-                                "sha256": "cbb8198d864e4a9830cacf7a19992a6712fd61607bd92684967a0b913b7f5a6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-live-kernel-x86_64.sig",
+                                "sha256": "ed60ee3dce287f90eef9101aefae1ae0aa6036365ed59df71984321f8c83b6f4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "da89cc4e90aebcaec2b733e526582220a1e54e1677f2063b70ef8b27ca4fb97a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "05f0118aff811717a78ce6bce135f357dc6fd9144da8610f5b9fd56a5e10f555"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "26723ef421204b865a4a04584a7167bcfa7741aeb7bc4348230370a446a4c6df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "b33a3777476ed3da7b1022eda0ad3e3d59446666e2e15406a93a726144ba3694"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "b6a3c8f9795ebb71ec5a1549015b5ff4794422c9e0941c394102bbb81aa6f4b8",
-                                "uncompressed-sha256": "3edaa090e0c9d68acb12b05bf1d7f113e2d73c7c3fe831e41a032ee2c3cbf253"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "1e66ca1f69ef1ceb140ca8568f5bef839cb433a4b0e57ada3f9701b46355ed5e",
+                                "uncompressed-sha256": "cd5329c7f2886a05bcd87695717ea4cd6c7dabe024786b5fe50254a996e9011a"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "fb78681adff081ad3175ce4df484d8c9a79d8db51705b86537387da1871ed9fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "9e6907542f32b8c979d286715e3e0ef97c11b5abf6f48c6500d2b0cfa66d39eb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "fb124a7f44a5fb156d7a742e93c5bdbc6d4212521bb957ecce3ee9400789b06d",
-                                "uncompressed-sha256": "4bdcd1b3854214d4dc246b421a2176b330d9ed1303775d0e4eca95663da16860"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "361d4a652e7b557e3a1bb9b70ca7a9a524f935f074d98fa34f2362feacd1bca9",
+                                "uncompressed-sha256": "d1a2166f734c40e055695429311f66b566bafa4aef3fb7737472f062f960b013"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e735ccd685b4fc8582b83a251dbbd37810f1683264305e2d72e8168f0b26fab7",
-                                "uncompressed-sha256": "a9f6f3df70d0c0e9716c41f9a7c141643421497a1f635465c30b8988f4a810b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e0fa1101f5c14788b68eb35c97a2afd3e6cfb8fbd43e8c55bf0276471c3f7012",
+                                "uncompressed-sha256": "d1433190486488ee13a04920a442f2abe512db8368605ded78fd4ae9403e9571"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "7034f07141b8872b5a41ca5f2cbd25ab74d879fff0b48fa2453907ee900c3685"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "ca3a818b79ba60801793015510a944b1e8571d587dc0d155943beb87523a188d"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "aa5804e3467856f539ec770b6f3e2fd715c305f4dedb8d66a230966757fab4e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "e83fd4c60f922478c154943138a5e39f22fe44c183826f6bc3610ddcbe2187aa"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220820.2.0/x86_64/fedora-coreos-36.20220820.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "01758fca2b79fc82f2b785fa8d38e37c82334de6b7dd9e0ce19b37cd6ae94227",
-                                "uncompressed-sha256": "67b8d3060675294b7871e4b1c8d26643986c622544fddbb822aace952fefc9fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "7f64efc0be68a74021a2578f763d1ddcf4a4142d7b6dcf60e37e5d5f838c3918",
+                                "uncompressed-sha256": "1ca231f502398e1699e9c090ead96f078a6043fbba6f91d833c336359f358f6e"
                             }
                         }
                     }
@@ -507,100 +507,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-074c021670e46d7b7"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-07465ccb4b4137e2e"
                         },
                         "ap-east-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-03b5f725e3061c65c"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-043d3a257e60af3f8"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-073e77035e0525114"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0d8f183e656f1d9c2"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-0b0d9924d093472f4"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0a0ccb31e0a988ee3"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-0672acb1a03792911"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-072c3d095c7608207"
                         },
                         "ap-south-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-0280e855ddbd0df43"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0084f4c87914827bb"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-0174d25def780003c"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-01ff7bc4577ccfa07"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-0099b6040d122865c"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-009d33746d4ece589"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-034c16631564d95cc"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-013660d5389164336"
                         },
                         "ca-central-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-0422b706da93bf9d3"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-016a98e37b59f3dc2"
                         },
                         "eu-central-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-02272ccec09d81b35"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0ef8d277c7eba145c"
                         },
                         "eu-north-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-0e4b352c6b70deb5b"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-04c25866721e37d8c"
                         },
                         "eu-south-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-04b861777f45a9f39"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0dcc19fe74476853a"
                         },
                         "eu-west-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-07deb5921d5a2c411"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-05fd8664ed0a52c7c"
                         },
                         "eu-west-2": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-0c607e850b5ba119e"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0821d719ca5c3546e"
                         },
                         "eu-west-3": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-0bb400c590f4da0b7"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-01b73c60e4fb5d6b8"
                         },
                         "me-south-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-0e31b6127afd908db"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0d3601036c9f5b0aa"
                         },
                         "sa-east-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-086fc9aae209b8cff"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-00d27e405f59bb365"
                         },
                         "us-east-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-080680b3e616a6d82"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0d52f4218c348ab6d"
                         },
                         "us-east-2": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-08d969c83ade88942"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0ad7e4c3b4bbeb943"
                         },
                         "us-west-1": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-0a6a5ab91477296b7"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0c721eb056ab907db"
                         },
                         "us-west-2": {
-                            "release": "36.20220820.2.0",
-                            "image": "ami-019d8ff961278aee9"
+                            "release": "36.20220906.2.0",
+                            "image": "ami-0e927cdafd3a34d79"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220820.2.0",
+                    "release": "36.20220906.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-36-20220820-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220906-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-08-23T20:09:20Z"
+    "last-modified": "2022-09-07T09:12:53Z"
   },
   "releases": [
     {
@@ -53,7 +53,7 @@
       }
     },
     {
-      "version": "36.20220806.1.2",
+      "version": "36.20220820.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -61,11 +61,11 @@
       }
     },
     {
-      "version": "36.20220820.1.0",
+      "version": "36.20220906.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1661349600,
+          "start_epoch": 1662559200,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-08-23T20:09:16Z"
+    "last-modified": "2022-09-07T09:12:51Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "36.20220723.3.1",
+      "version": "36.20220806.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "36.20220806.3.0",
+      "version": "36.20220820.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1661349600,
+          "start_epoch": 1662559200,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-08-23T20:09:18Z"
+    "last-modified": "2022-09-07T09:12:52Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "36.20220806.2.0",
+      "version": "36.20220820.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "36.20220820.2.0",
+      "version": "36.20220906.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1661349600,
+          "start_epoch": 1662559200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @cverna via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).