### PR TITLE
release-notes: updates for the 37.20221021.1.0 `next` release

### DIFF
--- a/release-notes/next.yml
+++ b/release-notes/next.yml
@@ -1,5 +1,11 @@
 releases:
+  37.20221021.1.0:
+    issues:
+      - text: "Update hardware version in VMware OVA after 6.5/6.7 EOL date"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1141"
   37.20221015.1.0:
+    issues: []
+  37.20221008.1.0:
     issues: []
   37.20221003.1.0:
     issues:


### PR DESCRIPTION
Also add an entry for `37.20221008.1.0`, which we had missed in the past.