### PR TITLE
Roll out stable 36.20221014.3.1, testing 36.20221030.2.1, next 37.20221031.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-11-01T22:22:28Z",
+        "last-modified": "2022-11-02T18:50:23Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "0da2957e93b4e223de3f74142d8f20d4babc921dc2eb85a4cf452bb20510b471",
-                                "uncompressed-sha256": "31bb075e8ab23b6cb310b2298ff40431d4659f4e59dec218ae631feec1d6351f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "20d5a76d26797a133a399a917caecae0baa2f74763b53761fee305ace10a77a7",
+                                "uncompressed-sha256": "97d635c38b183ac7d45b7204b11950caf4c4b8bfdf17182ceb7c2a690948c097"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "83641fdc8034e298fb7577bff560436e85c51005d1c4dcb37bf8123af67511ed",
-                                "uncompressed-sha256": "816f9cb7a49a94574826c709efb110c2b58592379d343ce16fd67b7600265cdd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "a5eac814c0c6e2b91594f0849d44536c2cbcdc80660a76895efcad298a611d5c",
+                                "uncompressed-sha256": "57349c9b4105cf98b2ea99a2894982995798b304d3b91217215b2f705c2edaf3"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "6e302fd865ddccf6c30e15bad9f5a9fa7d42d8f6fa86eb7da78d0ca1828136fe",
-                                "uncompressed-sha256": "5a4169e9662aed8fbdb7f8a22b5587c538491831455af410afe76b6f6bfd6b0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "7e9273877876591bb068977083596a8b98e52efa6b5bb7c525fa0d379533baeb",
+                                "uncompressed-sha256": "4a782ed447ee542ce9d4c48b8d6dc03d7fe8e18b6cb0996514ec5f0bfdbf63b1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-live.aarch64.iso.sig",
-                                "sha256": "c55fc57b42d522d236c7d0266b9ce8fbe3101cee6e170ea17cae0acf002ce67e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-live.aarch64.iso.sig",
+                                "sha256": "ded1de44a6ea5bf8f68147c42636b716bd06acb89889d7a216da12fb9b1baab5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-live-kernel-aarch64.sig",
-                                "sha256": "d8bb2c77cac304198619b87dd842666ff340adeb7b3f06ec748d0f1ebaa56af4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-live-kernel-aarch64.sig",
+                                "sha256": "17b3c9615c354ec6470d52a65254cdaaf0c51675b79dd81cc29f533ff11ce081"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "468b689a21c1a211496fb19d43ed2395bbfb78939fc65a87cdcea855decca2ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "72d2df664081f0fc6a44c0613b730c2bae2914262cd52baeaa4d449980727ae4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "a756ff55bb917d81542e92cd250b9431867a367dcecac6e184f9b25d250a0e8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "d6127926cc33b4ac2d122ee8b27de59c966c7b92504f2b811caac9cc49aca9a6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "001277d2d9facaf0f57947582b60f72acf73a49e022316c666a9862e0e233e87",
-                                "uncompressed-sha256": "e75b6a7b705d3fdeab13c7c26cb60a35e9af0541fa0d523f50d94224b29cd59d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "181b741b2daf2023b7c0b5967cb07a392ef0df1fde6fa953ee29557b497ed03b",
+                                "uncompressed-sha256": "7c11c677b9a7a6c179df1ab2e1a8af31ff03b129fca733a0031915a94a5a27ba"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "7cd7ec08c5c675f1a070e9b532cb75d15df0ec0288b0be0137a811d03df5b242",
-                                "uncompressed-sha256": "5d6f374a97dc474949d9a7e9b19ac915f0f6fbae83fbcb906cbe14d2b62a6531"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "3e50d5f1b0ffb19e1147cbe8e9be14f54718a1cd1621613fd93efd7324060d0f",
+                                "uncompressed-sha256": "f4d4231b24c563cb8db9cd75b05876cb1d6fb808115ed64accb15a8afb1bf0d0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/aarch64/fedora-coreos-37.20221021.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "d3ebc99ba5cedc03a0c4bf41204cbe450e1bf637af01528fb3d4608bc670ff09",
-                                "uncompressed-sha256": "5c34400b433d59e0be19cc2061ae1ecefda4307dafd5e315cdaef55cd77f20fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "14de9d78ab2cbb047ef8c46417436c514fa178f21725819c3e9ae4aa3fb27eca",
+                                "uncompressed-sha256": "40775d2158fb3a1cf20466e03f38fea47214b8f44e4191cfc15833d58606dcff"
                             }
                         }
                     }
@@ -109,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-094decb45d8a9935b"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-07f6c1f2177d8b896"
                         },
                         "ap-east-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-03202531bf01f3950"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0f5e8f337b4c8ca7d"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0cb2dc5ba1c4752e4"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0c217367a63feb847"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-00883185f1ec4cb0d"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-05cc43c8e2df79fba"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0bda81ac5e284fdfc"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0adb835fb38b015e2"
                         },
                         "ap-south-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0181361ab25ba72f8"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-068567f0de27fa135"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-08f2319330975c266"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0adaae49f261422db"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-02c79007839c22028"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0841206f6cfdbc775"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0606c0f170e614104"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-08026dd6098fd6256"
                         },
                         "ca-central-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0d0484a01c934b062"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0200be109165e0d0d"
                         },
                         "eu-central-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-054178804e7f87f59"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0a2ef3443ff0ea0d5"
                         },
                         "eu-north-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-02a9ca2f3e0da24d2"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-074903645d06c9349"
                         },
                         "eu-south-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-02fa6574e5e4a160c"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0732df0f1bfa8f6ff"
                         },
                         "eu-west-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-025c86d227fcbd4c4"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-069bd510815307c52"
                         },
                         "eu-west-2": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-07608072bf380b214"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-01bf6cc69823e0188"
                         },
                         "eu-west-3": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-00c198261d281ca8a"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-056bb3d31ea0ccb66"
                         },
                         "me-central-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-016ca53314a1c7924"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-053b813d7747f2696"
                         },
                         "me-south-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0bc273676fb884908"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0f1f63215f8c5c19f"
                         },
                         "sa-east-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-03a52133239957c80"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-04a54aaa57549a4aa"
                         },
                         "us-east-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0e2082987a5377a24"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0e4c461ac877c83b1"
                         },
                         "us-east-2": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-09dc644a6621a679d"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-08e767196961024b4"
                         },
                         "us-west-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-05f546b3e0ac685dd"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0dc3d412b3d04d994"
                         },
                         "us-west-2": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0b3108965df0a9318"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-05504540ed943b830"
                         }
                     }
                 }
@@ -207,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "6e420f5ca90449a60ef219a6337658f134a0648af83864ef7829f09d2558e62d",
-                                "uncompressed-sha256": "440d69075984aab5cc6a786936ee77449733a9413a23cb603f9113a533606995"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "67f339cf3e3377a9910982b4211c2f42a98d032a9742f36407b34799d4d4301b",
+                                "uncompressed-sha256": "a236c767a310e9e77c987a788254a033effeed7804df9bb7f65bc092742c8d6f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "889c52f80d0a1029e856ed01e0558887821129693980a3658664bc480453171f",
-                                "uncompressed-sha256": "524eb81326e6d71e7914e92cea8a7c3169efcbc2ac21ad9b2398d33ea924fec2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "5573b885dc79fa4e6e2ddccf1681ef70943149b7f815b016237695df4da37a16",
+                                "uncompressed-sha256": "671b4a14320975de6c42923b3aeda5674ab5b551afd143ad58cd21ba520ed220"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-live.s390x.iso.sig",
-                                "sha256": "8d2adb4dc058694ae35b3a62cdd630175458bd692f37bffc4ce3167b273f5c88"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-live.s390x.iso.sig",
+                                "sha256": "42041c977c19fb1f419f724e1c313d002bcb7c4d4bfea99e50fd1232cb37eb60"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-live-kernel-s390x.sig",
-                                "sha256": "584cc1b17cf6a645f86353e37a6c3d29268afd7e5fc49d453f108faa4b2f5f0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-live-kernel-s390x.sig",
+                                "sha256": "bc7e7eaf84f4414dc681f8e43f1e5b09a3b1159008e00284fb2c750e75f4c852"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "0a78789f3642d4197222eded21393ca86ccde4d7b4823478b19fab1ff0056113"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "23921e893139341fe0ea138a032b8afd3393f9bcd806fe4c246c6321d8c1ff41"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "fc0392d17d981d45fcc937c2191bb6e97c3d1acd739c27426f87906d2ecdb9b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "62b4d82cfbba840e1440c5601035c9a057bb7c62a46b8018d9b9adad08ce9508"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "70ad23f3ddcd22035b07bc360583cb10d1574d4573987c6f1c8e28da642786a3",
-                                "uncompressed-sha256": "ad99767aff2015ddf19c17c0442a977d9a8676659e9d0b872ac51334b0f1d4de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "726faf854e1bac17b12fb6c4bae066059320907591857a6941bc62b232721996",
+                                "uncompressed-sha256": "6e20cd0075a1eec6446c5fc8c17ca477125df545d568d4c7dbb1af542a65222e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "e5f48b218da8c513e61766ceecd35306ac25c3859c7226bda6ae9d4f523a99b8",
-                                "uncompressed-sha256": "ca93a7c17f98721b51c25592a764882e28df2a98247b70903c25f20058d88694"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "9db2a3818e2744a5d2762d148cb444e4286f21c2985a012be4bdf766c0ab8e5b",
+                                "uncompressed-sha256": "3a2d67a47e318540ee10ffcdae6e27b58658853353f8023fc60ebf2822f24ba0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/s390x/fedora-coreos-37.20221021.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "4d1265444ff5eaf123210674df87d9ffbde39dddaee5cc071b174fc46dc9667a",
-                                "uncompressed-sha256": "a803c996d8a3365dc8ba71396ac843acfd8ad686ed0f312a6973721b226a160a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "ed26ebb0e3a5f72fe128937c41846a3e148ce711180029f5457455bb30651235",
+                                "uncompressed-sha256": "3a14f81bcf96cfb32eba2658b3470ae0fc9caa41678e6c066331f93d6281804e"
                             }
                         }
                     }
@@ -296,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "d3e193c33cccced254c900bd2ffdb0f0a94e53e932abe157d6485b914827d259",
-                                "uncompressed-sha256": "b21e423665b808c0dc991f5f0610efe1be4631f7d3bf65e5f28fccdc3bdb76c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "c4f786c52b369cab266e726c617f1a70b175af88cc2a90a421e3083852af9170",
+                                "uncompressed-sha256": "1930011da6b908c658fc6dcf74cce0ca008908ae6bce239189910036a9262180"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "c38d243eb4f1a7b5aef852e45d78fdb8feaba8c6ec085df2e52a9f363e2a2737",
-                                "uncompressed-sha256": "93f381080c8545b12f61ca2185325797d6859c5ff711323dd660cc7565ae6684"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "ab3b6487a9529bd8370f8febc7dde9c75deda11a7419356a62ed5e04468dd931",
+                                "uncompressed-sha256": "3289b568e2e97f05acabf4a4471699b99127df332ba33312537db3c82c3f51b4"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "09529ad80410ce52e8353eefdbfa8077bf8dbfbb82084806f2a933337ff83556",
-                                "uncompressed-sha256": "125e3ad157f570e9551e3677b9fab72ff4d5fe759ed6b7d337b7c72c23471526"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "ac1d33ae38c92d0ce1bd5994cf2daef9ade53975c28ca6474a4446817878343c",
+                                "uncompressed-sha256": "607a7848559c35841c910618c25252318b349f80888ed7b98b6b37690531a257"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "314618b74ab9248e5d32bf20e7ac5e2c9524330f2f85f0c946f64da948723743",
-                                "uncompressed-sha256": "860e065e8fddc5add893cb49846b0f275d24589697a5ede6382e56e00cb6024b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "3918457b710514baaded38204df3434a4170660843001121fb8ba6406abfbfb8",
+                                "uncompressed-sha256": "7af1594240b65b2192e030b415903213925ac2cc4944ed8c53f793c30e1763f9"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "efdef7f533f5faa47509ccb0cf865c88e77b8427275f3416318d78d192504a78",
-                                "uncompressed-sha256": "02acff1c24742ef8eceed3c2da9ceb83fc78b2156eee6fca50ff6ad372ac9325"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "01b4bc67a81a058cfedc99c63bb871299c4e62bb91a9d7dc215b59a2e78610f9",
+                                "uncompressed-sha256": "950e41f8b5da53911c19360a34ad08122c788e5171e02da6cf0a32f16c881233"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "389724fa66aced0449769aaf1538ce9065415796263f4cd0f3d4605547d047c7",
-                                "uncompressed-sha256": "dece9e11c3665cdeb6735d5266d2811c63ee49cbbf825db69775eda194d3afb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "4a0e3f5f564b13ef85edc2d2795c1862117ff70385ab773e0f4e043ffc2d412b",
+                                "uncompressed-sha256": "599352c5c14ce247d7720468005ee9e4b165fe59118c81d8af61efa9e9f5d411"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "da9b0bd4cbb70d225af5353a00a93371470ebb6fe85152370775a5f3625694ff",
-                                "uncompressed-sha256": "bba66236410286cdf601cb98ac708c5db23e2c314e78a9d4ae5716d39b586fef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "0148352190986f2ad4920b46387522276b646464f94fd6a0317d92dde6e285ee",
+                                "uncompressed-sha256": "197470e164d18318646e7b3c7895925ad2202e7263293550eeff4c5772f268a4"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "3f1dfed7ca54d548da0b9fdc71f0117b5a39e8a4207c9aa22ceaf586d7091402",
-                                "uncompressed-sha256": "be803e28a4dde31f8325c1df7882e89d3745206bd3d85eeb776bb13ebd67852c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "3bd6c30a233172ead4e3733a91811ef088e6d404e7b2d94c5eeaeec3c34f3166",
+                                "uncompressed-sha256": "ef778a1e3fd68f3f631f75a56269cf42c946608ed149ca5ae84139c07b5e0480"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "c1957155f7f5de06c84c8aabfdeb3ee420fa76117cbb9ebf89c7b04d5a31778b",
-                                "uncompressed-sha256": "16db6573a0407cd784fd52a88b97f30750a8c7750f6e3c209d6d84ec58e10c3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "a4c5de4435185867d839b2500352e0ee45a8e2860274b0f2bb2e768404dfe1fe",
+                                "uncompressed-sha256": "5d4a800c5d0eaf62c083b5ab37b7211e25e1d03b1bc5b8ab45d2f3f664d4e49b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-live.x86_64.iso.sig",
-                                "sha256": "cbfe0223f0137e61b478b4b3bd4398c5ea2d0db8b44859cad7a29c147d4c59e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-live.x86_64.iso.sig",
+                                "sha256": "40f442b654dcdb3106333a9779474ba2279118cd13b421ef4b7d3999d6511e3f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-live-kernel-x86_64.sig",
-                                "sha256": "697726589e305bb32e877747f6ecdf9027145a7baab2301f3db7583ef357e698"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-live-kernel-x86_64.sig",
+                                "sha256": "f28835fd12e72da1592ecc5f26e6403847acba5beea329fe7d754015a731e64b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "a98338223c3a627ebe373643e3e8d5387c74e24238390deaa0ec70d1f443ab51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "a8b18be1d370abdcb1a537396c16a714ebcfc75c6d6718e7cb491032c98585bd"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "d3c019c9a0cddc1e4f2e8070d3586f524992a77c4af34866e79b63e45ae9445d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "037e4c02bb442ab0668a0b43a1b4fcd8f68cc65099bd974c3e2049ec941e3705"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "7fa82a697bfadcd18c28d882dfccbedf2df0f6ecd09d0c5d62e3fd1a77e43214",
-                                "uncompressed-sha256": "f8813c79d4bb8b10727706ff8433f041ffcfc74ca6cfcd9ccda143e117f3aff7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "6529c67358eabfe96091eac6ccf4ae6e4f0b9c4773c2fd61dca76bf8fced96d1",
+                                "uncompressed-sha256": "96fe1ad80e78b67a4298ae37c8bcc61ff222d9c9ca5db1e55953031ccc81786b"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "88fe8f348a447dc33f5acd937b1145f0831c6ad685b148e367390c975f15c229"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "70328bd84a316eff91d488b16686b2afd842b5333ef4557e15d1228b2c8da24d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "f682cac9798d16cadf9185bd3282244190db41843c492a30ab30ffb22bd27c72",
-                                "uncompressed-sha256": "49a41e51c53ae263cec76dd1381fb8d0d413f2f9970425b379763c1ab4dacffe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "414b0508279e0843bbda582669bc64eee6ae693a978fe2df69480bf627cbbcc0",
+                                "uncompressed-sha256": "36b42f1705abb60eaa3385eb648a34685ff0644ab403529be90178c9fe8c4cfd"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "2a280a7311ebf1de14915b8feebcc45a4bd38de224d23c4eda80a9072dcab707",
-                                "uncompressed-sha256": "50b066eb2e575ace18d60ac96c1fa112604e721f4f8773bdc6e0a51ce8282d6d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "01bb6414158c0edfdf9e8451ac13be793ce062cc07371dd289aab1b880ed68fa",
+                                "uncompressed-sha256": "3c12e1fc2b441747a75b30821fce7b785b57113b873604d108cbce1a7dd4fb96"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "910b13cd3e6fad466e639025f2daafff0a11762a4cd82a3229880971f4f53691"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "0cff64ca4ef65bbb46481603604109b5b3cce19f4c17e972bbce6778f3da802b"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "e7cea18b25189f36252e61299c6f3131bd48367888689462537cbfe430054dab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "247ced7369af0360f190b2fe161e7e58a176c4f8e5c730c1c1cd41d4583374d2"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221021.1.1/x86_64/fedora-coreos-37.20221021.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "0434a3f0a83c61f393294317ef8705bbaa241512e547c303aba9278fa51cf6ed",
-                                "uncompressed-sha256": "86c19fa14c24ed9f7d27c5e5b2f3974adfd857046c05315e6cf4d4e4998208e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "8c6ffa59e260e8153fb6ace9aa72812a8d27f0b001f269c74d8ccbcbd98d0ed6",
+                                "uncompressed-sha256": "7c9ae65004bf24df6f6120099bec9a9818d2ac97d9592caddda0a69815ca151d"
                             }
                         }
                     }
@@ -524,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-035dd8dc3323b0c32"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-059842e9becc3a616"
                         },
                         "ap-east-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0205be775e60439ce"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-072fe16fd1889fadd"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0f4a18e2030efe0e2"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0e27a79ad8eccaa56"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-06cf957fc07163018"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0b89d8b61b75b7daf"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-01968af545fa16b79"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-093eeae3f4f36203c"
                         },
                         "ap-south-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0a4f206e80820fe43"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-012f2e85b45700a69"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0eb347266ded615c8"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-00a54a95e4e926de8"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-035229c43ea87d5d2"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0ab9a8dbff0ff6f85"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-09939edbf03148732"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0bf18bc6f20791fbd"
                         },
                         "ca-central-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0a786f4048f668d40"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-000a76005e714cc91"
                         },
                         "eu-central-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0e41bb386d29c830d"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0a65791eb3ce2d070"
                         },
                         "eu-north-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0215b59a2c99b9e1d"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-03f3a887c6ca74a1e"
                         },
                         "eu-south-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0e683dce88f08208e"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-090cd20bec7be5db2"
                         },
                         "eu-west-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0b1b05e1b76e41aee"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-061aff48c029d45e2"
                         },
                         "eu-west-2": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0f58eb1635ae59668"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0d79356621b42e53e"
                         },
                         "eu-west-3": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-09c67e94c29e023d1"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0bf453b99d5a8a118"
                         },
                         "me-central-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-069dd52f35647504d"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0609f6007dd706ea2"
                         },
                         "me-south-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-07fde866762b1ea13"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0d18a83afde51f91c"
                         },
                         "sa-east-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0c628f108d63ebdd2"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0dad499b7975a0360"
                         },
                         "us-east-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-04628680427e0ec93"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0b0c35babd04ca695"
                         },
                         "us-east-2": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0aa6c2ca73e830405"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-0ba847155da6c6173"
                         },
                         "us-west-1": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-0a45b91be388a65b5"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-08fedc0b71fbb25f2"
                         },
                         "us-west-2": {
-                            "release": "37.20221021.1.1",
-                            "image": "ami-03843196c1a505022"
+                            "release": "37.20221031.1.0",
+                            "image": "ami-083ee13bb603822a6"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221021.1.1",
+                    "release": "37.20221031.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-37-20221021-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-37-20221031-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,105 +1,105 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-10-18T09:42:07Z",
+        "last-modified": "2022-11-02T18:50:21Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "0920a8fb39192d57e37a32e98737c2bff185774690e3b976a7a895fe8ec8eba7",
-                                "uncompressed-sha256": "e31f1192e8e9fa1ea5bfb52afbe975cd471a9e43103022aef142797535bc877a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "4c712f77d5266de05e537194693d3fd32ae9c8c39d1f5961bf42bdab3034e8f6",
+                                "uncompressed-sha256": "e6c01405aef6a8a73b9632c288f06dfe385d402a9f99f3a3c477c588ba63f031"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "a4ea4f0a5785e5668fe5a48b1ddee60083d1371e2aa082ebf048f7f0a29d3d79",
-                                "uncompressed-sha256": "cfac6eafd0ddaa67f5c76b2b7618ff6dab1efe2ad14c845b14acc3f92bc41a2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "3b8ff361600cd32174d48d8087d400628b817690f22d73460ad5fb28ba8f177a",
+                                "uncompressed-sha256": "c8014328e32cc53708fdced7791f09bf8840af917dfa58be60e48f281b99146e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "d55a26a55359c8561167b093042c450716394924326722a2c33dec4b91d7a4bc",
-                                "uncompressed-sha256": "32677c99d103e813d8aec9b7f546c9e2586282630d7a99b64b4703405d6eeb9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "71804f0240f94ae0ccc426ab67e099f935e3ea965f1892b3dfb9f6a34f9704ae",
+                                "uncompressed-sha256": "fc617ef7dac4114edab54fa3f13fff2fcdb4debce76757cda2dea93382f148f5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-live.aarch64.iso.sig",
-                                "sha256": "491764c8ea07513179d1f96ac0f5ab6fb77322f3bb49ef5397e668f2fa4616d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-live.aarch64.iso.sig",
+                                "sha256": "0944a209d7091ff084fec7deb091fd031cad53c1e3d4bc94fc90f79fca741df1"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-live-kernel-aarch64.sig",
-                                "sha256": "181453f03fd4562a41a3012b24f11b3044db4c037aa0a6cccabeba42f22759b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-live-kernel-aarch64.sig",
+                                "sha256": "1a654a618aca6ec8a7f38c0f83ea34971aa52925e07fa99a8b082cfc080a975f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "a3897b17850ffa6af82d81633751eeffe902caf0335d812cc0790130aac36e66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "8072ce7b47f46b45b8a91032a38d571610052aa8ca90890c65d88b291208ba8b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "aa2a9f695117d234ad03bf062e8ee8f8c610a5163f14f0f1e689bc1e52a7f5fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "16936519593bde117cedc5a34d90834016a3fd542f77790a5a1e23f0d26d6de1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "5200e9e1da1b6e71f5a213130adb3439e671343ccdd34fc5da04e66a8f6a6e83",
-                                "uncompressed-sha256": "380c2c2fe8736d1d6ddc2cd3287581e3380de16d9b43fe82f3d1ff47403021f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "c07f24f922206d3c6620d8dcbdd50d64e8ce98e6b0dd787f5f8e74ed18d67c6b",
+                                "uncompressed-sha256": "e306d5f9a18e66dde95a8ea60e6ab1632d99487a12438663283bde439be07037"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "3b2ccb2d20e6de9e507646b3c7c7400fcaaddbcb5bfba0329f69ab03555c84db",
-                                "uncompressed-sha256": "389fe63cf36478a4dd38857f408bd75daf1929efae7e568666d4ea417f573694"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "67d835f909afe06f12cf1b43518dc930b908402e745eaa880b460025626d4181",
+                                "uncompressed-sha256": "c1d89d63b70ecd54be83e4061c54d551a5327d265fa29fd68b35ad67d87c4b5f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/aarch64/fedora-coreos-36.20221001.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "8b4bea8501097e3e8a25ac7e663bd05a2424e8206f2d30c73f85897609b9bc37",
-                                "uncompressed-sha256": "f5b05b6fd610e7cbe4e25ac04b110546dbde164dedca42635effb63306435272"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "f54ebd453d3ee5c5e2d77fa30193a4c101569205e3b7151eeb4cc58a6b165c7e",
+                                "uncompressed-sha256": "d17eaeff40d2ed944b8659c52991bbbf18252409ce62b985079e6cc47fb07dad"
                             }
                         }
                     }
@@ -109,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-040d13661e075c47f"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-036a90c511827f07e"
                         },
                         "ap-east-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0bc5b4e0758a4efbb"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-03e2e08e60e568b9c"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0c706c03cf4cee3a8"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-02b55e657338af497"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0f6ec284e400bf865"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0df0292996af7e2e7"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-013899b6cb04061b7"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-03891be095eb9464d"
                         },
                         "ap-south-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0f30fb756d77bee54"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0ea66310feaf94608"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-00b87fe6bf71a7a7c"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-034dadbf5a4285384"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0e3efbcd47aa4ee83"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0c3a6a523e586b08a"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0284f0300ce05c567"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0251023c60d8ec093"
                         },
                         "ca-central-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-02a5766794dd9f622"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-057ea9d399f3f2125"
                         },
                         "eu-central-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-09b398989e82351c6"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-05bb287d89acd213a"
                         },
                         "eu-north-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0a4925c2cee71bf75"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-06f2628bb886a7c59"
                         },
                         "eu-south-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-03a9478e98036d15f"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0a9a24df99a712d84"
                         },
                         "eu-west-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0c136d4b5945c87a6"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-03a09d7d1c9c6d7d8"
                         },
                         "eu-west-2": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-04742364cbeeab083"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0a410342dbda412fb"
                         },
                         "eu-west-3": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-040a590bc3f02529b"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0ccf7aa5f7e91a44c"
                         },
                         "me-central-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-006499d7da615e507"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-03f44e00892d1893a"
                         },
                         "me-south-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0462aaab09c3306fd"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-09bf9f526ed45daf9"
                         },
                         "sa-east-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0aaa78f86583df9f2"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-06d606bc9d6ea61a5"
                         },
                         "us-east-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-094d1e681f74d1644"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0e1197667e37d709a"
                         },
                         "us-east-2": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-02b1787bae8ad231c"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0a80fbe909923cd07"
                         },
                         "us-west-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-014c1a8279b7e143c"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-06ddc197557635731"
                         },
                         "us-west-2": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-090c7ab5356b74de5"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0fb04186575f641d7"
                         }
                     }
                 }
@@ -207,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "00251a58af6bfd2202e94135c950a44e722db7d0fbf1c582e98ded5a89ee6e19",
-                                "uncompressed-sha256": "ac68e72b61d3898da0bf639b0e3efe58734de27247dd4c9cd77b0653fa997f79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "9ff691cf7acac0e2b9629e38bbf03a4d37cf1bec8af84abf0592ebdefc1e7a1c",
+                                "uncompressed-sha256": "84d801060fdd27c784c98bc528632e141f3374a1088aacdacf18c898077d4f9c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "f4de0b598a06f2b4433abe9d9b1faf9e476d8b9b0fdaa001e0d74f5feabca848",
-                                "uncompressed-sha256": "5a48233f1b84e48e72d33a20c19fc381b30f807c9b5658ab4a463ad8b82e5a43"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "74b9093a9f67619ff1f42d941d50d69556a310a748fc16f1b8ef87fb98933c49",
+                                "uncompressed-sha256": "ae3643e2236bef019a90624e6df20568a2188187d4d089761f0f06a822f380f9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-live.s390x.iso.sig",
-                                "sha256": "99d813fa217ce8eb2d85734e66237e7361e5bdea576f97c95619015969fb00db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-live.s390x.iso.sig",
+                                "sha256": "28a186e05bb9498f7c853f8b329f2af1a3c6f4c4ec7e6f4988e8732cdcce16f9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-live-kernel-s390x.sig",
-                                "sha256": "cb5f7b56dc1554895a8bd7efda9f574bc1b4f612a61a310ee8aceda484b85544"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-live-kernel-s390x.sig",
+                                "sha256": "817ecfde938475c79dd93021ad1f87587768ae496d36663e6aa0608a383279ab"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "cfd1affcaf784edac9769509f370dd267ff1c5048ec0ed8bfa0d1576c88b4833"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "9bfe667d748839154ab35780e2c52770f15abbc809b7bf6bf83eaa84ee02fa4a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "745ce347e0724219fd00e31b9fd9bef838992398e8dad2b0f35bf9cee001295d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "fa815e9daf93da7889476a0bdde9bb6a11ceda6c60b4732b7614d7fe45a144dc"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "d1676d6f7d4b1c71509dce9da5b849520a58e3f5ff80ea91676f16cea031b41c",
-                                "uncompressed-sha256": "a90721fc2b2206af1cb90408d1e6dacf325d791dc5b9b719278e5873ed3a6ab8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "b2a8b95284e76b016d14c8e3d27abb04a4d9d2f79f67fd632cbe92af3bed0829",
+                                "uncompressed-sha256": "80835e93c18c17bbc9d7f0ef4bfc80ff1ba5998f4e95fcc6963fd39a764cc012"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "69a215abde82f89742a843b125987843d340a287304621e1a4030eab654573de",
-                                "uncompressed-sha256": "990ea118681f2fe4273b0e0ab26af2b64358b29c48c24ae72195ac4af720c1e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "1756e378aa80282545385439b354ae41b356592dbb00eab4a875f9d06a637e2f",
+                                "uncompressed-sha256": "8d9f5d1503bdb5a8702e3e4c83d1210f241cff06e8577e165f8ec15f67b9385a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/s390x/fedora-coreos-36.20221001.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "acd6e196ccccdb04d03dd0dfb528514115b748aad4a6638f2df4b6791082f642",
-                                "uncompressed-sha256": "bccf96f090a2a2800952266ed8f1587cb80fe115e03b441d83b747abfd41811c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "47c937d0aa95bba062c3af3de13de1cbd12a487b0acefc699499dd81f25de24a",
+                                "uncompressed-sha256": "e2ec23bb8e6262f9222332d3a495593efd7c7c2af951f607abb61600add3de10"
                             }
                         }
                     }
@@ -296,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "aa24a0ec7076babcec733fa69ebf2da247e4623280cd9458cb7b84185bf49b1f",
-                                "uncompressed-sha256": "5a778e0ffa0e25a623fadf381bac7a324843818b511cec25ab45045c33a98825"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "b12f3705ad036a266a7e133f772aa6ca5814f994d5351af90877193e6df307d6",
+                                "uncompressed-sha256": "e1522185a7422bcf36011de35273f9b909fb54df8c3ce9b121996192d5ffb398"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "7c8671cf2ff3e3178fbfd93616fae776c970497021189174af512e64d032f47e",
-                                "uncompressed-sha256": "d76ed6d04144782ecd22a122340f03433174174dd7ba3c63a2cf40d2491c267c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "0de0d54b141313ddf5f865a972628954f095ed158777be5cd804428bbdcbac42",
+                                "uncompressed-sha256": "954cc2295f6606a0a6269e4c8b517c8e1f37194882f1df7a8424475350a8e44b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "a1a7caaa1db763f224a7926f78af75bb8fb04e1c07670c9fa15a3310d94397bd",
-                                "uncompressed-sha256": "a7dbe3d410bbdf591004b821a0e1e0c468e513af56e6c27492375c20ed4cb888"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "3a6f9ce1e6d5fbb93a30228f20105e17d37a9c4b4eec15b067e45bdddbb22293",
+                                "uncompressed-sha256": "b6a60b8ed9193e32498f9ab94a5bf02821ed18369f846cfa9370f236a085c16a"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "ce88058a7ce456f1fcb822f69964fbba63fecbf4652a5e1d5f59d15dde99983a",
-                                "uncompressed-sha256": "106f9e831d40dcbd6a7c701723de331e11c3368f27d03e9e37c4398d0f076671"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "964fef40531f09fd1968464b7ce5e4846244ac4a8a562d0340557031c6b58027",
+                                "uncompressed-sha256": "bef984e9e7da4c0a7544b099d68d03bb90850f7015b0ff87e83feeac594243f1"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "20ef9920472768022c3cd064481c5ad04d42b894b8e8d147ea4ea38358e56192",
-                                "uncompressed-sha256": "8a44103356060bc386ed58b554fd0d1779fa7653fadd129e26cb4db26a26b16f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "f861ba6da69c9a050fa1ecbeb69cc1914949dc640705160ea2ca6d7d4e390ead",
+                                "uncompressed-sha256": "0bab5a189eb92ec266241d96548ae010d5a210859c607d181f84d4add14d3216"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "f4a2ecd88befc4b990083e6a9a0fe0b88b15636971d1ea644c5d71ff62659f18",
-                                "uncompressed-sha256": "f9e329155e943028df45c17563eb1df1e538e40c3241c2eb86dbe0fdba987554"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "a51347073e88b50dadd2795157cef88419999dae9b364d5cb7dd092d9a4111ca",
+                                "uncompressed-sha256": "dc04d63d91449d14a9fc86958924f21fd15c457d7ad91fd86b2d6eccbabc1d4a"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "a1e019bd4001233bf793544300a373b39b88f4f0a6d7d43f347442ca95ee9961",
-                                "uncompressed-sha256": "f961534f20c7a633a5c2910aed71e0bf21346f5a21aae64ff966c4d580be318c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "199e1ad363d21423e7c17ed160106f6dd7638639184b695e1a546495ad8d2c8a",
+                                "uncompressed-sha256": "029c936ff360ea284971aad3a6d6a659ac011dd1a43ff3f6c6f85448ed9575d5"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "94fdb7a0ecce9e2a4a0fb5e12fce82777be3858f261d37bb47c3656f6b54bb3c",
-                                "uncompressed-sha256": "5e48ea1fae918026bea0078a256c7ef9374072a8229521563b2df406eaffd484"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "69f8cdfc58518800502bf90d456ac76c5ae0d4b141d54818e9a9053b60393d56",
+                                "uncompressed-sha256": "6c4bde723083ac82f29e6665f0b1034e12ddfe6d5176c5ec8e0d82db50d04ea5"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "b7b3d89d46eb61e5060564e93fb4d2f348726e6a7fb44c1464ed25d8d25ae1cd",
-                                "uncompressed-sha256": "66df2bff43b14796f4090307ad2cc41a9487a5f7c7ed3d320fd2fb347b4db8ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "47e1c7bf9cfa24859fe097e73ee647d53c973cdac7eef616c9b897aa1b48baba",
+                                "uncompressed-sha256": "e4cb0d496c1ec669f6211565ab5449c068ec5349e74f530aa9a2066b160e4eb8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-live.x86_64.iso.sig",
-                                "sha256": "426ea537ea55cd7adaaf398d58167fa3ff246296712add1fa1ae52420c0f1b52"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-live.x86_64.iso.sig",
+                                "sha256": "bdb928179705959a557fddfdd7ed34d57a194447a63aa5805e8e6055e866710f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-live-kernel-x86_64.sig",
-                                "sha256": "b57933cbf73c1a19ba25030edd771f69e2ec5bd0895ea06b43e91247cfa43d9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-live-kernel-x86_64.sig",
+                                "sha256": "8ba8c8895e42dd1efa08d338c930bcb8707663ab3a42433584b70c6dcdcb7dd8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "7133cad5934cf9b78f4b14b4e7b62fcbadd1673f7633c33e575f0d45af8e7ac4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "f78a2258f7ff4d289ab4834b81bb42e4e499827cbefba8babdb1382ecf05129a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "876d84bdc4fec8c2e87fe8d351428bb555183a84b247d4d3533ec02b5f6431d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "c02a7fef891e9580d2806be7e61484f65c59a968083e6eb5477559427e3dd3f5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "d2aa89b69649efb2b2b29246b0ca50411f75f557c969d3d983adb811c06cb898",
-                                "uncompressed-sha256": "f14a6d25100bac1356b8ea1d5701a313c5ded679793dc7990e0d02d35821107c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "92a7b419c2e2864bb423fc17123bbe0f86a56ef6fb00ad8a8a843db1b2a4b0de",
+                                "uncompressed-sha256": "86ab6a3ca1fe64ed04910cd28aae0029843978cb79ea6a45ed9e009a99bd3190"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "934bd319bb978f92d90cb8e831947baa047f453d89d3beb953840e223eac86e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "c434dfdb0bc96d9b68c4b3bc52b5d2b21705164a00003a145c1c670f43f71940"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "f8e9538fb4ba2a294a637adaf999dbb194819cd2dc68503b23fd8e8b6ab577fb",
-                                "uncompressed-sha256": "a9f1186e95a8fb9ad3ca7a3be2365d0d78f895d4490c6afa7e2e16fc4f7bf9c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "1f6f9316458f2d8d34ec15aa75c2ffb560d4190aea690c05368c78d769ad87f8",
+                                "uncompressed-sha256": "bc980b8aa6c898f20a6c370aa10d0566d9817ecc7c9dce4509cb2fd2bb3ef868"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "9697627bf3377986cfc6973a0349168789ab4b4a02eea9f80c8b290976def11f",
-                                "uncompressed-sha256": "3f5a5a849268b1a644606818b2724b838660bffde14dd8aa6739a38a14dc2642"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "36fcbb2f0a88d96311abca715f89dbb1804a95ebdaf7c9e1f1773b38e24faadc",
+                                "uncompressed-sha256": "58e6b43a9ff157166b3d06723b17b0607916aaf4983751ac502608d8c02f4c84"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "1228c1b5258b6be667682f7077ee8d5691d3cf42c0a6083e4d35064ec19bba9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "5c47fd27784edc55f3e354857555ad6cfa15f9407a4c46b607425a23526bfc48"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "15b486ea26a1e8f2b734f89512e0dbead01d288cac10b5ff135e0eefb2d1f41d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "d77213b8f94ee794471b908dfcd067a9e48d225e8abda704e293392935a2a191"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221001.3.0/x86_64/fedora-coreos-36.20221001.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "9f54b4733eec63a665a4fb8538a30c392de2a799458191089e5f41c0ce86fd65",
-                                "uncompressed-sha256": "6c612bfd71f4ed9c346bfa0827028525991fb4daec1e0298846907adb66d8971"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "1ef7132dab448ef30cf80be5212929675079f69a6e0f376e8afeb09a2838f6df",
+                                "uncompressed-sha256": "0587a2bb969ad17e2fcab14f1379570c32cf0c64e055ea2b5f85ef826877b640"
                             }
                         }
                     }
@@ -524,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0230d3a56899fbc7a"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0c8661ee1060c6926"
                         },
                         "ap-east-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-01b3a42dc6d99276a"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0f6195bf7148e3190"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0056d14e665eb6ff5"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0414c64aee0ea1ac1"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-07faf7025d61d261d"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0084007a62839cace"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0d5903731597a43c4"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-077e4fa40ab8e6702"
                         },
                         "ap-south-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-082fb18892e0d5f4a"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0fa8891216ee5689a"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0aefe7bf289162c30"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-04b6f9378df4122fa"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0246c6b2db1234fe3"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-00ea4d323a9581790"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0c3e7f363c9dc5305"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0430b0c3736e4b7ed"
                         },
                         "ca-central-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-045d98e1fadd94073"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0062e38e2cfe0c039"
                         },
                         "eu-central-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0ab9cb3e4fdc499c8"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-00ff0fbe23149b696"
                         },
                         "eu-north-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-06d6a98695e5aa67f"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-08e2459371a6b45f6"
                         },
                         "eu-south-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0e3f0f63a1a849596"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0eefac3c163e74187"
                         },
                         "eu-west-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0974163b9b691606a"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-032abea8c266c07f0"
                         },
                         "eu-west-2": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0f3b02cc026c8d7ed"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-03a17bdc7ad5c45b6"
                         },
                         "eu-west-3": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-097869fbc18b42e35"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-01812ebc51b11f001"
                         },
                         "me-central-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0f48dae682a12dafd"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0c29b643b51916530"
                         },
                         "me-south-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-05cf201617cb312d1"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0f390f6f6cbf114c1"
                         },
                         "sa-east-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0d40b3fe32fdab8fe"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0294c8d01b8c5ad18"
                         },
                         "us-east-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0756632d3ab28028a"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0103e7a695f6179f9"
                         },
                         "us-east-2": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0b15212075daaf3d6"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-0e82145ef9134946b"
                         },
                         "us-west-1": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-02ec9abaf7e01e944"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-02364398b51982593"
                         },
                         "us-west-2": {
-                            "release": "36.20221001.3.0",
-                            "image": "ami-0d5de38b95d36ba92"
+                            "release": "36.20221014.3.1",
+                            "image": "ami-02b29cd2f9aba628a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20221001.3.0",
+                    "release": "36.20221014.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-36-20221001-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-36-20221014-3-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-11-01T22:22:27Z",
+        "last-modified": "2022-11-02T18:50:22Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "648435bb96bf7e7595e4838de12afb059bc359b86dc8e44281b9d4046b33f497",
-                                "uncompressed-sha256": "23f11c208ce6631c98517513febb53ee9a693b0ebc170edb44ba933ca3dffb26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "ac35fd8a413055c630c43687a3f0f31620e8d8418d84241fb8cf25636e382f4c",
+                                "uncompressed-sha256": "bb9331a5fc843058d2e77611b8e8e4230fd6e41b9467a125fd9047795eea5337"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "22893606a942877ba55a8d102776c5e3aa03492ae39d1a21e62dd1fd2922a3ec",
-                                "uncompressed-sha256": "33ff9d8589ef7c22a6f42db865e09f99c6691ef504523a644548952790250559"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "a6a052d8d927e2f7c5b18dfe05e378613b49155c0f41f1a565a0eec584889b2d",
+                                "uncompressed-sha256": "742f2ed8cdcf75a7d6d7bc6259d621a6ee1655798a80f3ffa3fec1762f388bb4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "df3d86f268b2878459706cfe33943192ea696b7667b0eeb45acad8f9cd41da96",
-                                "uncompressed-sha256": "dee3550a3ea81a5db43085989de7135ea4b4660db94b1061598abc0a21a8d827"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "b0c6478ed8f3e76efe760f30297d04e646d3b6831066f496b978cc13b39f65bd",
+                                "uncompressed-sha256": "56d7f66f9c0eb579815c496fad1bcc5c5dd60b472c5f5b2709bce4b964cb16ac"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-live.aarch64.iso.sig",
-                                "sha256": "85673e0ea7e8ef4789fda20915eab3c8016422026c196c717c4046ff812c9fc3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-live.aarch64.iso.sig",
+                                "sha256": "64ac9a02c6a89935cf903a74198b94721ac649fcbbd1b311e242f8af602cb279"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-live-kernel-aarch64.sig",
-                                "sha256": "1a654a618aca6ec8a7f38c0f83ea34971aa52925e07fa99a8b082cfc080a975f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-live-kernel-aarch64.sig",
+                                "sha256": "30437e6ccfa45657f7e1fb498537d942253bd8677a1c3b897f20a17226bb1d1e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "c76761b06ca3c0e817ff67cabd1738f39a97886e862771ae34e7815320bf6dd4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "ff7c78335ec1dbcfa0e258b45f872dfc0df87d6223b03a2a8c623aae22d6890d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "4f966f04190c93b5c42d95d4ac66f1a4f328414b4b1c766815d26fc8d5bb508a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "3f17825d1a7a5587925ba9facd1527fe049fad098268c2911e5f6a0f9f5b81f0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "fd88857d9abebe4c6b8b757459a3e482aa8271a8141bc58f2c4bf5800dfaeff8",
-                                "uncompressed-sha256": "94078e75e0137787d1a01162e785fb7f88365745ac4118a7c5081623ab92ee85"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "765c1d02c4302b1dd497e5be06185077276f2afed17abf402aa73b594af64a40",
+                                "uncompressed-sha256": "48e960f7aa3d59279b9ca119e1a4bed96b629cb2b247e0a15ea0520d7db17614"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "0238ebc5afa5821b8ad55524c6a71257241f6dc932d060e60093556362ab36a9",
-                                "uncompressed-sha256": "58bd6cba1b1d81e741a853a99a44d2715b837c6fc08b0fa0626e9821b739b15b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "65fef7eab5518eba4fe776032a262f54dfc07d3f8be2805d37f23238f2a06583",
+                                "uncompressed-sha256": "7904e0d8bf49c8a447fcfb2fe17f5c6451bcc5633e10c358e8685b13cbd331d2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/aarch64/fedora-coreos-36.20221014.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "7a052f3ef36190cb8498ca5f04d4dd2a9a56bee68a62b8cf98d825783577380a",
-                                "uncompressed-sha256": "8031d4c639d71e2a5fae55abcd6930e649ac22b28d1e373c3f68145a2ae34577"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "8bb00a585d1b7d2d9d987f9620d2799bc068fda1582eb8db5bd06946d89eae2c",
+                                "uncompressed-sha256": "f6c02f5468bd90cf442888bf4b08cb2a32493a9b0f5ed8b7f437d20e938768a0"
                             }
                         }
                     }
@@ -109,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0d56139b4058b6674"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0d08c26f3d9f9876f"
                         },
                         "ap-east-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-00dd6057e961d6753"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-04d59b14e4df653d1"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0f22c5139bf071f8a"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0f19aa794223547c3"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-087ca06e7ff926ab9"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0ed3a3810eb366a53"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-055058a09ce0b5e88"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0c73744e7112a50cb"
                         },
                         "ap-south-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-09b259330efa993f2"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-041ce023456821574"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-06cd5feac633c6a24"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0ca3465a89db74232"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-01e12bf53b14e254c"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0380d4414f5bb1091"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-000db5aecad7f956b"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-06eb07e354ba59f70"
                         },
                         "ca-central-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0a668ff5122d5360d"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0357f6cbe6cac6555"
                         },
                         "eu-central-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0fbb018c6f460f7a5"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-05593fb6e3bd3351e"
                         },
                         "eu-north-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0910237edcf0afff5"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-064a99d59608bb066"
                         },
                         "eu-south-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0f68213f746859787"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-08f58bfd8623b38df"
                         },
                         "eu-west-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0c6554f72692717e1"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0e08fdf7980f85d98"
                         },
                         "eu-west-2": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-05b0785f8fd69d46a"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-02c6f99492fc72d50"
                         },
                         "eu-west-3": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-079539d362c0cf8b2"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-00cf3391bfd5c1cfd"
                         },
                         "me-central-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-00767b826ec3d9278"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0f869d6330f224d71"
                         },
                         "me-south-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-092db11a732752485"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-02a97a2f9a5e46b04"
                         },
                         "sa-east-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-00a2d65e89f9b876e"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0d18877c155567163"
                         },
                         "us-east-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0fc7257134cd10f8b"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0f27fb16ea2a76e7b"
                         },
                         "us-east-2": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0dc9ad26fbbcd0717"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0bf64b7a8a443d8a9"
                         },
                         "us-west-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0cdbd96b939cf721a"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0e7c7dfe0ba4ee415"
                         },
                         "us-west-2": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-09e71bdcd6e3eb741"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0dc0388a67c55fc25"
                         }
                     }
                 }
@@ -207,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "fd456ec8eaab8d7738d0bea6699e8b04276372a44e931639053612b1073ab8cb",
-                                "uncompressed-sha256": "575bcbd451b95a9c4d338e53e729855ba3cf4fddd1488cd83971508f586db514"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "40cf872f38b96d7b4934bce2ef9a213eda5943a4247a30ea77863655b7ced7ba",
+                                "uncompressed-sha256": "580de03c58f22c209113342d2edbf6bdab801eb1a63f3be9f8f0c8c0039aab7c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "fa017cd3f7bdb893460df54987ecfdc1641d42ebdebc76e10468af0c2a76961d",
-                                "uncompressed-sha256": "36cde912b7273cb3401e09411dd4dfeccc32364206d88d212e67bba69014ae63"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "1bb7bb4a58205cd9dc724607f030d443fe2f593b8bd1d29c6ecdd7778adaa3c7",
+                                "uncompressed-sha256": "f9785e168d1c46ed321bc6cc0c644d44605e6f5c587dc8fb8a2bed9961ecfc03"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-live.s390x.iso.sig",
-                                "sha256": "8da0addf43e6dc02ea45bbeadf01ab94a3cf762623c4ba52b2a8994cdcd8deba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-live.s390x.iso.sig",
+                                "sha256": "671ba28b68647b5cf8d27a890034b382dbeb6509ed751609c24842b34cac2aec"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-live-kernel-s390x.sig",
-                                "sha256": "817ecfde938475c79dd93021ad1f87587768ae496d36663e6aa0608a383279ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-live-kernel-s390x.sig",
+                                "sha256": "9ac47b13ab5888eca1a665e6933e9831d2bb0a6468fd4348f51e77fb29aa8573"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "a9dcc34728068192eb28254eb3c8443ca220fba7eda12a665d59a87bc26dba1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "d940c92342db0a183204fa5de57692b0d20139d601b8d42c07c316d5506ca2f4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "144488f5dec7e2c22b356b9eb0474766c86b9edd8fb5765b1010477d4934184e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "983fd0211d2466185e02176f4edc748b4ea272c1809646e331cc472813ba15a3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "c94c18cc932636177a037cb6ec783aa66d89afc271c33045a981d039b9b045ae",
-                                "uncompressed-sha256": "4cb5c8de7df6bbc2bb1f9e7a8df6a61a94e424667f5e47563d30e1661285c3fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "b855b9d3473e1ff712d4788899a44929e22a267b5eb8b165c232da51baef1ec1",
+                                "uncompressed-sha256": "6414f4ad78a7c653c4c014d1f662f65115fe187404f103e3586c54c439ca078b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "21fc70df86c4724c44be791eaddb7cfef5bb97f2887501e85fe7e97aa32a1a54",
-                                "uncompressed-sha256": "a4ed293fb934d3a8bde72a5c39f9c73c130b1b23c60cffc323e0acb1652de2f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "e32c3c2c5ff8dd4cece1401e34013d76606358d519a1c79952d651a27b723639",
+                                "uncompressed-sha256": "d7bf149967231d29848485e8f925c349903e2a0cd239eae59ddc7bca58f93f2e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/s390x/fedora-coreos-36.20221014.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "c6f555b3ccc7bedb59ebfb31d0959ac0f216767fece5c7049c9079b49e35bcd4",
-                                "uncompressed-sha256": "78042837eb682a056c38ed91f2628dfea08f036e3bf1566f004329354cdcb622"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "71df154947765d6cbf6bbf6337d6727aed79583ba4ebe7c1f058a0c87925ad47",
+                                "uncompressed-sha256": "9c39cd8d16d77fad2166fd0871a61a0cc781f91931d90661fbe8af00fff8ffbc"
                             }
                         }
                     }
@@ -296,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "99cdc8236f4ac1de9d08d794fe09c56add64feba87683bac3124bef635257981",
-                                "uncompressed-sha256": "9ff444d0dc7edf90a7592a98845de33c39bd513337c8fb62482ca545477f6bcc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "2047351bd509e8a6f4e0e86bf553d00b04f93b1201345e5c0202007b7c4de8da",
+                                "uncompressed-sha256": "f2686ed1047ee79c7ddc522f54736ea78173696f74615733183a41d9b4593db7"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "3f591aee9ac3632226a43f9960e2236042932aa761f90af406b97cbb677b1cee",
-                                "uncompressed-sha256": "8ce8376e55a72906bc9933ffe59c11211a27c2d7c6135e727a60ca877547702e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "91192ad30cc0e5dea69c158936787eddf083604ab50fb4ed1de505b81d3a03b3",
+                                "uncompressed-sha256": "8a4265a98ee9c0895b07de805766163cbcb02e2d59bd4ed886496ec533ea026b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "e6e6e7e01721c3a7e5b5fb46fb4971da8e862e2e3e3d905ba42211ec3f495f8d",
-                                "uncompressed-sha256": "c29d8e199b57fd66fd3346b6a82bcea0ed019f0b3c440cb5e71faf11b9775b20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "d8a60e1fd421b4378561df1c7097a7abae89830f8151b9f6eb23cde83bef62f4",
+                                "uncompressed-sha256": "c2eb5d7a7fa82113b67408137edf399d0df368079857ce7c76934cc027b41e40"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "4e36ec10c9ba111066634e933fea814b901a8633d06de52fecc78ca154a5bd24",
-                                "uncompressed-sha256": "cd94ad9832a0b766096dd78f09548fe8ee4809e8d60f6412b05013db2d57ef05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "a5183c8fe096ff3c330a78f64508e6734c34834e8e33a5bd2a803909b81d4fe6",
+                                "uncompressed-sha256": "0f00f5e7a03b7070f35d08ceafebb71592cdc7d8b3c3d42fa52331e702f188d5"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "1dfb772a7727dc289bf6fbbd64136891c8b9055e75dfc62aa7499998732bb5b4",
-                                "uncompressed-sha256": "5377718ef0b6e6f756ddf1e0e0e675fa4740e07ae7905cbef2dc6b2927646915"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "40de07f0d3692a47d5175c16bd899dc6df6857d2cd5f587e774eb7120fe49e90",
+                                "uncompressed-sha256": "d246219973b4b4d593bd5177b5fdb3aa35257cefa4ee00714429d93dbe356139"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "5707cf85af11e34160732a4b1bbbc8ee4922e91d2a854018906923e5be97d627",
-                                "uncompressed-sha256": "e7b1dc2fd5ba779c3f33e25898083a9ca7426de371a0f92f65104537b5cd8aba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "22d14fb2c154ccd34131d51a25ed5a18b4a30b1538314e72d58c51ed8ca4c819",
+                                "uncompressed-sha256": "22252835e4ff46ef3a988f374f5d930fa4e8219a7e907323285f458af01773ac"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "490794397aef62217594ca83543dc28eaf72c9bb2e7e4a07ab8dbf9fe39ec7c1",
-                                "uncompressed-sha256": "8f0512e24f247633dcdb5d6edf88895b9f05471893252123dce0dded90fb70f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "2dbe1c529740d1dbd160d5761e1de6be429b1f68a13577ca04af8f13dbb94e72",
+                                "uncompressed-sha256": "6db8dd5a54461e986dfc6f7369fdc96a727c267fa2ad722c8ff4ed9046fe5ffd"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "2c992e5b71129914892da2a2099643e5a16e11aa309fa41dbdb8287872918085",
-                                "uncompressed-sha256": "cbd8b4e7e6c7c94d88d1a55d4babbc81604b0655043b50d5034e0b43d71c6cd8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "a7688811cbff61db209d7d1e571b218a70de5e3d91d200df13866d1efb251d6f",
+                                "uncompressed-sha256": "63d9825100a9439078e6bfffc87ef0bb30f7d28444f1689db43b3911d5feaa8d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "2f1b7202d007ebb6c814a3c7b1f372d88cfe586d9aabee3db3080ec8d69e4f7a",
-                                "uncompressed-sha256": "8d3a9b737945d60215d464c7df25fc28d60c9d794e85ea1d668e7ec42828d9c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "e8ea18809eec8705c9a9cd8779be90c47ba2e396f32e5b8095a1785d3fba2bc0",
+                                "uncompressed-sha256": "4d59546ce5de566f6c7661b058726a23d58f93b580e436f5e373b81a1d9e755b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-live.x86_64.iso.sig",
-                                "sha256": "a347700178fc1b8ceace5295b8b18048f0301fc3970fc1b1b94563773f11d307"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-live.x86_64.iso.sig",
+                                "sha256": "69b20834cc8701f17f33aa6d8e2d8ebe5dfd134c5d895bc63e4592dcc0d15375"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-live-kernel-x86_64.sig",
-                                "sha256": "8ba8c8895e42dd1efa08d338c930bcb8707663ab3a42433584b70c6dcdcb7dd8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-live-kernel-x86_64.sig",
+                                "sha256": "952baf3fe442e051a29b153db08161aedc63baaf4e920ad01f36ab886b3c4bf8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "999572be3b22c881787b7bbba4bfe5f9978c576a0188a9ef3e135e094809b5fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "5d14a5e8f521444aa78c42e451582e12676d24f28db825c98be71b9920a6355b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "fc651f8fba4b16944c7f28d740e8b259fcb8b068d45a053c3354114abe3c5f1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "d3ef7d70ed90511db9404d4f2bc6c9d945b66741f517fef537320194f7a80fc1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "e8a90762a60b39a29cd1dd7d3d5a32c2c90f24cd018059f342fabd3499f5cd91",
-                                "uncompressed-sha256": "038de28874ed8446da1777ee7bb8a4ef57f01ce9a471094dc56b3213581fae93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "3d10e02ad6a95fc39d8ef013be2997f706452cda89f84b35de504e6146a09826",
+                                "uncompressed-sha256": "f0aa3149325a3ba2e90aad40abe2055120ff169ce535a6d6117c995eb9f0a043"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "6ef5eea8b04386dddd3c823c1ddd0a598b562771b6a575044129da5ee65bee5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "113b3e887a6386e7b9a3206ee6d748a3c5308ff9affc347ae559dec0beeb6d44"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "1df9d899ccae6c34a5239b143088b263e01e83eb8fa748be5f6901645d21620a",
-                                "uncompressed-sha256": "f14b7e38b714b0fb4eb01fa75fe497eaee93b2a4cdfbead35c93834e613e38f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "31b64c1716e0b7c7dda7a4185fde66e62d917a1ec252b8b103875ee6ce9d48c6",
+                                "uncompressed-sha256": "4860ffa28324e22751ff53e3f35ea1419f01e88ff70e68fbac8b88fbb3328470"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "d6b3a1d8ef3d411d8b7e10e6dfe86b49761a5a826789bf45f914911c5a2bbdf7",
-                                "uncompressed-sha256": "dc70029302bd32ae277e255bd22fd47187a5807734d2c22afa3f28de331e7ee3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "ee1f0dbfbb07045d0ba6863c8d93a4aaf4b6e86ee1ece51a8dcc3aa2c36380e6",
+                                "uncompressed-sha256": "34d1353384230de6eed82048469f75bdaf72dbaf287f6a00f59d8a52737e4215"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "92cb443c5bfe20c3017da4e5e9a049916d0cbdf0f636452f5235fa9286742c8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "8bd6a97cabd1b9eff355d459245e1bdc20166b86c255b89ef5a24223df113b7f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "a3ab663089878696ef2d2c08492de24a2cf6785bd521743060133510e89ec100"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "8d56fa2a611ce0fce2fd0922d047d9ac3a6b767bdcf361dc112168d1df65272a"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221014.2.1/x86_64/fedora-coreos-36.20221014.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "0333138c9891528a7d605c59357cbb7eff6b15c4f677cd0f918b153c8f2b27d0",
-                                "uncompressed-sha256": "525f01d56fabac73b05b2685bd755485a590522870587a9cc0f4a1f7a5553abf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "5d63c26626810f749c879b2a41e074d1720e629ddb420f38a0af28bf8c4f57e7",
+                                "uncompressed-sha256": "52de11249f736fd1fadb6e5fc6018af9802366691f135b141f8127df744715df"
                             }
                         }
                     }
@@ -524,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-073444e1fbee49cc2"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-02e60abc58f6c13f5"
                         },
                         "ap-east-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0b1bfcd5582f6faa9"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-08e9e1d95a5e4a69e"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-08913dc9295aa2906"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0b1c2992c0604335c"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0626917ecd7431c3a"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0e7139951081b239e"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-054fc61f0a4e8046d"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0d78ff393bc20c493"
                         },
                         "ap-south-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0c2cc72acf182e3ce"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-00840a62a20d53618"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-03fb644b2e10d836c"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-09fa1e1194b2c7b32"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0536bb6bc880f50cd"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0297c5f24ca2885eb"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-027f7e8185c3404f9"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0ec615ca3398a2152"
                         },
                         "ca-central-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0277f7423ef1aef23"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0094b67ab3fe624a3"
                         },
                         "eu-central-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-07cf1fe881379a8d1"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-008eb82adc97a3972"
                         },
                         "eu-north-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-07187f703a4e934bd"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0a66d2f281a557fbf"
                         },
                         "eu-south-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0ac23123049622061"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-023bbf9ca3ce47326"
                         },
                         "eu-west-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0842e7171487841f4"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0720a37ebaa9d54f0"
                         },
                         "eu-west-2": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0c84a6a1ed71b72c9"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0f16605acf8bf81f8"
                         },
                         "eu-west-3": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0e779fa11636e819f"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-03846078530b35fd1"
                         },
                         "me-central-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0664a07e1faf25310"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-078bc0d0298c965f6"
                         },
                         "me-south-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0f886a591609b75f1"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-05d1670564621e148"
                         },
                         "sa-east-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-0b3a4767cd9177d41"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-008a147f21c3f8fb3"
                         },
                         "us-east-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-014e4080efd29bc93"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0e5779204cb785224"
                         },
                         "us-east-2": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-034370ac82f285f17"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-08559331306ba1cfa"
                         },
                         "us-west-1": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-09d77c4ca15af959a"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-053743f32fcb80ff9"
                         },
                         "us-west-2": {
-                            "release": "36.20221014.2.1",
-                            "image": "ami-09673a09a39515070"
+                            "release": "36.20221030.2.1",
+                            "image": "ami-0477b8e335730746c"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20221014.2.1",
+                    "release": "36.20221030.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-36-20221014-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-36-20221030-2-1-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-11-01T22:22:29Z"
+    "last-modified": "2022-11-02T18:50:24Z"
   },
   "releases": [
     {
@@ -74,6 +74,16 @@
         "rollout": {
           "duration_minutes": 1440,
           "start_epoch": 1667343600,
+          "start_percentage": 0.0
+        }
+      }
+    },
+    {
+      "version": "37.20221031.1.0",
+      "metadata": {
+        "rollout": {
+          "duration_minutes": 2880,
+          "start_epoch": 1667419200,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-10-18T09:42:07Z"
+    "last-modified": "2022-11-02T18:50:22Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "36.20220918.3.0",
+      "version": "36.20221001.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "36.20221001.3.0",
+      "version": "36.20221014.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1666101600,
+          "start_epoch": 1667419200,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-11-01T22:22:28Z"
+    "last-modified": "2022-11-02T18:50:23Z"
   },
   "releases": [
     {
@@ -90,6 +90,16 @@
         "rollout": {
           "duration_minutes": 1440,
           "start_epoch": 1667343600,
+          "start_percentage": 0.0
+        }
+      }
+    },
+    {
+      "version": "36.20221030.2.1",
+      "metadata": {
+        "rollout": {
+          "duration_minutes": 2880,
+          "start_epoch": 1667419200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @lucab via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).