### PR TITLE
Roll out stable 36.20220906.3.2, testing 36.20220918.2.2, next 37.20220918.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-09-12T21:19:33Z",
+        "last-modified": "2022-09-22T19:43:56Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/aarch64/fedora-coreos-37.20220910.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/aarch64/fedora-coreos-37.20220910.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "9ea4ab0c429a7536857d6a74646cd7a16e156af879280d18e9407d79ce65e576",
-                                "uncompressed-sha256": "36b0ee9cc6810a74ddd7b356e5bbaa5ed878f62daf8c1d529ba6467e853f1d76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "3163c2ac15ba377b5f3d5a313880bcf0c87493833e5ad4fd234c35584d984ab8",
+                                "uncompressed-sha256": "d6c139fe53afdbef51c1033b72bfd96816877f3b28394d02ac4b0366a98fbfec"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/aarch64/fedora-coreos-37.20220910.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/aarch64/fedora-coreos-37.20220910.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "6376b87584fb96b3f7da808f5df51da81e360d89e33314401107d5a7b3a956a4",
-                                "uncompressed-sha256": "89b500c2bf1eb5fda7906cdbb3fc8eefd76ff5fc8c7b60b363971d72b58d0536"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "91544b61fd4f1f943cfc05d02f2607750d15636f28deda98d83505f4014e634f",
+                                "uncompressed-sha256": "f89614753a578cc0f5e1fc4484c8c1c54788e9797dc3a2eb65f31e28c2a834ec"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/aarch64/fedora-coreos-37.20220910.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/aarch64/fedora-coreos-37.20220910.1.0-live.aarch64.iso.sig",
-                                "sha256": "4145a43a2db7a0dda7f099fdd74973857263779f08ab70e0d20dfed4f5c4a72a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-live.aarch64.iso.sig",
+                                "sha256": "536465285118b749bd6425513b7fd4c66bf3cc3a13f3e5dee4feb04dc577c414"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/aarch64/fedora-coreos-37.20220910.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/aarch64/fedora-coreos-37.20220910.1.0-live-kernel-aarch64.sig",
-                                "sha256": "04d093c4c020c1a83b6b708720a021bd724116f4b7d7bd2b400a7c469733b31c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-live-kernel-aarch64.sig",
+                                "sha256": "f233618d8c7e35e710e25827eb25e1574f17c7c3000e357d3b3d662c8bb79d60"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/aarch64/fedora-coreos-37.20220910.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/aarch64/fedora-coreos-37.20220910.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "d180462580b5af8c871793c2735d39315b7d17e2a5c47fc5364a752907b02f1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "55aac3cc0ddbbf0ae14568d3f097fdf2dba79cac76937113fbb2ec438184bed0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/aarch64/fedora-coreos-37.20220910.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/aarch64/fedora-coreos-37.20220910.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "d19172428641d7a61b2cb57d6075aae4bc2132935587029c2970f92627f7d139"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "e5789ce8ac6d11ec1eff03d7de1d8026c19f99462784f5279cc05fa1be4bde6c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/aarch64/fedora-coreos-37.20220910.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/aarch64/fedora-coreos-37.20220910.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "8cf331b96295acd19e032462f56dd09d21936179c04956cf353a1b3b11c6f804",
-                                "uncompressed-sha256": "e046c133316f7e385255d2276fb4b3a87e5e17ca791b1f06d60de76817ee52db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "cce1c336d1ca7bbbc021dfb107e2b6e6387f7902e5be7e60dc295a4867baf294",
+                                "uncompressed-sha256": "c4acfce8946cb9b077fa1dfdccab682e49b6959735652e7b1485818e27f6b18d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/aarch64/fedora-coreos-37.20220910.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/aarch64/fedora-coreos-37.20220910.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "f426ee0a62c8ea21d860afa6d52715929ce1b3efe0de80da4feda46e8e3fb7a2",
-                                "uncompressed-sha256": "320ce1b85ae938ebdd0aa60f432cd85423b163d1d653b607a6ff2f21a4407310"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "347350da4065c23254663c968791edef18828025cd9cf7492e9aa37d92813c0e",
+                                "uncompressed-sha256": "e86531b04bb7c2f9fb8f718bac0b796720fb4648a33483eb6e0f8d2d76552eb9"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/aarch64/fedora-coreos-37.20220910.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/aarch64/fedora-coreos-37.20220910.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "c67b96f2d3e24f78c374697da581b9a389fb081dcf8ac6553579c4f72fb0d18d",
-                                "uncompressed-sha256": "f42345feb5a4757118cdce36698858823fedd2686cb8e18fc339598b825be0a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "2ec6894b9c9ace9950e0276edf9301c4667e85f26c94622c7df10e8254b8cbdc",
+                                "uncompressed-sha256": "e23d888cd507bac5c449db38c33561edfab6b19f1323aeca9b017c9ba7720e18"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-0da4bd14ac034564a"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0bef9f6e6ec6e2a09"
                         },
                         "ap-east-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-0097f83493b6709a6"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0ecd37a83025afca8"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-0283d447047eface2"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-048220de358711837"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-0a9112fd5543b2a31"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0e6b9d555ad4256d6"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-071718cb7053f5d6f"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0858542b957fd3707"
                         },
                         "ap-south-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-0b2b9656cf705433b"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0ad933436eec96ab7"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-0d5058593f18ae432"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0cfdd568e69af7073"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-089892eec2b4f86c3"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-02f933a8b6ea4d717"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-0086cda88c1ade010"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0f34594c9f50f065a"
                         },
                         "ca-central-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-072d87828749eb14a"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-056192f55667c4a77"
                         },
                         "eu-central-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-0f95f01c482fcd3c7"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-049965835289d930f"
                         },
                         "eu-north-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-0700e5c1a29802413"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0ac56d679b2695713"
                         },
                         "eu-south-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-0da3d4f69eb91c3fa"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-027444d6f9a33b376"
                         },
                         "eu-west-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-0d64fc154158dc1cc"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-013ee7fa879dc8b69"
                         },
                         "eu-west-2": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-07021843dc12204ae"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-016ba9c3c3d6be6d7"
                         },
                         "eu-west-3": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-006dcc5de502e82aa"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0ebcad4c021a6dc39"
                         },
                         "me-south-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-07ab1b85d83750fb2"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-08dace6bda1c956cd"
                         },
                         "sa-east-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-05eeb1181e78bcbb6"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0d02b429550cd586a"
                         },
                         "us-east-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-052eff5e18ab5caf3"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0baa70045d18e13b3"
                         },
                         "us-east-2": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-089e8267ad9ce85d5"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-06becd99800701083"
                         },
                         "us-west-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-02a711d215c996eb9"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0dd31964c3588f1be"
                         },
                         "us-west-2": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-086ec79a9a706c6e2"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0d5dacb108f1009f1"
                         }
                     }
                 }
@@ -190,85 +190,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/s390x/fedora-coreos-37.20220910.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/s390x/fedora-coreos-37.20220910.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "1dca2ab74d9ed46d5eaee723d5d557d4eba8d83f19cdc6a7501f8a71162c221d",
-                                "uncompressed-sha256": "0ffbeb96905491cf027e833e218d4277fc5a3549a273487bc0ac6201bfb71561"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "64c4b2c2d633caa5fc5e2f49b7de373770f91b77140d218417c30e54e3f071ad",
+                                "uncompressed-sha256": "9aeef1d920c58c9faae15e591b2078e604153d92b12cb580d7a4c49d29d6334f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/s390x/fedora-coreos-37.20220910.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/s390x/fedora-coreos-37.20220910.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "4b25bb4cdfebe469932c2d8428f38745f824bd4e9c91f4e3f4cc4fcbf24c868b",
-                                "uncompressed-sha256": "663252b4cbf407e5a81ecb7b3a3afe614e8d1df1c1683c7ae491bbc2cb7bf90d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "f54e254e608b8888c0ea599c3ff8d119d19eca618f1fa3161f5664ea53a5b631",
+                                "uncompressed-sha256": "31820201b3de5da7dd0bc62d4df2391cafd412feb39f6f399910a2a0f08543c9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/s390x/fedora-coreos-37.20220910.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/s390x/fedora-coreos-37.20220910.1.0-live.s390x.iso.sig",
-                                "sha256": "8f65215b13ac8bb432608ab9d41932c3faa0bb0ef01dcdaf2d8e39fdd2fbad19"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-live.s390x.iso.sig",
+                                "sha256": "2444dd938b116654cc43118aed14a1b9bd677bcf35e1285ad39fb9cee066fe33"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/s390x/fedora-coreos-37.20220910.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/s390x/fedora-coreos-37.20220910.1.0-live-kernel-s390x.sig",
-                                "sha256": "342c4f59cb25b38dda56d7ca470dc233e711f46d4c134790ab40a4ce8ab5bb3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-live-kernel-s390x.sig",
+                                "sha256": "b31e6c7240fcb30d77fcdddf165d65d4a4b0325c43fd24298cd034ab3044fb1d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/s390x/fedora-coreos-37.20220910.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/s390x/fedora-coreos-37.20220910.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "68e4f3db3a0f8aa0143565979d3adcf06f01926744ab9812278a8c6858ac0a3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "8a47b196f54982c0be4a5dcb4ac53a3e43a4762df57f6aadae8eccca9e10484e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/s390x/fedora-coreos-37.20220910.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/s390x/fedora-coreos-37.20220910.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "cdf33069829692e20a52da75e80b4fe060d21dcdc746df04c209c3d84b8d81c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "bb7dab0d77962224a70ec07468b772eca790ae9223e3139ec2ae81c2bdcc7878"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/s390x/fedora-coreos-37.20220910.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/s390x/fedora-coreos-37.20220910.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "d0af023123fc4b79f9650828735a4d3a23e9ba31d0cbaad30acc5d55635bad5a",
-                                "uncompressed-sha256": "5af42814a14753f0d8fae0705972520a1dee64d333b3a6b2e1aebd8b928df215"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "ebdcf208559a9597b3b61f4b0b93081864f2f46c812d4efb7cafcbd20ff64ae8",
+                                "uncompressed-sha256": "f27a1795adafdac3534ba9c0f42b6c10fc094b4971128fc5247a2836b58b1032"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/s390x/fedora-coreos-37.20220910.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/s390x/fedora-coreos-37.20220910.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "39b6f49b120878772b2c84d8cce0c419b89029ae44277a4574e9d2b16fc8c7fd",
-                                "uncompressed-sha256": "90c48a7a778795da5ebc20bb7250ef6afcb6a77383a9b660d22c51588ba834b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "47bfca175bd4204dba94798c52e0156108905a3d954c99b3dd58d2fd1639fc31",
+                                "uncompressed-sha256": "80d651d18672a8126a156ab2b09f24cfac9ca242863614c84394e0d7d86f0fa8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/s390x/fedora-coreos-37.20220910.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/s390x/fedora-coreos-37.20220910.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "2bcceecf3db6a5ec1c3067ff72260727b5111a2a2c39621701b0c6bff8cf9dc0",
-                                "uncompressed-sha256": "b7f251ba1c97fbd6812a79fa402a0bb9ff9dc3e7a2ee36cededb177e9141903b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "fd0324c3b4dbba77aac7c0c7895c1a2f93ca1a2885a83bb270a0e67da43a36d6",
+                                "uncompressed-sha256": "078a0e44c6e7d5b71e80a024214cf9d5caeb05b38be0dc3528c83a81f2558402"
                             }
                         }
                     }
@@ -279,225 +279,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "fc4939abf11f7483a36a6a5cea145f8a8f13e795538743566b456bd68b0ca714",
-                                "uncompressed-sha256": "0a32c36ba21b269f626a9e8665a79b49d5c409e372a8479e044de6c32d4cfaeb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "e9624992301fa2ebe42d3dba030257c2a5453a35cee295be894a6c7c62fad801",
+                                "uncompressed-sha256": "3a99742c2633091e0767c55404282370ea6352a22c73cb20742b78278dd6c877"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "81dedf37859c99009d39b6d3270bed5d4de007d5f38d747c8cc36e49bc5a66bb",
-                                "uncompressed-sha256": "ceba34639a91b1ae9054135f9b10ff42f6ec03b196c930d8570e2aebeb69bf10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "2793e71d1159caeabed46002b0ebbfa8408b7939e7d914eb6cc9d9ee45a637cf",
+                                "uncompressed-sha256": "a52da87facda047d8635fc847f25ca3de09e65175c0ddfbebc2be65ed7ebe3be"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "c9c9e13b1a2a6155a366df85fdec108a155e5f2a969642fb67f1f8c85bb46982",
-                                "uncompressed-sha256": "1438d7c0723a662851985708fe10530ca6ec0c1053b57c265ec0d0e9738b719b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "44ff1e60aadd1afc2d1bc760e18a88badea58ed1b6c660496a7d48bd99802cb2",
+                                "uncompressed-sha256": "9a326be2f3baf9f26197b324c323cffa52613fdf415a233eea404491663d182b"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "67ec6e3c1d2193481deda3cf6bb73f332b2746a4e00483647482b4ac8fc9ee81",
-                                "uncompressed-sha256": "616c96d893f5db97c91dec97cb59ce1cd2fe41383d7b7d3bbd6a3524be862fa7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "ad5058fce126f9bb9975608dc34ec274ebe033c67fb9a444c8e1fd7cb06b017c",
+                                "uncompressed-sha256": "df32ccbdd9497de399435435e4ec4d77d077be03a1d77e0fbcf93f09050ad43c"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "9479561486b41c9302949134c2dddfd26f3a3db834da518d61d1e761f789179f",
-                                "uncompressed-sha256": "8d966363ca817036591a5aa3d687a9d86817ac77cab727b4bd3f9bdb84200b12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "c5fce44f8c3fd6dda7132ab6e765289bd0d254a4b08d2d8ed7a76cee2caae74b",
+                                "uncompressed-sha256": "0e92b3001534a500a55dcd971fa9be2f96512c2d0f6d8a9bb3d9327ceb76678a"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "3315de7afb5d21716b6672d1a1fcb167a7a431a4925dd7be8b565a2e99d23b82",
-                                "uncompressed-sha256": "92ce23463fdaaeb530adcc5cbdeb044bc2844c1e94f3fbb3a02c2b99dc90b9ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "128dfb46c26d2e10710da61e2fa5f052a423afcd14b653addfbd900fad7a025f",
+                                "uncompressed-sha256": "da57615884a23354289aa223a7e752ecbec59b6713ace8693f42072daf556299"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "0fefd6c0952b090303225851550f0612a9587285af549d0534c3c2c8a00a4dd5",
-                                "uncompressed-sha256": "a2f4e47ef45aaa0d4f7acb0c2133be48e289a02b8ee753215f877eaf53dd4e7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "c4c811a8552a463bc16392cd5843c47eed6efd0e17c4fa440733150e9b1544d6",
+                                "uncompressed-sha256": "654bd256972651183aa9497a655c683eaf8161abac132144747feb10f4ce6d9e"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "7a207d1ddf3b7313bb6c41424fd7bfa35e272b11b4a65155b16aeba8fe3910bf",
-                                "uncompressed-sha256": "352e8200266478326810c65ba2401231114eb99a730e6ad07c7fd1efa3618975"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "c7058c70a2ca25a215615e356e7d939c7cb8f5c61b6c0e68796e478808cfffc6",
+                                "uncompressed-sha256": "1d0f940cb4400b6f954dc9b58bb340603603b6388ea808be5122838b7e9ec418"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "52615a935fa1fe6c7338eb7286d9cdfc8c1d195801ff0a12b4cf21501a9ce1b1",
-                                "uncompressed-sha256": "73d82bd3abe2a62ffeeac29b440b9f83060ce508c5f59603ee90ae6cd282f2fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "b321b5f23ced9830f088a37f6e04788081c3feb012c002204a5c62cd0b92256a",
+                                "uncompressed-sha256": "e31c737ac70528969c2affdbdf18f5f4f41d5d34e09684f619be0ee9465dba03"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-live.x86_64.iso.sig",
-                                "sha256": "1e185e32d3ce6cde8bc997b8addd5ecbb67e5057f815d7582f972128fc59b509"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-live.x86_64.iso.sig",
+                                "sha256": "80efe22e36f63edacdb9d58f4e3e43a85887ef6d6007edb1e505f9daa4841c03"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-live-kernel-x86_64.sig",
-                                "sha256": "5f66b94acf71ad1686dc54e08bd5a5dbcd549931e8ff5d087f15f55a88213327"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-live-kernel-x86_64.sig",
+                                "sha256": "42af9ad167d09272c3913522a0b42223e3eff326d1dfed85884e8f113f5f6da4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "cbf951c59cc745c69d1ba4f65ebe8d076e20e49be8456ebc19a173835fd9b7d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "d5ef9d7849b0b508220997e382ccb8321c34c03c37847b9e914dcb8791a3ed8a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "ffaee187f888baa4f4b9519d1787ca757681bea7d9d9b37f2f8fe166def45595"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "bfd023a5020f415bd928f65cc87d5ece8ade90e5ffd9c39b36ce3aa6f8728da4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "834a1e5e1f58c0792809faa5fd5e78da731d60d78ae70547257e9fe0925d1e7d",
-                                "uncompressed-sha256": "c8e90b2eec6d4afadc3540ab0132ae9847fe7bb4268021a6b65513b25adae03f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "ab25ee39034c6b49c265e337fd1565918d0cdcd97cded43445e61c1b42f6bcfa",
+                                "uncompressed-sha256": "cb853f66e437c4df5903dd5de42aa3b1d7a962c87812d566ad09682f9573b243"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "4e0459dc66d222bf0f51e0a9e11f9f4d29ed101fe6c0ac8c51b52a04b35cf5a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "93776c201ac2f44af07bcd41b1ec5d4a36db9335b9a681b9b6609c6ecdb696ed"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "6a21e518cf029a83af2f546a883c23d20fee0f67121b5d6c98b5152edebd699e",
-                                "uncompressed-sha256": "b1b8bf90661e01631896d913fdd89169059d6d1f152fda29051684dd4b98f8a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "0b413794ca6472fc16e0b4cdcea0adf7dfa4a609d63fff6379e1a10b4d52d32c",
+                                "uncompressed-sha256": "b76b43dc410e023cca8ec8136de3e8450d042cd095cc8a9103b7d84022f6865b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "f97b1b0c32b9947d482e757d7b59cc089e8847706f1c685a806b34b59fde19ef",
-                                "uncompressed-sha256": "2488375b68d66333f3ce0c023291ad99bb0266d0779bf5a4121fb98e2ceb97ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "751ba40a4b0a8a9d81c6da13424fef87aa9195df95bd83ccfae0b5427d374fd0",
+                                "uncompressed-sha256": "d087259c730282b76a55d46d7a240e561485a1f416e1ac29ffb1a28b9bc055bc"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "43dd5cafae2d4bdd145cfe21f292156401ef36437de7d160577ee7b360ad495c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "4cde9f255c93d5a3296bf725c88eb59bb93d455f7fe9f2d1a301f9713508f18e"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "8a78b0be292715cd88b6704257e4c9c559d1eebfb68e08e7b9762b0a7dfcbe92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "ea1add3e9e15ec838cc808ff5699b36e336cb224f479eced9067f29d9c81e804"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220910.1.0/x86_64/fedora-coreos-37.20220910.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "15e649580d5273f7a84d7b4cdc7ce2732a7f1a58ebd52c4fab8ddc25ee2c7d6b",
-                                "uncompressed-sha256": "66911cf124878091fae45f4d745c5a47a6aaef86b5c6659597d2abace3b937c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "7149b0eb3e65a22b5f07541a13d6750d9ad2841e5a4574c94d8b5b73fdfd0c42",
+                                "uncompressed-sha256": "46335ed90c011d1a3d14d49980d15da773d73d2a9b801d0d72b9568149c23946"
                             }
                         }
                     }
@@ -507,100 +507,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-0e8bbcfab0b4db952"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0e7a745615faa071a"
                         },
                         "ap-east-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-07bd58988b2de54f9"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-014c87889322d73f4"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-09361d3cd9feaf21a"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-05632554cd632bbd4"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-01f5354c118607e7d"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-08bd66f2c41f4d5f6"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-00f3878d485f23a14"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0378d277c8d496845"
                         },
                         "ap-south-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-0108985d239ce99be"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-05b12d4bff99de377"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-02eb83725db03d6e3"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-030da899e78be8051"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-082175ed42faf6879"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0f1bf742d1c35c4a7"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-0e0147a025dccb8eb"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-093f70b27c744636f"
                         },
                         "ca-central-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-0faff54b343c89187"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0c7c9d952418977e4"
                         },
                         "eu-central-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-06e985146ccbc373a"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0b50ac3172416f133"
                         },
                         "eu-north-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-0948d307f66d4b8d5"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0f281f5a33fdd9991"
                         },
                         "eu-south-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-043dc3ea3c1ff19e8"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-015301cf73e332132"
                         },
                         "eu-west-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-03ca0ff027c8f6b24"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-03b24ea4d3ed3257d"
                         },
                         "eu-west-2": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-07488bdc309f7b1c3"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-04228a47fcaa8e720"
                         },
                         "eu-west-3": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-06cc2a934a55620d3"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0a8f3b5bee9d1f0e0"
                         },
                         "me-south-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-0c4dd856fa07c5ca8"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-08742072ba3b0bf1f"
                         },
                         "sa-east-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-086f13e3b595aa854"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-022e9d1ce173e9cf5"
                         },
                         "us-east-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-025c258c34c5b265a"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0cc44f17718713be9"
                         },
                         "us-east-2": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-0a21718458d6c69f2"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-0e4214d77eafbb852"
                         },
                         "us-west-1": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-08c040ae5864761f5"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-036892bb973ffd22f"
                         },
                         "us-west-2": {
-                            "release": "37.20220910.1.0",
-                            "image": "ami-03cf08124af2a9518"
+                            "release": "37.20220918.1.1",
+                            "image": "ami-021a1fad234c879b4"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20220910.1.0",
+                    "release": "37.20220918.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-37-20220910-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20220918-1-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,92 +1,92 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-09-07T09:12:50Z",
+        "last-modified": "2022-09-22T19:43:54Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "fd4477e9de3f623c537090adf9e1620818973b1db86d07b250340b378752b6c1",
-                                "uncompressed-sha256": "3736de81051da36c566204af2eb239f0ec3f412057450925680c2ca5634935a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "12bc0d12f736d588a031f0687a35d266517fe0d6531f43da66687d8644be0a8a",
+                                "uncompressed-sha256": "65215cf14ec9aaa3a487d501fd9edbf7ff24b32d64924f80dfce1010e5678c17"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "1d17dd525adc1a8727f8ff5c3ba0ad6b83d11fbb05bd43cdfc666b3f5a53179e",
-                                "uncompressed-sha256": "9f4ed9a5dee4e0009363ea79c79d784c11cf34fc2c0e4af470b8c6507ef15d69"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "b8ebd358886ccee08fb121f037a26c9a66a586e2dfda922cfa6a3064e654cfb6",
+                                "uncompressed-sha256": "45dcff0e3ff75390c881c5739dd77daf292436f3d19cc01b38b7cc2b373c37e1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-live.aarch64.iso.sig",
-                                "sha256": "305568733acafe4cb420879fb6704874930d54effda40492b364f0db8031fabd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-live.aarch64.iso.sig",
+                                "sha256": "4c7502519e34b0a4a59060ec93f73c68a4e791e283bca6169b2113fa7091f9ee"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-live-kernel-aarch64.sig",
-                                "sha256": "fd78e3253466ca4e2243b13ba81fb6283442d665e914c2911cd07330a9a054c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-live-kernel-aarch64.sig",
+                                "sha256": "02fa706427a69e9bf24dfa14e7ecf694c6646293216b38808648134efe65fd47"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "18fd3ef389b3d05847008485d673cf277f265955f68063a85767f35a13935b18"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-live-initramfs.aarch64.img.sig",
+                                "sha256": "88730ec67e82052d4fef03d06073e14bd6e623ec5909d1a874d4353e17c8542a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "a6ed3dd34d9c9f60a1209fbbfa43e7bcbd658eed9bb98e5dea4c8ad4e4cbad63"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-live-rootfs.aarch64.img.sig",
+                                "sha256": "def87d447a1662f77f7273d4368c62730b04376ab6e8f1bf1408cb4fb3c1b8f4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "ae35530be826af9d84ace0e78380597bd0496d237fbbc1d885d1dcc564e39137",
-                                "uncompressed-sha256": "5aa03b902c5de867c81ac98e28f8f1eba8cb9923d7f8fb2a51ae5b91de7544c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-metal.aarch64.raw.xz.sig",
+                                "sha256": "27f6640b8de8fe7ba3482bafeea3cf3a2dc2f0d6f34e549f59fde9d10ebb89e2",
+                                "uncompressed-sha256": "2b7802492168a682186eeda095c95baacf2f11c346cc9d8adaf26264a79cea54"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "4357ab3cf5abd01693ef880e17eeb9aa633d752fe8ab6badf761b4316e340ad1",
-                                "uncompressed-sha256": "0dfc04eeda314c30666ce8de9729253d198fea1ca71d5a1eba03192be12380a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "b7a7917b057f6eda7b5f3225b4164f5f5b7c1c7f83f96a64b60dc1268bae3cd8",
+                                "uncompressed-sha256": "4c2d1608517712f12063d7d147f21114454edf8b7b46fa394ea4182a22ce7e6f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/aarch64/fedora-coreos-36.20220820.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "d94c42294a510e87fb9260c5b9bdbca434285802b8c378ce86d8e49a03c9e4c7",
-                                "uncompressed-sha256": "9f58ad3fd3ccb979d30382cdf6d48db5405d36a6d8922ed202c1db37c9381831"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "c10e64b8552bb006606af8aa1a7dde809c08b715fdb42d118506e35927c61747",
+                                "uncompressed-sha256": "e7bcf67b82a9c7c97bf5e871bb9070baddcd86783401889bd184da6278a75aab"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0dd04e7e693b60094"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0032e0e0c8e24b02d"
                         },
                         "ap-east-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-02b0d7472060a5032"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-03b754e524555bb3c"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-020ae75ca012b328a"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-02c345730f8dad931"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0e068630d4765c233"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0cff1d5c49ea173d5"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0f43167ad55b9b0d2"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0117eca9127e53e82"
                         },
                         "ap-south-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-026516bccf0a6ab45"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-01ccf678aa34e00a1"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0e77f96b972a72353"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-089ca82f283b6dd39"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0306c4bea6642083a"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0b9acc7ea9a645be9"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0554e7762e94adbbd"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0c58fc7d28a8796ba"
                         },
                         "ca-central-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0359c22a6bf23cda6"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-09253e71aa6cd3b6e"
                         },
                         "eu-central-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0ee3adbf93a178701"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0af49f719656e8514"
                         },
                         "eu-north-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0064b3638b9c0931e"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-05ec5471bff07b843"
                         },
                         "eu-south-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-03d5f16e8d524c0fd"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0ba2d26862e55f123"
                         },
                         "eu-west-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0be00bd3a0568226c"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0ecf2c864157cf718"
                         },
                         "eu-west-2": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0663424d1c6664a41"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-005732ec14763ecbb"
                         },
                         "eu-west-3": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0eaec7eb7ec99c475"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0992180a4fd001c77"
                         },
                         "me-south-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0ab0618848ad482c7"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0dbd58f1b5ba65c8b"
                         },
                         "sa-east-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0ee1a6cb5b0025e10"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0b795867e8957f03f"
                         },
                         "us-east-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0e520022b70b9e8f2"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0230b3773bc3ead1d"
                         },
                         "us-east-2": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-051d048ac8f03d55e"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0e217f0097f6a41b9"
                         },
                         "us-west-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0fd56f9cfbcb40ad1"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0439f1a8d0d86157a"
                         },
                         "us-west-2": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-050a32df8495c375f"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-00550d3265982f08c"
                         }
                     }
                 }
@@ -190,85 +190,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "db320892af54b69c0f5336aa1490f1d02f2278c3fa5f7ab158af50c858773953",
-                                "uncompressed-sha256": "4d6116e5bf82d7537f08d412690af28d79822999156e719f9e88b33e3a4cbbf7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "cacc031ab3795bcfadc4bf8939c0dbd8d4a5020958a5fd55f5384bda0b32e0a9",
+                                "uncompressed-sha256": "f4c0afcd80f35e6cd8c5c50001b0096e149ca87bd78c8dfb73f416ed94ac1af6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "4b691fe7e72116b6064781e44b445509118b74b3adbdc7cf05f5e05c13f02500",
-                                "uncompressed-sha256": "157c8c345797fc3500ef1bd55abb7154453e4963d0f69ab14090f8af64c4b775"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-metal4k.s390x.raw.xz.sig",
+                                "sha256": "aac650b9b7d555301eca108c6a45f9f590cbfcdf524397070695fabe48c50d42",
+                                "uncompressed-sha256": "3bf6ec367c54b400a68880bc144162134355b27b507564be5d1ce92e0c56fed3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-live.s390x.iso.sig",
-                                "sha256": "1a51051745ed70e4bc155070934f019d36ee63efbb078fe59cd22be5a43bc274"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-live.s390x.iso.sig",
+                                "sha256": "506f263568389c953629c0cb05576e75bdbcedee198aef15e470fdabbe384bb5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-live-kernel-s390x.sig",
-                                "sha256": "d17160937e8a5062a451c7e161825048233408bb3b96d4d688f22f234afdb50e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-live-kernel-s390x.sig",
+                                "sha256": "d226a10a5afb66d81cf2f6b78498ad8808fa515779c68e2f8c946582b58c77d7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "608979f1c592555ec8a7c2794e09141abec73d6730e7a371b9c6969ad8d1d044"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-live-initramfs.s390x.img.sig",
+                                "sha256": "aeb7921332613b064987909a6c5257d915bf9c118d2530c9955e8cba59914cb8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "982904c9c5607883a77d70ecdc6e6e628822bfa5ddd7ebe8ef1f2f51b6ff06aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-live-rootfs.s390x.img.sig",
+                                "sha256": "d32172a14eff28c58ae84c7c1b3f0490021ef7525389fd8495420bf9e99d6f97"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "144aadeeae40cc80bfe2cef1054a9f4993178e7357bd8328493e151aecc557e9",
-                                "uncompressed-sha256": "294b8edda412834057f6a9b77bf1c027b24cadf561dee34cebe1962080449cec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-metal.s390x.raw.xz.sig",
+                                "sha256": "8dfa838576e04fe81c2361e3e22e44ebe3373954a56364074b007fbba0b87eae",
+                                "uncompressed-sha256": "3130365c019c5ceab09303d5ccc6b96b3964e45e05049c2f03baddcc1f4b680e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "a3a7d2c8be6979fa2438f8387aaaaffc2c80f3b95f28cbfc20465c6c73446f42",
-                                "uncompressed-sha256": "664d86a8e8864bfc881fd0c8f977c0316eb1cd8158275dfaf6053deb8576992f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "541acf2c00ded56a9a634d1595c2a4e7b857bc91a38fc77429a83d391c781a52",
+                                "uncompressed-sha256": "7034a306d1f898db335212b93f589ee560fd4944b2b8875ed567a9794d37ee23"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/s390x/fedora-coreos-36.20220820.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "118968fe3d5425ea54864034f99a46f621b3dd9a1c399e743dc31a395abbe0af",
-                                "uncompressed-sha256": "dba387d6f5d627356770d0615938ff986e4e207c11f7a00ea0523828e77611fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "9ba9f90159240b338f56e8425d715846fdaeb03dacc9e75fc593424494487493",
+                                "uncompressed-sha256": "18c4aa1fe951d5b17dfba608a78e49b27c35423eb99b399ba7c77ba528662cde"
                             }
                         }
                     }
@@ -279,225 +279,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "0d53cdfe90d0efcc6472b58b39c87c7449658e451ec882b2dce5f20701170823",
-                                "uncompressed-sha256": "d161ca0c63721493b6ed01ef59e5eb043b0dfaab7d3c955af4549a5245454a89"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "1d2f7fef500b449f35444e15c382005f936a931ca401b1e1df3ab9e17aa966a4",
+                                "uncompressed-sha256": "98b2224aaa9456e9872042a172c732d25f51c70ac11217aa3c077d0a8f2fa65a"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "b4b56d28d882b5fc42c23a3b6f7f2adc21457ced1d2b19cfb5c8fd49bc672d4d",
-                                "uncompressed-sha256": "c04f41c9a1606e77a1dab542e0daa864cab21e6eccfdac8f607036261be4dd46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "b36ddeb50410cc094bb6650adc0013d843dd1cc8199c8a342a35f8acb3550618",
+                                "uncompressed-sha256": "ee423657bc6e805486ad976ce522fe1d7bf62c0d70916fcccef5a8bb57af1fa3"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "4ff9d7f924c18d20a2e865222d63eb2b70906b2edf966337457995fd3f9a3321",
-                                "uncompressed-sha256": "9b43ad73c77e90974cce242e04889c459ed36bc51791a0504091488d58083809"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "4dcdf96563a5e46fe22f94b1902fe79e807d9d235b7513d7e6513a52b8f45fc3",
+                                "uncompressed-sha256": "d4e7d8b7f801e9984731e1dd059835339b278a904bc2187591df6ee61ccdd5fb"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "e1cbbe9ef70bceb1fb5098c216c7ef99bfa25f1e583b918e23d217f411adc16c",
-                                "uncompressed-sha256": "aa2d4a707e0e324806736a53e67e684abdeca043e954b91af1a42fbbe80d8929"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "f6e925bd8dcfcac0e0a39e4094509b34b1e33e2e17c5d4eaa138e0701295aa98",
+                                "uncompressed-sha256": "cf281f1ba7f478fcb7b75ffc4cdae7cda1e4e527dcbb738f253d9241b6f4e059"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "3370947ccc6e5c7246b71bd65e8426a7f6c754e068360efd892c74b89b29783c",
-                                "uncompressed-sha256": "7f34e9f8c8723b1c06340f0e7273b02255bd6fe737de1bda0daf36d94fffc05c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "3eb6371330d3be2337f1923a06160b7c5a7c00b0bb7992fc30111158794a70be",
+                                "uncompressed-sha256": "474142316131999a7988848e73a43a6cc3ae96ae474f74d2ffa29a893ad98edb"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "907c206e4441af2a5aabc3601b497e03c74d02b04439715561a3c081a760f2b9",
-                                "uncompressed-sha256": "c6de69fd6366995632753efa218e4ba8c6c38b101cc94a4e98fb8fede9fa5378"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "454d5a3da2ef184572d77ac50881ec175695f0d099843d92c1c9de674378c553",
+                                "uncompressed-sha256": "640f19c96154867b1788b209af931dee7e60f4ab1bb7fdcd23d932903c79c855"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "c2f4367aaa858e729eaaa0501420f123921b39b7612654295da6402ab1c4a722",
-                                "uncompressed-sha256": "71449b12f5f105b785de09d67bd1cb567eb8bccabb624f0f14f89898752390e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "d05103038f5489ec53d2e5899eb52f8d7e5a9d6b0bce5f59ab047469650c434f",
+                                "uncompressed-sha256": "2bae25157fc467a06e12615637e9ac1232ec6b8c2be149945f8b4b9f0129c990"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "b6768f1b33705131f5e0717b95df4f33b71ce2fbb603e66f27a4df7115399479",
-                                "uncompressed-sha256": "83e76f0c3de9d5621085c37a6f00360398428480e2ebde4ca7f015d15a6bf15a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4b6bdfca1b3e221ee791e509de8b68ef431e3d41bef79781e79820b69322c50a",
+                                "uncompressed-sha256": "3fe0439bcf89dfd47ebcdd1b8d0f45894a39ed6a76c8fcb60514ed7202b67cc9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "dc26389a92944e4f0fe8afe2d41d1d519be47c217c2f485bb5b90356e0ce0bf2",
-                                "uncompressed-sha256": "c3580ae9e1df8c39c933f8f3bf721b1ff3826837fb20ad51c999e3bf13ccaf86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "da53145a5d8d5ff744b12da7cc6a4eb7fe2a77a0c5db9d90203abadc846676d0",
+                                "uncompressed-sha256": "ca3f0d83c6d9092e8fd6ed278bd9bd94d3e1457e4fd9457b3a786f64b25b8b77"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-live.x86_64.iso.sig",
-                                "sha256": "8c1668684848a07346ee3f723ae576441f93cabfd7b9fa64a69d9dac396bdbc9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-live.x86_64.iso.sig",
+                                "sha256": "bf127f030239f1cb545e265f1bcfa7c2368b8a6104381faf06be2faf37f3ba6a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-live-kernel-x86_64.sig",
-                                "sha256": "cbb8198d864e4a9830cacf7a19992a6712fd61607bd92684967a0b913b7f5a6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-live-kernel-x86_64.sig",
+                                "sha256": "ed60ee3dce287f90eef9101aefae1ae0aa6036365ed59df71984321f8c83b6f4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "85c13d3777e1ddc4d09bfae4f5218699dd21b28a6f8f56fa5229e80202dcded1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "4b447da76af552bf0475548d61c3bc934e866d19d01c2368eb5bd8d0a8990769"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "427036df6cd2158e343e0b338ba24b2b050d02fb7eeda64ec96177798e29c4ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-live-rootfs.x86_64.img.sig",
+                                "sha256": "ecad0eb1ab1f43e6ab491344bb196cebeb258a658d35c6b3571ed5a78b8b3e67"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "d89014a554eb44bdd445995cc97a7a9ee217d6032c9acc9cc620a2944e12301b",
-                                "uncompressed-sha256": "05c5849f458aace92df0bda0d76e859fcc849560c1c4dd519265788bc06f4a24"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "086fc1bfc4a54f64c55ece81080fc9191fb9d5a648e70937823432773c52e3de",
+                                "uncompressed-sha256": "0f1f897e38c69b4e57c62700053e4c080b9a883fffc09660d16872d30a6a0891"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "0589cc8af605944585555138a24934596c32e9c5b181d3bd1ad20f5818f1c1e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-nutanix.x86_64.qcow2.sig",
+                                "sha256": "e9fbfd4683a804c736706f551dae7c76b925c6a0b8762f9afc1fe310ed9bf254"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e3bc0fa8b0a86afad1d444aff9c5245de10935697625fc7ff1a01343c2ffd821",
-                                "uncompressed-sha256": "8daca8f4ac61840560f82208900057eac0bf36a19ea619e528597a2e0a4629bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "473b7fc95c1d875ec8fe9ab344f5c5eb3f1c2e98301c73c13340d1b753f08d21",
+                                "uncompressed-sha256": "49e1dab0fd994f8d9f14e183dfd50a4ebf763994f91206b3169300dd06743a76"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "3f9cf657e20ea3af7816b4ccc8d703bb3f6d4718de82a258061d08497ddffe3c",
-                                "uncompressed-sha256": "90c8f98235e3c939a888dbd67bebe99a6bfb313feca550866f1ed9e56e5ac364"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "cdfc53aedb4db26894cf845e084d3164b471a1649ea175f17a48e76176727476",
+                                "uncompressed-sha256": "b86a8c6afde8e58dee6726fea4dc57e4aa62cf0a0c0670a10ff60f68c66e55d8"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "864b81e2c23573d98a07bc37d1e0eeffd594e2ac31edecfc6e0c7cbb16037f06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-virtualbox.x86_64.ova.sig",
+                                "sha256": "edc65130cba69b1ab472bb44d49cfb464dd146b772801ef824dfc9f6d62d0f78"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "4ff659fab770a4c8166a7b8cb24833d7e63d6ddb6158b648ba6016789af20e69"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-vmware.x86_64.ova.sig",
+                                "sha256": "6f3331ec801d69030c34c12684cdcae9b2e0568f50d08c357ba014673d66a9cd"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220820.3.0/x86_64/fedora-coreos-36.20220820.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "55c7bae6c24b41f151aa7aad5791d664a6148b0a2c1b4c75e284203cbf9205a6",
-                                "uncompressed-sha256": "da9678a63694d91bbc317ceb4f6592ec02a3678e122ed9590861525e97545a40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-vultr.x86_64.raw.xz.sig",
+                                "sha256": "460af68a33b83c843c9a3594cea62b4f0cbfd20bee43986cea6e87079c1e763d",
+                                "uncompressed-sha256": "cc64440cde581f73623bb32bccd5749e27addda37485b35de6166d6495e8d7b7"
                             }
                         }
                     }
@@ -507,100 +507,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-01ffecfb00820935d"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0155ff9a190a86681"
                         },
                         "ap-east-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-035c2146d112f84a9"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0cbeabc916c5204cf"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-07048af161653626f"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-05a90cc2efcb3ec8e"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0b5e652981c0f6a2a"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0ed66cf3e7102604e"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0748ccb19c1ce604b"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0c1b4361e82a90e16"
                         },
                         "ap-south-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-00b1a8c786be1bc01"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-010ae83d389b1d965"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-01381e1d7fbaf4734"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-053b87e07b0d577a2"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-002c5d41dd388096e"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-008cd82d67994ba04"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0074a92c8ec5602e3"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0bf2869d86f5202a6"
                         },
                         "ca-central-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0e1bda07a5d29db55"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-02e30038cfb8a94cc"
                         },
                         "eu-central-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-07298551f92dcb6bb"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-052732116e3c32df6"
                         },
                         "eu-north-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0ecced23f715449c3"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-07d6f237d638fffa1"
                         },
                         "eu-south-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-06d8d7019daabc076"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0e688a97222d97191"
                         },
                         "eu-west-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-09a16cf524101e46d"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-01296aacdd034fcd9"
                         },
                         "eu-west-2": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-05b022eade229a660"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-056da988a0c56c7e1"
                         },
                         "eu-west-3": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-04e6d34f953a22746"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-08facdfbb45aac5a5"
                         },
                         "me-south-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-037b58599758c457a"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-09460eddc8c0ff5b5"
                         },
                         "sa-east-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-06ff7ad679a3936a5"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0ef569633a6433138"
                         },
                         "us-east-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0331ce6a9b2537088"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0dbce9bea71a2ee29"
                         },
                         "us-east-2": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-0e6f4ffb61e585c76"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0291fcafcbd03ca5f"
                         },
                         "us-west-1": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-04f2a5462112fc48f"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0b6b987141b85af1e"
                         },
                         "us-west-2": {
-                            "release": "36.20220820.3.0",
-                            "image": "ami-02453b490b0fea552"
+                            "release": "36.20220906.3.2",
+                            "image": "ami-0aa1ad6359c49277e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220820.3.0",
+                    "release": "36.20220906.3.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-36-20220820-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220906-3-2-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-09-07T09:12:51Z",
+        "last-modified": "2022-09-22T19:43:55Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "02b6b66f55f033b4d0068086d2d76e3d6efabc49dc05e2c54e98104034ee07cb",
-                                "uncompressed-sha256": "7334ed3b9335fd1a93cc468e18cf6921eb7ab00ee9a2014ef7963e1b047ca161"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "08d1c6c82a217c8af15111b914de917edd389c13a39e160a5677068d10a073f7",
+                                "uncompressed-sha256": "a926b5a91cd3dd09b86f3db713cd4f8c778469ab792437704985eac18e552e93"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "3e667b2f47e39597c0e12147a12561d4fc048a1d9da40d1becf669edd080aae3",
-                                "uncompressed-sha256": "a3474a68b80891b424fddfe8bb64b20476a94446bac0d7ed17c363f6a5a50283"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "f0b2753584becd57ba5f9ff6e064d893ca73214a236a4a4e2c7c628eb285caee",
+                                "uncompressed-sha256": "5bc19a91c442397b70439f392cdfefc84c03ced7d9ad31d93999f4c65e4634cc"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-live.aarch64.iso.sig",
-                                "sha256": "97da63435f84090e90bdd8dc4e9308369bc00096ef57c05505b75a4752360833"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-live.aarch64.iso.sig",
+                                "sha256": "81df17011d475ffbc3265fef0e7e76dced8d55cd4d7cb2eb041f2bb32a943746"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-live-kernel-aarch64.sig",
-                                "sha256": "02fa706427a69e9bf24dfa14e7ecf694c6646293216b38808648134efe65fd47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-live-kernel-aarch64.sig",
+                                "sha256": "b8cc1d8c3b1f18b2868de8aad6d6644fe9529956afa6d6f8f16d03816bf3c96b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "7f9dc6ec0c8a78f39220e77947e181381fc58b3067d92dec91d129bf2155787a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-live-initramfs.aarch64.img.sig",
+                                "sha256": "550e346850a38f6c52490a5d54668277216f2bf267e1cf30e120eac1420b15a9"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "0ddd96c9651039c40501b1ffb0d9733191c62a71879cb149da0fcf013971282d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-live-rootfs.aarch64.img.sig",
+                                "sha256": "6963bda58844262e2bbaed09d526e6d5277282f2e63f239bc19eee6762378bf4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "8a9fdf5211107fe1d2b606401e35b6c301f368aed7bac8d53d308fa475f3aec9",
-                                "uncompressed-sha256": "f3094a4eb7a2c95c6c23064ac4fd1dfc5c26b5b58c95ec16b75739624552d883"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-metal.aarch64.raw.xz.sig",
+                                "sha256": "650e987c43df98343733ad935d95b7f2e2f3f516e06956df1e3b8cf933def9a6",
+                                "uncompressed-sha256": "fd83852d023769bb0ee3eb96ccc5eb2fcacbb00f4b87de961670f4af8f1a7d46"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "897e82621dfb01dc965d84101a562de4de7f1c3a8a8bcd5719d31c75dd4e79e7",
-                                "uncompressed-sha256": "aadd955f272e6e7c35a09e005b68d53abf894b9107ec98fbd0103324454e0e64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "01897219132dfda1fc741ee894ef65eafb29440899852a49c9877fcccafbcca1",
+                                "uncompressed-sha256": "2c9ac8698dc312735e11b96001725e4fbb1ef383fb93377f1a8a8c1fb63738cf"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/aarch64/fedora-coreos-36.20220906.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "4b988acd58490cb91fdb4a7f7dda1af5b671548639c078432b12f8eff7d3ec40",
-                                "uncompressed-sha256": "a9f72888fc8b764f7fb06f191a7ec3cccafea28f52cb7313fdf73942944b1246"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "8e67bcdfb368beff6c2f3b033b5552657e8379dd2f16a1680d22bd3789a76d34",
+                                "uncompressed-sha256": "025a3c28c4f5def1b6010875aad40fb5d01d44c3fb8aadf2fb5eb0d1a6de5dc7"
                             }
                         }
                     }
@@ -96,92 +96,92 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0db4fa22f041df4f6"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-058ef60c406cd4782"
                         },
                         "ap-east-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0577f89e86dfa032d"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-061a0943b14efcfc8"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0827938b65ad14315"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0cb4f6a6aa23f0c57"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0e0daabda610abcc9"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0403d9a9124254046"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0ee5d46b3c850ba8f"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0416b135f6a93ca31"
                         },
                         "ap-south-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0055981b36b6583b2"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0c06408b03aeec2d0"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0203386a06d7a9650"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0f0b766213bea82ed"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0ece7e95a636fda78"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0ca2061aa6e566aa0"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-03eee21172d716090"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0e1b4db6887148530"
                         },
                         "ca-central-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0814b6030bc92eefe"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-02600846bd048d8ad"
                         },
                         "eu-central-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-085e466fdecb1694c"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-09f2d0de026221a17"
                         },
                         "eu-north-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-079b7d137524aeb1d"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0306d0e6ef0c724b2"
                         },
                         "eu-south-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-061052833e33b470a"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0861772374ec3e13b"
                         },
                         "eu-west-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0410b484c7dcb001b"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-01bfb4133b87ccb96"
                         },
                         "eu-west-2": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-08dd5ad67998566be"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-00dbeec90294bb92d"
                         },
                         "eu-west-3": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-02f974db08a259338"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-09aab0f116083869e"
                         },
                         "me-south-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-00d9261958b002427"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0d9be652deb29729e"
                         },
                         "sa-east-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-071ca062282748956"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-03f9316dd115936c9"
                         },
                         "us-east-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0b5e8e821edf1ec27"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0f95b798076a9d24f"
                         },
                         "us-east-2": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-06c7aff6ef2c39909"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0e3ea0b8ea7df75ef"
                         },
                         "us-west-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-001934f1193bb00bb"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-02da154b33fb2e04d"
                         },
                         "us-west-2": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-020d6b4f239711b4e"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-014e253b2b0015aa0"
                         }
                     }
                 }
@@ -190,85 +190,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "244983884c8db2b784d632ad07429c2b6e9afc0fcb286cd01fb52f1fa37d7062",
-                                "uncompressed-sha256": "55fd6ce7ba296b86403aa9b6a7149ae02238d2c79e3f0c657c077f92f59aa7db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "d9a2c1139c7590a61d06769600f18e8aaf88fbb357d07b057ae92227d831254c",
+                                "uncompressed-sha256": "939fd1cc76fc487267c415029624b47fec9c822c2910982cadca8e4e022c29eb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "5509d1c2a3c6bea7f087b44727842b4f5615aea9cfc95a1cc2f6819cfd478eba",
-                                "uncompressed-sha256": "6ae94cd15d4c29dd54b73ea3c020938b94253e24ae17e123b66343f0525472c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-metal4k.s390x.raw.xz.sig",
+                                "sha256": "d142514dd4b753a40706ef5ba25afe00e947309d1f74d9152ce527c8f837bd41",
+                                "uncompressed-sha256": "09a03bc354bdfcaffd64b8d20c3b92b6fcee0a6ded7144ae4f4551c8931e2c7d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-live.s390x.iso.sig",
-                                "sha256": "6dd27f08e536759d351ef8d208ef1ff47e1efbeadffd97a0ba5c68fa94b07eba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-live.s390x.iso.sig",
+                                "sha256": "d0bf667f5b72e28ecdb8a7707da2ca236d545cba0f5d38523d11c8bc1211ba42"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-live-kernel-s390x.sig",
-                                "sha256": "d226a10a5afb66d81cf2f6b78498ad8808fa515779c68e2f8c946582b58c77d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-live-kernel-s390x.sig",
+                                "sha256": "4e74db27d0ae816f1fd4041d2d64a6e38686f77b6bba50686d5e9da9ac3d1a81"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "64476c9cfb7835427c2c234e6eaec2091c3bc210632e9d8658ba8d60e16ac8b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-live-initramfs.s390x.img.sig",
+                                "sha256": "0671e63c77fa68a02a8e0bf1ab3e45f4c26de546ed5163c2e31ece073ed7a65f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "cd3a235295c335eee3754e45ad917c3ef644b3971474668a6a5303cdf01afc3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-live-rootfs.s390x.img.sig",
+                                "sha256": "4ae61cd253ff312d0f1dd2fee433cd7c533636b0fb942d34d31bf47d7a01a189"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "94e875272c2efde3145e519dd9a65187807a89baf3f91c2482d0b5de31a0db78",
-                                "uncompressed-sha256": "320eb78cf27c8b58d019a3706e78bd391298b214e85295eca46e2e9381690a1c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-metal.s390x.raw.xz.sig",
+                                "sha256": "b914642a4bf3f177188e72c13d633d8cabc0ea36ec912105338b529551a2028f",
+                                "uncompressed-sha256": "5c820ee856b14ac12da218d9ee0719193425ce77d6f4e497a9e97c083bc6f427"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "12be57df37afbe15104a365583d3bdbebf589326c6543c4fc4cd386ccb697237",
-                                "uncompressed-sha256": "6d0bca597ad1a7a03b3f2f01639c5ba687a85ccd2dddeedeb20feadf18f7ddf0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "64df1e2b85dfdf460bc64169da212f75c0291d65905ea133de27716b734e40fe",
+                                "uncompressed-sha256": "141c90b53d7700d79bf6fee75d8e985855293166dbdff019f4d896a9c4a350f8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/s390x/fedora-coreos-36.20220906.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "61ed5144dd38536fde7478adf8037d49c0691505ef1ea6a96d4c147678719e70",
-                                "uncompressed-sha256": "64753bc5a143b43089df1aab551b6e4773b53d859d34e036f7269986ddc82572"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "4ace26801f4800d114f87ef8e21a6566d15b032b5c6d0f01c1e3827387a0fe39",
+                                "uncompressed-sha256": "c969f8016f8bf80ce238dd0fe68731dfe3396cfc156c499c99aa62af2ac5c3fd"
                             }
                         }
                     }
@@ -279,225 +279,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "edb25685fea56ea5b2ba043d8784226e3798ec807d85ef4066359e2fcb686850",
-                                "uncompressed-sha256": "67a76223a259e217c4c2165488784698336843f765ee41538046235f8b138946"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "f2f44b94a133ee5447c81ba064311ff4d1ff80464189bedb5c5f38d6d3eb3169",
+                                "uncompressed-sha256": "22bc4d7d7cd42258eb9c872c43798243169f9539cb135fa30d028676163bae5f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "6a6e4180ea757c03b1d91810f52a9c16c3e9a6111af48d5e90c5d1c7ee3bce74",
-                                "uncompressed-sha256": "bc50eb54b2a8f9b36b1d788c260cac20123f024dbcf194b08b30dc6203de6361"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "9655626c95be3493e1c5d0b356ef24d41b24865452527b089a4a0e49840d15da",
+                                "uncompressed-sha256": "73bf1778684913656c30750b081e8c7a6982df957b964a19ca20da8b0204f494"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "1901195735251c742b1f67a2de1d97b815f8e2fc5fca31b5467056999012935a",
-                                "uncompressed-sha256": "3ec89e86b8c17af1aeab8033508727c9812f21c1df4a64138793adc563ee30cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "72c21ec9a37bf8cdb42a312da854a5a5975d0c16ed390b694c04c4e64e6a218a",
+                                "uncompressed-sha256": "2ec0c22aa1c6e79034fb53b4ef8ede96e5433a64fe053dbfd5aff9132c7bbf4c"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "c129689e52b148d9357330ca37944b591e17639bda64d3148075ce6336a67b63",
-                                "uncompressed-sha256": "6bbb4de2a4fdcd350abb3d44a5929133b2a0523dec77bdfca318056ceef051b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "e13b9c8d404b038e9c3c0144989102c99bd5847a37a1487c5702fccd2c4991e0",
+                                "uncompressed-sha256": "28e59874a1edbf1a04e3eba0ddbfd713334aac88673ba72de9e354d1973da0ed"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "64d29a9f8a98492386b60be9160b0cdaab77ca2412fcb592245f04d0f42cd5d4",
-                                "uncompressed-sha256": "f817fd0dc6a80fed46bddcf77e7062668b23f97f85e912f6dd469d9a1adc1272"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "ad4d401bfcd3d32df1aa2df658d470c8a5cab413af0e98e17b9b42f3ebb31d67",
+                                "uncompressed-sha256": "ee9612e59ec1ac57844872adb68101d960df2ad63f1d7f88ed0c660e2e27b7db"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "5c2f5362ffe29713f5486ff3d6ba0044248d06b8dc1972b21174d1b90fb684a9",
-                                "uncompressed-sha256": "f1d5768ccf6e06b3cd1abffc9bd2333c14bdaae475dec60c785aad38cafd89cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "fdc4ac1dac8e1db3be65e142a72343349885459479c9372ac321ecd53d3fc92c",
+                                "uncompressed-sha256": "bffc0dcd22f1e7206139fa64221e8c2edb967071fa6a9fff0a1564f9bc5be061"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "3ac00ca726c10db05a006ae3a987a4c5beccaa0747101bc8b0f02ebfcc12a27d",
-                                "uncompressed-sha256": "9bdd39f508932d967fe3e57d16ba42ff90a70d333f8eb51d577fb8b33e5c5acd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "d78b1df72157d4fe59226b15cb3b81b799b73745daff1596952c67768c2fea8f",
+                                "uncompressed-sha256": "2c3ea63635e22dcdceb0b3443cdc91d81a58f72ac965d9684dd701523c998fe6"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "02bf3aa83ed953f8382c71cc7c0bac85a4b44be673e5ca84bbb6340faeb1a225",
-                                "uncompressed-sha256": "95e2ec8b82468da5c7a0473499d4881709887b2170ad528c3e7dceadbb5ddbcf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "c8744491d4deba03bfaec091f2bc46c1924ea0bf168e241a0ce23aca1c6c1b43",
+                                "uncompressed-sha256": "65d15cd12e8c2696af8d08a88ebd0663131c28ba92c13c51cfb3af6c2fe58ab7"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "044883dba021274587b98596fcca97930e984f558336b949f99d95cd3188b0b4",
-                                "uncompressed-sha256": "612ecf1e84e2c11ece12545647e301669af6072bca8351bf9aa0d3ce2b6c3941"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "760c0f29bc1f9ffa6ae84b5d8ba35d59d851b5818866a7368e49b7d246e99104",
+                                "uncompressed-sha256": "569b645ef6e863cbd14633d1089f66c0b722441bbaafbd8e3b34a6c43d7afcbf"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-live.x86_64.iso.sig",
-                                "sha256": "19a7d9fd2e521d6fa59138743c4418e91a4c7d0af58c5d1ed3e350e2f0079994"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-live.x86_64.iso.sig",
+                                "sha256": "6247e6f91bece974461cee34be664693000b982cf4790670c2b789b6d78b5d5d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-live-kernel-x86_64.sig",
-                                "sha256": "ed60ee3dce287f90eef9101aefae1ae0aa6036365ed59df71984321f8c83b6f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-live-kernel-x86_64.sig",
+                                "sha256": "83e1ee4e85695d86db6b49b97f595e850a9768031df0c855e9ca1dd2ba3f7e54"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "05f0118aff811717a78ce6bce135f357dc6fd9144da8610f5b9fd56a5e10f555"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "c8dc896964ae1e441e969e04da27b3ef478857641de3514341d83f01029b9789"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "b33a3777476ed3da7b1022eda0ad3e3d59446666e2e15406a93a726144ba3694"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-live-rootfs.x86_64.img.sig",
+                                "sha256": "a127b5097d2abc7304943a7e3708708c3744c273d3519b90ea4c06be8490edbc"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "1e66ca1f69ef1ceb140ca8568f5bef839cb433a4b0e57ada3f9701b46355ed5e",
-                                "uncompressed-sha256": "cd5329c7f2886a05bcd87695717ea4cd6c7dabe024786b5fe50254a996e9011a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "537e8b6f6348909d1c46a4038af2305fd5d30a88b2e5b559af3c30478225119b",
+                                "uncompressed-sha256": "0db78a9b124375b0cf267ef54068f69760eecf210a863b54e8b3745115ec9f6e"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "9e6907542f32b8c979d286715e3e0ef97c11b5abf6f48c6500d2b0cfa66d39eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-nutanix.x86_64.qcow2.sig",
+                                "sha256": "2c695bf69d907c6574384b5d377409e7b6ca0c2cd587773308f1bbda14442e34"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "361d4a652e7b557e3a1bb9b70ca7a9a524f935f074d98fa34f2362feacd1bca9",
-                                "uncompressed-sha256": "d1a2166f734c40e055695429311f66b566bafa4aef3fb7737472f062f960b013"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "5a18c9ed881b27294eaeda5c654daf8ce11ee7a19cba1c4a2b205466cb48b717",
+                                "uncompressed-sha256": "0ca967bfbaf86a3f44a2049fbf9f8c55f36288b6139cb002d257b9a5c288dfbd"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e0fa1101f5c14788b68eb35c97a2afd3e6cfb8fbd43e8c55bf0276471c3f7012",
-                                "uncompressed-sha256": "d1433190486488ee13a04920a442f2abe512db8368605ded78fd4ae9403e9571"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "0b486885ddd823632e11b25220bbe6dad6c37a88adabd6e4f9df63e077b82f07",
+                                "uncompressed-sha256": "9a1125b8efe3a85697aad4357de29b05b8f420f274b8d181af90ef5a40e11379"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "ca3a818b79ba60801793015510a944b1e8571d587dc0d155943beb87523a188d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-virtualbox.x86_64.ova.sig",
+                                "sha256": "5d124a7c1192870284703705490aaf2bd5ac289cdb08154b5afed3fcc485a3f0"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "e83fd4c60f922478c154943138a5e39f22fe44c183826f6bc3610ddcbe2187aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-vmware.x86_64.ova.sig",
+                                "sha256": "c231210d1d667147d8d325f85ba4f3de09cfe4d8b16f74d48f89ecb8b298c6d9"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220906.2.0/x86_64/fedora-coreos-36.20220906.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "7f64efc0be68a74021a2578f763d1ddcf4a4142d7b6dcf60e37e5d5f838c3918",
-                                "uncompressed-sha256": "1ca231f502398e1699e9c090ead96f078a6043fbba6f91d833c336359f358f6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-vultr.x86_64.raw.xz.sig",
+                                "sha256": "1a600b03ddbd501d64f52551a564fa8ccf704ab42ffe46876de404960159efdb",
+                                "uncompressed-sha256": "8c16f48dc4b40fdb5aa468c0baa3ccfc187a20ead4290d8a664033341885374a"
                             }
                         }
                     }
@@ -507,100 +507,100 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-07465ccb4b4137e2e"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-005c8a9d43c283ab9"
                         },
                         "ap-east-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-043d3a257e60af3f8"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-001c5ad8212fd2211"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0d8f183e656f1d9c2"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0c4f1f97ba6bd42a5"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0a0ccb31e0a988ee3"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0d7f0c6823be8f8b0"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-072c3d095c7608207"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-021194c18fbe86592"
                         },
                         "ap-south-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0084f4c87914827bb"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-08d028cb4bee5270b"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-01ff7bc4577ccfa07"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-07dc371a3dbde1f91"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-009d33746d4ece589"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0a0ee28158b74aa7c"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-013660d5389164336"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-09033b2723b3ae6ff"
                         },
                         "ca-central-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-016a98e37b59f3dc2"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-047f709184123889f"
                         },
                         "eu-central-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0ef8d277c7eba145c"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-04d0a629d21f44497"
                         },
                         "eu-north-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-04c25866721e37d8c"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-00aecf13ffaeef698"
                         },
                         "eu-south-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0dcc19fe74476853a"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-02f47aeac09547bfb"
                         },
                         "eu-west-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-05fd8664ed0a52c7c"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0725d155c00285432"
                         },
                         "eu-west-2": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0821d719ca5c3546e"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-019178b07b59ab1f7"
                         },
                         "eu-west-3": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-01b73c60e4fb5d6b8"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-01d8dcf293cf8d1c5"
                         },
                         "me-south-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0d3601036c9f5b0aa"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0d95f7e9cc7cc2315"
                         },
                         "sa-east-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-00d27e405f59bb365"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-08e699c9585d69429"
                         },
                         "us-east-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0d52f4218c348ab6d"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0e28563a054b49a10"
                         },
                         "us-east-2": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0ad7e4c3b4bbeb943"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0aeb52f6057662a90"
                         },
                         "us-west-1": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0c721eb056ab907db"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0ba5e43f3ee562405"
                         },
                         "us-west-2": {
-                            "release": "36.20220906.2.0",
-                            "image": "ami-0e927cdafd3a34d79"
+                            "release": "36.20220918.2.2",
+                            "image": "ami-0193844ec50960574"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220906.2.0",
+                    "release": "36.20220918.2.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-36-20220906-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220918-2-2-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-09-12T21:19:34Z"
+    "last-modified": "2022-09-22T19:43:57Z"
   },
   "releases": [
     {
@@ -55,9 +55,6 @@
     {
       "version": "36.20220906.1.0",
       "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        },
         "barrier": {
           "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
@@ -67,8 +64,16 @@
       "version": "37.20220910.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 4320,
-          "start_epoch": 1663077600,
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "37.20220918.1.1",
+      "metadata": {
+        "rollout": {
+          "duration_minutes": 1440,
+          "start_epoch": 1663876800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-09-07T09:12:51Z"
+    "last-modified": "2022-09-22T19:43:55Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "36.20220806.3.0",
+      "version": "36.20220820.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "36.20220820.3.0",
+      "version": "36.20220906.3.2",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1662559200,
+          "duration_minutes": 1440,
+          "start_epoch": 1663876800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-09-07T09:12:52Z"
+    "last-modified": "2022-09-22T19:43:56Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "36.20220820.2.0",
+      "version": "36.20220906.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "36.20220906.2.0",
+      "version": "36.20220918.2.2",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1662559200,
+          "duration_minutes": 1440,
+          "start_epoch": 1663876800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).