### PR TITLE
Roll out testing 36.20221030.2.3, next 37.20221106.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-11-02T18:50:23Z",
+        "last-modified": "2022-11-07T20:40:33Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "20d5a76d26797a133a399a917caecae0baa2f74763b53761fee305ace10a77a7",
-                                "uncompressed-sha256": "97d635c38b183ac7d45b7204b11950caf4c4b8bfdf17182ceb7c2a690948c097"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "491b378c7cee2213a066382869124baefe6b7a0b357f7a599bb7f2353086eaa0",
+                                "uncompressed-sha256": "f13727cc40ee03518ccc9bc124eec2588ae63beaafb76b7381040cf6d95ea5f6"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "a5eac814c0c6e2b91594f0849d44536c2cbcdc80660a76895efcad298a611d5c",
-                                "uncompressed-sha256": "57349c9b4105cf98b2ea99a2894982995798b304d3b91217215b2f705c2edaf3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "8c35a4ddb17176a0bf683ed04d5325f4788f37096532daf4adebd666730a1b49",
+                                "uncompressed-sha256": "a8a637a16bc486513c9293b7aaa311938ad63f04ee6757e65c26e4b72f165edf"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "7e9273877876591bb068977083596a8b98e52efa6b5bb7c525fa0d379533baeb",
-                                "uncompressed-sha256": "4a782ed447ee542ce9d4c48b8d6dc03d7fe8e18b6cb0996514ec5f0bfdbf63b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "fb5b6f742f62e54b705be95fb413f64341602a24d278c335076323a7fc3d9f73",
+                                "uncompressed-sha256": "30036f09198a6e2b90a9d0531c35cfc35a12769dcfe685d468dddfaf322f5c0e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-live.aarch64.iso.sig",
-                                "sha256": "ded1de44a6ea5bf8f68147c42636b716bd06acb89889d7a216da12fb9b1baab5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-live.aarch64.iso.sig",
+                                "sha256": "60ce067872de2a676c8b81edbb0e2d04573d795ce69d67f59e1da60c21b5a626"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-live-kernel-aarch64.sig",
-                                "sha256": "17b3c9615c354ec6470d52a65254cdaaf0c51675b79dd81cc29f533ff11ce081"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-live-kernel-aarch64.sig",
+                                "sha256": "e5f22a13b48f397d17a0b50f7844d03a7f6e81a000b323db7baddc29570001ec"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "72d2df664081f0fc6a44c0613b730c2bae2914262cd52baeaa4d449980727ae4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "254c9c63dcda31c8fe435586d41ea814e5bc8c3335ab3140cdf1ea01f8da90d5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "d6127926cc33b4ac2d122ee8b27de59c966c7b92504f2b811caac9cc49aca9a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "a4d3b13b0b798831f37863b7f2001a59698b9cb7faada8068df24add940773a9"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "181b741b2daf2023b7c0b5967cb07a392ef0df1fde6fa953ee29557b497ed03b",
-                                "uncompressed-sha256": "7c11c677b9a7a6c179df1ab2e1a8af31ff03b129fca733a0031915a94a5a27ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "0eac4d86a47af120dbd479d1628813a7670e55676c722c45bc3f76f4cc63ff74",
+                                "uncompressed-sha256": "4b832da9b6383c033d47d8a89e8ffaf8a4e52166013f76cb78f0769355434e21"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "3e50d5f1b0ffb19e1147cbe8e9be14f54718a1cd1621613fd93efd7324060d0f",
-                                "uncompressed-sha256": "f4d4231b24c563cb8db9cd75b05876cb1d6fb808115ed64accb15a8afb1bf0d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "6d71a6ff219a27297f07310e801f8cb111fef22530b88c6972a47c9eb6c1db48",
+                                "uncompressed-sha256": "5d8eada1df724431e6538bd1a85992ab5dc3994cb752d47c7f2a348f0dc84db9"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/aarch64/fedora-coreos-37.20221031.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "14de9d78ab2cbb047ef8c46417436c514fa178f21725819c3e9ae4aa3fb27eca",
-                                "uncompressed-sha256": "40775d2158fb3a1cf20466e03f38fea47214b8f44e4191cfc15833d58606dcff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "8829caf5535e8725b9e233c4abbf6429b96945f36297a2c677f89734c0a8da8b",
+                                "uncompressed-sha256": "38910da2e8479ba5e24af216cf4b095603279cbfb23237e10838b5e1aab0053c"
                             }
                         }
                     }
@@ -109,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-07f6c1f2177d8b896"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0f68343aca0cd6401"
                         },
                         "ap-east-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0f5e8f337b4c8ca7d"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-08611fc2f637e1ee7"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0c217367a63feb847"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-00e39f9aaf946cffd"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-05cc43c8e2df79fba"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0e0f335b90e513cdf"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0adb835fb38b015e2"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-017d5450be92cc9cc"
                         },
                         "ap-south-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-068567f0de27fa135"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-087bc46bbfdc72c11"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0adaae49f261422db"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-07b825bf16a3bcd8c"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0841206f6cfdbc775"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0f58710f44ee1f234"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-08026dd6098fd6256"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-002c73a034fd6b133"
                         },
                         "ca-central-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0200be109165e0d0d"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-043a411234f9f34aa"
                         },
                         "eu-central-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0a2ef3443ff0ea0d5"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0a24ebc5cb5e970f7"
                         },
                         "eu-north-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-074903645d06c9349"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-05174a9db32342a96"
                         },
                         "eu-south-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0732df0f1bfa8f6ff"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0ae4a6f17700d098e"
                         },
                         "eu-west-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-069bd510815307c52"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0e96c7111058059a7"
                         },
                         "eu-west-2": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-01bf6cc69823e0188"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0c5a2eed630c582e3"
                         },
                         "eu-west-3": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-056bb3d31ea0ccb66"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-01b97a4877f2554a8"
                         },
                         "me-central-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-053b813d7747f2696"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-04bfb262ab93f85f8"
                         },
                         "me-south-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0f1f63215f8c5c19f"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-04b70f7cab618a64f"
                         },
                         "sa-east-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-04a54aaa57549a4aa"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-01d3f515aac9e16f4"
                         },
                         "us-east-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0e4c461ac877c83b1"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-093b1944ee90cbf65"
                         },
                         "us-east-2": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-08e767196961024b4"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-07bee15df4fcc143e"
                         },
                         "us-west-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0dc3d412b3d04d994"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0d3a14ec3a4ead303"
                         },
                         "us-west-2": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-05504540ed943b830"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0d43f5c10585c4621"
                         }
                     }
                 }
@@ -207,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "67f339cf3e3377a9910982b4211c2f42a98d032a9742f36407b34799d4d4301b",
-                                "uncompressed-sha256": "a236c767a310e9e77c987a788254a033effeed7804df9bb7f65bc092742c8d6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "60970e9c86cb5028b5e69faaf7d78297a0082cf8a5e6fdecd6841db27c0adda6",
+                                "uncompressed-sha256": "f3eeabc441d3eab2ad61cf3c51ea4a7a39df4935e5574ec749062c674f0441a5"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "5573b885dc79fa4e6e2ddccf1681ef70943149b7f815b016237695df4da37a16",
-                                "uncompressed-sha256": "671b4a14320975de6c42923b3aeda5674ab5b551afd143ad58cd21ba520ed220"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "f65ebdc3aa6b49d51cb129dfca8fc982b5c803aa59e384b20c1d56a9dbf69fff",
+                                "uncompressed-sha256": "add4eb2299790f16d4efe699cebe02c29aec4e436b3ed013fa3844b6b9f7fda1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-live.s390x.iso.sig",
-                                "sha256": "42041c977c19fb1f419f724e1c313d002bcb7c4d4bfea99e50fd1232cb37eb60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-live.s390x.iso.sig",
+                                "sha256": "eee64606d3d03afa477d83cebcaa49987582f538e98cbaa03c0a5397a911f216"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-live-kernel-s390x.sig",
-                                "sha256": "bc7e7eaf84f4414dc681f8e43f1e5b09a3b1159008e00284fb2c750e75f4c852"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-live-kernel-s390x.sig",
+                                "sha256": "75cd92f1654274d8b446969d2c966892e8af5b5398bc805ae243d7e6da09efd0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "23921e893139341fe0ea138a032b8afd3393f9bcd806fe4c246c6321d8c1ff41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "eaba3df5d4f0861a3a0c0954525422b8805e5dd2aa3cbdac1f0fb6a77da1259f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "62b4d82cfbba840e1440c5601035c9a057bb7c62a46b8018d9b9adad08ce9508"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "3d85e047feede1a83944ca4f465f5b41a49ee75eccb6bdd5829746613b38a339"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "726faf854e1bac17b12fb6c4bae066059320907591857a6941bc62b232721996",
-                                "uncompressed-sha256": "6e20cd0075a1eec6446c5fc8c17ca477125df545d568d4c7dbb1af542a65222e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "7624dfcf8b9ab371d0705861da4393fd1337c1e502d4854283a21539e20eebf5",
+                                "uncompressed-sha256": "7cb3677660feafb22e4a1490b8b5010a9238f854f692169f94182ae4c67ed176"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "9db2a3818e2744a5d2762d148cb444e4286f21c2985a012be4bdf766c0ab8e5b",
-                                "uncompressed-sha256": "3a2d67a47e318540ee10ffcdae6e27b58658853353f8023fc60ebf2822f24ba0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "18022f496de6479238468ae0cd4979e2e826969596a422b603eaf1ff560ac729",
+                                "uncompressed-sha256": "1036f58c1acb861368b24fd06528eb85bc7badc659fbf01bb1d58d18d8c02c65"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/s390x/fedora-coreos-37.20221031.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "ed26ebb0e3a5f72fe128937c41846a3e148ce711180029f5457455bb30651235",
-                                "uncompressed-sha256": "3a14f81bcf96cfb32eba2658b3470ae0fc9caa41678e6c066331f93d6281804e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "4fa98b2771442dc15f91bec53f6247c2da6d4be76d7397eb37a130ceaf94d2d1",
+                                "uncompressed-sha256": "f7d76cd58b4ebea568eefbabc14697c5b02d01687bda9206bf280bee9802d9b7"
                             }
                         }
                     }
@@ -296,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "c4f786c52b369cab266e726c617f1a70b175af88cc2a90a421e3083852af9170",
-                                "uncompressed-sha256": "1930011da6b908c658fc6dcf74cce0ca008908ae6bce239189910036a9262180"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "e497ea1f888770c2f0fea78d1a7cb33ad3fd9a69f1252705c08e5950f6438946",
+                                "uncompressed-sha256": "a57d15f5f3443a52c630260825109f2d9547764ea0b5c5e4d9554045bfa6df74"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "ab3b6487a9529bd8370f8febc7dde9c75deda11a7419356a62ed5e04468dd931",
-                                "uncompressed-sha256": "3289b568e2e97f05acabf4a4471699b99127df332ba33312537db3c82c3f51b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "49269d618a3277b3e8f01435bca1ff4d59614530d5a7d4d849c75c9c44f73064",
+                                "uncompressed-sha256": "b52234079bf69d61467524c2288afe39f1b5f8d69afbe2f0caadd99c63b1b88b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "ac1d33ae38c92d0ce1bd5994cf2daef9ade53975c28ca6474a4446817878343c",
-                                "uncompressed-sha256": "607a7848559c35841c910618c25252318b349f80888ed7b98b6b37690531a257"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "639248b77dee0a1d0a3338ebc30d5d4c1bdd45e6dc494c10fa6bc18fa97af2ed",
+                                "uncompressed-sha256": "859251b72adb814b3f45567ab7c8c11dfcd4c15e1d64496099ca6e65f3d47b99"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "3918457b710514baaded38204df3434a4170660843001121fb8ba6406abfbfb8",
-                                "uncompressed-sha256": "7af1594240b65b2192e030b415903213925ac2cc4944ed8c53f793c30e1763f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "1fe025e8206a3036da1f629e42952c314865ea4a643d5067d1d7cffb9791abe9",
+                                "uncompressed-sha256": "de4dde8ab62dc2e64c2de1ba875c7fa1e8b5e43c6d2af5ceb6a5c86fe238a620"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "01b4bc67a81a058cfedc99c63bb871299c4e62bb91a9d7dc215b59a2e78610f9",
-                                "uncompressed-sha256": "950e41f8b5da53911c19360a34ad08122c788e5171e02da6cf0a32f16c881233"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "9c88dd558d9e7112d2612c77c0b65c79d01a88e87c147df7ec022f5be8c3f821",
+                                "uncompressed-sha256": "a3e554e7c5c4e9a4e9760eda7533cea3a721081e40e55fdca64ffcb3fa943b42"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "4a0e3f5f564b13ef85edc2d2795c1862117ff70385ab773e0f4e043ffc2d412b",
-                                "uncompressed-sha256": "599352c5c14ce247d7720468005ee9e4b165fe59118c81d8af61efa9e9f5d411"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "7a918488faf9ae15b15f09f72257d22bec6fea21ae19401f58e97044499705d2",
+                                "uncompressed-sha256": "9da6cc878e0a03154578329e4c5010aaf61e080d6f56c75e27b5831647353d13"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "0148352190986f2ad4920b46387522276b646464f94fd6a0317d92dde6e285ee",
-                                "uncompressed-sha256": "197470e164d18318646e7b3c7895925ad2202e7263293550eeff4c5772f268a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "2aa3d9fd1e52186f9f42e225bc88bc2f77649873446a87a025c7616057318a63",
+                                "uncompressed-sha256": "e30fcca6ed203b7a35089142c2dbc9e7884bf20fb82206f3c6ee20e7c120c72d"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "3bd6c30a233172ead4e3733a91811ef088e6d404e7b2d94c5eeaeec3c34f3166",
-                                "uncompressed-sha256": "ef778a1e3fd68f3f631f75a56269cf42c946608ed149ca5ae84139c07b5e0480"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "7ea8b4274c09c4ca6966101f26ad1055a5792b71fc3d44248ac640e686508955",
+                                "uncompressed-sha256": "1dea04da156e0cc129a98a0b65ead95f798ae8528d93cd5a702900f93fb39f78"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "a4c5de4435185867d839b2500352e0ee45a8e2860274b0f2bb2e768404dfe1fe",
-                                "uncompressed-sha256": "5d4a800c5d0eaf62c083b5ab37b7211e25e1d03b1bc5b8ab45d2f3f664d4e49b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "8db4ff94a5f9ed16f62fc7ab7a424e607c9ef6311e7efe763963d3f2478a18d1",
+                                "uncompressed-sha256": "d62f5676e2ad180544b32d80cffe600f2a761a065b52a922141573ade40c1f13"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-live.x86_64.iso.sig",
-                                "sha256": "40f442b654dcdb3106333a9779474ba2279118cd13b421ef4b7d3999d6511e3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-live.x86_64.iso.sig",
+                                "sha256": "164a5b8b8c4d956073ea966ff2da0e64e3be094c7a5f0464b823c2fee790475b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-live-kernel-x86_64.sig",
-                                "sha256": "f28835fd12e72da1592ecc5f26e6403847acba5beea329fe7d754015a731e64b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-live-kernel-x86_64.sig",
+                                "sha256": "2bd5f834349313d10a9dbeb41d9f71d985f7b9c4f7e2ba750a1dd6558f082ba9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "a8b18be1d370abdcb1a537396c16a714ebcfc75c6d6718e7cb491032c98585bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "9c597ac16400766205554fe53b06ac5be430e974ba04a99a5678e7dee56dc47e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "037e4c02bb442ab0668a0b43a1b4fcd8f68cc65099bd974c3e2049ec941e3705"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "4f18ef6cbd494b27290c8d46555952122d2369c2814fa0418107a004cf98e291"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "6529c67358eabfe96091eac6ccf4ae6e4f0b9c4773c2fd61dca76bf8fced96d1",
-                                "uncompressed-sha256": "96fe1ad80e78b67a4298ae37c8bcc61ff222d9c9ca5db1e55953031ccc81786b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "60122f9cbe3061a9ad1614d1c1820a378594255bf0d597650fd128bf389794b7",
+                                "uncompressed-sha256": "23116f6837ffe872a6f2f86d0e22024d0360a3c05453a15b7e65796a68fe2f74"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "70328bd84a316eff91d488b16686b2afd842b5333ef4557e15d1228b2c8da24d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "2ce87fbb6c9ef6c00269c1d4de55485ce4d186f6d35b569327cfc637d050d2d9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "414b0508279e0843bbda582669bc64eee6ae693a978fe2df69480bf627cbbcc0",
-                                "uncompressed-sha256": "36b42f1705abb60eaa3385eb648a34685ff0644ab403529be90178c9fe8c4cfd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "3bf42db442dc15f97dfdce52fca8d82fafe42cb64886d78c7c6520bcbf91b2f5",
+                                "uncompressed-sha256": "741ee422638a4a7e7c8e8aabfa684ee5d4b63286213752e998b7f87191425af5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "01bb6414158c0edfdf9e8451ac13be793ce062cc07371dd289aab1b880ed68fa",
-                                "uncompressed-sha256": "3c12e1fc2b441747a75b30821fce7b785b57113b873604d108cbce1a7dd4fb96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "5c84e47817cfc72e3a16b68cbc46524859f0718d2bd22b2b356e5dc5271207f0",
+                                "uncompressed-sha256": "c9b7a914224732cebba1997d3baf72a463ebccc63b1adc7d5007539812e4d853"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "0cff64ca4ef65bbb46481603604109b5b3cce19f4c17e972bbce6778f3da802b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "679eab9577000cbcd51a61b8f059c400f025f1b806f2426abd56a25f4c6b4e10"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "247ced7369af0360f190b2fe161e7e58a176c4f8e5c730c1c1cd41d4583374d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "2c4a5d7eaced59c021cb385a8252a6bb89fd6c4c9978c734d442261ac95d17ab"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221031.1.0/x86_64/fedora-coreos-37.20221031.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "8c6ffa59e260e8153fb6ace9aa72812a8d27f0b001f269c74d8ccbcbd98d0ed6",
-                                "uncompressed-sha256": "7c9ae65004bf24df6f6120099bec9a9818d2ac97d9592caddda0a69815ca151d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "eef24837e2fcc4578cf506f56b084169f9ca09f4ef7b1f0a858bdc1e86859b79",
+                                "uncompressed-sha256": "bd0f9210d96c4dcd00441b212d923573994bf1351aac41acadb8362b7d91151b"
                             }
                         }
                     }
@@ -524,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-059842e9becc3a616"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0f8b7098c7e9859c5"
                         },
                         "ap-east-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-072fe16fd1889fadd"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0c3922ec077f8c375"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0e27a79ad8eccaa56"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0340f53599bfd389d"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0b89d8b61b75b7daf"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0a8aae07d1c646571"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-093eeae3f4f36203c"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-08a30d0935d637125"
                         },
                         "ap-south-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-012f2e85b45700a69"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0a4e77eede808e318"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-00a54a95e4e926de8"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-07c3984d367af34a1"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0ab9a8dbff0ff6f85"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-095b9f9b1d32a1d8f"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0bf18bc6f20791fbd"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-007fac21517a7cd7e"
                         },
                         "ca-central-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-000a76005e714cc91"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0dc7e52905493a574"
                         },
                         "eu-central-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0a65791eb3ce2d070"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0fdf0e7d2336d0e1c"
                         },
                         "eu-north-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-03f3a887c6ca74a1e"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-049b99d460f87c607"
                         },
                         "eu-south-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-090cd20bec7be5db2"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-07a56241148413990"
                         },
                         "eu-west-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-061aff48c029d45e2"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0a9d43189d06bbb47"
                         },
                         "eu-west-2": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0d79356621b42e53e"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-043868c191c5c1d98"
                         },
                         "eu-west-3": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0bf453b99d5a8a118"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-05d206f5ab6e5b6d3"
                         },
                         "me-central-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0609f6007dd706ea2"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-055f2f9dfc1534d97"
                         },
                         "me-south-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0d18a83afde51f91c"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0df89dde5fb1dd7b9"
                         },
                         "sa-east-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0dad499b7975a0360"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0fc574f9d3a0723d0"
                         },
                         "us-east-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0b0c35babd04ca695"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-06fc3845f416e37f2"
                         },
                         "us-east-2": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-0ba847155da6c6173"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0a4c097577df5ec44"
                         },
                         "us-west-1": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-08fedc0b71fbb25f2"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-008fef546167600bd"
                         },
                         "us-west-2": {
-                            "release": "37.20221031.1.0",
-                            "image": "ami-083ee13bb603822a6"
+                            "release": "37.20221106.1.0",
+                            "image": "ami-0c38ac5b284851124"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221031.1.0",
+                    "release": "37.20221106.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-37-20221031-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20221106-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-11-02T18:50:22Z",
+        "last-modified": "2022-11-07T20:40:32Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "ac35fd8a413055c630c43687a3f0f31620e8d8418d84241fb8cf25636e382f4c",
-                                "uncompressed-sha256": "bb9331a5fc843058d2e77611b8e8e4230fd6e41b9467a125fd9047795eea5337"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "f4c52bf5607eedde4d83676102d57f7b533cb255ba1ce51e2d06a00438586f2d",
+                                "uncompressed-sha256": "5e85bd5647c03c9b8c870d43fe3ce992adeb87c597b3ada5994888e7da21c377"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "a6a052d8d927e2f7c5b18dfe05e378613b49155c0f41f1a565a0eec584889b2d",
-                                "uncompressed-sha256": "742f2ed8cdcf75a7d6d7bc6259d621a6ee1655798a80f3ffa3fec1762f388bb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-azure.aarch64.vhd.xz.sig",
+                                "sha256": "63dffac0b512f703314215fe26906e0008246b377ce92f129fcf8accdadc8d41",
+                                "uncompressed-sha256": "cfbd1bc2985fc23c9fae84136c427ff22b89a6e9ad443eb814cefae21a056d4e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "b0c6478ed8f3e76efe760f30297d04e646d3b6831066f496b978cc13b39f65bd",
-                                "uncompressed-sha256": "56d7f66f9c0eb579815c496fad1bcc5c5dd60b472c5f5b2709bce4b964cb16ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "d28e4553b708a59874ad6aefda3fa2cb0709a24d448048f1ff588380cf3cdb85",
+                                "uncompressed-sha256": "23f239eee86cb206fd573d91da9840d23d954499a092be4f88315605104fc3b8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-live.aarch64.iso.sig",
-                                "sha256": "64ac9a02c6a89935cf903a74198b94721ac649fcbbd1b311e242f8af602cb279"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-live.aarch64.iso.sig",
+                                "sha256": "6bc7f7afc04be6e3692c5af3b171674bd7606c1896d4dafde134ec53d71bfad6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-live-kernel-aarch64.sig",
                                 "sha256": "30437e6ccfa45657f7e1fb498537d942253bd8677a1c3b897f20a17226bb1d1e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "ff7c78335ec1dbcfa0e258b45f872dfc0df87d6223b03a2a8c623aae22d6890d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-live-initramfs.aarch64.img.sig",
+                                "sha256": "079e8dd6dbeccce889b13f0a7310f58d269a627ac4070dde19b0ea8fa13c284d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "3f17825d1a7a5587925ba9facd1527fe049fad098268c2911e5f6a0f9f5b81f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-live-rootfs.aarch64.img.sig",
+                                "sha256": "40dc513cf846537e3f3b77442e46b814fa8ddcf2ad14324bbceb77e886bde240"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "765c1d02c4302b1dd497e5be06185077276f2afed17abf402aa73b594af64a40",
-                                "uncompressed-sha256": "48e960f7aa3d59279b9ca119e1a4bed96b629cb2b247e0a15ea0520d7db17614"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-metal.aarch64.raw.xz.sig",
+                                "sha256": "9437f401568d17985c614b478dbf9915760b080463109780c5ffe09c811817d5",
+                                "uncompressed-sha256": "6fd6fc911c0f3bd5e107d762b5271df756bf848e8f1699f9c37409a9e19f0402"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "65fef7eab5518eba4fe776032a262f54dfc07d3f8be2805d37f23238f2a06583",
-                                "uncompressed-sha256": "7904e0d8bf49c8a447fcfb2fe17f5c6451bcc5633e10c358e8685b13cbd331d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "a368ee6f9c68ce531e8029a63f5f77127a4ea9b674b289ea55dd7ccade247bc9",
+                                "uncompressed-sha256": "ed8d00491a931297c8c2d9e534bb087f338f0edba860a7966b7998a957699377"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/aarch64/fedora-coreos-36.20221030.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "8bb00a585d1b7d2d9d987f9620d2799bc068fda1582eb8db5bd06946d89eae2c",
-                                "uncompressed-sha256": "f6c02f5468bd90cf442888bf4b08cb2a32493a9b0f5ed8b7f437d20e938768a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "5edb114f0279de0dc3b473756a834b42d71c1eea304c04bf05f3313c4b57711f",
+                                "uncompressed-sha256": "c6086be6e8b78f6fc8b02d8ef00adf2f001708951e5b2554fbc660afde30f7dd"
                             }
                         }
                     }
@@ -109,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0d08c26f3d9f9876f"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0b1971fbd87b7fb30"
                         },
                         "ap-east-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-04d59b14e4df653d1"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0a9352d69d7b23cb8"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0f19aa794223547c3"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-02ec72f808110e54d"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0ed3a3810eb366a53"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0b27bd9a224bef9d5"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0c73744e7112a50cb"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0873f81fd993c0891"
                         },
                         "ap-south-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-041ce023456821574"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-04916ab06624b5db9"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0ca3465a89db74232"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0e92ac3a4bbfab9b9"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0380d4414f5bb1091"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-017a45a86a4222201"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-06eb07e354ba59f70"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-087a5e3b711e7908c"
                         },
                         "ca-central-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0357f6cbe6cac6555"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0b594f3c560344565"
                         },
                         "eu-central-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-05593fb6e3bd3351e"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-04519e28b9136a3e9"
                         },
                         "eu-north-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-064a99d59608bb066"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-08db1855fd430d02a"
                         },
                         "eu-south-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-08f58bfd8623b38df"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-07031852884616e9e"
                         },
                         "eu-west-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0e08fdf7980f85d98"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0cbbd336faec78a34"
                         },
                         "eu-west-2": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-02c6f99492fc72d50"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-01e56ef0cfd91f020"
                         },
                         "eu-west-3": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-00cf3391bfd5c1cfd"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0635c2769f99a05eb"
                         },
                         "me-central-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0f869d6330f224d71"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0354c9fecc63ed0a6"
                         },
                         "me-south-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-02a97a2f9a5e46b04"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0bc3df67121c481bc"
                         },
                         "sa-east-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0d18877c155567163"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-058c87938eb7d3083"
                         },
                         "us-east-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0f27fb16ea2a76e7b"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0371d2fcbaf9e0a89"
                         },
                         "us-east-2": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0bf64b7a8a443d8a9"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0f3d047ee5ef5bbc3"
                         },
                         "us-west-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0e7c7dfe0ba4ee415"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0a0a975155e4dc313"
                         },
                         "us-west-2": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0dc0388a67c55fc25"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0b1786312284fb83b"
                         }
                     }
                 }
@@ -207,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "40cf872f38b96d7b4934bce2ef9a213eda5943a4247a30ea77863655b7ced7ba",
-                                "uncompressed-sha256": "580de03c58f22c209113342d2edbf6bdab801eb1a63f3be9f8f0c8c0039aab7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "a2f4b168599dec4155074487c62aada90bc62080fc797bb660b30563b2c931ee",
+                                "uncompressed-sha256": "790c833f645888ed1d5d3e72075ce2fad7e56f43462c9bd4e73aaaff5caf1f9b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "1bb7bb4a58205cd9dc724607f030d443fe2f593b8bd1d29c6ecdd7778adaa3c7",
-                                "uncompressed-sha256": "f9785e168d1c46ed321bc6cc0c644d44605e6f5c587dc8fb8a2bed9961ecfc03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-metal4k.s390x.raw.xz.sig",
+                                "sha256": "c49d07bb7bc97dc7cfeb23f694b59a7ff108f16d51f15af7dfbd9531e1092609",
+                                "uncompressed-sha256": "4c5124954613c7b5bd21f10c584775aa0a73d6ce409cda3e376aabaa48dd1887"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-live.s390x.iso.sig",
-                                "sha256": "671ba28b68647b5cf8d27a890034b382dbeb6509ed751609c24842b34cac2aec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-live.s390x.iso.sig",
+                                "sha256": "98389f411dfe3cc1ee42a796e597e36bd7cf9ec93eabf9491d2918c94c687509"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-live-kernel-s390x.sig",
                                 "sha256": "9ac47b13ab5888eca1a665e6933e9831d2bb0a6468fd4348f51e77fb29aa8573"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "d940c92342db0a183204fa5de57692b0d20139d601b8d42c07c316d5506ca2f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-live-initramfs.s390x.img.sig",
+                                "sha256": "16af8503d4a1a4206316c8a7d36b127efad7d033b18ce0b97f8b35844bf1dc87"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "983fd0211d2466185e02176f4edc748b4ea272c1809646e331cc472813ba15a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-live-rootfs.s390x.img.sig",
+                                "sha256": "39da15494be1d593ed9fc8f0aaf83ae27869700cabd1dc01232b81bb447bd46a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "b855b9d3473e1ff712d4788899a44929e22a267b5eb8b165c232da51baef1ec1",
-                                "uncompressed-sha256": "6414f4ad78a7c653c4c014d1f662f65115fe187404f103e3586c54c439ca078b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-metal.s390x.raw.xz.sig",
+                                "sha256": "f1bbd9972d50797797868f0fa13c4ae37af879b5a4e61edbe43e5cff59c03939",
+                                "uncompressed-sha256": "8ae8a96ab0a2b1f9831b61a613a6ca34e38a10275fb89252278b84b8a3efb492"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "e32c3c2c5ff8dd4cece1401e34013d76606358d519a1c79952d651a27b723639",
-                                "uncompressed-sha256": "d7bf149967231d29848485e8f925c349903e2a0cd239eae59ddc7bca58f93f2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "2fb1a5c4423851c75c61ff4ebf13e97a96f56891f31b00388706fb89d4dccecb",
+                                "uncompressed-sha256": "b305944b1331a1f688eff53683abf0e28d9d4dbbaf92691cb20bc6e3bdc9eb91"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/s390x/fedora-coreos-36.20221030.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "71df154947765d6cbf6bbf6337d6727aed79583ba4ebe7c1f058a0c87925ad47",
-                                "uncompressed-sha256": "9c39cd8d16d77fad2166fd0871a61a0cc781f91931d90661fbe8af00fff8ffbc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "3fdeccc35a0a2914903af8d6b0285161578dfc472b742c8a28ffd57d6fe43a46",
+                                "uncompressed-sha256": "b61d28a2787f9b75633b6b9606ef2a116bde38f11736c8bd06af05467203db8f"
                             }
                         }
                     }
@@ -296,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "2047351bd509e8a6f4e0e86bf553d00b04f93b1201345e5c0202007b7c4de8da",
-                                "uncompressed-sha256": "f2686ed1047ee79c7ddc522f54736ea78173696f74615733183a41d9b4593db7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "f57eabaaa209430539ceb1540dc77dfde8297ed18f874888d5a393702b4b4818",
+                                "uncompressed-sha256": "42930a90e3c8b770dbc78b99511ec4237222d479ae66997c51641cdc566b5299"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "91192ad30cc0e5dea69c158936787eddf083604ab50fb4ed1de505b81d3a03b3",
-                                "uncompressed-sha256": "8a4265a98ee9c0895b07de805766163cbcb02e2d59bd4ed886496ec533ea026b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "0608a857ea984f4365b7dcae7134181405bbf1066374034ede79c0a6d6da86f6",
+                                "uncompressed-sha256": "4ea8e453f5a0a0be3357472ce4de2e22d2c87f3155373fc4951708889eeddbb8"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "d8a60e1fd421b4378561df1c7097a7abae89830f8151b9f6eb23cde83bef62f4",
-                                "uncompressed-sha256": "c2eb5d7a7fa82113b67408137edf399d0df368079857ce7c76934cc027b41e40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-azure.x86_64.vhd.xz.sig",
+                                "sha256": "8f3cc9d67e3e0a6db5be942922c79f981fa7a4a86d319de9aeceb88e5f94ce22",
+                                "uncompressed-sha256": "1577bb9ec3cd7034de93ebe2e328d4df1aadac87ca9dc58d7342004cc615717e"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "a5183c8fe096ff3c330a78f64508e6734c34834e8e33a5bd2a803909b81d4fe6",
-                                "uncompressed-sha256": "0f00f5e7a03b7070f35d08ceafebb71592cdc7d8b3c3d42fa52331e702f188d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "58fc312c0bbb730af78d95de581b4008ac03762c134dd48548ec194206db6a86",
+                                "uncompressed-sha256": "54265bc18180fd46442adf1cdd998884d031fbdfd22847ebfd61de3b4e986c91"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "40de07f0d3692a47d5175c16bd899dc6df6857d2cd5f587e774eb7120fe49e90",
-                                "uncompressed-sha256": "d246219973b4b4d593bd5177b5fdb3aa35257cefa4ee00714429d93dbe356139"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "86feaaae8ae57fcb0b30495fe18cd1a19a42475191a1d64828991846149cfd1d",
+                                "uncompressed-sha256": "fe8d77087843366df031ced897922b4e406cc0b4f5ea739051bb45f54e2a14d9"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "22d14fb2c154ccd34131d51a25ed5a18b4a30b1538314e72d58c51ed8ca4c819",
-                                "uncompressed-sha256": "22252835e4ff46ef3a988f374f5d930fa4e8219a7e907323285f458af01773ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "cd69c99637f19c1199d4d4141ca16cb88e5d3ab4fe5b5ba4fcdae27455dd0090",
+                                "uncompressed-sha256": "b0e778fbfa3f5fbbf40b010c0255c3ff64d30ccdb1371f0c1b521bf3a8935e08"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "2dbe1c529740d1dbd160d5761e1de6be429b1f68a13577ca04af8f13dbb94e72",
-                                "uncompressed-sha256": "6db8dd5a54461e986dfc6f7369fdc96a727c267fa2ad722c8ff4ed9046fe5ffd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-gcp.x86_64.tar.gz.sig",
+                                "sha256": "422f07354e7604a5e50e1d9ff3ba6a745f883c25b2eab468e12262fa30c98b0c",
+                                "uncompressed-sha256": "51afb7c6903d076fe6420d0d6dd10b9496fd3d6d1d61e6baecf14c4dbdd8eb20"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a7688811cbff61db209d7d1e571b218a70de5e3d91d200df13866d1efb251d6f",
-                                "uncompressed-sha256": "63d9825100a9439078e6bfffc87ef0bb30f7d28444f1689db43b3911d5feaa8d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "2ef5561acad05dab10e253776c7e8ee01bd2789314d88c2dd472fedf1cc871f0",
+                                "uncompressed-sha256": "b0d6f3edfa56ff6935902ccd156dd374faa8eb3ae174bda0f9fe354684976f7e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "e8ea18809eec8705c9a9cd8779be90c47ba2e396f32e5b8095a1785d3fba2bc0",
-                                "uncompressed-sha256": "4d59546ce5de566f6c7661b058726a23d58f93b580e436f5e373b81a1d9e755b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "cd43c53040c2ee8bb8e45bfa2307e49de7d9058b21e03b1762aae9edc47ee5d1",
+                                "uncompressed-sha256": "34e44a5ff4238d082e80f4ca25135d538013669334d171ca7a5d420aadcc916a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-live.x86_64.iso.sig",
-                                "sha256": "69b20834cc8701f17f33aa6d8e2d8ebe5dfd134c5d895bc63e4592dcc0d15375"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-live.x86_64.iso.sig",
+                                "sha256": "734a5b469ec22b9644f332c8b8bab61a621457932cf8da215dc620577a974558"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-live-kernel-x86_64.sig",
                                 "sha256": "952baf3fe442e051a29b153db08161aedc63baaf4e920ad01f36ab886b3c4bf8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "5d14a5e8f521444aa78c42e451582e12676d24f28db825c98be71b9920a6355b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-live-initramfs.x86_64.img.sig",
+                                "sha256": "3fadda34249317218ac3b7ec04db02a4a8cbbe72c760c6b0cc0fd5b182dc975f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "d3ef7d70ed90511db9404d4f2bc6c9d945b66741f517fef537320194f7a80fc1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-live-rootfs.x86_64.img.sig",
+                                "sha256": "616203b8cd62a1d32ad64178ba356049139dc99d3298cba43c35897c9133a976"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "3d10e02ad6a95fc39d8ef013be2997f706452cda89f84b35de504e6146a09826",
-                                "uncompressed-sha256": "f0aa3149325a3ba2e90aad40abe2055120ff169ce535a6d6117c995eb9f0a043"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-metal.x86_64.raw.xz.sig",
+                                "sha256": "7fe2b4eb6dd19c947087483f55f1f6a17d657195f957178ac085c1ed4cc10f13",
+                                "uncompressed-sha256": "8c6c882f352d340be3146f245ba7418056e82ceb36a948aeacd9af106e3e56e5"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "113b3e887a6386e7b9a3206ee6d748a3c5308ff9affc347ae559dec0beeb6d44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-nutanix.x86_64.qcow2.sig",
+                                "sha256": "dd2cd65c8b0a492537f1570de9c120c90fd5193c2432ee07366364b3e38297e7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "31b64c1716e0b7c7dda7a4185fde66e62d917a1ec252b8b103875ee6ce9d48c6",
-                                "uncompressed-sha256": "4860ffa28324e22751ff53e3f35ea1419f01e88ff70e68fbac8b88fbb3328470"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "93a10d9c9c0b8a581037634215cd86ee0f6ece31dd41a3da79168a4da9046812",
+                                "uncompressed-sha256": "82878e566564f16cde7f1dc757aacfe1ecf29e596ed6ea733a187e5afcc571c4"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "ee1f0dbfbb07045d0ba6863c8d93a4aaf4b6e86ee1ece51a8dcc3aa2c36380e6",
-                                "uncompressed-sha256": "34d1353384230de6eed82048469f75bdaf72dbaf287f6a00f59d8a52737e4215"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "caf19caeaaed0b04224b4736e080d04e73e89c6d9d38c60fb4517094838e2cc7",
+                                "uncompressed-sha256": "04d224a27a97ce3ce517fb731e7037efb5051eb9646eb23bcdb351770c28f700"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "8bd6a97cabd1b9eff355d459245e1bdc20166b86c255b89ef5a24223df113b7f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-virtualbox.x86_64.ova.sig",
+                                "sha256": "a48da94ff8dc696d3b151e837a8f097c02d7a8058c6bdc87baa53c59fe51291e"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "8d56fa2a611ce0fce2fd0922d047d9ac3a6b767bdcf361dc112168d1df65272a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-vmware.x86_64.ova.sig",
+                                "sha256": "7d13778acd01692048135266d032048783670cbabbc3c815609798d8c8510177"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.1/x86_64/fedora-coreos-36.20221030.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "5d63c26626810f749c879b2a41e074d1720e629ddb420f38a0af28bf8c4f57e7",
-                                "uncompressed-sha256": "52de11249f736fd1fadb6e5fc6018af9802366691f135b141f8127df744715df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-vultr.x86_64.raw.xz.sig",
+                                "sha256": "efcb7faf8239d7a68769938203710d62a9bd354345dcec40e6d1da3a13954a0a",
+                                "uncompressed-sha256": "aebe67a63ab93f1e8690dc379f179cf24cdfa8766cb9e15f6411fcfca123936b"
                             }
                         }
                     }
@@ -524,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-02e60abc58f6c13f5"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0dee918920b4ba998"
                         },
                         "ap-east-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-08e9e1d95a5e4a69e"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-020eb0033dc290d20"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0b1c2992c0604335c"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-02d613915c3a89548"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0e7139951081b239e"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0c34b40e7180c1cd6"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0d78ff393bc20c493"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-01a1a5ec96c2cfb38"
                         },
                         "ap-south-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-00840a62a20d53618"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-009a514f019018b53"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-09fa1e1194b2c7b32"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-04f77b491b4a4989a"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0297c5f24ca2885eb"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0588a8217098bd038"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0ec615ca3398a2152"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-06f700f8797b0d6d0"
                         },
                         "ca-central-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0094b67ab3fe624a3"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0889518725a653994"
                         },
                         "eu-central-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-008eb82adc97a3972"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-036f66d64e0164b8c"
                         },
                         "eu-north-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0a66d2f281a557fbf"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-012cc14c3a2562d91"
                         },
                         "eu-south-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-023bbf9ca3ce47326"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-052ea5640534bc798"
                         },
                         "eu-west-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0720a37ebaa9d54f0"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0f67c3be09960a4de"
                         },
                         "eu-west-2": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0f16605acf8bf81f8"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0d0cf5fc29987a471"
                         },
                         "eu-west-3": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-03846078530b35fd1"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0135792a18fc0677b"
                         },
                         "me-central-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-078bc0d0298c965f6"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0399fc6453413a821"
                         },
                         "me-south-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-05d1670564621e148"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-01b210886631f4342"
                         },
                         "sa-east-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-008a147f21c3f8fb3"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0ececaef6efe8a10b"
                         },
                         "us-east-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0e5779204cb785224"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0c3e3ffc34004bfc3"
                         },
                         "us-east-2": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-08559331306ba1cfa"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-01a26db2cfab08377"
                         },
                         "us-west-1": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-053743f32fcb80ff9"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0ec27dcf53d3a25b2"
                         },
                         "us-west-2": {
-                            "release": "36.20221030.2.1",
-                            "image": "ami-0477b8e335730746c"
+                            "release": "36.20221030.2.3",
+                            "image": "ami-0b631c8759a57190c"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20221030.2.1",
+                    "release": "36.20221030.2.3",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-36-20221030-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-36-20221030-2-3-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-11-02T18:50:24Z"
+    "last-modified": "2022-11-07T20:40:34Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "37.20221021.1.0",
+      "version": "37.20221031.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,21 +69,11 @@
       }
     },
     {
-      "version": "37.20221021.1.1",
-      "metadata": {
-        "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1667343600,
-          "start_percentage": 0.0
-        }
-      }
-    },
-    {
-      "version": "37.20221031.1.0",
+      "version": "37.20221106.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1667419200,
+          "start_epoch": 1667919600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-11-02T18:50:23Z"
+    "last-modified": "2022-11-07T20:40:33Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "36.20221014.2.0",
+      "version": "36.20221030.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,21 +85,11 @@
       }
     },
     {
-      "version": "36.20221014.2.1",
-      "metadata": {
-        "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1667343600,
-          "start_percentage": 0.0
-        }
-      }
-    },
-    {
-      "version": "36.20221030.2.1",
+      "version": "36.20221030.2.3",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1667419200,
+          "start_epoch": 1667919600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).