### PR TITLE
updates: add barrier for final last F36 `next` build

### DIFF
--- a/updates/next.json
+++ b/updates/next.json
@@ -57,6 +57,9 @@
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        },
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     },


### PR DESCRIPTION
As discussed in the meeting today:
https://github.com/coreos/fedora-coreos-tracker/issues/480#issuecomment-1247314065