### PR TITLE
Roll out stable 36.20220918.3.0, testing 36.20221001.2.0, next 37.20221003.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,92 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-09-22T19:43:56Z",
+        "last-modified": "2022-10-04T16:44:38Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "3163c2ac15ba377b5f3d5a313880bcf0c87493833e5ad4fd234c35584d984ab8",
-                                "uncompressed-sha256": "d6c139fe53afdbef51c1033b72bfd96816877f3b28394d02ac4b0366a98fbfec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/aarch64/fedora-coreos-37.20221003.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/aarch64/fedora-coreos-37.20221003.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "f5f1bd71fcec71521c604445bd8da931b5658723e4a6a55d7a2ae9090a0dbdd9",
+                                "uncompressed-sha256": "bc2e7ad1773d87e2416d9d7c1086a1c18e46ce245bdb9a95e5336d5aedfdf9da"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "91544b61fd4f1f943cfc05d02f2607750d15636f28deda98d83505f4014e634f",
-                                "uncompressed-sha256": "f89614753a578cc0f5e1fc4484c8c1c54788e9797dc3a2eb65f31e28c2a834ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/aarch64/fedora-coreos-37.20221003.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/aarch64/fedora-coreos-37.20221003.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "818175847a96dd98e922feef7fb0fb85a10ab2c241c8a5bab3e23be84ff5408f",
+                                "uncompressed-sha256": "450492a6a4c24ae51bb3692445c2a9615127340b33d74652530772767edad7cd"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-live.aarch64.iso.sig",
-                                "sha256": "536465285118b749bd6425513b7fd4c66bf3cc3a13f3e5dee4feb04dc577c414"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/aarch64/fedora-coreos-37.20221003.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/aarch64/fedora-coreos-37.20221003.1.0-live.aarch64.iso.sig",
+                                "sha256": "815543334f48e2f39bdbe0cf74366962478aa4ce62abd6310512975abbd53d61"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-live-kernel-aarch64.sig",
-                                "sha256": "f233618d8c7e35e710e25827eb25e1574f17c7c3000e357d3b3d662c8bb79d60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/aarch64/fedora-coreos-37.20221003.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/aarch64/fedora-coreos-37.20221003.1.0-live-kernel-aarch64.sig",
+                                "sha256": "222b83f6402f81108dc1b992717057c1ba694173ae4d59fcba00abe2662ff01d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "55aac3cc0ddbbf0ae14568d3f097fdf2dba79cac76937113fbb2ec438184bed0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/aarch64/fedora-coreos-37.20221003.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/aarch64/fedora-coreos-37.20221003.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "bf6a901c697c7d22dc54455a5b8331360ccdb064d9fcb466e97e44fb002dd42f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "e5789ce8ac6d11ec1eff03d7de1d8026c19f99462784f5279cc05fa1be4bde6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/aarch64/fedora-coreos-37.20221003.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/aarch64/fedora-coreos-37.20221003.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "f1c3dbe097702ce8c6eec262a053aafacd6148169dd4d7e65f01ce9a9ae1db85"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "cce1c336d1ca7bbbc021dfb107e2b6e6387f7902e5be7e60dc295a4867baf294",
-                                "uncompressed-sha256": "c4acfce8946cb9b077fa1dfdccab682e49b6959735652e7b1485818e27f6b18d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/aarch64/fedora-coreos-37.20221003.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/aarch64/fedora-coreos-37.20221003.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "c3fe81e02b8933ede57527dc1081458c6db37f683265040430efab50f5064ccd",
+                                "uncompressed-sha256": "ae103d07ca4648471c07bedec4093a4c8a400630807829241db20b3e5ca70446"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "347350da4065c23254663c968791edef18828025cd9cf7492e9aa37d92813c0e",
-                                "uncompressed-sha256": "e86531b04bb7c2f9fb8f718bac0b796720fb4648a33483eb6e0f8d2d76552eb9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/aarch64/fedora-coreos-37.20221003.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/aarch64/fedora-coreos-37.20221003.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "3c62afc021fd3f6659e79fc3a1310059afd0d05093bc7d169ee5b5808f9ddfa2",
+                                "uncompressed-sha256": "34c5ef6bdf068d2952626056a7eac76569974b57829aa5361d13f7bbd76c71be"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/aarch64/fedora-coreos-37.20220918.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "2ec6894b9c9ace9950e0276edf9301c4667e85f26c94622c7df10e8254b8cbdc",
-                                "uncompressed-sha256": "e23d888cd507bac5c449db38c33561edfab6b19f1323aeca9b017c9ba7720e18"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/aarch64/fedora-coreos-37.20221003.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/aarch64/fedora-coreos-37.20221003.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "b88a46b966e3c4a19e58292af5f5f599c9e1440217d275017ffd47a2c98ae08f",
+                                "uncompressed-sha256": "e5743b53be36612768d35246d4e43c1b3cc460c68cfe3505d90c050c3470dd59"
                             }
                         }
                     }
@@ -96,92 +96,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0bef9f6e6ec6e2a09"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-02d8e2836c08aa99e"
                         },
                         "ap-east-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0ecd37a83025afca8"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0ba284860fb159781"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-048220de358711837"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0caa1da61e092be61"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0e6b9d555ad4256d6"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0644b62948a1ce526"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0858542b957fd3707"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0149d6f4a91a99e1d"
                         },
                         "ap-south-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0ad933436eec96ab7"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-013a63d61979330c6"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0cfdd568e69af7073"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0087e7a3bbbcefb49"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-02f933a8b6ea4d717"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0ad7eaed0ba012e3f"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0f34594c9f50f065a"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-06ab8817bb8f51b31"
                         },
                         "ca-central-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-056192f55667c4a77"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0d0489b3ca3be74d4"
                         },
                         "eu-central-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-049965835289d930f"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0baeae10ff776d9f3"
                         },
                         "eu-north-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0ac56d679b2695713"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-08d9814df5de3078f"
                         },
                         "eu-south-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-027444d6f9a33b376"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0ac637f1611b8acbe"
                         },
                         "eu-west-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-013ee7fa879dc8b69"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0d7c16b7c260275f1"
                         },
                         "eu-west-2": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-016ba9c3c3d6be6d7"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-01e9f1689654f9586"
                         },
                         "eu-west-3": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0ebcad4c021a6dc39"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-07f2e2c4f1b093d47"
+                        },
+                        "me-central-1": {
+                            "release": "37.20221003.1.0",
+                            "image": "ami-05b7e9afa7fae5212"
                         },
                         "me-south-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-08dace6bda1c956cd"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0cc0d71f7ab8e30fd"
                         },
                         "sa-east-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0d02b429550cd586a"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0c3c47c9de8f8d03f"
                         },
                         "us-east-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0baa70045d18e13b3"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-08bb287b82f5eacab"
                         },
                         "us-east-2": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-06becd99800701083"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0b6e55116cff353e0"
                         },
                         "us-west-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0dd31964c3588f1be"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0c071cbc973e4da92"
                         },
                         "us-west-2": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0d5dacb108f1009f1"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0ad8916a0736fb25d"
                         }
                     }
                 }
@@ -190,85 +194,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "64c4b2c2d633caa5fc5e2f49b7de373770f91b77140d218417c30e54e3f071ad",
-                                "uncompressed-sha256": "9aeef1d920c58c9faae15e591b2078e604153d92b12cb580d7a4c49d29d6334f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/s390x/fedora-coreos-37.20221003.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/s390x/fedora-coreos-37.20221003.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "e5562b7ff8c03ab6ea81181286c754d1eff1fdffa64c565e1884bf5a64299e35",
+                                "uncompressed-sha256": "a4bbe1f5f0820c7605f92fd335249d3d7d672ecd86053439abbdd1e7cb4f750c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "f54e254e608b8888c0ea599c3ff8d119d19eca618f1fa3161f5664ea53a5b631",
-                                "uncompressed-sha256": "31820201b3de5da7dd0bc62d4df2391cafd412feb39f6f399910a2a0f08543c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/s390x/fedora-coreos-37.20221003.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/s390x/fedora-coreos-37.20221003.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "bf09da2f57f70865dae76556a1df7fdee6d670d4c4afa0cc13463aea8cfa37cb",
+                                "uncompressed-sha256": "7dba3e537b777abfddcdb613779bbdfdc96452e24cae7f479e8bac3b0957b130"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-live.s390x.iso.sig",
-                                "sha256": "2444dd938b116654cc43118aed14a1b9bd677bcf35e1285ad39fb9cee066fe33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/s390x/fedora-coreos-37.20221003.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/s390x/fedora-coreos-37.20221003.1.0-live.s390x.iso.sig",
+                                "sha256": "4522f61624f4fe2604076b7c5c668bdd0b650a44122559cacc367c0b771a2127"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-live-kernel-s390x.sig",
-                                "sha256": "b31e6c7240fcb30d77fcdddf165d65d4a4b0325c43fd24298cd034ab3044fb1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/s390x/fedora-coreos-37.20221003.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/s390x/fedora-coreos-37.20221003.1.0-live-kernel-s390x.sig",
+                                "sha256": "3e6b638c45e8d39cc2a0d2588375debb16c37418e3556f7d95802763ee654184"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "8a47b196f54982c0be4a5dcb4ac53a3e43a4762df57f6aadae8eccca9e10484e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/s390x/fedora-coreos-37.20221003.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/s390x/fedora-coreos-37.20221003.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "8de3b2d6b6efb285f65be0cc47c3ce0494a0e32bfb2624671c15fc2d3174d022"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "bb7dab0d77962224a70ec07468b772eca790ae9223e3139ec2ae81c2bdcc7878"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/s390x/fedora-coreos-37.20221003.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/s390x/fedora-coreos-37.20221003.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "a0f339847e6e77f3e8ccb2dbf569f71bec18069b070a2bb722b579dfe94bc00f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "ebdcf208559a9597b3b61f4b0b93081864f2f46c812d4efb7cafcbd20ff64ae8",
-                                "uncompressed-sha256": "f27a1795adafdac3534ba9c0f42b6c10fc094b4971128fc5247a2836b58b1032"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/s390x/fedora-coreos-37.20221003.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/s390x/fedora-coreos-37.20221003.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "2904dad6456b2571d7d7048222a29a4f49024ac99d9313cc6f7957bcb6c2a0a8",
+                                "uncompressed-sha256": "cec7817dff9ec0ba634e761f4148c46b450679e63082c74b6c0ce7386680af90"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "47bfca175bd4204dba94798c52e0156108905a3d954c99b3dd58d2fd1639fc31",
-                                "uncompressed-sha256": "80d651d18672a8126a156ab2b09f24cfac9ca242863614c84394e0d7d86f0fa8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/s390x/fedora-coreos-37.20221003.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/s390x/fedora-coreos-37.20221003.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "83ce99caa34b0c682431f61390a81b133303a37b0438a126b87ae5e2d2924345",
+                                "uncompressed-sha256": "a70bade4c0add28477415f7ac83dbfa5820111de1b30f19e1a3d8426b205b9be"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/s390x/fedora-coreos-37.20220918.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "fd0324c3b4dbba77aac7c0c7895c1a2f93ca1a2885a83bb270a0e67da43a36d6",
-                                "uncompressed-sha256": "078a0e44c6e7d5b71e80a024214cf9d5caeb05b38be0dc3528c83a81f2558402"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/s390x/fedora-coreos-37.20221003.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/s390x/fedora-coreos-37.20221003.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "5ebb66b58b77429bf7c996ee9107e6b48c426b5bbbacf0e324e03f618b11e448",
+                                "uncompressed-sha256": "43b85e3aa2d92c88cca3bdfa3642b4d591e24ac474a06664194c560f64637216"
                             }
                         }
                     }
@@ -279,225 +283,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "e9624992301fa2ebe42d3dba030257c2a5453a35cee295be894a6c7c62fad801",
-                                "uncompressed-sha256": "3a99742c2633091e0767c55404282370ea6352a22c73cb20742b78278dd6c877"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "c7d832ad558a3e0d9a36adb90faa7ae096f74fb31ad6acfde8486a6aa1a4361c",
+                                "uncompressed-sha256": "7c3e1e1fb4f58e74b629916c979e105cd4b9e9ccbc33a96ee58acbd65373dfd5"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "2793e71d1159caeabed46002b0ebbfa8408b7939e7d914eb6cc9d9ee45a637cf",
-                                "uncompressed-sha256": "a52da87facda047d8635fc847f25ca3de09e65175c0ddfbebc2be65ed7ebe3be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "f13a801221fc3af1e12acec81a6aab3be52ffd92c7f71370867c5d2e924e41c1",
+                                "uncompressed-sha256": "aa4707b5f42f0b94a19625196d718899ea53d47abbe06ecb15446e710fbd6026"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "44ff1e60aadd1afc2d1bc760e18a88badea58ed1b6c660496a7d48bd99802cb2",
-                                "uncompressed-sha256": "9a326be2f3baf9f26197b324c323cffa52613fdf415a233eea404491663d182b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "d687832501b0b6c3016bc2127574f3ce8e35fe27144a827bccabe4e79c178dca",
+                                "uncompressed-sha256": "2668655fbae99d3381421218fc56ac5a824b0139721908f97557e2b37e32db3b"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "ad5058fce126f9bb9975608dc34ec274ebe033c67fb9a444c8e1fd7cb06b017c",
-                                "uncompressed-sha256": "df32ccbdd9497de399435435e4ec4d77d077be03a1d77e0fbcf93f09050ad43c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "bc45f26056415d968f12e868c39dbc0f140d171159ab6f27434ae347452c4d2a",
+                                "uncompressed-sha256": "88801549011bc9b94ab13bb74f19b53b091ff3f02743d7bdab160a2ad7c53ee3"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c5fce44f8c3fd6dda7132ab6e765289bd0d254a4b08d2d8ed7a76cee2caae74b",
-                                "uncompressed-sha256": "0e92b3001534a500a55dcd971fa9be2f96512c2d0f6d8a9bb3d9327ceb76678a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "d184f0ab5086164e539b5f03c0f202f6bf2e4f7dab99faa5dbccf53898b03d5b",
+                                "uncompressed-sha256": "8676fa94b7a38625223cc5afd19fe44602ec2419029960d59e9397aeb20ddb12"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "128dfb46c26d2e10710da61e2fa5f052a423afcd14b653addfbd900fad7a025f",
-                                "uncompressed-sha256": "da57615884a23354289aa223a7e752ecbec59b6713ace8693f42072daf556299"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "a869a94aef85e5ee427bd851e49b459328b5b137c85b2b524189d6b570e463f3",
+                                "uncompressed-sha256": "6fda6bc7e65dc3ce89c179811bd2734e5654e79d04652de6471173bbc9b5d671"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "c4c811a8552a463bc16392cd5843c47eed6efd0e17c4fa440733150e9b1544d6",
-                                "uncompressed-sha256": "654bd256972651183aa9497a655c683eaf8161abac132144747feb10f4ce6d9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "4d848461a03ccb239064585a3ca34e70ffeea1379034a9d824d0d1fb5f1e5528",
+                                "uncompressed-sha256": "961e8263d433e1888266b8d2972967865e8050717152babccb3baa39c5856962"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "c7058c70a2ca25a215615e356e7d939c7cb8f5c61b6c0e68796e478808cfffc6",
-                                "uncompressed-sha256": "1d0f940cb4400b6f954dc9b58bb340603603b6388ea808be5122838b7e9ec418"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "45ed31f1f091b76500f59c6c036057a7e10b8d3d6f1256c6f225199fa3fd47c5",
+                                "uncompressed-sha256": "5f395f5f47cd33504afa580efc73d15b343a82b9e507646e1beea9951863998b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "b321b5f23ced9830f088a37f6e04788081c3feb012c002204a5c62cd0b92256a",
-                                "uncompressed-sha256": "e31c737ac70528969c2affdbdf18f5f4f41d5d34e09684f619be0ee9465dba03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "5431923fe32a01d04f5f7816d0e47c7796204a81ced33261fb10a32c70668bad",
+                                "uncompressed-sha256": "7e2ab5f8f2d6141ca4579a061f2fe7828f159c3b7e3d280c5a36ae817cbad440"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-live.x86_64.iso.sig",
-                                "sha256": "80efe22e36f63edacdb9d58f4e3e43a85887ef6d6007edb1e505f9daa4841c03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-live.x86_64.iso.sig",
+                                "sha256": "9dfbb339066e1bf5b56467ce989bfcd303c5c65009606f62840ff78104234a4d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-live-kernel-x86_64.sig",
-                                "sha256": "42af9ad167d09272c3913522a0b42223e3eff326d1dfed85884e8f113f5f6da4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-live-kernel-x86_64.sig",
+                                "sha256": "cb96983ba625a231ffdb298769948369e4f47c9e582c392909fb2551308e818c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "d5ef9d7849b0b508220997e382ccb8321c34c03c37847b9e914dcb8791a3ed8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "f36d73bbce277a1bc62819c8ebdcbbb0f0c0e8d9ddfd47ad0dd00c875529bd1a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "bfd023a5020f415bd928f65cc87d5ece8ade90e5ffd9c39b36ce3aa6f8728da4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "cf708df490a0ffc38ee5cc2b4ac1d53c6135ef3e4b0968f3e98cddb91a7ad48a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "ab25ee39034c6b49c265e337fd1565918d0cdcd97cded43445e61c1b42f6bcfa",
-                                "uncompressed-sha256": "cb853f66e437c4df5903dd5de42aa3b1d7a962c87812d566ad09682f9573b243"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "0798359060e7e578f6af6e739d02cead58e2723d70dd80d520cace12bb1598a1",
+                                "uncompressed-sha256": "3136ee31448bb2a88bbec7deef4621b303b2fb5577b08ab4f7c6551820468261"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "93776c201ac2f44af07bcd41b1ec5d4a36db9335b9a681b9b6609c6ecdb696ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "2525066b2e3c7a2a61493a7eb2c78e468f6b0f4add3fcfca83fba7be88cda974"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "0b413794ca6472fc16e0b4cdcea0adf7dfa4a609d63fff6379e1a10b4d52d32c",
-                                "uncompressed-sha256": "b76b43dc410e023cca8ec8136de3e8450d042cd095cc8a9103b7d84022f6865b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "01c5e3bb31939884f1998d3103c32cc942287829106af3910ede445c3f95f065",
+                                "uncompressed-sha256": "fc49bfb67ce5dc049dcfd598fc41e2bc2cbf69efa48a36dd3ae038d6fb522a5c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "751ba40a4b0a8a9d81c6da13424fef87aa9195df95bd83ccfae0b5427d374fd0",
-                                "uncompressed-sha256": "d087259c730282b76a55d46d7a240e561485a1f416e1ac29ffb1a28b9bc055bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "188794d5cbd49c12611a1a5b67f00b4c6c18df2f54221632a7d05b8b7cd0cfdd",
+                                "uncompressed-sha256": "744d0cd71fbb63fe930b4cade55463cc4d916322746bfd0efdb3f1c49315f6ce"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "4cde9f255c93d5a3296bf725c88eb59bb93d455f7fe9f2d1a301f9713508f18e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "f236a6953ac8e9bcebf0ce57e5817f5d6ccf3295c5ebc6f2bf1ae00ea671a828"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "ea1add3e9e15ec838cc808ff5699b36e336cb224f479eced9067f29d9c81e804"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "d11608245f5d947e25b0b0fbbcda8314622311ada1828331068e18ef7be947b2"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20220918.1.1/x86_64/fedora-coreos-37.20220918.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "7149b0eb3e65a22b5f07541a13d6750d9ad2841e5a4574c94d8b5b73fdfd0c42",
-                                "uncompressed-sha256": "46335ed90c011d1a3d14d49980d15da773d73d2a9b801d0d72b9568149c23946"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221003.1.0/x86_64/fedora-coreos-37.20221003.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "9777c17cd2f496dde075fbde49a034a901de538bb1bd8b8cdeddbc7bee095a1e",
+                                "uncompressed-sha256": "dbacd487477f0338a0b744e279fe5f60dfc9f76201ac841b2d3c58385e1f41d5"
                             }
                         }
                     }
@@ -507,100 +511,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0e7a745615faa071a"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-077156479840ccd82"
                         },
                         "ap-east-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-014c87889322d73f4"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-042fc83f59db312e4"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-05632554cd632bbd4"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-05dd91daf77ed2fdb"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-08bd66f2c41f4d5f6"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0e99839138a70b831"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0378d277c8d496845"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-09afa52837796bf6b"
                         },
                         "ap-south-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-05b12d4bff99de377"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-007d724ab551b8180"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-030da899e78be8051"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0b6fed00ede6fa388"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0f1bf742d1c35c4a7"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-05787e91fd75fbecc"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-093f70b27c744636f"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-00d63d0c8ad0af58f"
                         },
                         "ca-central-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0c7c9d952418977e4"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-071a910c2c1d130b6"
                         },
                         "eu-central-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0b50ac3172416f133"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0c31dc0d039d0e0a8"
                         },
                         "eu-north-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0f281f5a33fdd9991"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0b929e2f3939313e5"
                         },
                         "eu-south-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-015301cf73e332132"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-03ddb22d19461a7f0"
                         },
                         "eu-west-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-03b24ea4d3ed3257d"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0b376cfc9984f3f31"
                         },
                         "eu-west-2": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-04228a47fcaa8e720"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0d4b30e2044ad7727"
                         },
                         "eu-west-3": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0a8f3b5bee9d1f0e0"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0a02ee9b566dcc49a"
+                        },
+                        "me-central-1": {
+                            "release": "37.20221003.1.0",
+                            "image": "ami-0a44ce97b9d2d4258"
                         },
                         "me-south-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-08742072ba3b0bf1f"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-06683d3f8e53d9b54"
                         },
                         "sa-east-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-022e9d1ce173e9cf5"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-029fee26c6e3fb135"
                         },
                         "us-east-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0cc44f17718713be9"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-06201fd6d632b1efc"
                         },
                         "us-east-2": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-0e4214d77eafbb852"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-09a7d22df82ce4867"
                         },
                         "us-west-1": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-036892bb973ffd22f"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-00cb0be332f8368b6"
                         },
                         "us-west-2": {
-                            "release": "37.20220918.1.1",
-                            "image": "ami-021a1fad234c879b4"
+                            "release": "37.20221003.1.0",
+                            "image": "ami-016b01fec8fec7764"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20220918.1.1",
+                    "release": "37.20221003.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-37-20220918-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-37-20221003-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,92 +1,92 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-09-22T19:43:54Z",
+        "last-modified": "2022-10-04T16:44:34Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "12bc0d12f736d588a031f0687a35d266517fe0d6531f43da66687d8644be0a8a",
-                                "uncompressed-sha256": "65215cf14ec9aaa3a487d501fd9edbf7ff24b32d64924f80dfce1010e5678c17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "676bc17d4dc7e015ff47948055711e9d03d58e9b5e69a66755da6cebd2f27c0e",
+                                "uncompressed-sha256": "b6d14600ebba42f06bcb51f9ec0b73501fcc99e4f21d4b9f70de81093280bcdb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "b8ebd358886ccee08fb121f037a26c9a66a586e2dfda922cfa6a3064e654cfb6",
-                                "uncompressed-sha256": "45dcff0e3ff75390c881c5739dd77daf292436f3d19cc01b38b7cc2b373c37e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "378fa748a504a828d25e88f9859b0cd0e8250e0e89458705b7cfd00de436876a",
+                                "uncompressed-sha256": "24a57676946c608c2aaef19e6843108178a99c138c02c79266112d721045b4a7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-live.aarch64.iso.sig",
-                                "sha256": "4c7502519e34b0a4a59060ec93f73c68a4e791e283bca6169b2113fa7091f9ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-live.aarch64.iso.sig",
+                                "sha256": "8987038762740ad96162441055f729561f825474c26f4ad4401d4d3a4a4cd7b7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-live-kernel-aarch64.sig",
-                                "sha256": "02fa706427a69e9bf24dfa14e7ecf694c6646293216b38808648134efe65fd47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-live-kernel-aarch64.sig",
+                                "sha256": "b8cc1d8c3b1f18b2868de8aad6d6644fe9529956afa6d6f8f16d03816bf3c96b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-live-initramfs.aarch64.img.sig",
-                                "sha256": "88730ec67e82052d4fef03d06073e14bd6e623ec5909d1a874d4353e17c8542a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "a191cb4f5fb328eb286bea0d294830ec4b6c6eb059d6a554dd51f363df223247"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-live-rootfs.aarch64.img.sig",
-                                "sha256": "def87d447a1662f77f7273d4368c62730b04376ab6e8f1bf1408cb4fb3c1b8f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "2607e07c003a47d9dea48a7b8a8e7f3714aa08772d07bf85a4858e4428331ce1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-metal.aarch64.raw.xz.sig",
-                                "sha256": "27f6640b8de8fe7ba3482bafeea3cf3a2dc2f0d6f34e549f59fde9d10ebb89e2",
-                                "uncompressed-sha256": "2b7802492168a682186eeda095c95baacf2f11c346cc9d8adaf26264a79cea54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "77737f61e37f155b8278a556ab045c7c8a6d5962bf0958c7d4b9b24f360f5a68",
+                                "uncompressed-sha256": "cd8fa1af52a0cd987fefd9969478dd689b33e610e03f1e4b63bfa0a10c14f44c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "b7a7917b057f6eda7b5f3225b4164f5f5b7c1c7f83f96a64b60dc1268bae3cd8",
-                                "uncompressed-sha256": "4c2d1608517712f12063d7d147f21114454edf8b7b46fa394ea4182a22ce7e6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "ff16affd345a6fb6f1a38ed8d4513ad44e52af16b6de4c9ec3d979d90aa7b24e",
+                                "uncompressed-sha256": "046674df99e8104eca6e1a8a2999bf135281faf5f77c90cf00521379fc7c55c8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/aarch64/fedora-coreos-36.20220906.3.2-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "c10e64b8552bb006606af8aa1a7dde809c08b715fdb42d118506e35927c61747",
-                                "uncompressed-sha256": "e7bcf67b82a9c7c97bf5e871bb9070baddcd86783401889bd184da6278a75aab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "110ff113944f144a4f87fb5a512649289291529f2a0ff2230c86519ac1e03073",
+                                "uncompressed-sha256": "4201fb11a4ade8545485302f4f7a969a56e2e418483bfa69f17f884703167c3c"
                             }
                         }
                     }
@@ -96,92 +96,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0032e0e0c8e24b02d"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-03cd3872725f8d26b"
                         },
                         "ap-east-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-03b754e524555bb3c"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-07ee61cd026a815c1"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-02c345730f8dad931"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0264bb07ae97f7026"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0cff1d5c49ea173d5"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0533a59daaf9d9f3b"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0117eca9127e53e82"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-067aeb7fd11c37ce9"
                         },
                         "ap-south-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-01ccf678aa34e00a1"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0f8eb46adf1de170b"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-089ca82f283b6dd39"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-027b03e66356576de"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0b9acc7ea9a645be9"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0026a78c3f159c0d9"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0c58fc7d28a8796ba"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0dc17790bf5142bd6"
                         },
                         "ca-central-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-09253e71aa6cd3b6e"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-099c91465534841e8"
                         },
                         "eu-central-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0af49f719656e8514"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-032583827ac9ebf04"
                         },
                         "eu-north-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-05ec5471bff07b843"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-031da64a49a242754"
                         },
                         "eu-south-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0ba2d26862e55f123"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0f5ca5e5d551b72a0"
                         },
                         "eu-west-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0ecf2c864157cf718"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-03b16280182e0c9ab"
                         },
                         "eu-west-2": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-005732ec14763ecbb"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0b244539713253763"
                         },
                         "eu-west-3": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0992180a4fd001c77"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-06edd1da2c1a5d634"
+                        },
+                        "me-central-1": {
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0703b0b1be73ead80"
                         },
                         "me-south-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0dbd58f1b5ba65c8b"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0dd38d53345251737"
                         },
                         "sa-east-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0b795867e8957f03f"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0aa4f62a87c179d6c"
                         },
                         "us-east-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0230b3773bc3ead1d"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-010b84c8a74bfa893"
                         },
                         "us-east-2": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0e217f0097f6a41b9"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0e944b0793901d791"
                         },
                         "us-west-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0439f1a8d0d86157a"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0be53cada51fd5e62"
                         },
                         "us-west-2": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-00550d3265982f08c"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-00872428c05e79c7f"
                         }
                     }
                 }
@@ -190,85 +194,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "cacc031ab3795bcfadc4bf8939c0dbd8d4a5020958a5fd55f5384bda0b32e0a9",
-                                "uncompressed-sha256": "f4c0afcd80f35e6cd8c5c50001b0096e149ca87bd78c8dfb73f416ed94ac1af6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "de61ba48a0c0e33897b2b93dda4249a00d83a26e0917f2e3308e28f16b07b5c1",
+                                "uncompressed-sha256": "1aeca3cf75a65696f87494b65184b7008a795a74b6f651ba16c830acc4196a2a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-metal4k.s390x.raw.xz.sig",
-                                "sha256": "aac650b9b7d555301eca108c6a45f9f590cbfcdf524397070695fabe48c50d42",
-                                "uncompressed-sha256": "3bf6ec367c54b400a68880bc144162134355b27b507564be5d1ce92e0c56fed3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "2604e4eaa775bcda25ecee876090fc8f3410cbf23bd1bcd66292657ed9b276e3",
+                                "uncompressed-sha256": "24d55fdebaf5ccc203c9919e7997cd20ec14a905f0c11a6f2fee73ef0650c886"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-live.s390x.iso.sig",
-                                "sha256": "506f263568389c953629c0cb05576e75bdbcedee198aef15e470fdabbe384bb5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-live.s390x.iso.sig",
+                                "sha256": "7dc1a7720a458e2269e70293a9d69c39db768c55018d0b9328108b3fee387042"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-live-kernel-s390x.sig",
-                                "sha256": "d226a10a5afb66d81cf2f6b78498ad8808fa515779c68e2f8c946582b58c77d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-live-kernel-s390x.sig",
+                                "sha256": "4e74db27d0ae816f1fd4041d2d64a6e38686f77b6bba50686d5e9da9ac3d1a81"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-live-initramfs.s390x.img.sig",
-                                "sha256": "aeb7921332613b064987909a6c5257d915bf9c118d2530c9955e8cba59914cb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "02677795cea9ae82f4a418c168931d24d8e4916690f387792e6cd69b96f2e2aa"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-live-rootfs.s390x.img.sig",
-                                "sha256": "d32172a14eff28c58ae84c7c1b3f0490021ef7525389fd8495420bf9e99d6f97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "5f53a07e102a34b5655a6f6e47d7583740028e76674751e30af9ea4a19b2c57e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-metal.s390x.raw.xz.sig",
-                                "sha256": "8dfa838576e04fe81c2361e3e22e44ebe3373954a56364074b007fbba0b87eae",
-                                "uncompressed-sha256": "3130365c019c5ceab09303d5ccc6b96b3964e45e05049c2f03baddcc1f4b680e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "b4526fe7f74d86ebcf317922f3cde9298b85968d6ddd4288b3ee7e8a302bb787",
+                                "uncompressed-sha256": "f17718b99b12bc358870757308b461ce2e4676d5b70f2ca2f4a24b1c3f203cee"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "541acf2c00ded56a9a634d1595c2a4e7b857bc91a38fc77429a83d391c781a52",
-                                "uncompressed-sha256": "7034a306d1f898db335212b93f589ee560fd4944b2b8875ed567a9794d37ee23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "5f537aaf4cac594dc8f60fc90e88c3eaa9ff53f1eb76b3b2f65cc417adbb0dd3",
+                                "uncompressed-sha256": "693869506a90e9e7a395897761111942dce32a5499d0923bcbbb9533bcfb7858"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/s390x/fedora-coreos-36.20220906.3.2-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "9ba9f90159240b338f56e8425d715846fdaeb03dacc9e75fc593424494487493",
-                                "uncompressed-sha256": "18c4aa1fe951d5b17dfba608a78e49b27c35423eb99b399ba7c77ba528662cde"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "086ca67a67c87b20df5bc944551fee0f5ebac8173a216a1c973e6193878ab138",
+                                "uncompressed-sha256": "d5b773fd0db27190ecabe89b54b7ba3a222a9f07c81f35c020b73931730b2e54"
                             }
                         }
                     }
@@ -279,225 +283,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "1d2f7fef500b449f35444e15c382005f936a931ca401b1e1df3ab9e17aa966a4",
-                                "uncompressed-sha256": "98b2224aaa9456e9872042a172c732d25f51c70ac11217aa3c077d0a8f2fa65a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "af5c95cbb7a57fccd4e37cd50ef1f192055b0bead1df67870f3adbf13401a496",
+                                "uncompressed-sha256": "3bff56af92c283e9a31ab2e9eca0fb241f7ee43f73a6ed40b71a7976b12f22c3"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "b36ddeb50410cc094bb6650adc0013d843dd1cc8199c8a342a35f8acb3550618",
-                                "uncompressed-sha256": "ee423657bc6e805486ad976ce522fe1d7bf62c0d70916fcccef5a8bb57af1fa3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "715bfe3d2600f491000c41f26b928ae153ce7543f97770c5dc850d234d435533",
+                                "uncompressed-sha256": "c013726ce9e330e2fc2531c53226d68e4e65ca14fbca7c0b8c64d7adea7aeca1"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-azure.x86_64.vhd.xz.sig",
-                                "sha256": "4dcdf96563a5e46fe22f94b1902fe79e807d9d235b7513d7e6513a52b8f45fc3",
-                                "uncompressed-sha256": "d4e7d8b7f801e9984731e1dd059835339b278a904bc2187591df6ee61ccdd5fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "bf57ae6ecfe8ce1453ea79ddfdf020f1271db935ceb9214115d319990840e9b6",
+                                "uncompressed-sha256": "390988f93dc64906aa071abd1e993cf053a42c0aa11806453884a444e7625384"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "f6e925bd8dcfcac0e0a39e4094509b34b1e33e2e17c5d4eaa138e0701295aa98",
-                                "uncompressed-sha256": "cf281f1ba7f478fcb7b75ffc4cdae7cda1e4e527dcbb738f253d9241b6f4e059"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "c65117a0cadb7196dfe32a23d701271f0fd48c996322fe8adc441a8461911eb3",
+                                "uncompressed-sha256": "2cc16d0ef04465a077e6c009efcdd7e2722810148dc8b143ad866fe77b5484b5"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "3eb6371330d3be2337f1923a06160b7c5a7c00b0bb7992fc30111158794a70be",
-                                "uncompressed-sha256": "474142316131999a7988848e73a43a6cc3ae96ae474f74d2ffa29a893ad98edb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "15a25abb8eca8c5d7a041c314bc4116403d93e702606b256cb3e0489f697813b",
+                                "uncompressed-sha256": "aeff4919d6c726b4f09ade95b99100b02e7218cfb4bf1b6dfdc4ee6b8ae14b0a"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "454d5a3da2ef184572d77ac50881ec175695f0d099843d92c1c9de674378c553",
-                                "uncompressed-sha256": "640f19c96154867b1788b209af931dee7e60f4ab1bb7fdcd23d932903c79c855"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "234ca47ca41957c0508b7e88c6fefff72c06344b54b132fec12d886515a934b1",
+                                "uncompressed-sha256": "ff8afb2492a04ef99a1f29f0358eb00299c27f5594a82790ef1fa6db567e2dc9"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-gcp.x86_64.tar.gz.sig",
-                                "sha256": "d05103038f5489ec53d2e5899eb52f8d7e5a9d6b0bce5f59ab047469650c434f",
-                                "uncompressed-sha256": "2bae25157fc467a06e12615637e9ac1232ec6b8c2be149945f8b4b9f0129c990"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "9fdbc17ec2648af989a410a21462a3f03b7f55d4515149e07d5b96529de95615",
+                                "uncompressed-sha256": "40f2557f42085e6df529f809531794cce04ec22d9a78b79de51b512286a267c8"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "4b6bdfca1b3e221ee791e509de8b68ef431e3d41bef79781e79820b69322c50a",
-                                "uncompressed-sha256": "3fe0439bcf89dfd47ebcdd1b8d0f45894a39ed6a76c8fcb60514ed7202b67cc9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "0d69500da1b6bd8fe70d5bc2fccf01a14b3375c59da55ba03dd7334a327b1384",
+                                "uncompressed-sha256": "7dc82020ad92446f368fc53a04825e1a726beb85d28b4bfa50fa378919bc25b4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "da53145a5d8d5ff744b12da7cc6a4eb7fe2a77a0c5db9d90203abadc846676d0",
-                                "uncompressed-sha256": "ca3f0d83c6d9092e8fd6ed278bd9bd94d3e1457e4fd9457b3a786f64b25b8b77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "6994f699ed5c5602dfd1c7699e7e63d145abc3fdb167b63b3095d50254c5c31f",
+                                "uncompressed-sha256": "6f2b4d4b64d66c5f6880df5a2640952b44dbbf294428458f140375f69c7a19ce"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-live.x86_64.iso.sig",
-                                "sha256": "bf127f030239f1cb545e265f1bcfa7c2368b8a6104381faf06be2faf37f3ba6a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-live.x86_64.iso.sig",
+                                "sha256": "8dcc75c9108db3f83bc35f00eba4d48da3d965d22a9bb8304e351a514b64d062"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-live-kernel-x86_64.sig",
-                                "sha256": "ed60ee3dce287f90eef9101aefae1ae0aa6036365ed59df71984321f8c83b6f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-live-kernel-x86_64.sig",
+                                "sha256": "83e1ee4e85695d86db6b49b97f595e850a9768031df0c855e9ca1dd2ba3f7e54"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-live-initramfs.x86_64.img.sig",
-                                "sha256": "4b447da76af552bf0475548d61c3bc934e866d19d01c2368eb5bd8d0a8990769"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "cd8cbf96cfc852c78418858b830b8d0c6607d060a22fecc0f11bb3e29bfe9404"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-live-rootfs.x86_64.img.sig",
-                                "sha256": "ecad0eb1ab1f43e6ab491344bb196cebeb258a658d35c6b3571ed5a78b8b3e67"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "74c76799436eb17afe07b08e1361e87b1ebbe95b01664f711b7eb3492fc80ef8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-metal.x86_64.raw.xz.sig",
-                                "sha256": "086fc1bfc4a54f64c55ece81080fc9191fb9d5a648e70937823432773c52e3de",
-                                "uncompressed-sha256": "0f1f897e38c69b4e57c62700053e4c080b9a883fffc09660d16872d30a6a0891"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "9f286434724f09a236db6dea8d54a3f9bf4a7412ca358c65d9baada94c03d10d",
+                                "uncompressed-sha256": "029999b15eb8cf6c567d7bd4940abf6c385ff6800f3f9ced0090fe61498f4267"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-nutanix.x86_64.qcow2.sig",
-                                "sha256": "e9fbfd4683a804c736706f551dae7c76b925c6a0b8762f9afc1fe310ed9bf254"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "910fda14096d9b24ca6c702513002d985382f30d6a244e02e5789dda3e532dfd"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "473b7fc95c1d875ec8fe9ab344f5c5eb3f1c2e98301c73c13340d1b753f08d21",
-                                "uncompressed-sha256": "49e1dab0fd994f8d9f14e183dfd50a4ebf763994f91206b3169300dd06743a76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "abb52a4cc7fccbe78b259e0e2d7066580f34ada469ad7467384584b29ec7dc9b",
+                                "uncompressed-sha256": "ffb8353ce62ab7a1d96dc7257cc939da15d3633f0a6f288550cf18fa49524823"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "cdfc53aedb4db26894cf845e084d3164b471a1649ea175f17a48e76176727476",
-                                "uncompressed-sha256": "b86a8c6afde8e58dee6726fea4dc57e4aa62cf0a0c0670a10ff60f68c66e55d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "97761dd97f6c8ec25080323a12d614ff546757dce360acf4c0f3363a9233e71a",
+                                "uncompressed-sha256": "4a22836c1c1445850f74886f2ed8150847b787dfcdab060a0d19ee3920655a5f"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-virtualbox.x86_64.ova.sig",
-                                "sha256": "edc65130cba69b1ab472bb44d49cfb464dd146b772801ef824dfc9f6d62d0f78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "0b821aa7ef829938a4f527843dfeaf366171d3fceba3afe4a2a5af5d1192a9b3"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-vmware.x86_64.ova.sig",
-                                "sha256": "6f3331ec801d69030c34c12684cdcae9b2e0568f50d08c357ba014673d66a9cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "baa6705da4cbead950a53ea0e760a381431e3fe567033d551a1eeee3b1adbd49"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-vultr.x86_64.raw.xz.sig",
-                                "sha256": "460af68a33b83c843c9a3594cea62b4f0cbfd20bee43986cea6e87079c1e763d",
-                                "uncompressed-sha256": "cc64440cde581f73623bb32bccd5749e27addda37485b35de6166d6495e8d7b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "43e27b2a1b570379cc8e660f035102478599ca94b190f6a8b48764cf4392b302",
+                                "uncompressed-sha256": "a4b3270c2bf516d9094881543a1764345858526a4a66d70fc6f5b58de1a88445"
                             }
                         }
                     }
@@ -507,100 +511,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0155ff9a190a86681"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0a728a70a4b3324dd"
                         },
                         "ap-east-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0cbeabc916c5204cf"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0f891e0d5bc5792cc"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-05a90cc2efcb3ec8e"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-08e708eb5a2a76f48"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0ed66cf3e7102604e"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0cddd0479e5ef82fd"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0c1b4361e82a90e16"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-045aadd2e21fa8acd"
                         },
                         "ap-south-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-010ae83d389b1d965"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0c1f5616f11211f69"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-053b87e07b0d577a2"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-073f574c5cc28f99c"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-008cd82d67994ba04"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0f892a6d8f8323b57"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0bf2869d86f5202a6"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0bdb176fb82f65651"
                         },
                         "ca-central-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-02e30038cfb8a94cc"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-04619de55b86c190c"
                         },
                         "eu-central-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-052732116e3c32df6"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-026e5aee730cfc84c"
                         },
                         "eu-north-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-07d6f237d638fffa1"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-098ec358c8d626373"
                         },
                         "eu-south-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0e688a97222d97191"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-06a9237e8ccb615bc"
                         },
                         "eu-west-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-01296aacdd034fcd9"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-08afd8b9bb6e4f707"
                         },
                         "eu-west-2": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-056da988a0c56c7e1"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0f009924a5f1d9c22"
                         },
                         "eu-west-3": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-08facdfbb45aac5a5"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-02a1e0cccacd73d68"
+                        },
+                        "me-central-1": {
+                            "release": "36.20220918.3.0",
+                            "image": "ami-033fa9ed541ebcdf5"
                         },
                         "me-south-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-09460eddc8c0ff5b5"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0b7424db65e2cb95c"
                         },
                         "sa-east-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0ef569633a6433138"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0f413c0eb1bc6d589"
                         },
                         "us-east-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0dbce9bea71a2ee29"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0e0a572654f0947ab"
                         },
                         "us-east-2": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0291fcafcbd03ca5f"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0fd3d4c64994895dd"
                         },
                         "us-west-1": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0b6b987141b85af1e"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0d4a18d7a21cf7de4"
                         },
                         "us-west-2": {
-                            "release": "36.20220906.3.2",
-                            "image": "ami-0aa1ad6359c49277e"
+                            "release": "36.20220918.3.0",
+                            "image": "ami-0c398d8db68a07e11"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220906.3.2",
+                    "release": "36.20220918.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-36-20220906-3-2-gcp-x86-64"
+                    "name": "fedora-coreos-36-20220918-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,92 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-09-22T19:43:55Z",
+        "last-modified": "2022-10-04T16:44:36Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "08d1c6c82a217c8af15111b914de917edd389c13a39e160a5677068d10a073f7",
-                                "uncompressed-sha256": "a926b5a91cd3dd09b86f3db713cd4f8c778469ab792437704985eac18e552e93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "5e772f58f6a8dcde6b53e1a9ea6ee16e949bf0a970793481058ae1c46500b3a4",
+                                "uncompressed-sha256": "ab6446f7a6ddf7219ad8defd4cfab7c3ac3a279b389c1f6136852df935c8892d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "f0b2753584becd57ba5f9ff6e064d893ca73214a236a4a4e2c7c628eb285caee",
-                                "uncompressed-sha256": "5bc19a91c442397b70439f392cdfefc84c03ced7d9ad31d93999f4c65e4634cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "196429d1f0c7a9d5e6a3c1ba5365abec584282066a775333763632274ca87c80",
+                                "uncompressed-sha256": "60b6698690cfa1c1880e2da47c460970769d3bc1089756f72ca0fec308e2830f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-live.aarch64.iso.sig",
-                                "sha256": "81df17011d475ffbc3265fef0e7e76dced8d55cd4d7cb2eb041f2bb32a943746"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-live.aarch64.iso.sig",
+                                "sha256": "863a573edb04ea2cb153bbb075d587b75ab80e3fe32c22b0a485173953676477"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-live-kernel-aarch64.sig",
-                                "sha256": "b8cc1d8c3b1f18b2868de8aad6d6644fe9529956afa6d6f8f16d03816bf3c96b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-live-kernel-aarch64.sig",
+                                "sha256": "181453f03fd4562a41a3012b24f11b3044db4c037aa0a6cccabeba42f22759b1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-live-initramfs.aarch64.img.sig",
-                                "sha256": "550e346850a38f6c52490a5d54668277216f2bf267e1cf30e120eac1420b15a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "68b6ec9117bbd2c19f600affbdca8fce87adb22234ff10381150c8b34c593daf"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-live-rootfs.aarch64.img.sig",
-                                "sha256": "6963bda58844262e2bbaed09d526e6d5277282f2e63f239bc19eee6762378bf4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "ceac5ad270c43004a1639e595af3bb0f328c2248fb336b0449d3e16c3c6c8d49"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-metal.aarch64.raw.xz.sig",
-                                "sha256": "650e987c43df98343733ad935d95b7f2e2f3f516e06956df1e3b8cf933def9a6",
-                                "uncompressed-sha256": "fd83852d023769bb0ee3eb96ccc5eb2fcacbb00f4b87de961670f4af8f1a7d46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "88f3e2f197d6d34c590f7d039459f615ba2ae9db177f1f41b089fa8204ea3de9",
+                                "uncompressed-sha256": "3b42f40ca9efcd283ee1a9cec7a7565e71c77da757b6cc177ee614f042c216f7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "01897219132dfda1fc741ee894ef65eafb29440899852a49c9877fcccafbcca1",
-                                "uncompressed-sha256": "2c9ac8698dc312735e11b96001725e4fbb1ef383fb93377f1a8a8c1fb63738cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "09da2a3f8380ee7c7142bf13535f55344391d9fa9a1c3881d01d443e3d7fac74",
+                                "uncompressed-sha256": "1bbc50a2d0753cf0cd6b76add3c24e62347ad128024ad3d111d5b8af7fa5f158"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/aarch64/fedora-coreos-36.20220918.2.2-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "8e67bcdfb368beff6c2f3b033b5552657e8379dd2f16a1680d22bd3789a76d34",
-                                "uncompressed-sha256": "025a3c28c4f5def1b6010875aad40fb5d01d44c3fb8aadf2fb5eb0d1a6de5dc7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "a2471cbde63480c6c7133ba6bd1c3b9150915ef78ef15f322106b28553c854c0",
+                                "uncompressed-sha256": "3d20dfa8f718f6506c6cc37e41ce58b7359fbc8e28789bc9166d05002afa2c14"
                             }
                         }
                     }
@@ -96,92 +96,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-058ef60c406cd4782"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-01d87d2255f69a72d"
                         },
                         "ap-east-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-061a0943b14efcfc8"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0d6ebe89e1d0f7d0f"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0cb4f6a6aa23f0c57"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0d0ff1d5b58bc039d"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0403d9a9124254046"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0e6f6fc9181821392"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0416b135f6a93ca31"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-088910cdca644808d"
                         },
                         "ap-south-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0c06408b03aeec2d0"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0ad57155e49c1d9ce"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0f0b766213bea82ed"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-023508917ce740c24"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0ca2061aa6e566aa0"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-07f7984a2f8f7aa76"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0e1b4db6887148530"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-050a814aada97e24c"
                         },
                         "ca-central-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-02600846bd048d8ad"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-010f9018e7fad38cf"
                         },
                         "eu-central-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-09f2d0de026221a17"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0385a9c8dd8e9cb4e"
                         },
                         "eu-north-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0306d0e6ef0c724b2"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0a5b72b0cd64feb4c"
                         },
                         "eu-south-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0861772374ec3e13b"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0abc27c36eba4da9c"
                         },
                         "eu-west-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-01bfb4133b87ccb96"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0553af3ee040772d4"
                         },
                         "eu-west-2": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-00dbeec90294bb92d"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-09bb6f09468031abf"
                         },
                         "eu-west-3": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-09aab0f116083869e"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-03d9c19937d636222"
+                        },
+                        "me-central-1": {
+                            "release": "36.20221001.2.0",
+                            "image": "ami-035ad00c0521b2157"
                         },
                         "me-south-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0d9be652deb29729e"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-08fa911754b82ac9d"
                         },
                         "sa-east-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-03f9316dd115936c9"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0ad537ad0f4ca4fbe"
                         },
                         "us-east-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0f95b798076a9d24f"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0de89cdba8de38183"
                         },
                         "us-east-2": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0e3ea0b8ea7df75ef"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0619411633201af28"
                         },
                         "us-west-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-02da154b33fb2e04d"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-026215f7d2dad085f"
                         },
                         "us-west-2": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-014e253b2b0015aa0"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-06ffb76420d675965"
                         }
                     }
                 }
@@ -190,85 +194,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "d9a2c1139c7590a61d06769600f18e8aaf88fbb357d07b057ae92227d831254c",
-                                "uncompressed-sha256": "939fd1cc76fc487267c415029624b47fec9c822c2910982cadca8e4e022c29eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "082c792bd537f5b02cc339521fdbb6cf93fd5b52f09b1043ce1bd63721430092",
+                                "uncompressed-sha256": "67fad5fe9cb0ea451790804d1a3cf6a209a4db9985935c969b9b78de3c9acac4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-metal4k.s390x.raw.xz.sig",
-                                "sha256": "d142514dd4b753a40706ef5ba25afe00e947309d1f74d9152ce527c8f837bd41",
-                                "uncompressed-sha256": "09a03bc354bdfcaffd64b8d20c3b92b6fcee0a6ded7144ae4f4551c8931e2c7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "7d7b3bbf19ba7d6201fedaf06f5d6344213085f3ae8e84e5262c0c42e3542501",
+                                "uncompressed-sha256": "ad594e91ea28bff76298ca0adb85f600a726e27b8381e7f01b3081f14a10fd55"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-live.s390x.iso.sig",
-                                "sha256": "d0bf667f5b72e28ecdb8a7707da2ca236d545cba0f5d38523d11c8bc1211ba42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-live.s390x.iso.sig",
+                                "sha256": "7761adb472072a6d40d146872fac491224c0fa14ad21d669f43882fa31a601da"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-live-kernel-s390x.sig",
-                                "sha256": "4e74db27d0ae816f1fd4041d2d64a6e38686f77b6bba50686d5e9da9ac3d1a81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-live-kernel-s390x.sig",
+                                "sha256": "cb5f7b56dc1554895a8bd7efda9f574bc1b4f612a61a310ee8aceda484b85544"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-live-initramfs.s390x.img.sig",
-                                "sha256": "0671e63c77fa68a02a8e0bf1ab3e45f4c26de546ed5163c2e31ece073ed7a65f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "7bea7bffaa94be870777e60bbe5672d6908fac3ff473645f8f7fbb01e94df103"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-live-rootfs.s390x.img.sig",
-                                "sha256": "4ae61cd253ff312d0f1dd2fee433cd7c533636b0fb942d34d31bf47d7a01a189"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "e310a73b43f4eb923602ac18bc74a86bdbef70b01da5c51847af5f1f91ac4366"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-metal.s390x.raw.xz.sig",
-                                "sha256": "b914642a4bf3f177188e72c13d633d8cabc0ea36ec912105338b529551a2028f",
-                                "uncompressed-sha256": "5c820ee856b14ac12da218d9ee0719193425ce77d6f4e497a9e97c083bc6f427"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "1d31028d67a66d2df08d741a3ca9e5d69b78372f283d738ad3b2edcbd1186fb2",
+                                "uncompressed-sha256": "67fd6e9a52ec0a37a6209aaff82000ab1f38c7cf6c523b93f5a27e1dd553220a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "64df1e2b85dfdf460bc64169da212f75c0291d65905ea133de27716b734e40fe",
-                                "uncompressed-sha256": "141c90b53d7700d79bf6fee75d8e985855293166dbdff019f4d896a9c4a350f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "36866890a28d61444cbb60fa6f053a9c82065166db0e6c3137f29a06b9ef4c82",
+                                "uncompressed-sha256": "1e08552ad1f8e6e7b436972969ca05e71b9126d6d4c6f4f5d52b54d9075c8d63"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/s390x/fedora-coreos-36.20220918.2.2-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "4ace26801f4800d114f87ef8e21a6566d15b032b5c6d0f01c1e3827387a0fe39",
-                                "uncompressed-sha256": "c969f8016f8bf80ce238dd0fe68731dfe3396cfc156c499c99aa62af2ac5c3fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "13f57c9f3d5daaa27256a439ba3bc3767fb8f7a969ca2e3c6b64bef3fa3d1738",
+                                "uncompressed-sha256": "c29c02da187da4cc7c4e1256794111bf7c0267b00cfe1bc0291ca052fd10c319"
                             }
                         }
                     }
@@ -279,225 +283,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "f2f44b94a133ee5447c81ba064311ff4d1ff80464189bedb5c5f38d6d3eb3169",
-                                "uncompressed-sha256": "22bc4d7d7cd42258eb9c872c43798243169f9539cb135fa30d028676163bae5f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "2ecfa9a8c0fb26cc212c1732716ac6f24a8a52ab77b48e75d9e1929c465bc2cb",
+                                "uncompressed-sha256": "e2de9d3888c9a1c28942e6632002902e12eecd42a0d50c647919efec085f4ef8"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "9655626c95be3493e1c5d0b356ef24d41b24865452527b089a4a0e49840d15da",
-                                "uncompressed-sha256": "73bf1778684913656c30750b081e8c7a6982df957b964a19ca20da8b0204f494"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "a2951df335bfd59cd2d57f1ac5a536efe4f4a6282b3d32faa82903e74be02502",
+                                "uncompressed-sha256": "f20a779c4fba0a78ba258e7ed9475364c142fa6533cb7be4533d6ba74aed7e0d"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-azure.x86_64.vhd.xz.sig",
-                                "sha256": "72c21ec9a37bf8cdb42a312da854a5a5975d0c16ed390b694c04c4e64e6a218a",
-                                "uncompressed-sha256": "2ec0c22aa1c6e79034fb53b4ef8ede96e5433a64fe053dbfd5aff9132c7bbf4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "f03e997938a534185c15baf40f74521a306bc454d88770065923b0e906245aaf",
+                                "uncompressed-sha256": "036611a036b3f63b6edb767b18c606cb37d6ca9f7ad247c3bb8306ef648b7199"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "e13b9c8d404b038e9c3c0144989102c99bd5847a37a1487c5702fccd2c4991e0",
-                                "uncompressed-sha256": "28e59874a1edbf1a04e3eba0ddbfd713334aac88673ba72de9e354d1973da0ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "ea0d28ffc940078cdf3e2b43416d62beda891e4e46871cd41bab8c92d690fcab",
+                                "uncompressed-sha256": "bd9f93c22de4dd65e5168fd6ad8080f6dd2a7d44453629bbb8ba92bebd556ecd"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "ad4d401bfcd3d32df1aa2df658d470c8a5cab413af0e98e17b9b42f3ebb31d67",
-                                "uncompressed-sha256": "ee9612e59ec1ac57844872adb68101d960df2ad63f1d7f88ed0c660e2e27b7db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "7bb9068ecd6bf8de2448c743e0832b4751f9a701a8da7a552e317be0c763aff7",
+                                "uncompressed-sha256": "b6cdf6c64f8b47bbd5c53f19f1cab05211288665a3c2adcf4d54f418420190b2"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "fdc4ac1dac8e1db3be65e142a72343349885459479c9372ac321ecd53d3fc92c",
-                                "uncompressed-sha256": "bffc0dcd22f1e7206139fa64221e8c2edb967071fa6a9fff0a1564f9bc5be061"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "3f5ef6001bda9eb001d91c98393ebd98cec5bad08c7e970dc21653d6d3cc901e",
+                                "uncompressed-sha256": "4477e2b0a8cb825c71ff93039d86e5b23399593d311ca054ee8c5fad1f156a31"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-gcp.x86_64.tar.gz.sig",
-                                "sha256": "d78b1df72157d4fe59226b15cb3b81b799b73745daff1596952c67768c2fea8f",
-                                "uncompressed-sha256": "2c3ea63635e22dcdceb0b3443cdc91d81a58f72ac965d9684dd701523c998fe6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "6163fac88b65708af489d912794a972d494e6b817771676e3b4e4c18124d44e9",
+                                "uncompressed-sha256": "05701e8278c4ee7e44f6f62533604d3ee6d84ff5a5832ec14cff417e0c68b4f1"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "c8744491d4deba03bfaec091f2bc46c1924ea0bf168e241a0ce23aca1c6c1b43",
-                                "uncompressed-sha256": "65d15cd12e8c2696af8d08a88ebd0663131c28ba92c13c51cfb3af6c2fe58ab7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "798e67f7ee8178c623066a0331b1602d2ad0079c3cf88ddead9302e64275a654",
+                                "uncompressed-sha256": "38fafdfab345cf0fa56792ceade05476584d3d62bb6c25e17b38c1935ab753fb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "760c0f29bc1f9ffa6ae84b5d8ba35d59d851b5818866a7368e49b7d246e99104",
-                                "uncompressed-sha256": "569b645ef6e863cbd14633d1089f66c0b722441bbaafbd8e3b34a6c43d7afcbf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "97958f2929944a13da751ac34a895a04f70cd20dcd0667e067181cd301cbc981",
+                                "uncompressed-sha256": "7b4a3419f414f2f36b6ccfce45d3fe969a3309dfed8267db1c274fdef62b3ec5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-live.x86_64.iso.sig",
-                                "sha256": "6247e6f91bece974461cee34be664693000b982cf4790670c2b789b6d78b5d5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-live.x86_64.iso.sig",
+                                "sha256": "33983a35ea26d81b2a6673e53c570cafef86d933ec7982745b03102a5c97bed8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-live-kernel-x86_64.sig",
-                                "sha256": "83e1ee4e85695d86db6b49b97f595e850a9768031df0c855e9ca1dd2ba3f7e54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-live-kernel-x86_64.sig",
+                                "sha256": "b57933cbf73c1a19ba25030edd771f69e2ec5bd0895ea06b43e91247cfa43d9a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-live-initramfs.x86_64.img.sig",
-                                "sha256": "c8dc896964ae1e441e969e04da27b3ef478857641de3514341d83f01029b9789"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "e843bc01e9701a88015ae932812344e3253fec883b176f16377dee65a5bb3daa"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-live-rootfs.x86_64.img.sig",
-                                "sha256": "a127b5097d2abc7304943a7e3708708c3744c273d3519b90ea4c06be8490edbc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "10855faf2ea2e03a6262d8186cd09aa59d60b056930764d65407332098296639"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-metal.x86_64.raw.xz.sig",
-                                "sha256": "537e8b6f6348909d1c46a4038af2305fd5d30a88b2e5b559af3c30478225119b",
-                                "uncompressed-sha256": "0db78a9b124375b0cf267ef54068f69760eecf210a863b54e8b3745115ec9f6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "60ffb31edfeb5d787135fe2f3bf618f472a266480ec0712a5e2d184b346bb08c",
+                                "uncompressed-sha256": "c527020f28e83b4e4a353d324cd16d3a7f73bef2a0f6b036471dd995b419aa92"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-nutanix.x86_64.qcow2.sig",
-                                "sha256": "2c695bf69d907c6574384b5d377409e7b6ca0c2cd587773308f1bbda14442e34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "dcf02b52f411d5320c34d6f99153afa11c783317e725855c486269f2491ca36b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "5a18c9ed881b27294eaeda5c654daf8ce11ee7a19cba1c4a2b205466cb48b717",
-                                "uncompressed-sha256": "0ca967bfbaf86a3f44a2049fbf9f8c55f36288b6139cb002d257b9a5c288dfbd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "b68fea956161c793729e051103d817746e390368071a6a6fa8ed5e330a1cd31c",
+                                "uncompressed-sha256": "773fc58b4f29b337ddb2593ad8b112bfc14c222a1b8024b2661e59a76b2d265f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "0b486885ddd823632e11b25220bbe6dad6c37a88adabd6e4f9df63e077b82f07",
-                                "uncompressed-sha256": "9a1125b8efe3a85697aad4357de29b05b8f420f274b8d181af90ef5a40e11379"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "c16edbb1b0015ccda3da2ea851ab626a722782b249d7834a13e42830be9ed368",
+                                "uncompressed-sha256": "c3bd3fc245c68de5a91daf8393639731deef9fb9fc87bac59468429451334a14"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-virtualbox.x86_64.ova.sig",
-                                "sha256": "5d124a7c1192870284703705490aaf2bd5ac289cdb08154b5afed3fcc485a3f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "7637a29bf5f889852b9d78fd3ad2c0d140be08ec0c1e728aa1e11a7309fdc1e2"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-vmware.x86_64.ova.sig",
-                                "sha256": "c231210d1d667147d8d325f85ba4f3de09cfe4d8b16f74d48f89ecb8b298c6d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "386b69f799de47ecdb32ef142315cc092c257b37175bfd39364c229835ec378a"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20220918.2.2/x86_64/fedora-coreos-36.20220918.2.2-vultr.x86_64.raw.xz.sig",
-                                "sha256": "1a600b03ddbd501d64f52551a564fa8ccf704ab42ffe46876de404960159efdb",
-                                "uncompressed-sha256": "8c16f48dc4b40fdb5aa468c0baa3ccfc187a20ead4290d8a664033341885374a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "07b9379dfae40587a9c4803cf742a0678f8c6d98cd36ea0c1dbb497a23936446",
+                                "uncompressed-sha256": "2a4964d03dd0a495e0a11df56f14df129a186396b4b3645904683a427ace65bf"
                             }
                         }
                     }
@@ -507,100 +511,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-005c8a9d43c283ab9"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0e19dad4b6a4e79c3"
                         },
                         "ap-east-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-001c5ad8212fd2211"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0018953f95bee034f"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0c4f1f97ba6bd42a5"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-059c1d413ddc1ad73"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0d7f0c6823be8f8b0"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0981c92b55a5f5cc5"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-021194c18fbe86592"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0c099ff765f3849da"
                         },
                         "ap-south-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-08d028cb4bee5270b"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-008ebcf94d737d6d8"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-07dc371a3dbde1f91"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0e9c61eca68ef3f09"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0a0ee28158b74aa7c"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0cfa02e9112b3ab61"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-09033b2723b3ae6ff"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0ed1b7ded536a0824"
                         },
                         "ca-central-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-047f709184123889f"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0a269c57f05b79ef2"
                         },
                         "eu-central-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-04d0a629d21f44497"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0e9a21b238bfe824c"
                         },
                         "eu-north-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-00aecf13ffaeef698"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-00e7e925afdbfa512"
                         },
                         "eu-south-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-02f47aeac09547bfb"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-089af165b02d7963b"
                         },
                         "eu-west-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0725d155c00285432"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-09df294ddcbfd49e9"
                         },
                         "eu-west-2": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-019178b07b59ab1f7"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0a8dcf99f29e53676"
                         },
                         "eu-west-3": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-01d8dcf293cf8d1c5"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0317526e054480bc1"
+                        },
+                        "me-central-1": {
+                            "release": "36.20221001.2.0",
+                            "image": "ami-06164d1f1367dd576"
                         },
                         "me-south-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0d95f7e9cc7cc2315"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-062f3ebf59bbbcf07"
                         },
                         "sa-east-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-08e699c9585d69429"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0a5aae23a2e501280"
                         },
                         "us-east-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0e28563a054b49a10"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-059610cfab81654e4"
                         },
                         "us-east-2": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0aeb52f6057662a90"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-0a6f10ca0f6c83ad4"
                         },
                         "us-west-1": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0ba5e43f3ee562405"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-02bc390447d09e972"
                         },
                         "us-west-2": {
-                            "release": "36.20220918.2.2",
-                            "image": "ami-0193844ec50960574"
+                            "release": "36.20221001.2.0",
+                            "image": "ami-00132048440d9b763"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220918.2.2",
+                    "release": "36.20221001.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-36-20220918-2-2-gcp-x86-64"
+                    "name": "fedora-coreos-36-20221001-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-09-22T19:43:57Z"
+    "last-modified": "2022-10-04T16:44:39Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "37.20220910.1.0",
+      "version": "37.20220918.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "37.20220918.1.1",
+      "version": "37.20221003.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1663876800,
+          "duration_minutes": 2880,
+          "start_epoch": 1664906400,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-09-22T19:43:55Z"
+    "last-modified": "2022-10-04T16:44:36Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "36.20220820.3.0",
+      "version": "36.20220906.3.2",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "36.20220906.3.2",
+      "version": "36.20220918.3.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1663876800,
+          "duration_minutes": 2880,
+          "start_epoch": 1664906400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-09-22T19:43:56Z"
+    "last-modified": "2022-10-04T16:44:37Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "36.20220906.2.0",
+      "version": "36.20220918.2.2",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "36.20220918.2.2",
+      "version": "36.20221001.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1663876800,
+          "duration_minutes": 2880,
+          "start_epoch": 1664906400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).