### PR TITLE
Roll out stable 36.20221001.3.0, testing 36.20221014.2.0, next 37.20221015.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,92 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-10-11T13:48:47Z",
+        "last-modified": "2022-10-18T09:42:09Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/aarch64/fedora-coreos-37.20221008.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/aarch64/fedora-coreos-37.20221008.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "87bbb6ebb0135ed3a739784f7a09c9d7636a3fd5ff7de8da5547805ac2536892",
-                                "uncompressed-sha256": "65af79274539adb73a89cfaf6a471061c9326d01b9569cc11d6ae65a364e2a15"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/aarch64/fedora-coreos-37.20221015.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/aarch64/fedora-coreos-37.20221015.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "615bdb95444e2c4f4062f8541dd3af0a2c69cbfb17e84f4c76f08e2a34c8e1cf",
+                                "uncompressed-sha256": "caf8d0b958cca30dca7c1666d8653abdda85a8832ff24666a4b8fa23f2b933cf"
+                            }
+                        }
+                    }
+                },
+                "azure": {
+                    "release": "37.20221015.1.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/aarch64/fedora-coreos-37.20221015.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/aarch64/fedora-coreos-37.20221015.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "5864397cc01cc5491e73a9ef5be189b0ebf3f3d02fcabed145b2a59358a71461",
+                                "uncompressed-sha256": "e6858f8c6c81cc5ac8cff4bfb2e4e7dce8b0c49484060b452c4f139346fca8f2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/aarch64/fedora-coreos-37.20221008.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/aarch64/fedora-coreos-37.20221008.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "54836b4ec208175bd15196a1c0075e1973673e21a34f31e862f9d7a6f85420dc",
-                                "uncompressed-sha256": "9b83561b9be9b7b1ff8a952a19cb691b2bde57a99f399ab6824bdfc25580c471"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/aarch64/fedora-coreos-37.20221015.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/aarch64/fedora-coreos-37.20221015.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "05288efe041168386bce1b494de9fe0ae6d8b03dc1bf82dad24a590a204c9e88",
+                                "uncompressed-sha256": "9d632266e7085b15d7be0470d3e46924fa15dfd9cc8f31fa78888b5fda0c5733"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/aarch64/fedora-coreos-37.20221008.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/aarch64/fedora-coreos-37.20221008.1.0-live.aarch64.iso.sig",
-                                "sha256": "840f01586151ef11890a960b740846f1bd787de7c264a2180eccb791d6ebefbc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/aarch64/fedora-coreos-37.20221015.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/aarch64/fedora-coreos-37.20221015.1.0-live.aarch64.iso.sig",
+                                "sha256": "ba8d2532be6340f1b2635e122b48b3d16f79e5ef166810730fcf81dab6156f26"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/aarch64/fedora-coreos-37.20221008.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/aarch64/fedora-coreos-37.20221008.1.0-live-kernel-aarch64.sig",
-                                "sha256": "8dda425a3f0c7159fe46271afb457954fb4c220e9bbc5925f165a2831a044a70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/aarch64/fedora-coreos-37.20221015.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/aarch64/fedora-coreos-37.20221015.1.0-live-kernel-aarch64.sig",
+                                "sha256": "69c5ca6f567510b7eb2fbcbaafd4987993316a1c5ea09b19a3c13e7959800056"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/aarch64/fedora-coreos-37.20221008.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/aarch64/fedora-coreos-37.20221008.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "f37879b5944bb0034850448bc097ba02d285b6daadfd571f2b2ea1e1cb5dd4cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/aarch64/fedora-coreos-37.20221015.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/aarch64/fedora-coreos-37.20221015.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "1dc85a7203551db3d155028bc401ca9760b241f73e0d8717f84668fc966b2c8e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/aarch64/fedora-coreos-37.20221008.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/aarch64/fedora-coreos-37.20221008.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "4cf52cb83ceedb333a423a5070bf39c05d898c0b6a8bd7f6f97f7a991b7d67ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/aarch64/fedora-coreos-37.20221015.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/aarch64/fedora-coreos-37.20221015.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "df853e45d1ce4d93d355e17579c558e369c6435268c7ec23e46591c249c0af29"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/aarch64/fedora-coreos-37.20221008.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/aarch64/fedora-coreos-37.20221008.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "944326832310ac7abf51142f0b0b49f1cb6094b8ddad854a3d4c3b0561274626",
-                                "uncompressed-sha256": "ac2d4fa57aad5be680707dfa6fc28dd7fc6086c0e4d89e49574f4ca2cb96244e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/aarch64/fedora-coreos-37.20221015.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/aarch64/fedora-coreos-37.20221015.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "e7a11e1658548c55c3e79ed0071d63c8969d32c61659d835063e84b78ab4b147",
+                                "uncompressed-sha256": "73a88964001ea35675d38ef648798da48e4b8c63a117975a98f8e02dcefb5358"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/aarch64/fedora-coreos-37.20221008.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/aarch64/fedora-coreos-37.20221008.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "e9689f9cb4c595ee257dc891a34dbf2dd7066f7b8f5939bb9b5d400a78d97801",
-                                "uncompressed-sha256": "90934b5ae4f78eb8c2b4eb63fd5a1f0456e436940476e42192abff43b7a29158"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/aarch64/fedora-coreos-37.20221015.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/aarch64/fedora-coreos-37.20221015.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "44d04aa187fa2888469c202287d8228c00de409c498fc4157547df81d0075077",
+                                "uncompressed-sha256": "6f7946042170141f4edb494acf845d733ec62fe008349ff397d458a2f2187201"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/aarch64/fedora-coreos-37.20221008.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/aarch64/fedora-coreos-37.20221008.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "7edd0af1413b71cc5586f70a22085d0aa13123fa9448ca957c3a45f1f0cb299d",
-                                "uncompressed-sha256": "2c8f7f06331e2251d580e3351bd18e62f4f6f0cdf8c418c9f5b53efc0b1ceb9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/aarch64/fedora-coreos-37.20221015.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/aarch64/fedora-coreos-37.20221015.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "31a527c729b014c392dd948464104cbce3ca69461270d60b01be772f4337e68b",
+                                "uncompressed-sha256": "39152ebfca568d78af3722712145486385f2db0f25c98a6d9d00bb5e1e9d0d39"
                             }
                         }
                     }
@@ -96,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-086394c8123f1eb44"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-05a704f2265b5d43b"
                         },
                         "ap-east-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0727d133de9daf542"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-0deb6460cfba39937"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-03768f06bc0c5cd47"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-01f6365d2de648f29"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-080d2ab9fb90156d3"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-0dd632e53f6833c8c"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0c9865567681cd396"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-00481abdc558d017c"
                         },
                         "ap-south-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-046bf18973bee456d"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-07dcd4a7c76d63046"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0a37a3613efffbcda"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-08af9b881fa6179d1"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-00a8f112665720ca2"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-04660d70cef568491"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0743c562ec03a3347"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-05263c5ced16f2752"
                         },
                         "ca-central-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-08986b53a3262fd80"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-098654db406fb47c9"
                         },
                         "eu-central-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0131afc0f04972d53"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-09e5b77311a305fb6"
                         },
                         "eu-north-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-01d03bcbb6b08d3f3"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-07668addce7d9609c"
                         },
                         "eu-south-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-04f5a3b04b0cf3609"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-09fe997a096d368a7"
                         },
                         "eu-west-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-015f7a1f7b62e9cce"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-07813eb8ee5d3a5f3"
                         },
                         "eu-west-2": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-021c7c499245c24c8"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-07af3fb2950d805d4"
                         },
                         "eu-west-3": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0b7d0f7827d191467"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-0b3544f5269e160ae"
                         },
                         "me-central-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-07c21d07f04549e08"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-03c9da61777718143"
                         },
                         "me-south-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0abcee0b18f9ccda1"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-041180c9e27483113"
                         },
                         "sa-east-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0dd2bc08fee9d8ebd"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-00d8df4403e77bda5"
                         },
                         "us-east-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-097bde3fcad3d408c"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-012bd50ee67ead2ef"
                         },
                         "us-east-2": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-087d12bbf52151785"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-09dd1b339ac55ea3c"
                         },
                         "us-west-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0243566c31c992de0"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-0d2ee0cee9bc8144f"
                         },
                         "us-west-2": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0fbb495ff54732658"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-07d849c50e0db85bd"
                         }
                     }
                 }
@@ -194,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/s390x/fedora-coreos-37.20221008.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/s390x/fedora-coreos-37.20221008.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "d2ef6ff1e3bbe0b4d0861602ea1fbc9b96950ddddfd2d07974bc33c14db1e7af",
-                                "uncompressed-sha256": "491cb8a4d423eb8c39620fe6edbe0e9b000a364953dfc3b13690445ccbc88b0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/s390x/fedora-coreos-37.20221015.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/s390x/fedora-coreos-37.20221015.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "d2a6e3148f570dc8c07913cda27a0f0082bbd6e9cc3fc37fa69d5ed8d2440e93",
+                                "uncompressed-sha256": "12d918c8b0b1dbaec1afeaddf0f3445a73dbea21d9d5e9e445f6bb2718d38381"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/s390x/fedora-coreos-37.20221008.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/s390x/fedora-coreos-37.20221008.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "9f98de314a8931cb29e1e377b69a07185b4d858c20e3814cf35087ca40160b00",
-                                "uncompressed-sha256": "553abe8da18530bddc84a22c6580e743ce583be9d917a4c9bb34aa759b27ea00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/s390x/fedora-coreos-37.20221015.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/s390x/fedora-coreos-37.20221015.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "1382e89401e6fd74039f003e2cb486e31a3d8680676c16840738a7d0ea02f6f7",
+                                "uncompressed-sha256": "78bc032d60572e8f303e9ad15d27c23bb941a1e08d56748a8b76460b7931ca4d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/s390x/fedora-coreos-37.20221008.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/s390x/fedora-coreos-37.20221008.1.0-live.s390x.iso.sig",
-                                "sha256": "9be13f84a8a502e9cfe2676ea06b0d08696adaa737531ff7f2d968c93c6fce1c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/s390x/fedora-coreos-37.20221015.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/s390x/fedora-coreos-37.20221015.1.0-live.s390x.iso.sig",
+                                "sha256": "03b45fbccb21975e05eb57e46da5c5403b7c9117a0554c4df58d6d94f375ed86"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/s390x/fedora-coreos-37.20221008.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/s390x/fedora-coreos-37.20221008.1.0-live-kernel-s390x.sig",
-                                "sha256": "ef53daa210e72eb336bf45f7bdb569e2e96a0ba4b5fd6ba8d26f9f35ff5648b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/s390x/fedora-coreos-37.20221015.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/s390x/fedora-coreos-37.20221015.1.0-live-kernel-s390x.sig",
+                                "sha256": "ca99d43a16d9d58638b7884d6a03d3f8e3ed8fb1e130edbe87da6a5d8d723f3e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/s390x/fedora-coreos-37.20221008.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/s390x/fedora-coreos-37.20221008.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "0df42da68c372d19c6236b7411da8e50fcfcbf24185cbdfac72dfd373e9e402c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/s390x/fedora-coreos-37.20221015.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/s390x/fedora-coreos-37.20221015.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "4acddf21455d7bbd38f05f75a83dafd026c8b0643fe95121ae8526e3b69fb864"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/s390x/fedora-coreos-37.20221008.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/s390x/fedora-coreos-37.20221008.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "fbe2bd5b1a4db7f15be3a45bc9d11bde64ca7fee474ad2e3419d76bac520b0e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/s390x/fedora-coreos-37.20221015.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/s390x/fedora-coreos-37.20221015.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "b91134bec9e8e406935a68859a78b79ee38c9890df931e6057c7df499ebdf273"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/s390x/fedora-coreos-37.20221008.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/s390x/fedora-coreos-37.20221008.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "212dd4eb6ee8750a6d96632b91f5bc06ac0bec6cc79483948488b4aa0e4bb53d",
-                                "uncompressed-sha256": "9c6531167c2643be0a02633b18e7de02768fc849d1315d98a0e257c642b7f805"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/s390x/fedora-coreos-37.20221015.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/s390x/fedora-coreos-37.20221015.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "da1e52070a45698279ecbb5b6c26923f38e2f296c6db4d73ff3972bd041be2a7",
+                                "uncompressed-sha256": "7a824a87ee03668900cd1bc142d856fc264c6f95f242196841c6a905cb14ccd7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/s390x/fedora-coreos-37.20221008.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/s390x/fedora-coreos-37.20221008.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "fa977822069f97f386b4dcb4d89a92e9cb1f590c23947e8a6caba7d8b2cf9ba1",
-                                "uncompressed-sha256": "563a0c6084c31b3faf4d543deab1cca85840e896895fbcc5c74869b2d9a4584f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/s390x/fedora-coreos-37.20221015.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/s390x/fedora-coreos-37.20221015.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "4190216a18fc0d684d0145d5c9afe09c691f25c664d4da6017dfc8e88de3a6e6",
+                                "uncompressed-sha256": "60b6aed2bcc421d78a9753e2de543975018a14e7faa3991420f6ae940b81e1f6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/s390x/fedora-coreos-37.20221008.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/s390x/fedora-coreos-37.20221008.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "45fc449dfd5968175b2b7f1bef55bd449c0f7fd7a27cead7223f240170a99e5a",
-                                "uncompressed-sha256": "bc3acb96cf63fa8a1fcb8efbbaf781c95ae4c051bdc1cbe6be54127d739b84d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/s390x/fedora-coreos-37.20221015.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/s390x/fedora-coreos-37.20221015.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "4f77078f75ec09f338b81e67e0578b27cb0b9685f9ffcc99b68ce8848ebbada9",
+                                "uncompressed-sha256": "aa94cc622928dcf52fa6baa9b3e1c5cd82c8e798e844e5edf8eae7b7ddfeb229"
                             }
                         }
                     }
@@ -283,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "21d3a65f415b27ad5c30e30d5e740f9f2080aaddca05c88201cc7cd665642ad8",
-                                "uncompressed-sha256": "031eab239b9919f5facccb1eec4b59b6f84cf79bea21b3d9ed00c8f8fa6b5d40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "69056f991f4b4c8b1130228d41485d5bec57e340958aa0724e4f363f623e56aa",
+                                "uncompressed-sha256": "4ea0e60969ec84779b6ec2400d6718336d9e9eb95875d8e44ab4cd773923f0ca"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "61b0b221717edce52929636f81018a79ad580caac81ef88ce704275b05b230e3",
-                                "uncompressed-sha256": "b6f738e3847066e1909518f4532c903bc87d040381329e82c2f1d12ace1c616c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "bebfc4ddc2a28fc8b3222e844fe0b14132ccfb582bcfc3c76edf7eb21cc48c59",
+                                "uncompressed-sha256": "f379b94b38636dc83b3fc1829233e17e022c4590d15d8e8c2bb5bb5d0dc1935e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "e33b833066a58718f71f064b44ba7c169ab5f56ab97e295f8b02a0724d32f1eb",
-                                "uncompressed-sha256": "3865ee5282285083fbb0ca78154f0a7b1b77edf6041100a90e0cc81a78a1c52f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "34a7f705fdfb29ad48c235fdc508e4776c93a7bee68ff99e5ea8f495a8ad3ae5",
+                                "uncompressed-sha256": "2a68c4c814c21e165fa21fd9f608798fd8872b91d950218edabef7283c55da23"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "07ed937dd45f24d0cd74fd1ca643d44708ac5b67060c6640b7710060370279a2",
-                                "uncompressed-sha256": "f55d3f7c73b00c785e0795807b890e4daa121d1b4b20df97fc4898838867b5e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "bc113b34f1d653d42a1c3f87ae65ec7bf9e443d3417bef54674a43808fde5de1",
+                                "uncompressed-sha256": "7a238e04ba33bfb49df410675b0c319dc8e100ab6791693d5c8f43877d4156b1"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c64bde76dc0a213ebc556dffdb4a5e7b4b3d8c4ba66b58acd2e4ace4341b4897",
-                                "uncompressed-sha256": "8bcc3e6e992515eb1b88a2b8bd16a1810aa03c0a85fed541f9f88ad693d08ee8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "9b5ac43ab853650cbbbf06d1d5290bfaf43f7887e677ea46dbf0f8445bd566ef",
+                                "uncompressed-sha256": "28ce30f90949fa4ff08cbad839570a8b60a7317f4709bdb05cbe56a38a950895"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "bb3f98e6e456c16388f57a0b874e49bd2a870a93727cb38146b452be65e0b447",
-                                "uncompressed-sha256": "6cb641a4ce92cb94151b6fc6343faa015d91cbea71d6768fa7902b5bf3368400"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "47af6fac57c8919c66e16a060bfc3c5214335c0abe12150a36edb2e86f2d8505",
+                                "uncompressed-sha256": "edd0ab899b3719c3018d1549eb7c20535f567245e3547ca6e9a7c297af30d10e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "de6e0de9b9d201225d55cb194d53603c26c3e78f754d830efd7580251f11d681",
-                                "uncompressed-sha256": "77f533e1716ccd13b3f5f41af0cc8fca9dea6e8ec14548d5879b6953d63a62a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "8589779636a03a34aebc892932e835cc7ced690cf7539472d62c4add5a02dbd2",
+                                "uncompressed-sha256": "797ab560c7ae05deeab1be4d66af908c5c35d2afa1374275de16dbd060aef8a8"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "dc2a67992b44d7fa68bfeb985fc467c6680b3eeae0a9dfc6ebfb55714f84c65f",
-                                "uncompressed-sha256": "d0b4a8aff6e86618320323b331c5316c188d09b0b3febc40bcf84f02069c61e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "8718c69c0101fec7c1ecd43798488cd3d9930c0775d0588c33cf455d74d95fc7",
+                                "uncompressed-sha256": "14434aee9d76209ccea08347172f8ee7f14725d6527a290112df645b13c9342d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "f4192b965f509618ced7b70f457cc2224832d46642cb1b1716b7305560bb9adb",
-                                "uncompressed-sha256": "da91265abdcd4d3424c3ff30ae38790cf94542bc621621fb496259d8d5c24dac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "bbd28d70d4cc459e8574d18a8095eb1ad448561b9167dfd40d47668b1ecc4e00",
+                                "uncompressed-sha256": "3091db4c8d3cad3bfeb97be7bebac5cb90894db6d52ebb3073208eebfcc2c817"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-live.x86_64.iso.sig",
-                                "sha256": "c1627b7d1c885421868d646847a32ad63c3a39e7f5bb66bfd16f8d1266adcb80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-live.x86_64.iso.sig",
+                                "sha256": "d80ef0fa319ddb53bf9937e5e47d7690d99b4d5b18ca32afa5d88cf140a79a47"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-live-kernel-x86_64.sig",
-                                "sha256": "0bdfabd4acee32313a9880847f42dd8939efc91e0b7e8b1f818e89b38db66183"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-live-kernel-x86_64.sig",
+                                "sha256": "72979e061d82c439079d3245b7274060f408a85bb9e6abe7186afd85a4857658"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "8457572e86bbf142ea820174113fcdba866c8a60af596346139e0812d968b0b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "160977d387740475285a5a2933c42b70cf28db68327e6cd1ceb3cfe9e49c1352"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "d4957fa05504a8e730bd5afefd586fa9b55176ed05cace63127389f9074ef59e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "0583a04bd624029cdbb3538a0332b647272df74c91cec777bc362ab92bf57bfe"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "88b30e78638f0849e243166035c6a3109c2e3b72dcb3494cd664a18f59da32c8",
-                                "uncompressed-sha256": "acdabf412b6da2abe47a3574738582cb87fa5ef199206f6ea88ca38bb68050db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "09e624906dc5be14f94fff94fb9b9d2d658a3c2a966ee9a1573c305343eca678",
+                                "uncompressed-sha256": "6de17f03b311768c529473c9e96599c7c8070d5a1c54daebf0081c68b6d205d5"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "f8a67e13a3150833d6fa1f19bdb98382850e406df2376896623727cbfe1a9fc0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "391b3911ae9a19f2c100538cccff6531cb4d2591e468df2db45f4ea5633474f2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "b7125706f2ed1120cfcdb484e872382eb3b3782364a58f8013556ce60cb4dcca",
-                                "uncompressed-sha256": "422d6d2edc3ae54e92efe34f9779ac9773a5094cdda74c7ea143fadf2b6471b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "8f5995b74e0dfad14d6a2ae29aa7b4a01f978d6894872701efc9c449fd53215a",
+                                "uncompressed-sha256": "206352f10b94e5a60f9085dae77bf095efb735145ff9a9363c3e27c3e937bb6f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "d7419814edcce7870c1481a1390369e393008ac8670ea3d38698e87f479c82c9",
-                                "uncompressed-sha256": "c152b4ba3db35fc43e7acc6a7117f009c73a0b867830a9643ba6b60d0579f596"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "1ab70a854c3575590a8f83e410181861b3d394188f6147cc7ee963967a648104",
+                                "uncompressed-sha256": "9e16bcb3bd28826e5e92e5e41de8dd3fdc81ce1d526252c01dfe581c2c69b8b7"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "5f407f0254e1e4e8aa1010f2cf2795ed3b68272e00bba810ae4d1502a87c6afd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "89f56ccd6b34a1fe402dc63d8bfd85dc7326a857bc79b956acc55829b7b2aed0"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "66d6bf569fa0cab178ca125257057c1896979df1cacf0ae8712708f3c75abc55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "7a2e8d742192a2d7d0a57395638c7ffa9de7ecb829345fff1c1ddeebbaae4ff4"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221008.1.0/x86_64/fedora-coreos-37.20221008.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "8b726661abdb1d8345b5642cf4a18091582e0608a9628ec2f50c5fbaa1078e05",
-                                "uncompressed-sha256": "d64d4b68705edced563ff7df6e26367aa00f2033bf9f97ba8b0203fd12bde36f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221015.1.0/x86_64/fedora-coreos-37.20221015.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "40de33152aacb08b65c2366fb71d0a7372adf368522489f8ab75728b09da89ae",
+                                "uncompressed-sha256": "a3b3bc24f4fbf6351cf2bfe331fdc4dc133bce5535b32dd168a996d90ae67b4b"
                             }
                         }
                     }
@@ -511,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0bbdb2ca42472db48"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-000dbb2edc0a9b4c9"
                         },
                         "ap-east-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0312c3d024e1c2166"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-04d24ca2b7d7063ef"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-043e8db113ffd9a42"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-0bb3641fd8e53430d"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0b3de5bcaf7df9372"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-0c5680d14594bfb2e"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-06b8efb7f8e9fe85d"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-0aac620993674efd4"
                         },
                         "ap-south-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-07111acc2ae99701c"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-09c51626acfce40d1"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0bfccd76a87395bd7"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-07d5b71265daae0bd"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0fb256c229cfd5bd8"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-0394f33aa2fefebf1"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0194c28c12987618c"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-04da0bc090b5b43fd"
                         },
                         "ca-central-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0aa7926c6d4ae071e"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-04e0265d4af0a586a"
                         },
                         "eu-central-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-058184b77a4d06cf3"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-0f3977d27dda6f85c"
                         },
                         "eu-north-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0739e1b1e93c08e82"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-03ec165b7c119a6c5"
                         },
                         "eu-south-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0292e617fad59e77e"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-0635b87d3bf6f6e3d"
                         },
                         "eu-west-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0aa46d49b28078b35"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-0169b2e363d1fc54b"
                         },
                         "eu-west-2": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0b282a10ddc3c30e7"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-08d85e8fff1095fe6"
                         },
                         "eu-west-3": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0c506e0261f2f6af2"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-07b682f84aa0832bc"
                         },
                         "me-central-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0a9d074a7ee85412d"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-009eb7f0a6c7734aa"
                         },
                         "me-south-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-00c39d82a2232c1fc"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-001cdaa914dc29075"
                         },
                         "sa-east-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-00d2e3644095c68c5"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-0b1c0fb2216653ff3"
                         },
                         "us-east-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-05565962adbf153ee"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-0df8b995ad14e1d2d"
                         },
                         "us-east-2": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-0bde60638be9bb870"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-08a780992320fae12"
                         },
                         "us-west-1": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-00e8c43064c19e1e3"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-05ec509a88e76e831"
                         },
                         "us-west-2": {
-                            "release": "37.20221008.1.0",
-                            "image": "ami-006849ca4721e4b4c"
+                            "release": "37.20221015.1.0",
+                            "image": "ami-018fe0a9454ccc89a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221008.1.0",
+                    "release": "37.20221015.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-37-20221008-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20221015-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,92 +1,105 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-10-04T16:44:34Z",
+        "last-modified": "2022-10-18T09:42:07Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "676bc17d4dc7e015ff47948055711e9d03d58e9b5e69a66755da6cebd2f27c0e",
-                                "uncompressed-sha256": "b6d14600ebba42f06bcb51f9ec0b73501fcc99e4f21d4b9f70de81093280bcdb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "0920a8fb39192d57e37a32e98737c2bff185774690e3b976a7a895fe8ec8eba7",
+                                "uncompressed-sha256": "e31f1192e8e9fa1ea5bfb52afbe975cd471a9e43103022aef142797535bc877a"
+                            }
+                        }
+                    }
+                },
+                "azure": {
+                    "release": "36.20221001.3.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "a4ea4f0a5785e5668fe5a48b1ddee60083d1371e2aa082ebf048f7f0a29d3d79",
+                                "uncompressed-sha256": "cfac6eafd0ddaa67f5c76b2b7618ff6dab1efe2ad14c845b14acc3f92bc41a2d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "378fa748a504a828d25e88f9859b0cd0e8250e0e89458705b7cfd00de436876a",
-                                "uncompressed-sha256": "24a57676946c608c2aaef19e6843108178a99c138c02c79266112d721045b4a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "d55a26a55359c8561167b093042c450716394924326722a2c33dec4b91d7a4bc",
+                                "uncompressed-sha256": "32677c99d103e813d8aec9b7f546c9e2586282630d7a99b64b4703405d6eeb9b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-live.aarch64.iso.sig",
-                                "sha256": "8987038762740ad96162441055f729561f825474c26f4ad4401d4d3a4a4cd7b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-live.aarch64.iso.sig",
+                                "sha256": "491764c8ea07513179d1f96ac0f5ab6fb77322f3bb49ef5397e668f2fa4616d4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-live-kernel-aarch64.sig",
-                                "sha256": "b8cc1d8c3b1f18b2868de8aad6d6644fe9529956afa6d6f8f16d03816bf3c96b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-live-kernel-aarch64.sig",
+                                "sha256": "181453f03fd4562a41a3012b24f11b3044db4c037aa0a6cccabeba42f22759b1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "a191cb4f5fb328eb286bea0d294830ec4b6c6eb059d6a554dd51f363df223247"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "a3897b17850ffa6af82d81633751eeffe902caf0335d812cc0790130aac36e66"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "2607e07c003a47d9dea48a7b8a8e7f3714aa08772d07bf85a4858e4428331ce1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "aa2a9f695117d234ad03bf062e8ee8f8c610a5163f14f0f1e689bc1e52a7f5fb"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "77737f61e37f155b8278a556ab045c7c8a6d5962bf0958c7d4b9b24f360f5a68",
-                                "uncompressed-sha256": "cd8fa1af52a0cd987fefd9969478dd689b33e610e03f1e4b63bfa0a10c14f44c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "5200e9e1da1b6e71f5a213130adb3439e671343ccdd34fc5da04e66a8f6a6e83",
+                                "uncompressed-sha256": "380c2c2fe8736d1d6ddc2cd3287581e3380de16d9b43fe82f3d1ff47403021f0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "ff16affd345a6fb6f1a38ed8d4513ad44e52af16b6de4c9ec3d979d90aa7b24e",
-                                "uncompressed-sha256": "046674df99e8104eca6e1a8a2999bf135281faf5f77c90cf00521379fc7c55c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "3b2ccb2d20e6de9e507646b3c7c7400fcaaddbcb5bfba0329f69ab03555c84db",
+                                "uncompressed-sha256": "389fe63cf36478a4dd38857f408bd75daf1929efae7e568666d4ea417f573694"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/aarch64/fedora-coreos-36.20220918.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "110ff113944f144a4f87fb5a512649289291529f2a0ff2230c86519ac1e03073",
-                                "uncompressed-sha256": "4201fb11a4ade8545485302f4f7a969a56e2e418483bfa69f17f884703167c3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "8b4bea8501097e3e8a25ac7e663bd05a2424e8206f2d30c73f85897609b9bc37",
+                                "uncompressed-sha256": "f5b05b6fd610e7cbe4e25ac04b110546dbde164dedca42635effb63306435272"
                             }
                         }
                     }
@@ -96,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-03cd3872725f8d26b"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-040d13661e075c47f"
                         },
                         "ap-east-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-07ee61cd026a815c1"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0bc5b4e0758a4efbb"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0264bb07ae97f7026"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0c706c03cf4cee3a8"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0533a59daaf9d9f3b"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0f6ec284e400bf865"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-067aeb7fd11c37ce9"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-013899b6cb04061b7"
                         },
                         "ap-south-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0f8eb46adf1de170b"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0f30fb756d77bee54"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-027b03e66356576de"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-00b87fe6bf71a7a7c"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0026a78c3f159c0d9"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0e3efbcd47aa4ee83"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0dc17790bf5142bd6"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0284f0300ce05c567"
                         },
                         "ca-central-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-099c91465534841e8"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-02a5766794dd9f622"
                         },
                         "eu-central-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-032583827ac9ebf04"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-09b398989e82351c6"
                         },
                         "eu-north-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-031da64a49a242754"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0a4925c2cee71bf75"
                         },
                         "eu-south-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0f5ca5e5d551b72a0"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-03a9478e98036d15f"
                         },
                         "eu-west-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-03b16280182e0c9ab"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0c136d4b5945c87a6"
                         },
                         "eu-west-2": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0b244539713253763"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-04742364cbeeab083"
                         },
                         "eu-west-3": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-06edd1da2c1a5d634"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-040a590bc3f02529b"
                         },
                         "me-central-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0703b0b1be73ead80"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-006499d7da615e507"
                         },
                         "me-south-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0dd38d53345251737"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0462aaab09c3306fd"
                         },
                         "sa-east-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0aa4f62a87c179d6c"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0aaa78f86583df9f2"
                         },
                         "us-east-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-010b84c8a74bfa893"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-094d1e681f74d1644"
                         },
                         "us-east-2": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0e944b0793901d791"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-02b1787bae8ad231c"
                         },
                         "us-west-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0be53cada51fd5e62"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-014c1a8279b7e143c"
                         },
                         "us-west-2": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-00872428c05e79c7f"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-090c7ab5356b74de5"
                         }
                     }
                 }
@@ -194,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "de61ba48a0c0e33897b2b93dda4249a00d83a26e0917f2e3308e28f16b07b5c1",
-                                "uncompressed-sha256": "1aeca3cf75a65696f87494b65184b7008a795a74b6f651ba16c830acc4196a2a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "00251a58af6bfd2202e94135c950a44e722db7d0fbf1c582e98ded5a89ee6e19",
+                                "uncompressed-sha256": "ac68e72b61d3898da0bf639b0e3efe58734de27247dd4c9cd77b0653fa997f79"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "2604e4eaa775bcda25ecee876090fc8f3410cbf23bd1bcd66292657ed9b276e3",
-                                "uncompressed-sha256": "24d55fdebaf5ccc203c9919e7997cd20ec14a905f0c11a6f2fee73ef0650c886"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "f4de0b598a06f2b4433abe9d9b1faf9e476d8b9b0fdaa001e0d74f5feabca848",
+                                "uncompressed-sha256": "5a48233f1b84e48e72d33a20c19fc381b30f807c9b5658ab4a463ad8b82e5a43"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-live.s390x.iso.sig",
-                                "sha256": "7dc1a7720a458e2269e70293a9d69c39db768c55018d0b9328108b3fee387042"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-live.s390x.iso.sig",
+                                "sha256": "99d813fa217ce8eb2d85734e66237e7361e5bdea576f97c95619015969fb00db"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-live-kernel-s390x.sig",
-                                "sha256": "4e74db27d0ae816f1fd4041d2d64a6e38686f77b6bba50686d5e9da9ac3d1a81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-live-kernel-s390x.sig",
+                                "sha256": "cb5f7b56dc1554895a8bd7efda9f574bc1b4f612a61a310ee8aceda484b85544"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "02677795cea9ae82f4a418c168931d24d8e4916690f387792e6cd69b96f2e2aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "cfd1affcaf784edac9769509f370dd267ff1c5048ec0ed8bfa0d1576c88b4833"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "5f53a07e102a34b5655a6f6e47d7583740028e76674751e30af9ea4a19b2c57e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "745ce347e0724219fd00e31b9fd9bef838992398e8dad2b0f35bf9cee001295d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "b4526fe7f74d86ebcf317922f3cde9298b85968d6ddd4288b3ee7e8a302bb787",
-                                "uncompressed-sha256": "f17718b99b12bc358870757308b461ce2e4676d5b70f2ca2f4a24b1c3f203cee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "d1676d6f7d4b1c71509dce9da5b849520a58e3f5ff80ea91676f16cea031b41c",
+                                "uncompressed-sha256": "a90721fc2b2206af1cb90408d1e6dacf325d791dc5b9b719278e5873ed3a6ab8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "5f537aaf4cac594dc8f60fc90e88c3eaa9ff53f1eb76b3b2f65cc417adbb0dd3",
-                                "uncompressed-sha256": "693869506a90e9e7a395897761111942dce32a5499d0923bcbbb9533bcfb7858"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "69a215abde82f89742a843b125987843d340a287304621e1a4030eab654573de",
+                                "uncompressed-sha256": "990ea118681f2fe4273b0e0ab26af2b64358b29c48c24ae72195ac4af720c1e5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/s390x/fedora-coreos-36.20220918.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "086ca67a67c87b20df5bc944551fee0f5ebac8173a216a1c973e6193878ab138",
-                                "uncompressed-sha256": "d5b773fd0db27190ecabe89b54b7ba3a222a9f07c81f35c020b73931730b2e54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "acd6e196ccccdb04d03dd0dfb528514115b748aad4a6638f2df4b6791082f642",
+                                "uncompressed-sha256": "bccf96f090a2a2800952266ed8f1587cb80fe115e03b441d83b747abfd41811c"
                             }
                         }
                     }
@@ -283,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "af5c95cbb7a57fccd4e37cd50ef1f192055b0bead1df67870f3adbf13401a496",
-                                "uncompressed-sha256": "3bff56af92c283e9a31ab2e9eca0fb241f7ee43f73a6ed40b71a7976b12f22c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "aa24a0ec7076babcec733fa69ebf2da247e4623280cd9458cb7b84185bf49b1f",
+                                "uncompressed-sha256": "5a778e0ffa0e25a623fadf381bac7a324843818b511cec25ab45045c33a98825"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "715bfe3d2600f491000c41f26b928ae153ce7543f97770c5dc850d234d435533",
-                                "uncompressed-sha256": "c013726ce9e330e2fc2531c53226d68e4e65ca14fbca7c0b8c64d7adea7aeca1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "7c8671cf2ff3e3178fbfd93616fae776c970497021189174af512e64d032f47e",
+                                "uncompressed-sha256": "d76ed6d04144782ecd22a122340f03433174174dd7ba3c63a2cf40d2491c267c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "bf57ae6ecfe8ce1453ea79ddfdf020f1271db935ceb9214115d319990840e9b6",
-                                "uncompressed-sha256": "390988f93dc64906aa071abd1e993cf053a42c0aa11806453884a444e7625384"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "a1a7caaa1db763f224a7926f78af75bb8fb04e1c07670c9fa15a3310d94397bd",
+                                "uncompressed-sha256": "a7dbe3d410bbdf591004b821a0e1e0c468e513af56e6c27492375c20ed4cb888"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "c65117a0cadb7196dfe32a23d701271f0fd48c996322fe8adc441a8461911eb3",
-                                "uncompressed-sha256": "2cc16d0ef04465a077e6c009efcdd7e2722810148dc8b143ad866fe77b5484b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "ce88058a7ce456f1fcb822f69964fbba63fecbf4652a5e1d5f59d15dde99983a",
+                                "uncompressed-sha256": "106f9e831d40dcbd6a7c701723de331e11c3368f27d03e9e37c4398d0f076671"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "15a25abb8eca8c5d7a041c314bc4116403d93e702606b256cb3e0489f697813b",
-                                "uncompressed-sha256": "aeff4919d6c726b4f09ade95b99100b02e7218cfb4bf1b6dfdc4ee6b8ae14b0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "20ef9920472768022c3cd064481c5ad04d42b894b8e8d147ea4ea38358e56192",
+                                "uncompressed-sha256": "8a44103356060bc386ed58b554fd0d1779fa7653fadd129e26cb4db26a26b16f"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "234ca47ca41957c0508b7e88c6fefff72c06344b54b132fec12d886515a934b1",
-                                "uncompressed-sha256": "ff8afb2492a04ef99a1f29f0358eb00299c27f5594a82790ef1fa6db567e2dc9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "f4a2ecd88befc4b990083e6a9a0fe0b88b15636971d1ea644c5d71ff62659f18",
+                                "uncompressed-sha256": "f9e329155e943028df45c17563eb1df1e538e40c3241c2eb86dbe0fdba987554"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "9fdbc17ec2648af989a410a21462a3f03b7f55d4515149e07d5b96529de95615",
-                                "uncompressed-sha256": "40f2557f42085e6df529f809531794cce04ec22d9a78b79de51b512286a267c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "a1e019bd4001233bf793544300a373b39b88f4f0a6d7d43f347442ca95ee9961",
+                                "uncompressed-sha256": "f961534f20c7a633a5c2910aed71e0bf21346f5a21aae64ff966c4d580be318c"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "0d69500da1b6bd8fe70d5bc2fccf01a14b3375c59da55ba03dd7334a327b1384",
-                                "uncompressed-sha256": "7dc82020ad92446f368fc53a04825e1a726beb85d28b4bfa50fa378919bc25b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "94fdb7a0ecce9e2a4a0fb5e12fce82777be3858f261d37bb47c3656f6b54bb3c",
+                                "uncompressed-sha256": "5e48ea1fae918026bea0078a256c7ef9374072a8229521563b2df406eaffd484"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "6994f699ed5c5602dfd1c7699e7e63d145abc3fdb167b63b3095d50254c5c31f",
-                                "uncompressed-sha256": "6f2b4d4b64d66c5f6880df5a2640952b44dbbf294428458f140375f69c7a19ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "b7b3d89d46eb61e5060564e93fb4d2f348726e6a7fb44c1464ed25d8d25ae1cd",
+                                "uncompressed-sha256": "66df2bff43b14796f4090307ad2cc41a9487a5f7c7ed3d320fd2fb347b4db8ad"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-live.x86_64.iso.sig",
-                                "sha256": "8dcc75c9108db3f83bc35f00eba4d48da3d965d22a9bb8304e351a514b64d062"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-live.x86_64.iso.sig",
+                                "sha256": "426ea537ea55cd7adaaf398d58167fa3ff246296712add1fa1ae52420c0f1b52"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-live-kernel-x86_64.sig",
-                                "sha256": "83e1ee4e85695d86db6b49b97f595e850a9768031df0c855e9ca1dd2ba3f7e54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-live-kernel-x86_64.sig",
+                                "sha256": "b57933cbf73c1a19ba25030edd771f69e2ec5bd0895ea06b43e91247cfa43d9a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "cd8cbf96cfc852c78418858b830b8d0c6607d060a22fecc0f11bb3e29bfe9404"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "7133cad5934cf9b78f4b14b4e7b62fcbadd1673f7633c33e575f0d45af8e7ac4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "74c76799436eb17afe07b08e1361e87b1ebbe95b01664f711b7eb3492fc80ef8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "876d84bdc4fec8c2e87fe8d351428bb555183a84b247d4d3533ec02b5f6431d7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "9f286434724f09a236db6dea8d54a3f9bf4a7412ca358c65d9baada94c03d10d",
-                                "uncompressed-sha256": "029999b15eb8cf6c567d7bd4940abf6c385ff6800f3f9ced0090fe61498f4267"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "d2aa89b69649efb2b2b29246b0ca50411f75f557c969d3d983adb811c06cb898",
+                                "uncompressed-sha256": "f14a6d25100bac1356b8ea1d5701a313c5ded679793dc7990e0d02d35821107c"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "910fda14096d9b24ca6c702513002d985382f30d6a244e02e5789dda3e532dfd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "934bd319bb978f92d90cb8e831947baa047f453d89d3beb953840e223eac86e4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "abb52a4cc7fccbe78b259e0e2d7066580f34ada469ad7467384584b29ec7dc9b",
-                                "uncompressed-sha256": "ffb8353ce62ab7a1d96dc7257cc939da15d3633f0a6f288550cf18fa49524823"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "f8e9538fb4ba2a294a637adaf999dbb194819cd2dc68503b23fd8e8b6ab577fb",
+                                "uncompressed-sha256": "a9f1186e95a8fb9ad3ca7a3be2365d0d78f895d4490c6afa7e2e16fc4f7bf9c8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "97761dd97f6c8ec25080323a12d614ff546757dce360acf4c0f3363a9233e71a",
-                                "uncompressed-sha256": "4a22836c1c1445850f74886f2ed8150847b787dfcdab060a0d19ee3920655a5f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "9697627bf3377986cfc6973a0349168789ab4b4a02eea9f80c8b290976def11f",
+                                "uncompressed-sha256": "3f5a5a849268b1a644606818b2724b838660bffde14dd8aa6739a38a14dc2642"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "0b821aa7ef829938a4f527843dfeaf366171d3fceba3afe4a2a5af5d1192a9b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "1228c1b5258b6be667682f7077ee8d5691d3cf42c0a6083e4d35064ec19bba9e"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "baa6705da4cbead950a53ea0e760a381431e3fe567033d551a1eeee3b1adbd49"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "15b486ea26a1e8f2b734f89512e0dbead01d288cac10b5ff135e0eefb2d1f41d"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220918.3.0/x86_64/fedora-coreos-36.20220918.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "43e27b2a1b570379cc8e660f035102478599ca94b190f6a8b48764cf4392b302",
-                                "uncompressed-sha256": "a4b3270c2bf516d9094881543a1764345858526a4a66d70fc6f5b58de1a88445"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "9f54b4733eec63a665a4fb8538a30c392de2a799458191089e5f41c0ce86fd65",
+                                "uncompressed-sha256": "6c612bfd71f4ed9c346bfa0827028525991fb4daec1e0298846907adb66d8971"
                             }
                         }
                     }
@@ -511,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0a728a70a4b3324dd"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0230d3a56899fbc7a"
                         },
                         "ap-east-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0f891e0d5bc5792cc"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-01b3a42dc6d99276a"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-08e708eb5a2a76f48"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0056d14e665eb6ff5"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0cddd0479e5ef82fd"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-07faf7025d61d261d"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-045aadd2e21fa8acd"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0d5903731597a43c4"
                         },
                         "ap-south-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0c1f5616f11211f69"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-082fb18892e0d5f4a"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-073f574c5cc28f99c"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0aefe7bf289162c30"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0f892a6d8f8323b57"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0246c6b2db1234fe3"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0bdb176fb82f65651"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0c3e7f363c9dc5305"
                         },
                         "ca-central-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-04619de55b86c190c"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-045d98e1fadd94073"
                         },
                         "eu-central-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-026e5aee730cfc84c"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0ab9cb3e4fdc499c8"
                         },
                         "eu-north-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-098ec358c8d626373"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-06d6a98695e5aa67f"
                         },
                         "eu-south-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-06a9237e8ccb615bc"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0e3f0f63a1a849596"
                         },
                         "eu-west-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-08afd8b9bb6e4f707"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0974163b9b691606a"
                         },
                         "eu-west-2": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0f009924a5f1d9c22"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0f3b02cc026c8d7ed"
                         },
                         "eu-west-3": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-02a1e0cccacd73d68"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-097869fbc18b42e35"
                         },
                         "me-central-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-033fa9ed541ebcdf5"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0f48dae682a12dafd"
                         },
                         "me-south-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0b7424db65e2cb95c"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-05cf201617cb312d1"
                         },
                         "sa-east-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0f413c0eb1bc6d589"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0d40b3fe32fdab8fe"
                         },
                         "us-east-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0e0a572654f0947ab"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0756632d3ab28028a"
                         },
                         "us-east-2": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0fd3d4c64994895dd"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0b15212075daaf3d6"
                         },
                         "us-west-1": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0d4a18d7a21cf7de4"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-02ec9abaf7e01e944"
                         },
                         "us-west-2": {
-                            "release": "36.20220918.3.0",
-                            "image": "ami-0c398d8db68a07e11"
+                            "release": "36.20221001.3.0",
+                            "image": "ami-0d5de38b95d36ba92"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20220918.3.0",
+                    "release": "36.20221001.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-36-20220918-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20221001-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,92 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-10-04T16:44:36Z",
+        "last-modified": "2022-10-18T09:42:08Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "5e772f58f6a8dcde6b53e1a9ea6ee16e949bf0a970793481058ae1c46500b3a4",
-                                "uncompressed-sha256": "ab6446f7a6ddf7219ad8defd4cfab7c3ac3a279b389c1f6136852df935c8892d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "d40871be12ca285ebed13d1c16c94b5d58c63cf573b8a9f2e63c21b50d9c3022",
+                                "uncompressed-sha256": "593430b20e9064e94582cc35631385bc90acbe20dd48a43dc27c080a05978fcf"
+                            }
+                        }
+                    }
+                },
+                "azure": {
+                    "release": "36.20221014.2.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "98ab0001efe94352ba5d0666fb8bcb4e584514afd4131761bd88002db219138d",
+                                "uncompressed-sha256": "83e2746e2b3a5c16d9b648fcdd07c42253ca6711c64e686b6191c3d1cffc8576"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "196429d1f0c7a9d5e6a3c1ba5365abec584282066a775333763632274ca87c80",
-                                "uncompressed-sha256": "60b6698690cfa1c1880e2da47c460970769d3bc1089756f72ca0fec308e2830f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "65d322d89a23a49c62243e09b7a9832938512dfa1de6267221c76c3913a2954c",
+                                "uncompressed-sha256": "ded52c60230bf1c29e4b15f80a056b5ab8a9cd421fa5748348f2e86a27055533"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-live.aarch64.iso.sig",
-                                "sha256": "863a573edb04ea2cb153bbb075d587b75ab80e3fe32c22b0a485173953676477"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-live.aarch64.iso.sig",
+                                "sha256": "ac348e89aaa6808d70a6a9d2124ca2c427be956f0fcdf3d864270a9180aa7e68"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-live-kernel-aarch64.sig",
-                                "sha256": "181453f03fd4562a41a3012b24f11b3044db4c037aa0a6cccabeba42f22759b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-live-kernel-aarch64.sig",
+                                "sha256": "1a654a618aca6ec8a7f38c0f83ea34971aa52925e07fa99a8b082cfc080a975f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "68b6ec9117bbd2c19f600affbdca8fce87adb22234ff10381150c8b34c593daf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "baa642d6cb166497bf530a3e3cbf4098f059cdee215c88feb7e559e204ab7769"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "ceac5ad270c43004a1639e595af3bb0f328c2248fb336b0449d3e16c3c6c8d49"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "7dfbb32d118e5e51d3f6f774d1e7e0c34670935ac5ad9fcfcdb3a0f49bbdfd22"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "88f3e2f197d6d34c590f7d039459f615ba2ae9db177f1f41b089fa8204ea3de9",
-                                "uncompressed-sha256": "3b42f40ca9efcd283ee1a9cec7a7565e71c77da757b6cc177ee614f042c216f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "a260522587377ed54a5daf048516bb4b747aba82e4a7ba89f4ade13bfeaffff0",
+                                "uncompressed-sha256": "a0bf390d14ec06306973175ae799953ce93c811d592fe816e401bca02364c333"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "09da2a3f8380ee7c7142bf13535f55344391d9fa9a1c3881d01d443e3d7fac74",
-                                "uncompressed-sha256": "1bbc50a2d0753cf0cd6b76add3c24e62347ad128024ad3d111d5b8af7fa5f158"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "b419932bf0d6e476d7bb492ea222b446496b1253c27e4681504fb40934f3844c",
+                                "uncompressed-sha256": "e2701bda85ad75da67a8c3cc32a1eb40a18b615db7c17bfe3d23c49ac671ffcf"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/aarch64/fedora-coreos-36.20221001.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "a2471cbde63480c6c7133ba6bd1c3b9150915ef78ef15f322106b28553c854c0",
-                                "uncompressed-sha256": "3d20dfa8f718f6506c6cc37e41ce58b7359fbc8e28789bc9166d05002afa2c14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "6942e8871aacdc645f2f0887eb0794e0673a558ef10e1de22a47b37af21e1fcc",
+                                "uncompressed-sha256": "d1b9be8113332ded0f018d21cac4449d1a5dcd36b9c21a767c92c886a6b92064"
                             }
                         }
                     }
@@ -96,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-01d87d2255f69a72d"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-0d799318e28fe795a"
                         },
                         "ap-east-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0d6ebe89e1d0f7d0f"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-065c8ef2512e75ae9"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0d0ff1d5b58bc039d"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-0a3272593d5607d2f"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0e6f6fc9181821392"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-028f34eb8d41dffd3"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-088910cdca644808d"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-078a22ad858528829"
                         },
                         "ap-south-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0ad57155e49c1d9ce"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-0e4a5514a563dcecb"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-023508917ce740c24"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-07d66cc8ace22dc23"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-07f7984a2f8f7aa76"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-06f193b2f5aff9a3d"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-050a814aada97e24c"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-01fc5c94a7b1294be"
                         },
                         "ca-central-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-010f9018e7fad38cf"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-057f1ad1711d1bc61"
                         },
                         "eu-central-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0385a9c8dd8e9cb4e"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-0f50a3674cfaa0295"
                         },
                         "eu-north-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0a5b72b0cd64feb4c"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-0bf885a45f6cbbf25"
                         },
                         "eu-south-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0abc27c36eba4da9c"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-05e617ec25cab2871"
                         },
                         "eu-west-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0553af3ee040772d4"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-05e99c94d0eea1dc7"
                         },
                         "eu-west-2": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-09bb6f09468031abf"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-09cdfef9d167257c6"
                         },
                         "eu-west-3": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-03d9c19937d636222"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-0fcdcf768a6bfc9c0"
                         },
                         "me-central-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-035ad00c0521b2157"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-0c9890f1f7ba75c99"
                         },
                         "me-south-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-08fa911754b82ac9d"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-0e16c39be859b5140"
                         },
                         "sa-east-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0ad537ad0f4ca4fbe"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-07be28df4c3456e88"
                         },
                         "us-east-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0de89cdba8de38183"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-076b552fb21b897a3"
                         },
                         "us-east-2": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0619411633201af28"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-043e124f503260d05"
                         },
                         "us-west-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-026215f7d2dad085f"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-02228ef2c056d8ca8"
                         },
                         "us-west-2": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-06ffb76420d675965"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-084e68bc7234213e1"
                         }
                     }
                 }
@@ -194,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "082c792bd537f5b02cc339521fdbb6cf93fd5b52f09b1043ce1bd63721430092",
-                                "uncompressed-sha256": "67fad5fe9cb0ea451790804d1a3cf6a209a4db9985935c969b9b78de3c9acac4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "8068819d6a15e5893ade3849f37993feac9e7c12ab47e10a18c15c1dd6c5cd39",
+                                "uncompressed-sha256": "4625b40eff8d42cf3ee2356341cce125156b69b807859be489f57bc343bea11e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "7d7b3bbf19ba7d6201fedaf06f5d6344213085f3ae8e84e5262c0c42e3542501",
-                                "uncompressed-sha256": "ad594e91ea28bff76298ca0adb85f600a726e27b8381e7f01b3081f14a10fd55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "f791ca65194370e5b072e831c4fa9573310e82bd3d33aaee8aae0f919227cc57",
+                                "uncompressed-sha256": "a277ec89d54b0cd0cc870d7e116e5d92e306ddc9618637ea2af9f800ae625f8c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-live.s390x.iso.sig",
-                                "sha256": "7761adb472072a6d40d146872fac491224c0fa14ad21d669f43882fa31a601da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-live.s390x.iso.sig",
+                                "sha256": "6497d6a59ae5f4f962bbc0b05e7564b54e39ed8a85fc2c9e33c67dee1bdd7305"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-live-kernel-s390x.sig",
-                                "sha256": "cb5f7b56dc1554895a8bd7efda9f574bc1b4f612a61a310ee8aceda484b85544"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-live-kernel-s390x.sig",
+                                "sha256": "817ecfde938475c79dd93021ad1f87587768ae496d36663e6aa0608a383279ab"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "7bea7bffaa94be870777e60bbe5672d6908fac3ff473645f8f7fbb01e94df103"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "5b82baabba6a1e538747324010f94ca10c88139b65f7c7d09bf42362e98262c6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "e310a73b43f4eb923602ac18bc74a86bdbef70b01da5c51847af5f1f91ac4366"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "100c6c12ee546743fe93a5f21d90687ed109fc019afe87030bcc19827e632e4e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "1d31028d67a66d2df08d741a3ca9e5d69b78372f283d738ad3b2edcbd1186fb2",
-                                "uncompressed-sha256": "67fd6e9a52ec0a37a6209aaff82000ab1f38c7cf6c523b93f5a27e1dd553220a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "15dce6fe757697facf7925ed89ad40ee0fe3b1c65b1ba85cb4a2e95d7ca46fce",
+                                "uncompressed-sha256": "8dba94d2d0d6c1a96b2f4e12a64c0cafc73b30e92992cb1ffdc4b5b7c48eb583"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "36866890a28d61444cbb60fa6f053a9c82065166db0e6c3137f29a06b9ef4c82",
-                                "uncompressed-sha256": "1e08552ad1f8e6e7b436972969ca05e71b9126d6d4c6f4f5d52b54d9075c8d63"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "6951e076d8807db8175b7fd439096843c5d2d5e7ba6987a1948d0559ef813fd5",
+                                "uncompressed-sha256": "04425e3ce1f69e6859d8230a92fbf380dee1d98d76ca1737b6d0a0b0d140fbbb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/s390x/fedora-coreos-36.20221001.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "13f57c9f3d5daaa27256a439ba3bc3767fb8f7a969ca2e3c6b64bef3fa3d1738",
-                                "uncompressed-sha256": "c29c02da187da4cc7c4e1256794111bf7c0267b00cfe1bc0291ca052fd10c319"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "51287da1de61d239f2c9831ac178498ebb6572489448f595262845d22b9c11ba",
+                                "uncompressed-sha256": "1fa5c14c017595f981ab55f4cce2143328a955ea6745f6289e921891d3f93ec9"
                             }
                         }
                     }
@@ -283,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "2ecfa9a8c0fb26cc212c1732716ac6f24a8a52ab77b48e75d9e1929c465bc2cb",
-                                "uncompressed-sha256": "e2de9d3888c9a1c28942e6632002902e12eecd42a0d50c647919efec085f4ef8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "31613fc13771ab36f65d488c63438333c8bc189cd782fb5c5c02a9d2dd85e5e6",
+                                "uncompressed-sha256": "16b467c42b137478445334bf97855683f263cca9364a7dec3346286cd9f7b657"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "a2951df335bfd59cd2d57f1ac5a536efe4f4a6282b3d32faa82903e74be02502",
-                                "uncompressed-sha256": "f20a779c4fba0a78ba258e7ed9475364c142fa6533cb7be4533d6ba74aed7e0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "8d327c4b688a0016159f13a6e2a6c608bcbb0184cd1fdc47e3a0a5a8b2249713",
+                                "uncompressed-sha256": "1143837677ccd59ddef96ec4b8210bafdb204c4c24ea36c9c365fd43db205d54"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "f03e997938a534185c15baf40f74521a306bc454d88770065923b0e906245aaf",
-                                "uncompressed-sha256": "036611a036b3f63b6edb767b18c606cb37d6ca9f7ad247c3bb8306ef648b7199"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "c042b0ccfcf668dc5cc7aaba4291403d53ed6ea9874df114c954769f57860fe0",
+                                "uncompressed-sha256": "3f4e0bc2635a091f5bdb9f7556ea44a69c9e4a5c1b6cb462f783a73c9eae8bb6"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "ea0d28ffc940078cdf3e2b43416d62beda891e4e46871cd41bab8c92d690fcab",
-                                "uncompressed-sha256": "bd9f93c22de4dd65e5168fd6ad8080f6dd2a7d44453629bbb8ba92bebd556ecd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "a906181c8e1dd395f454009f8d66acd2b7742bf27ed0cb1a1bc13146f129c0fe",
+                                "uncompressed-sha256": "f3cd4edf9187dba8903106a12b27e0d3b4c54bb0439503ece6740fa77e99ff16"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "7bb9068ecd6bf8de2448c743e0832b4751f9a701a8da7a552e317be0c763aff7",
-                                "uncompressed-sha256": "b6cdf6c64f8b47bbd5c53f19f1cab05211288665a3c2adcf4d54f418420190b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "20df18fbe50a44a4343047ab06a3899f85540d242cce6272f11e7159f6589384",
+                                "uncompressed-sha256": "ff6c6d80121695af4f1f6ed58cd862b74ce87880389b70a8c0765634b9357328"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "3f5ef6001bda9eb001d91c98393ebd98cec5bad08c7e970dc21653d6d3cc901e",
-                                "uncompressed-sha256": "4477e2b0a8cb825c71ff93039d86e5b23399593d311ca054ee8c5fad1f156a31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "85e9b882267269c5200ca910f1736d83b178145fc3db9731dc9298726c8af3c3",
+                                "uncompressed-sha256": "9119c13a6c9935479f21336425a47b5576254039b6e0f9fd4d077e53c21c16d5"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "6163fac88b65708af489d912794a972d494e6b817771676e3b4e4c18124d44e9",
-                                "uncompressed-sha256": "05701e8278c4ee7e44f6f62533604d3ee6d84ff5a5832ec14cff417e0c68b4f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "8f7aefbf2209353e6382302a2421d58423411b4154c86ea9ef233856b130553f",
+                                "uncompressed-sha256": "c9383742cb80afa32c0ef52fd1fc3a7b0bfa0fff7c9f107db8c3317f01d2d0bc"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "798e67f7ee8178c623066a0331b1602d2ad0079c3cf88ddead9302e64275a654",
-                                "uncompressed-sha256": "38fafdfab345cf0fa56792ceade05476584d3d62bb6c25e17b38c1935ab753fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "074bf271b622ad8ee9713a75a548f5264b62d16a945bf3b524292826973baca0",
+                                "uncompressed-sha256": "824733fa3fd3f241a52ad42dc5ad683e2bfc44f814b61aa23721a9695a24a0a8"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "97958f2929944a13da751ac34a895a04f70cd20dcd0667e067181cd301cbc981",
-                                "uncompressed-sha256": "7b4a3419f414f2f36b6ccfce45d3fe969a3309dfed8267db1c274fdef62b3ec5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "a9aa834cc945027fa28763a082649ed84c589f9c2ad989783078a075b3ea67f8",
+                                "uncompressed-sha256": "adf5a7ed2dde2674841f2e17adb146829912f3efec35ec8ee08eac842a233298"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-live.x86_64.iso.sig",
-                                "sha256": "33983a35ea26d81b2a6673e53c570cafef86d933ec7982745b03102a5c97bed8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-live.x86_64.iso.sig",
+                                "sha256": "133a9c73f60aca9e97da93fd1dad9c874c7e9111ac2a1cdbd82aaadf30f27846"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-live-kernel-x86_64.sig",
-                                "sha256": "b57933cbf73c1a19ba25030edd771f69e2ec5bd0895ea06b43e91247cfa43d9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-live-kernel-x86_64.sig",
+                                "sha256": "8ba8c8895e42dd1efa08d338c930bcb8707663ab3a42433584b70c6dcdcb7dd8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "e843bc01e9701a88015ae932812344e3253fec883b176f16377dee65a5bb3daa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "5916fabeb27a64c35d9846f28b5cf264155b0cadef014abbec33bd7d657cf075"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "10855faf2ea2e03a6262d8186cd09aa59d60b056930764d65407332098296639"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "477b0e9de08c02c9ab85023191c3dc95ca414266d559862594b99d4bbc6c306f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "60ffb31edfeb5d787135fe2f3bf618f472a266480ec0712a5e2d184b346bb08c",
-                                "uncompressed-sha256": "c527020f28e83b4e4a353d324cd16d3a7f73bef2a0f6b036471dd995b419aa92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "ed2331acda57af33711ebe495a3e6d9e746b3b6404eb836d9e50e9301ed1504d",
+                                "uncompressed-sha256": "1c86b1659a9cec1e1349dfb41da4cf06f3fd31f1faaaefd29bca3c5f1c58f732"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "dcf02b52f411d5320c34d6f99153afa11c783317e725855c486269f2491ca36b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "625dce0010190241663f444719fec00d9490871a5ef8648f6c39cf713447ca85"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "b68fea956161c793729e051103d817746e390368071a6a6fa8ed5e330a1cd31c",
-                                "uncompressed-sha256": "773fc58b4f29b337ddb2593ad8b112bfc14c222a1b8024b2661e59a76b2d265f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "af4bfbbca3a98d26d76d0119376add0b8ea778e8688ee7634a91055db8079668",
+                                "uncompressed-sha256": "6ca7dd8f1d93a0800b1fe204dcaafb0766dff8e510ff0881f8f8626aae244b4e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "c16edbb1b0015ccda3da2ea851ab626a722782b249d7834a13e42830be9ed368",
-                                "uncompressed-sha256": "c3bd3fc245c68de5a91daf8393639731deef9fb9fc87bac59468429451334a14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "fe62dc9edaeb1ad8804c4f4c57fab89917f713e94f6bb5a2d5d39b8c6344f9b7",
+                                "uncompressed-sha256": "c04055d57833c5d247571027ebb4271f8163c61774b9a40e38a48619c1eb1087"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "7637a29bf5f889852b9d78fd3ad2c0d140be08ec0c1e728aa1e11a7309fdc1e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "4f47259d197bbd1a9417932b9a6fe3271746e3440c212fec6f79451cd87e4027"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "386b69f799de47ecdb32ef142315cc092c257b37175bfd39364c229835ec378a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "64bac37b7450b8d97ab222675293a0d5677de5f2d946f8f96add6600c860d7f4"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221001.2.0/x86_64/fedora-coreos-36.20221001.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "07b9379dfae40587a9c4803cf742a0678f8c6d98cd36ea0c1dbb497a23936446",
-                                "uncompressed-sha256": "2a4964d03dd0a495e0a11df56f14df129a186396b4b3645904683a427ace65bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "978fbcaa925e84763352772343e57701aa5ca49bdf568900548b6a7b4adf23e4",
+                                "uncompressed-sha256": "ddad69864a717903227aa30b2a7d8f47abbc30e9f59087a62851d21bc1dfc52c"
                             }
                         }
                     }
@@ -511,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0e19dad4b6a4e79c3"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-05312958a6efabbf0"
                         },
                         "ap-east-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0018953f95bee034f"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-02ae2ff4857e01a8b"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-059c1d413ddc1ad73"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-04654b08004881c60"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0981c92b55a5f5cc5"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-02ae4ec3915dc8d49"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0c099ff765f3849da"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-09f1311e43c87085c"
                         },
                         "ap-south-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-008ebcf94d737d6d8"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-0d30e9baf0f52b9cf"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0e9c61eca68ef3f09"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-08a587de82d6afd46"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0cfa02e9112b3ab61"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-02e86e6d6b765dd51"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0ed1b7ded536a0824"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-0e7c5c56ab649cd96"
                         },
                         "ca-central-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0a269c57f05b79ef2"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-091b85150a61b38ce"
                         },
                         "eu-central-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0e9a21b238bfe824c"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-0bcc2ab418fe685d6"
                         },
                         "eu-north-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-00e7e925afdbfa512"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-01368134e907db7a4"
                         },
                         "eu-south-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-089af165b02d7963b"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-0cb0d3470dd94a85a"
                         },
                         "eu-west-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-09df294ddcbfd49e9"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-08ebefddd7516d1d9"
                         },
                         "eu-west-2": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0a8dcf99f29e53676"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-0051d684d15d91fd4"
                         },
                         "eu-west-3": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0317526e054480bc1"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-0448e6c4092f3c2da"
                         },
                         "me-central-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-06164d1f1367dd576"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-0a4f414b25b8eac45"
                         },
                         "me-south-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-062f3ebf59bbbcf07"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-0453ad1ab58eaa656"
                         },
                         "sa-east-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0a5aae23a2e501280"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-08b72aed504b499ca"
                         },
                         "us-east-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-059610cfab81654e4"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-06ce37b8291c5f294"
                         },
                         "us-east-2": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-0a6f10ca0f6c83ad4"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-0251e827bf3c54ed4"
                         },
                         "us-west-1": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-02bc390447d09e972"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-069b915da48582bef"
                         },
                         "us-west-2": {
-                            "release": "36.20221001.2.0",
-                            "image": "ami-00132048440d9b763"
+                            "release": "36.20221014.2.0",
+                            "image": "ami-07f92076976219c4b"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20221001.2.0",
+                    "release": "36.20221014.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-36-20221001-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20221014-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-10-11T13:48:47Z"
+    "last-modified": "2022-10-18T09:42:09Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "37.20221003.1.0",
+      "version": "37.20221008.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "37.20221008.1.0",
+      "version": "37.20221015.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1665507600,
+          "start_epoch": 1666101600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-10-04T16:44:36Z"
+    "last-modified": "2022-10-18T09:42:07Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "36.20220906.3.2",
+      "version": "36.20220918.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "36.20220918.3.0",
+      "version": "36.20221001.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1664906400,
+          "start_epoch": 1666101600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-10-04T16:44:37Z"
+    "last-modified": "2022-10-18T09:42:08Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "36.20220918.2.2",
+      "version": "36.20221001.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "36.20221001.2.0",
+      "version": "36.20221014.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1664906400,
+          "start_epoch": 1666101600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @cverna via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).