### PR TITLE
Roll out testing 36.20221014.2.1, next 37.20221021.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-10-25T13:25:52Z",
+        "last-modified": "2022-11-01T22:22:28Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/aarch64/fedora-coreos-37.20221021.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/aarch64/fedora-coreos-37.20221021.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "eca28a8700341d6ec9846b2a9624f7139ffd4195b81775f09b0e89636e884fc5",
-                                "uncompressed-sha256": "c509ff2cc9e7e6d00ff04f75748d3ad080a6c90a88d034528ac40d702bdbb0bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "0da2957e93b4e223de3f74142d8f20d4babc921dc2eb85a4cf452bb20510b471",
+                                "uncompressed-sha256": "31bb075e8ab23b6cb310b2298ff40431d4659f4e59dec218ae631feec1d6351f"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/aarch64/fedora-coreos-37.20221021.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/aarch64/fedora-coreos-37.20221021.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "92c8e0b3dff27c713e1eddf8dbe687d58efd271e9f7420664ab9031d5a142b4d",
-                                "uncompressed-sha256": "4c3d5590088c0baf5366ec256a0e2b4e71581f874e4b4fd72a7bf17e15fcdc74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "83641fdc8034e298fb7577bff560436e85c51005d1c4dcb37bf8123af67511ed",
+                                "uncompressed-sha256": "816f9cb7a49a94574826c709efb110c2b58592379d343ce16fd67b7600265cdd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/aarch64/fedora-coreos-37.20221021.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/aarch64/fedora-coreos-37.20221021.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "f7f6e5c01634aa4428485ad4b02c9797c8a881afa324ea8d6ed539a4b92e02d0",
-                                "uncompressed-sha256": "259c4b4e23c03a8319fc075624bfd06c0faf1338a77a7f97d532b02ba3a0dfe7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "6e302fd865ddccf6c30e15bad9f5a9fa7d42d8f6fa86eb7da78d0ca1828136fe",
+                                "uncompressed-sha256": "5a4169e9662aed8fbdb7f8a22b5587c538491831455af410afe76b6f6bfd6b0c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/aarch64/fedora-coreos-37.20221021.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/aarch64/fedora-coreos-37.20221021.1.0-live.aarch64.iso.sig",
-                                "sha256": "303af8f49698177881e68829c9280417c42949bdfa55ebb40931ae268a74a10b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-live.aarch64.iso.sig",
+                                "sha256": "c55fc57b42d522d236c7d0266b9ce8fbe3101cee6e170ea17cae0acf002ce67e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/aarch64/fedora-coreos-37.20221021.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/aarch64/fedora-coreos-37.20221021.1.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-live-kernel-aarch64.sig",
                                 "sha256": "d8bb2c77cac304198619b87dd842666ff340adeb7b3f06ec748d0f1ebaa56af4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/aarch64/fedora-coreos-37.20221021.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/aarch64/fedora-coreos-37.20221021.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "9ff1734a5b51e4c94d9500e5c701816a5fd673d1e63acd4c77690f0373be1e5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "468b689a21c1a211496fb19d43ed2395bbfb78939fc65a87cdcea855decca2ad"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/aarch64/fedora-coreos-37.20221021.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/aarch64/fedora-coreos-37.20221021.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "784d17326462919e6fb9ec8f1fbd6b4e9815c064bc130ba1e7411e3f744dd4fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "a756ff55bb917d81542e92cd250b9431867a367dcecac6e184f9b25d250a0e8f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/aarch64/fedora-coreos-37.20221021.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/aarch64/fedora-coreos-37.20221021.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "60357edb532bb3cb88a3936135b1fc9e475939639bf8b055eaa73049ee92e90a",
-                                "uncompressed-sha256": "d5149592f1078b206b19ea5d85922505cda4672345825b1dd4405908f609b4ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "001277d2d9facaf0f57947582b60f72acf73a49e022316c666a9862e0e233e87",
+                                "uncompressed-sha256": "e75b6a7b705d3fdeab13c7c26cb60a35e9af0541fa0d523f50d94224b29cd59d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/aarch64/fedora-coreos-37.20221021.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/aarch64/fedora-coreos-37.20221021.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "f768e74f50d48df8c65deb7dc7146290df00fd91ab072526b54e6837055023f8",
-                                "uncompressed-sha256": "0c8e96b2b26f1217b1c746a61f1ea774deaa5f4b9a50f6f7968d06d86269bde1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "7cd7ec08c5c675f1a070e9b532cb75d15df0ec0288b0be0137a811d03df5b242",
+                                "uncompressed-sha256": "5d6f374a97dc474949d9a7e9b19ac915f0f6fbae83fbcb906cbe14d2b62a6531"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/aarch64/fedora-coreos-37.20221021.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/aarch64/fedora-coreos-37.20221021.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "068ff30814c2d146f11d6a959c85883a3ec3bff9324318f5716754ad313d023d",
-                                "uncompressed-sha256": "0e4543838ef8b213a93023289e483bc6190be1c44c404fc80ea3070f2b9304d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "d3ebc99ba5cedc03a0c4bf41204cbe450e1bf637af01528fb3d4608bc670ff09",
+                                "uncompressed-sha256": "5c34400b433d59e0be19cc2061ae1ecefda4307dafd5e315cdaef55cd77f20fa"
                             }
                         }
                     }
@@ -109,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0a8e0b538b17d24dd"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-094decb45d8a9935b"
                         },
                         "ap-east-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0e158d44b735954ee"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-03202531bf01f3950"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-033271f8e90baca1f"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0cb2dc5ba1c4752e4"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0e22f4eeacfabc9dd"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-00883185f1ec4cb0d"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0c1d2636fb739fe94"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0bda81ac5e284fdfc"
                         },
                         "ap-south-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-084837b48f3176281"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0181361ab25ba72f8"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0596228b65ba787c5"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-08f2319330975c266"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0e340e67633bd5613"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-02c79007839c22028"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0775a5b3f6f710b09"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0606c0f170e614104"
                         },
                         "ca-central-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-022c7f40c486f4f1f"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0d0484a01c934b062"
                         },
                         "eu-central-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-099422e4ecc1d5e91"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-054178804e7f87f59"
                         },
                         "eu-north-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-00cfce802f534c63a"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-02a9ca2f3e0da24d2"
                         },
                         "eu-south-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-025e0bffb5b63e581"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-02fa6574e5e4a160c"
                         },
                         "eu-west-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0c7a182a4b9195447"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-025c86d227fcbd4c4"
                         },
                         "eu-west-2": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0e92e7ee70a17a968"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-07608072bf380b214"
                         },
                         "eu-west-3": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0c121d2fca3855fa9"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-00c198261d281ca8a"
                         },
                         "me-central-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-030d2ebe87994c2e0"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-016ca53314a1c7924"
                         },
                         "me-south-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0c31078a483f3fec8"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0bc273676fb884908"
                         },
                         "sa-east-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-075485ddeeafc7ebb"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-03a52133239957c80"
                         },
                         "us-east-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-01444eed1e77ae4d3"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0e2082987a5377a24"
                         },
                         "us-east-2": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-001f8799475cedd8b"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-09dc644a6621a679d"
                         },
                         "us-west-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0139baac2ea662a4c"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-05f546b3e0ac685dd"
                         },
                         "us-west-2": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0d7f19c58632d3f73"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0b3108965df0a9318"
                         }
                     }
                 }
@@ -207,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/s390x/fedora-coreos-37.20221021.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/s390x/fedora-coreos-37.20221021.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "7dacea89d578c1020a4780d0cd5c673e734e34c3c85056bf7c19cb6786b5752b",
-                                "uncompressed-sha256": "a08a4d74593826218b4cb85f28c17eead5519f9ce0635d30df60ae03060be7fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "6e420f5ca90449a60ef219a6337658f134a0648af83864ef7829f09d2558e62d",
+                                "uncompressed-sha256": "440d69075984aab5cc6a786936ee77449733a9413a23cb603f9113a533606995"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/s390x/fedora-coreos-37.20221021.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/s390x/fedora-coreos-37.20221021.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "c880de5ffcb7ca6384e72717d4492d0c2fe5dc5cbcd9162fc64cdd377f8a3f5b",
-                                "uncompressed-sha256": "9587a55abe63b9f0f90c4e49a67d9fc9d6c7e9878e6a5328e9d1fb33d2e85da5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "889c52f80d0a1029e856ed01e0558887821129693980a3658664bc480453171f",
+                                "uncompressed-sha256": "524eb81326e6d71e7914e92cea8a7c3169efcbc2ac21ad9b2398d33ea924fec2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/s390x/fedora-coreos-37.20221021.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/s390x/fedora-coreos-37.20221021.1.0-live.s390x.iso.sig",
-                                "sha256": "d021a5ea9e1bdb6d55294f41832ef24de57d3f2a52dfb7b9e18818b2dd7c2ca4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-live.s390x.iso.sig",
+                                "sha256": "8d2adb4dc058694ae35b3a62cdd630175458bd692f37bffc4ce3167b273f5c88"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/s390x/fedora-coreos-37.20221021.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/s390x/fedora-coreos-37.20221021.1.0-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-live-kernel-s390x.sig",
                                 "sha256": "584cc1b17cf6a645f86353e37a6c3d29268afd7e5fc49d453f108faa4b2f5f0d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/s390x/fedora-coreos-37.20221021.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/s390x/fedora-coreos-37.20221021.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "70f2ec50e2d5a630b31befb0bfb7ba623c2234dd54bfb2247533ed0c9e059dcc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "0a78789f3642d4197222eded21393ca86ccde4d7b4823478b19fab1ff0056113"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/s390x/fedora-coreos-37.20221021.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/s390x/fedora-coreos-37.20221021.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "ee1b690ce55da97945fd4dc9510c0b1d351d24180ab592ae9baf662188dc8d66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "fc0392d17d981d45fcc937c2191bb6e97c3d1acd739c27426f87906d2ecdb9b9"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/s390x/fedora-coreos-37.20221021.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/s390x/fedora-coreos-37.20221021.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "92560571f44b119156990c382f60662298ea3ed213d2bc17f2970a7342d7b7b0",
-                                "uncompressed-sha256": "01caade476e565690f7b99368218e71cb235b9928ad96a1daa07a4bb4b68e10e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "70ad23f3ddcd22035b07bc360583cb10d1574d4573987c6f1c8e28da642786a3",
+                                "uncompressed-sha256": "ad99767aff2015ddf19c17c0442a977d9a8676659e9d0b872ac51334b0f1d4de"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/s390x/fedora-coreos-37.20221021.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/s390x/fedora-coreos-37.20221021.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "fad54e9480a52541cd4cdbf1a8001e2561a80d4583a61ddf2d99372a6938c504",
-                                "uncompressed-sha256": "5e5d918594e90ab54f0aefb2c229fb4292617defc9cd4a5af3c414552b72361f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "e5f48b218da8c513e61766ceecd35306ac25c3859c7226bda6ae9d4f523a99b8",
+                                "uncompressed-sha256": "ca93a7c17f98721b51c25592a764882e28df2a98247b70903c25f20058d88694"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/s390x/fedora-coreos-37.20221021.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/s390x/fedora-coreos-37.20221021.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "0a4c3198069b63402bc6eeaf9efe22407ecca51b52ba0f7c9d53b47a665c3127",
-                                "uncompressed-sha256": "a9225d410554caad29ec68f2cbecde73b7eeba216929992fb14da38f27ab8917"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "4d1265444ff5eaf123210674df87d9ffbde39dddaee5cc071b174fc46dc9667a",
+                                "uncompressed-sha256": "a803c996d8a3365dc8ba71396ac843acfd8ad686ed0f312a6973721b226a160a"
                             }
                         }
                     }
@@ -296,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "a5038650b85b60b19b25b1c28aa7cecf2e9cd7c1e4514841fbeae22f4ad9d60f",
-                                "uncompressed-sha256": "c445bb683414c311b8c4d3c6f8863a5757bd9aa80264d4b041430b3f50d485df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d3e193c33cccced254c900bd2ffdb0f0a94e53e932abe157d6485b914827d259",
+                                "uncompressed-sha256": "b21e423665b808c0dc991f5f0610efe1be4631f7d3bf65e5f28fccdc3bdb76c7"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "2b05d049d61a1dc57b59c8a0809644e3fe88fa5eab813d437084bb1314a488f3",
-                                "uncompressed-sha256": "221b12d3dd51d31bb2f58b504227149564bcfe1cf596d3c351b4402e3dab9a83"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "c38d243eb4f1a7b5aef852e45d78fdb8feaba8c6ec085df2e52a9f363e2a2737",
+                                "uncompressed-sha256": "93f381080c8545b12f61ca2185325797d6859c5ff711323dd660cc7565ae6684"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "921dd2549dd9278b4c7a0f002a0ac4a09d1eaf7dc627f9e2b277b193a97239b1",
-                                "uncompressed-sha256": "447b6b773dfa4090b2278773402aa4e639408995d241d987279b15653c00eb13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "09529ad80410ce52e8353eefdbfa8077bf8dbfbb82084806f2a933337ff83556",
+                                "uncompressed-sha256": "125e3ad157f570e9551e3677b9fab72ff4d5fe759ed6b7d337b7c72c23471526"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "b466678de4206023036bc901c549639943722bd48a84fe55c69d439a86367391",
-                                "uncompressed-sha256": "c7c753d7eb9098bcc2bffe89ade69a95f519c57456604e3ec48ba01cb76a2a5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "314618b74ab9248e5d32bf20e7ac5e2c9524330f2f85f0c946f64da948723743",
+                                "uncompressed-sha256": "860e065e8fddc5add893cb49846b0f275d24589697a5ede6382e56e00cb6024b"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "517fa310a0f6ac7f9f1324f0b01971f5f559c17faf2ad7ebc40a7d9d562c171f",
-                                "uncompressed-sha256": "eeb6a6d7a82f007263fc0fd4b09e970a6a1173d4d9a2c4d9c97c3523b1cbdb38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "efdef7f533f5faa47509ccb0cf865c88e77b8427275f3416318d78d192504a78",
+                                "uncompressed-sha256": "02acff1c24742ef8eceed3c2da9ceb83fc78b2156eee6fca50ff6ad372ac9325"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "2b3018c273d5fcb746c93ef1eac42a6de21a2b97cdd7525b5116b075184ffc12",
-                                "uncompressed-sha256": "5d052af525fe9fcd51de2228a7ca0e9bdee1b6dbef1a5aa328f7817e9090a022"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "389724fa66aced0449769aaf1538ce9065415796263f4cd0f3d4605547d047c7",
+                                "uncompressed-sha256": "dece9e11c3665cdeb6735d5266d2811c63ee49cbbf825db69775eda194d3afb4"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "d13baebd2b085e281ee9be716557a9ecf9427c88b0365915a733a07ae5ceed96",
-                                "uncompressed-sha256": "9cf38afefe8183ea96b6302c606d6abfecfc63dc5c82b3d331186e4484e5970d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "da9b0bd4cbb70d225af5353a00a93371470ebb6fe85152370775a5f3625694ff",
+                                "uncompressed-sha256": "bba66236410286cdf601cb98ac708c5db23e2c314e78a9d4ae5716d39b586fef"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "b2c478adb8e2b74f77d1ea10a978efc71087001b63ce9fcacdcde2761910281d",
-                                "uncompressed-sha256": "021272f8e9a400899180fa60687a7f0636afda52c2c9a7dbcf3cb6a9088344a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "3f1dfed7ca54d548da0b9fdc71f0117b5a39e8a4207c9aa22ceaf586d7091402",
+                                "uncompressed-sha256": "be803e28a4dde31f8325c1df7882e89d3745206bd3d85eeb776bb13ebd67852c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "e27e7bd31c5aed7c160622f649ab132daa8eb51e8bd681d48738c1fa269fcc13",
-                                "uncompressed-sha256": "892935cd1298afe9f4af2adff573cc273b632a071bf406f7b3351e85b60642d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "c1957155f7f5de06c84c8aabfdeb3ee420fa76117cbb9ebf89c7b04d5a31778b",
+                                "uncompressed-sha256": "16db6573a0407cd784fd52a88b97f30750a8c7750f6e3c209d6d84ec58e10c3f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-live.x86_64.iso.sig",
-                                "sha256": "66966308aea86829cac3d2fab9d7160f291513cb8a860b774a0c482791b6125e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-live.x86_64.iso.sig",
+                                "sha256": "cbfe0223f0137e61b478b4b3bd4398c5ea2d0db8b44859cad7a29c147d4c59e3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-live-kernel-x86_64.sig",
                                 "sha256": "697726589e305bb32e877747f6ecdf9027145a7baab2301f3db7583ef357e698"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "f1bfd6dfe4836f4c49b7871eae6c3ddfa44f8a8f69bb4c3cfb4344797dbde7f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "a98338223c3a627ebe373643e3e8d5387c74e24238390deaa0ec70d1f443ab51"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "8278d4ed2e7cec686f095c8b111b7a6b5e49bc4359d624c2b805c91ba969b885"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "d3c019c9a0cddc1e4f2e8070d3586f524992a77c4af34866e79b63e45ae9445d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "b3ae1b8cb9be4d415f2abbdd6a57b04924194b94fda32428ab21e5d33184aef6",
-                                "uncompressed-sha256": "930e3d95bc1cda285f09796c7c4fb29f3cd9ea375f9d4e5b23735a572706a740"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "7fa82a697bfadcd18c28d882dfccbedf2df0f6ecd09d0c5d62e3fd1a77e43214",
+                                "uncompressed-sha256": "f8813c79d4bb8b10727706ff8433f041ffcfc74ca6cfcd9ccda143e117f3aff7"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "b41064336a706cde5e0005f208e4f8f348e91d03ec740bd64559c5c3cb97cd30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "88fe8f348a447dc33f5acd937b1145f0831c6ad685b148e367390c975f15c229"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "9219648e3e5f71fbc209e1fa5eb0a219edef980ddaff7a9a9a4cefc6758a11b0",
-                                "uncompressed-sha256": "cef46574b1e31693929b93c8d3ce1b756391eede04afabf8418a21b0fcd953b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "f682cac9798d16cadf9185bd3282244190db41843c492a30ab30ffb22bd27c72",
+                                "uncompressed-sha256": "49a41e51c53ae263cec76dd1381fb8d0d413f2f9970425b379763c1ab4dacffe"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "f039c9e88aef4f6793fe2903b5641bc1bf0622f0c5b92571b9bfea8bba0bad90",
-                                "uncompressed-sha256": "0c260f7cc1981165c5482a7cb2e9f8cfead0c85625c824065bfa52cad437535e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "2a280a7311ebf1de14915b8feebcc45a4bd38de224d23c4eda80a9072dcab707",
+                                "uncompressed-sha256": "50b066eb2e575ace18d60ac96c1fa112604e721f4f8773bdc6e0a51ce8282d6d"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "309b2127504c82138d4a8ba7a37fa465da91c313643c521482c064bf9b856377"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "910b13cd3e6fad466e639025f2daafff0a11762a4cd82a3229880971f4f53691"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "48a66eede83a35d5b9e53ee2997b2ce6bfc6c2b1acffd0d6c3dbecf1b067794d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "e7cea18b25189f36252e61299c6f3131bd48367888689462537cbfe430054dab"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.0/x86_64/fedora-coreos-37.20221021.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "8d2a245187776ab8cd9836cd78760fed3146ac2e159c1f97a7607a6eb100951c",
-                                "uncompressed-sha256": "0e471aa9ca0bbeeb908566a16b6ac79ccfd4d129f3fb03494de82798c75f1b3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "0434a3f0a83c61f393294317ef8705bbaa241512e547c303aba9278fa51cf6ed",
+                                "uncompressed-sha256": "86c19fa14c24ed9f7d27c5e5b2f3974adfd857046c05315e6cf4d4e4998208e4"
                             }
                         }
                     }
@@ -524,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-00ec5c36709866fdf"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-035dd8dc3323b0c32"
                         },
                         "ap-east-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-076c45f38a6eb9c45"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0205be775e60439ce"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0269bbb58b8cc5548"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0f4a18e2030efe0e2"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0d9c497c17c6b52ea"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-06cf957fc07163018"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-09a4bbe1af81c413c"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-01968af545fa16b79"
                         },
                         "ap-south-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-032a998f580609ee1"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0a4f206e80820fe43"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0fc673efe8be6d918"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0eb347266ded615c8"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-02df7cfddb59138c5"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-035229c43ea87d5d2"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0cd3d5c6b6a28762d"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-09939edbf03148732"
                         },
                         "ca-central-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0dc7a11ac7baaca1a"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0a786f4048f668d40"
                         },
                         "eu-central-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0df19f72277f22665"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0e41bb386d29c830d"
                         },
                         "eu-north-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0076a9d8cf25c445b"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0215b59a2c99b9e1d"
                         },
                         "eu-south-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-03507cef815d2eb4e"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0e683dce88f08208e"
                         },
                         "eu-west-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-055b23e4fca0665d2"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0b1b05e1b76e41aee"
                         },
                         "eu-west-2": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-029e874278ad33758"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0f58eb1635ae59668"
                         },
                         "eu-west-3": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-04bc70bd9eb45a865"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-09c67e94c29e023d1"
                         },
                         "me-central-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0e527149c1202802e"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-069dd52f35647504d"
                         },
                         "me-south-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0d698a34dfe4185ec"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-07fde866762b1ea13"
                         },
                         "sa-east-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-004de13806f9ed561"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0c628f108d63ebdd2"
                         },
                         "us-east-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-08b62e76c3935182e"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-04628680427e0ec93"
                         },
                         "us-east-2": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0450e7c9c3d4a4088"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0aa6c2ca73e830405"
                         },
                         "us-west-1": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-063b9c1634b7bdfb3"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-0a45b91be388a65b5"
                         },
                         "us-west-2": {
-                            "release": "37.20221021.1.0",
-                            "image": "ami-0f4127bfb19b38002"
+                            "release": "37.20221021.1.1",
+                            "image": "ami-03843196c1a505022"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221021.1.0",
+                    "release": "37.20221021.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-37-20221021-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20221021-1-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-10-18T09:42:08Z",
+        "last-modified": "2022-11-01T22:22:27Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "d40871be12ca285ebed13d1c16c94b5d58c63cf573b8a9f2e63c21b50d9c3022",
-                                "uncompressed-sha256": "593430b20e9064e94582cc35631385bc90acbe20dd48a43dc27c080a05978fcf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "648435bb96bf7e7595e4838de12afb059bc359b86dc8e44281b9d4046b33f497",
+                                "uncompressed-sha256": "23f11c208ce6631c98517513febb53ee9a693b0ebc170edb44ba933ca3dffb26"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "98ab0001efe94352ba5d0666fb8bcb4e584514afd4131761bd88002db219138d",
-                                "uncompressed-sha256": "83e2746e2b3a5c16d9b648fcdd07c42253ca6711c64e686b6191c3d1cffc8576"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "22893606a942877ba55a8d102776c5e3aa03492ae39d1a21e62dd1fd2922a3ec",
+                                "uncompressed-sha256": "33ff9d8589ef7c22a6f42db865e09f99c6691ef504523a644548952790250559"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "65d322d89a23a49c62243e09b7a9832938512dfa1de6267221c76c3913a2954c",
-                                "uncompressed-sha256": "ded52c60230bf1c29e4b15f80a056b5ab8a9cd421fa5748348f2e86a27055533"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "df3d86f268b2878459706cfe33943192ea696b7667b0eeb45acad8f9cd41da96",
+                                "uncompressed-sha256": "dee3550a3ea81a5db43085989de7135ea4b4660db94b1061598abc0a21a8d827"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-live.aarch64.iso.sig",
-                                "sha256": "ac348e89aaa6808d70a6a9d2124ca2c427be956f0fcdf3d864270a9180aa7e68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-live.aarch64.iso.sig",
+                                "sha256": "85673e0ea7e8ef4789fda20915eab3c8016422026c196c717c4046ff812c9fc3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-live-kernel-aarch64.sig",
                                 "sha256": "1a654a618aca6ec8a7f38c0f83ea34971aa52925e07fa99a8b082cfc080a975f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "baa642d6cb166497bf530a3e3cbf4098f059cdee215c88feb7e559e204ab7769"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "c76761b06ca3c0e817ff67cabd1738f39a97886e862771ae34e7815320bf6dd4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "7dfbb32d118e5e51d3f6f774d1e7e0c34670935ac5ad9fcfcdb3a0f49bbdfd22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "4f966f04190c93b5c42d95d4ac66f1a4f328414b4b1c766815d26fc8d5bb508a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "a260522587377ed54a5daf048516bb4b747aba82e4a7ba89f4ade13bfeaffff0",
-                                "uncompressed-sha256": "a0bf390d14ec06306973175ae799953ce93c811d592fe816e401bca02364c333"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "fd88857d9abebe4c6b8b757459a3e482aa8271a8141bc58f2c4bf5800dfaeff8",
+                                "uncompressed-sha256": "94078e75e0137787d1a01162e785fb7f88365745ac4118a7c5081623ab92ee85"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "b419932bf0d6e476d7bb492ea222b446496b1253c27e4681504fb40934f3844c",
-                                "uncompressed-sha256": "e2701bda85ad75da67a8c3cc32a1eb40a18b615db7c17bfe3d23c49ac671ffcf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "0238ebc5afa5821b8ad55524c6a71257241f6dc932d060e60093556362ab36a9",
+                                "uncompressed-sha256": "58bd6cba1b1d81e741a853a99a44d2715b837c6fc08b0fa0626e9821b739b15b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/aarch64/fedora-coreos-36.20221014.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "6942e8871aacdc645f2f0887eb0794e0673a558ef10e1de22a47b37af21e1fcc",
-                                "uncompressed-sha256": "d1b9be8113332ded0f018d21cac4449d1a5dcd36b9c21a767c92c886a6b92064"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "7a052f3ef36190cb8498ca5f04d4dd2a9a56bee68a62b8cf98d825783577380a",
+                                "uncompressed-sha256": "8031d4c639d71e2a5fae55abcd6930e649ac22b28d1e373c3f68145a2ae34577"
                             }
                         }
                     }
@@ -109,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-0d799318e28fe795a"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0d56139b4058b6674"
                         },
                         "ap-east-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-065c8ef2512e75ae9"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-00dd6057e961d6753"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-0a3272593d5607d2f"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0f22c5139bf071f8a"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-028f34eb8d41dffd3"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-087ca06e7ff926ab9"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-078a22ad858528829"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-055058a09ce0b5e88"
                         },
                         "ap-south-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-0e4a5514a563dcecb"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-09b259330efa993f2"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-07d66cc8ace22dc23"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-06cd5feac633c6a24"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-06f193b2f5aff9a3d"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-01e12bf53b14e254c"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-01fc5c94a7b1294be"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-000db5aecad7f956b"
                         },
                         "ca-central-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-057f1ad1711d1bc61"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0a668ff5122d5360d"
                         },
                         "eu-central-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-0f50a3674cfaa0295"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0fbb018c6f460f7a5"
                         },
                         "eu-north-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-0bf885a45f6cbbf25"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0910237edcf0afff5"
                         },
                         "eu-south-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-05e617ec25cab2871"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0f68213f746859787"
                         },
                         "eu-west-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-05e99c94d0eea1dc7"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0c6554f72692717e1"
                         },
                         "eu-west-2": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-09cdfef9d167257c6"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-05b0785f8fd69d46a"
                         },
                         "eu-west-3": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-0fcdcf768a6bfc9c0"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-079539d362c0cf8b2"
                         },
                         "me-central-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-0c9890f1f7ba75c99"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-00767b826ec3d9278"
                         },
                         "me-south-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-0e16c39be859b5140"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-092db11a732752485"
                         },
                         "sa-east-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-07be28df4c3456e88"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-00a2d65e89f9b876e"
                         },
                         "us-east-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-076b552fb21b897a3"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0fc7257134cd10f8b"
                         },
                         "us-east-2": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-043e124f503260d05"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0dc9ad26fbbcd0717"
                         },
                         "us-west-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-02228ef2c056d8ca8"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0cdbd96b939cf721a"
                         },
                         "us-west-2": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-084e68bc7234213e1"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-09e71bdcd6e3eb741"
                         }
                     }
                 }
@@ -207,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "8068819d6a15e5893ade3849f37993feac9e7c12ab47e10a18c15c1dd6c5cd39",
-                                "uncompressed-sha256": "4625b40eff8d42cf3ee2356341cce125156b69b807859be489f57bc343bea11e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "fd456ec8eaab8d7738d0bea6699e8b04276372a44e931639053612b1073ab8cb",
+                                "uncompressed-sha256": "575bcbd451b95a9c4d338e53e729855ba3cf4fddd1488cd83971508f586db514"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "f791ca65194370e5b072e831c4fa9573310e82bd3d33aaee8aae0f919227cc57",
-                                "uncompressed-sha256": "a277ec89d54b0cd0cc870d7e116e5d92e306ddc9618637ea2af9f800ae625f8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "fa017cd3f7bdb893460df54987ecfdc1641d42ebdebc76e10468af0c2a76961d",
+                                "uncompressed-sha256": "36cde912b7273cb3401e09411dd4dfeccc32364206d88d212e67bba69014ae63"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-live.s390x.iso.sig",
-                                "sha256": "6497d6a59ae5f4f962bbc0b05e7564b54e39ed8a85fc2c9e33c67dee1bdd7305"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-live.s390x.iso.sig",
+                                "sha256": "8da0addf43e6dc02ea45bbeadf01ab94a3cf762623c4ba52b2a8994cdcd8deba"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-live-kernel-s390x.sig",
                                 "sha256": "817ecfde938475c79dd93021ad1f87587768ae496d36663e6aa0608a383279ab"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "5b82baabba6a1e538747324010f94ca10c88139b65f7c7d09bf42362e98262c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "a9dcc34728068192eb28254eb3c8443ca220fba7eda12a665d59a87bc26dba1e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "100c6c12ee546743fe93a5f21d90687ed109fc019afe87030bcc19827e632e4e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "144488f5dec7e2c22b356b9eb0474766c86b9edd8fb5765b1010477d4934184e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "15dce6fe757697facf7925ed89ad40ee0fe3b1c65b1ba85cb4a2e95d7ca46fce",
-                                "uncompressed-sha256": "8dba94d2d0d6c1a96b2f4e12a64c0cafc73b30e92992cb1ffdc4b5b7c48eb583"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "c94c18cc932636177a037cb6ec783aa66d89afc271c33045a981d039b9b045ae",
+                                "uncompressed-sha256": "4cb5c8de7df6bbc2bb1f9e7a8df6a61a94e424667f5e47563d30e1661285c3fd"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "6951e076d8807db8175b7fd439096843c5d2d5e7ba6987a1948d0559ef813fd5",
-                                "uncompressed-sha256": "04425e3ce1f69e6859d8230a92fbf380dee1d98d76ca1737b6d0a0b0d140fbbb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "21fc70df86c4724c44be791eaddb7cfef5bb97f2887501e85fe7e97aa32a1a54",
+                                "uncompressed-sha256": "a4ed293fb934d3a8bde72a5c39f9c73c130b1b23c60cffc323e0acb1652de2f1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/s390x/fedora-coreos-36.20221014.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "51287da1de61d239f2c9831ac178498ebb6572489448f595262845d22b9c11ba",
-                                "uncompressed-sha256": "1fa5c14c017595f981ab55f4cce2143328a955ea6745f6289e921891d3f93ec9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "c6f555b3ccc7bedb59ebfb31d0959ac0f216767fece5c7049c9079b49e35bcd4",
+                                "uncompressed-sha256": "78042837eb682a056c38ed91f2628dfea08f036e3bf1566f004329354cdcb622"
                             }
                         }
                     }
@@ -296,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "31613fc13771ab36f65d488c63438333c8bc189cd782fb5c5c02a9d2dd85e5e6",
-                                "uncompressed-sha256": "16b467c42b137478445334bf97855683f263cca9364a7dec3346286cd9f7b657"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "99cdc8236f4ac1de9d08d794fe09c56add64feba87683bac3124bef635257981",
+                                "uncompressed-sha256": "9ff444d0dc7edf90a7592a98845de33c39bd513337c8fb62482ca545477f6bcc"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "8d327c4b688a0016159f13a6e2a6c608bcbb0184cd1fdc47e3a0a5a8b2249713",
-                                "uncompressed-sha256": "1143837677ccd59ddef96ec4b8210bafdb204c4c24ea36c9c365fd43db205d54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "3f591aee9ac3632226a43f9960e2236042932aa761f90af406b97cbb677b1cee",
+                                "uncompressed-sha256": "8ce8376e55a72906bc9933ffe59c11211a27c2d7c6135e727a60ca877547702e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "c042b0ccfcf668dc5cc7aaba4291403d53ed6ea9874df114c954769f57860fe0",
-                                "uncompressed-sha256": "3f4e0bc2635a091f5bdb9f7556ea44a69c9e4a5c1b6cb462f783a73c9eae8bb6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e6e6e7e01721c3a7e5b5fb46fb4971da8e862e2e3e3d905ba42211ec3f495f8d",
+                                "uncompressed-sha256": "c29d8e199b57fd66fd3346b6a82bcea0ed019f0b3c440cb5e71faf11b9775b20"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "a906181c8e1dd395f454009f8d66acd2b7742bf27ed0cb1a1bc13146f129c0fe",
-                                "uncompressed-sha256": "f3cd4edf9187dba8903106a12b27e0d3b4c54bb0439503ece6740fa77e99ff16"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "4e36ec10c9ba111066634e933fea814b901a8633d06de52fecc78ca154a5bd24",
+                                "uncompressed-sha256": "cd94ad9832a0b766096dd78f09548fe8ee4809e8d60f6412b05013db2d57ef05"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "20df18fbe50a44a4343047ab06a3899f85540d242cce6272f11e7159f6589384",
-                                "uncompressed-sha256": "ff6c6d80121695af4f1f6ed58cd862b74ce87880389b70a8c0765634b9357328"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "1dfb772a7727dc289bf6fbbd64136891c8b9055e75dfc62aa7499998732bb5b4",
+                                "uncompressed-sha256": "5377718ef0b6e6f756ddf1e0e0e675fa4740e07ae7905cbef2dc6b2927646915"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "85e9b882267269c5200ca910f1736d83b178145fc3db9731dc9298726c8af3c3",
-                                "uncompressed-sha256": "9119c13a6c9935479f21336425a47b5576254039b6e0f9fd4d077e53c21c16d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "5707cf85af11e34160732a4b1bbbc8ee4922e91d2a854018906923e5be97d627",
+                                "uncompressed-sha256": "e7b1dc2fd5ba779c3f33e25898083a9ca7426de371a0f92f65104537b5cd8aba"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "8f7aefbf2209353e6382302a2421d58423411b4154c86ea9ef233856b130553f",
-                                "uncompressed-sha256": "c9383742cb80afa32c0ef52fd1fc3a7b0bfa0fff7c9f107db8c3317f01d2d0bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "490794397aef62217594ca83543dc28eaf72c9bb2e7e4a07ab8dbf9fe39ec7c1",
+                                "uncompressed-sha256": "8f0512e24f247633dcdb5d6edf88895b9f05471893252123dce0dded90fb70f3"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "074bf271b622ad8ee9713a75a548f5264b62d16a945bf3b524292826973baca0",
-                                "uncompressed-sha256": "824733fa3fd3f241a52ad42dc5ad683e2bfc44f814b61aa23721a9695a24a0a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "2c992e5b71129914892da2a2099643e5a16e11aa309fa41dbdb8287872918085",
+                                "uncompressed-sha256": "cbd8b4e7e6c7c94d88d1a55d4babbc81604b0655043b50d5034e0b43d71c6cd8"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "a9aa834cc945027fa28763a082649ed84c589f9c2ad989783078a075b3ea67f8",
-                                "uncompressed-sha256": "adf5a7ed2dde2674841f2e17adb146829912f3efec35ec8ee08eac842a233298"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "2f1b7202d007ebb6c814a3c7b1f372d88cfe586d9aabee3db3080ec8d69e4f7a",
+                                "uncompressed-sha256": "8d3a9b737945d60215d464c7df25fc28d60c9d794e85ea1d668e7ec42828d9c1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-live.x86_64.iso.sig",
-                                "sha256": "133a9c73f60aca9e97da93fd1dad9c874c7e9111ac2a1cdbd82aaadf30f27846"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-live.x86_64.iso.sig",
+                                "sha256": "a347700178fc1b8ceace5295b8b18048f0301fc3970fc1b1b94563773f11d307"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-live-kernel-x86_64.sig",
                                 "sha256": "8ba8c8895e42dd1efa08d338c930bcb8707663ab3a42433584b70c6dcdcb7dd8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "5916fabeb27a64c35d9846f28b5cf264155b0cadef014abbec33bd7d657cf075"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "999572be3b22c881787b7bbba4bfe5f9978c576a0188a9ef3e135e094809b5fe"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "477b0e9de08c02c9ab85023191c3dc95ca414266d559862594b99d4bbc6c306f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "fc651f8fba4b16944c7f28d740e8b259fcb8b068d45a053c3354114abe3c5f1d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "ed2331acda57af33711ebe495a3e6d9e746b3b6404eb836d9e50e9301ed1504d",
-                                "uncompressed-sha256": "1c86b1659a9cec1e1349dfb41da4cf06f3fd31f1faaaefd29bca3c5f1c58f732"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "e8a90762a60b39a29cd1dd7d3d5a32c2c90f24cd018059f342fabd3499f5cd91",
+                                "uncompressed-sha256": "038de28874ed8446da1777ee7bb8a4ef57f01ce9a471094dc56b3213581fae93"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "625dce0010190241663f444719fec00d9490871a5ef8648f6c39cf713447ca85"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "6ef5eea8b04386dddd3c823c1ddd0a598b562771b6a575044129da5ee65bee5d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "af4bfbbca3a98d26d76d0119376add0b8ea778e8688ee7634a91055db8079668",
-                                "uncompressed-sha256": "6ca7dd8f1d93a0800b1fe204dcaafb0766dff8e510ff0881f8f8626aae244b4e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "1df9d899ccae6c34a5239b143088b263e01e83eb8fa748be5f6901645d21620a",
+                                "uncompressed-sha256": "f14b7e38b714b0fb4eb01fa75fe497eaee93b2a4cdfbead35c93834e613e38f5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "fe62dc9edaeb1ad8804c4f4c57fab89917f713e94f6bb5a2d5d39b8c6344f9b7",
-                                "uncompressed-sha256": "c04055d57833c5d247571027ebb4271f8163c61774b9a40e38a48619c1eb1087"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "d6b3a1d8ef3d411d8b7e10e6dfe86b49761a5a826789bf45f914911c5a2bbdf7",
+                                "uncompressed-sha256": "dc70029302bd32ae277e255bd22fd47187a5807734d2c22afa3f28de331e7ee3"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "4f47259d197bbd1a9417932b9a6fe3271746e3440c212fec6f79451cd87e4027"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "92cb443c5bfe20c3017da4e5e9a049916d0cbdf0f636452f5235fa9286742c8f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "64bac37b7450b8d97ab222675293a0d5677de5f2d946f8f96add6600c860d7f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "a3ab663089878696ef2d2c08492de24a2cf6785bd521743060133510e89ec100"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.0/x86_64/fedora-coreos-36.20221014.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "978fbcaa925e84763352772343e57701aa5ca49bdf568900548b6a7b4adf23e4",
-                                "uncompressed-sha256": "ddad69864a717903227aa30b2a7d8f47abbc30e9f59087a62851d21bc1dfc52c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "0333138c9891528a7d605c59357cbb7eff6b15c4f677cd0f918b153c8f2b27d0",
+                                "uncompressed-sha256": "525f01d56fabac73b05b2685bd755485a590522870587a9cc0f4a1f7a5553abf"
                             }
                         }
                     }
@@ -524,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-05312958a6efabbf0"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-073444e1fbee49cc2"
                         },
                         "ap-east-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-02ae2ff4857e01a8b"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0b1bfcd5582f6faa9"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-04654b08004881c60"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-08913dc9295aa2906"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-02ae4ec3915dc8d49"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0626917ecd7431c3a"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-09f1311e43c87085c"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-054fc61f0a4e8046d"
                         },
                         "ap-south-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-0d30e9baf0f52b9cf"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0c2cc72acf182e3ce"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-08a587de82d6afd46"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-03fb644b2e10d836c"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-02e86e6d6b765dd51"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0536bb6bc880f50cd"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-0e7c5c56ab649cd96"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-027f7e8185c3404f9"
                         },
                         "ca-central-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-091b85150a61b38ce"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0277f7423ef1aef23"
                         },
                         "eu-central-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-0bcc2ab418fe685d6"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-07cf1fe881379a8d1"
                         },
                         "eu-north-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-01368134e907db7a4"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-07187f703a4e934bd"
                         },
                         "eu-south-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-0cb0d3470dd94a85a"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0ac23123049622061"
                         },
                         "eu-west-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-08ebefddd7516d1d9"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0842e7171487841f4"
                         },
                         "eu-west-2": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-0051d684d15d91fd4"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0c84a6a1ed71b72c9"
                         },
                         "eu-west-3": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-0448e6c4092f3c2da"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0e779fa11636e819f"
                         },
                         "me-central-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-0a4f414b25b8eac45"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0664a07e1faf25310"
                         },
                         "me-south-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-0453ad1ab58eaa656"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0f886a591609b75f1"
                         },
                         "sa-east-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-08b72aed504b499ca"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-0b3a4767cd9177d41"
                         },
                         "us-east-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-06ce37b8291c5f294"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-014e4080efd29bc93"
                         },
                         "us-east-2": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-0251e827bf3c54ed4"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-034370ac82f285f17"
                         },
                         "us-west-1": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-069b915da48582bef"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-09d77c4ca15af959a"
                         },
                         "us-west-2": {
-                            "release": "36.20221014.2.0",
-                            "image": "ami-07f92076976219c4b"
+                            "release": "36.20221014.2.1",
+                            "image": "ami-09673a09a39515070"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20221014.2.0",
+                    "release": "36.20221014.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-36-20221014-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20221014-2-1-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-10-25T13:25:53Z"
+    "last-modified": "2022-11-01T22:22:29Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "37.20221015.1.0",
+      "version": "37.20221021.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "37.20221021.1.0",
+      "version": "37.20221021.1.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 1440,
-          "start_epoch": 1666706400,
+          "start_epoch": 1667343600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-10-18T09:42:08Z"
+    "last-modified": "2022-11-01T22:22:28Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "36.20221001.2.0",
+      "version": "36.20221014.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "36.20221014.2.0",
+      "version": "36.20221014.2.1",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1666101600,
+          "duration_minutes": 1440,
+          "start_epoch": 1667343600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).