### PR TITLE
Roll out stable 36.20221030.3.0, testing 37.20221106.2.1, next 37.20221111.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-11-07T20:40:33Z",
+        "last-modified": "2022-11-15T15:38:07Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "491b378c7cee2213a066382869124baefe6b7a0b357f7a599bb7f2353086eaa0",
-                                "uncompressed-sha256": "f13727cc40ee03518ccc9bc124eec2588ae63beaafb76b7381040cf6d95ea5f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "5d49e0ec321bf8a5715075ecee863c9d394db7e712359d61ae7f950c1736c5d3",
+                                "uncompressed-sha256": "78410912dc92d627bc4b69ac49962fc572ec5e96ee9c552bc128398ed8643a2e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "8c35a4ddb17176a0bf683ed04d5325f4788f37096532daf4adebd666730a1b49",
-                                "uncompressed-sha256": "a8a637a16bc486513c9293b7aaa311938ad63f04ee6757e65c26e4b72f165edf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "d954cceef97e09a933d08d23092c396407f79fe16c1412c830ee6b33764f8a0b",
+                                "uncompressed-sha256": "ad0df45b03e8b23fb713293a20e2a15a8dda1fe6fd045abb54abe526d66f2be8"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "fb5b6f742f62e54b705be95fb413f64341602a24d278c335076323a7fc3d9f73",
-                                "uncompressed-sha256": "30036f09198a6e2b90a9d0531c35cfc35a12769dcfe685d468dddfaf322f5c0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "347a0e10c4850d2c5b3ae74f2ed5701e7e0224ca230d077c78ba196bc9660434",
+                                "uncompressed-sha256": "005459cdffefeacae8af7356ed5fc1d8b698e84426362bd790f5cab532d22cef"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-live.aarch64.iso.sig",
-                                "sha256": "60ce067872de2a676c8b81edbb0e2d04573d795ce69d67f59e1da60c21b5a626"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-live.aarch64.iso.sig",
+                                "sha256": "f72322c4a494b6c45559226a9108d73e14f3a6ffd3c2369e50c18be82dd3289c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-live-kernel-aarch64.sig",
                                 "sha256": "e5f22a13b48f397d17a0b50f7844d03a7f6e81a000b323db7baddc29570001ec"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "254c9c63dcda31c8fe435586d41ea814e5bc8c3335ab3140cdf1ea01f8da90d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "9e1eda26e3b437808dccd08e78c9bd7ba67e3599acb9b748288a48cbb86c311f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "a4d3b13b0b798831f37863b7f2001a59698b9cb7faada8068df24add940773a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "25b1f64a7624c14e35e901dc80db9eacef3dab8b3b77ecd26fc63b564ead2e0c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "0eac4d86a47af120dbd479d1628813a7670e55676c722c45bc3f76f4cc63ff74",
-                                "uncompressed-sha256": "4b832da9b6383c033d47d8a89e8ffaf8a4e52166013f76cb78f0769355434e21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "acdd8122d8a12c379abbdd472b7be934306cccda2310b991d8721d385290eec7",
+                                "uncompressed-sha256": "c2591c3f235294d3b9aecef17f6dc5e1446d9f4cc6c395491e9e08ff930f5177"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "6d71a6ff219a27297f07310e801f8cb111fef22530b88c6972a47c9eb6c1db48",
-                                "uncompressed-sha256": "5d8eada1df724431e6538bd1a85992ab5dc3994cb752d47c7f2a348f0dc84db9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "4976e45e90b6f92afbd1c30bfda11ad264db378bdd9b5d9bf8626cf8b5f49194",
+                                "uncompressed-sha256": "6fd290c61877809e5a6ba8c765496f65fa624fec02a4cee8becda16b32c75701"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/aarch64/fedora-coreos-37.20221106.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "8829caf5535e8725b9e233c4abbf6429b96945f36297a2c677f89734c0a8da8b",
-                                "uncompressed-sha256": "38910da2e8479ba5e24af216cf4b095603279cbfb23237e10838b5e1aab0053c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "6a773e82fe7e17c208a1dc84830a49de94a5c8800adf808e0af8c34349e95a45",
+                                "uncompressed-sha256": "b862e914a28d01d5ecf719f8bb17f410bb18aede30f754f6c6993011fa68d9b8"
                             }
                         }
                     }
@@ -109,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0f68343aca0cd6401"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0a92dab1342e5fbb3"
                         },
                         "ap-east-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-08611fc2f637e1ee7"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-07dfa1278e0f7dfa4"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-00e39f9aaf946cffd"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-01f2c3b5dba7a9ea8"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0e0f335b90e513cdf"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-08c225de7773a837b"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-017d5450be92cc9cc"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0d3d213887853fdd6"
                         },
                         "ap-south-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-087bc46bbfdc72c11"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-03a3518e0793fc099"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-07b825bf16a3bcd8c"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0be25ce8f542096c0"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0f58710f44ee1f234"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0bb889c951b0fdd72"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-002c73a034fd6b133"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0ec8eeb40f1f7627c"
                         },
                         "ca-central-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-043a411234f9f34aa"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-084f604532069a024"
                         },
                         "eu-central-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0a24ebc5cb5e970f7"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0aa44b5dcb2495e98"
                         },
                         "eu-north-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-05174a9db32342a96"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0b92e506c5d33a518"
                         },
                         "eu-south-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0ae4a6f17700d098e"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-04067fa2789e8c95c"
                         },
                         "eu-west-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0e96c7111058059a7"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0d7a077a34d94ab30"
                         },
                         "eu-west-2": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0c5a2eed630c582e3"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-08e2438d2d1835c0c"
                         },
                         "eu-west-3": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-01b97a4877f2554a8"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-02266f7199d1efb87"
                         },
                         "me-central-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-04bfb262ab93f85f8"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0e67dfba9b2499776"
                         },
                         "me-south-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-04b70f7cab618a64f"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0ee31a6cb48d2ce21"
                         },
                         "sa-east-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-01d3f515aac9e16f4"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0c6eabbfcb0b935ae"
                         },
                         "us-east-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-093b1944ee90cbf65"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0422f0b5f52345f4e"
                         },
                         "us-east-2": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-07bee15df4fcc143e"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0afcf8244a6c481ca"
                         },
                         "us-west-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0d3a14ec3a4ead303"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-00889b2cdb960363b"
                         },
                         "us-west-2": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0d43f5c10585c4621"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-01b28424aa8656fd3"
                         }
                     }
                 }
@@ -207,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "60970e9c86cb5028b5e69faaf7d78297a0082cf8a5e6fdecd6841db27c0adda6",
-                                "uncompressed-sha256": "f3eeabc441d3eab2ad61cf3c51ea4a7a39df4935e5574ec749062c674f0441a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "6a013fc53eda04ff213abc298a0e47b4f71ffc2e30c53f437a13990e2ef7fbb1",
+                                "uncompressed-sha256": "fb234571fa1553d0a393e08218091b6d74001bd4d5293a57892d2fcac6c74e14"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "f65ebdc3aa6b49d51cb129dfca8fc982b5c803aa59e384b20c1d56a9dbf69fff",
-                                "uncompressed-sha256": "add4eb2299790f16d4efe699cebe02c29aec4e436b3ed013fa3844b6b9f7fda1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "1e65ed939def3755be423fe313cb3843444ba1719ab9def7615af87414bde8e0",
+                                "uncompressed-sha256": "533723ca04836b92d35a7f5d3cc07c7281fcd87701df3d76e3159d1456793277"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-live.s390x.iso.sig",
-                                "sha256": "eee64606d3d03afa477d83cebcaa49987582f538e98cbaa03c0a5397a911f216"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-live.s390x.iso.sig",
+                                "sha256": "4ac1cc28b4fa811bf00617115360d3035221743f5dba76a979c83fe1a384a3d7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-live-kernel-s390x.sig",
                                 "sha256": "75cd92f1654274d8b446969d2c966892e8af5b5398bc805ae243d7e6da09efd0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "eaba3df5d4f0861a3a0c0954525422b8805e5dd2aa3cbdac1f0fb6a77da1259f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "a1a6ac90c94f1426cf5617e066bbbad722ac6a1fa953fb1b1921c422b03770e0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "3d85e047feede1a83944ca4f465f5b41a49ee75eccb6bdd5829746613b38a339"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "2f07717b00a091186a7ec9774956b5dd1798e368cdbb27ad8d23edbd106330dd"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "7624dfcf8b9ab371d0705861da4393fd1337c1e502d4854283a21539e20eebf5",
-                                "uncompressed-sha256": "7cb3677660feafb22e4a1490b8b5010a9238f854f692169f94182ae4c67ed176"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "926c51de20ac2f9a1cd91bd2da08f6456169d3ae5acb1972ed7f96998b0043f3",
+                                "uncompressed-sha256": "bb36df255473e503c7ae567b1cb505f7fb2ecc0c3713f7f70bf08e0e90e3b9fb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "18022f496de6479238468ae0cd4979e2e826969596a422b603eaf1ff560ac729",
-                                "uncompressed-sha256": "1036f58c1acb861368b24fd06528eb85bc7badc659fbf01bb1d58d18d8c02c65"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "ffba64633e5189244e65144c2aa29153f07231c5df9a92a5edeae9009982ec26",
+                                "uncompressed-sha256": "78a598f410411008c63bc3ff8be2a4c2f3203de501ee1be92c3728b8c9b44773"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/s390x/fedora-coreos-37.20221106.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "4fa98b2771442dc15f91bec53f6247c2da6d4be76d7397eb37a130ceaf94d2d1",
-                                "uncompressed-sha256": "f7d76cd58b4ebea568eefbabc14697c5b02d01687bda9206bf280bee9802d9b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "79c776ecbd122ebd50cae0bf1f1f74569f59f05c164bc48a79c253da7df11a93",
+                                "uncompressed-sha256": "5c17468005fcf3aab082e42900e46b57546659518bd06ce56a888f32c25930fb"
                             }
                         }
                     }
@@ -296,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "e497ea1f888770c2f0fea78d1a7cb33ad3fd9a69f1252705c08e5950f6438946",
-                                "uncompressed-sha256": "a57d15f5f3443a52c630260825109f2d9547764ea0b5c5e4d9554045bfa6df74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "239931b4cf0021b73b695c524c9897196503475e17bcba979f5a6a42afdd6700",
+                                "uncompressed-sha256": "7e6eae3b31ce9475b84a6837076cf8908b9b9e55fcd10d5a509a497373431e88"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "49269d618a3277b3e8f01435bca1ff4d59614530d5a7d4d849c75c9c44f73064",
-                                "uncompressed-sha256": "b52234079bf69d61467524c2288afe39f1b5f8d69afbe2f0caadd99c63b1b88b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "b4e3d4c1fc65b5494cc2221dc13a6b3b92f3c99072f2a88020a9ebce8d38aab6",
+                                "uncompressed-sha256": "244e94e28e439da8eb3870896fd44e450d956fae4a979f918946b53440b02493"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "639248b77dee0a1d0a3338ebc30d5d4c1bdd45e6dc494c10fa6bc18fa97af2ed",
-                                "uncompressed-sha256": "859251b72adb814b3f45567ab7c8c11dfcd4c15e1d64496099ca6e65f3d47b99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "803792fef65e4c82cee1ad412e9602c6ea240152dddf4ed0038aa32ac73b1f51",
+                                "uncompressed-sha256": "6efba7b901566420d62a150f4092ed28e285922aa67ee95e29e1a89c0e187d84"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "1fe025e8206a3036da1f629e42952c314865ea4a643d5067d1d7cffb9791abe9",
-                                "uncompressed-sha256": "de4dde8ab62dc2e64c2de1ba875c7fa1e8b5e43c6d2af5ceb6a5c86fe238a620"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "67d676e99119906b96caaf265f957a2d5a63dfdc4d12cbcd7c53dc5cdd911dc1",
+                                "uncompressed-sha256": "2381e1745af17b133ef3ed9325c13e75a3a0ee81c15299b8c22ceeb040a45da1"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "9c88dd558d9e7112d2612c77c0b65c79d01a88e87c147df7ec022f5be8c3f821",
-                                "uncompressed-sha256": "a3e554e7c5c4e9a4e9760eda7533cea3a721081e40e55fdca64ffcb3fa943b42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "4727cf7dbbaefb0c8adff30d3b8f158902806902a9b0d3212cfc2b6e77c04103",
+                                "uncompressed-sha256": "51572c88822b8b65072a6c7f1b067ff3a6966648374d8b97984a64b5f991afd2"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "7a918488faf9ae15b15f09f72257d22bec6fea21ae19401f58e97044499705d2",
-                                "uncompressed-sha256": "9da6cc878e0a03154578329e4c5010aaf61e080d6f56c75e27b5831647353d13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "07c834465a6a29b632105d4068577a7efbb4aad61273a18a8f1b59548db65989",
+                                "uncompressed-sha256": "26e142f4803a24b5fcd4688aa71e38581c0ee3d32fd4497f08a1e3f8f89e6df5"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "2aa3d9fd1e52186f9f42e225bc88bc2f77649873446a87a025c7616057318a63",
-                                "uncompressed-sha256": "e30fcca6ed203b7a35089142c2dbc9e7884bf20fb82206f3c6ee20e7c120c72d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "240c11d5c582e1468209b38670be4a50f7efd46ab937ef9a2d60bc1bc15e7824",
+                                "uncompressed-sha256": "02cf06d6dd55262f55b953916054ec7401f4bf9b0f77de65bf47cbaa93658b58"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "7ea8b4274c09c4ca6966101f26ad1055a5792b71fc3d44248ac640e686508955",
-                                "uncompressed-sha256": "1dea04da156e0cc129a98a0b65ead95f798ae8528d93cd5a702900f93fb39f78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "08f3fc9b9ba81bb62b91dd133718e2f396b2aa9ee87d33da282ebacf7eb8239f",
+                                "uncompressed-sha256": "10c1afc46d47a06a7d2898c2dc22d67b64890d52cd927b043f9320d64fac92cf"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "8db4ff94a5f9ed16f62fc7ab7a424e607c9ef6311e7efe763963d3f2478a18d1",
-                                "uncompressed-sha256": "d62f5676e2ad180544b32d80cffe600f2a761a065b52a922141573ade40c1f13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "f08ea481142f8904cbe535dd1668f88990613d81992dbffb4642218a7dbeaeb8",
+                                "uncompressed-sha256": "85fe7cd0dbaf22e3ab592dd6a5a578b828953e3d61cba911b0863b7b87bb5d46"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-live.x86_64.iso.sig",
-                                "sha256": "164a5b8b8c4d956073ea966ff2da0e64e3be094c7a5f0464b823c2fee790475b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-live.x86_64.iso.sig",
+                                "sha256": "8d1bf83aafe26d489181785cb7d892a56c5c439bbfba7125237006cfa7865abc"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-live-kernel-x86_64.sig",
                                 "sha256": "2bd5f834349313d10a9dbeb41d9f71d985f7b9c4f7e2ba750a1dd6558f082ba9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "9c597ac16400766205554fe53b06ac5be430e974ba04a99a5678e7dee56dc47e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "cc6ea008ae1004f7189f91e2a63f67dfa444b4d98f2e5971da82257f1ed3a524"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "4f18ef6cbd494b27290c8d46555952122d2369c2814fa0418107a004cf98e291"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "0de66c27349b3b12229baa933d5e41a0160c7ea48e5bd0331a3d617ecc092e62"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "60122f9cbe3061a9ad1614d1c1820a378594255bf0d597650fd128bf389794b7",
-                                "uncompressed-sha256": "23116f6837ffe872a6f2f86d0e22024d0360a3c05453a15b7e65796a68fe2f74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "497dc700075433f2eb42c707f187d507b36d243f13d2ac406e78dcd0cbb4bc99",
+                                "uncompressed-sha256": "a35c935b53088abd44bcbce3e31d394df54c21b6b74aa609330c28fc65de6f1f"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "2ce87fbb6c9ef6c00269c1d4de55485ce4d186f6d35b569327cfc637d050d2d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "6fe9e9eadd1bdeac164b8b191f641b9153cd7cbacc8b8834902daa555487af2b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "3bf42db442dc15f97dfdce52fca8d82fafe42cb64886d78c7c6520bcbf91b2f5",
-                                "uncompressed-sha256": "741ee422638a4a7e7c8e8aabfa684ee5d4b63286213752e998b7f87191425af5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "b0b444743be3ab2819b1441677df4e5b042b77f65c9154dd3506429ad03e79d2",
+                                "uncompressed-sha256": "da68dfada75807c348c7d1be92e761ef228e4f658259dcc5fb6946fd449ec982"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "5c84e47817cfc72e3a16b68cbc46524859f0718d2bd22b2b356e5dc5271207f0",
-                                "uncompressed-sha256": "c9b7a914224732cebba1997d3baf72a463ebccc63b1adc7d5007539812e4d853"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "aa1eef11464a096cea86513c54ccc573aee8880f28e69d719056b8419722ff56",
+                                "uncompressed-sha256": "d16b76c581bd74c9499f8e89d49ce72cc56f9ae32ba761369c2171e7d2aa1527"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "679eab9577000cbcd51a61b8f059c400f025f1b806f2426abd56a25f4c6b4e10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "4e942664c84dd472cc7516b9d0fe3d181341353192fb263df43b8d86db6063a7"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "2c4a5d7eaced59c021cb385a8252a6bb89fd6c4c9978c734d442261ac95d17ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "f4bd15c9cb87ba12f741b574b1096d3b52b7205dd924c17e2dada499985ac756"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221106.1.0/x86_64/fedora-coreos-37.20221106.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "eef24837e2fcc4578cf506f56b084169f9ca09f4ef7b1f0a858bdc1e86859b79",
-                                "uncompressed-sha256": "bd0f9210d96c4dcd00441b212d923573994bf1351aac41acadb8362b7d91151b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "23e25c80a275b90dd205a6c31861555b01df4f53ee533c40e187bfa5ae72901c",
+                                "uncompressed-sha256": "ce2fa87f55fbcde117af9a0dd916e738469c784314b7d5fb37d730422c1742e9"
                             }
                         }
                     }
@@ -524,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0f8b7098c7e9859c5"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0d7b07c20c4a5548c"
                         },
                         "ap-east-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0c3922ec077f8c375"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0a0889b78c00a1bc1"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0340f53599bfd389d"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-086e6afe795c65396"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0a8aae07d1c646571"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-03dee867ef15b89a5"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-08a30d0935d637125"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0977400ac6ce49a6f"
                         },
                         "ap-south-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0a4e77eede808e318"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-01872894d3469cf9a"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-07c3984d367af34a1"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0ac8315e08bb1b4f7"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-095b9f9b1d32a1d8f"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-002c9a2cfbebe1580"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-007fac21517a7cd7e"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-06d8bf61cdf310875"
                         },
                         "ca-central-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0dc7e52905493a574"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-03a7c3e75867d366c"
                         },
                         "eu-central-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0fdf0e7d2336d0e1c"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-03dba3c1e968e975d"
                         },
                         "eu-north-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-049b99d460f87c607"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-025e4ea1a5108b4fe"
                         },
                         "eu-south-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-07a56241148413990"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-00cd7304ea8d2ca71"
                         },
                         "eu-west-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0a9d43189d06bbb47"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-02015c18c845a147d"
                         },
                         "eu-west-2": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-043868c191c5c1d98"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-062d48dde28ef10fd"
                         },
                         "eu-west-3": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-05d206f5ab6e5b6d3"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0476ffa43631f99a2"
                         },
                         "me-central-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-055f2f9dfc1534d97"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0b088c84f54e3fd79"
                         },
                         "me-south-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0df89dde5fb1dd7b9"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-02d9ec5eb4ef0458f"
                         },
                         "sa-east-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0fc574f9d3a0723d0"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0f39b573bbd7776e2"
                         },
                         "us-east-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-06fc3845f416e37f2"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-025c5177ab8dd2d3c"
                         },
                         "us-east-2": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0a4c097577df5ec44"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-072f991cf8a65d37a"
                         },
                         "us-west-1": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-008fef546167600bd"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0f3d0906765ada69d"
                         },
                         "us-west-2": {
-                            "release": "37.20221106.1.0",
-                            "image": "ami-0c38ac5b284851124"
+                            "release": "37.20221111.1.0",
+                            "image": "ami-0b770545fdbefec4b"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221106.1.0",
+                    "release": "37.20221111.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-37-20221106-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20221111-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,105 +1,105 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-11-02T18:50:21Z",
+        "last-modified": "2022-11-15T15:38:05Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "4c712f77d5266de05e537194693d3fd32ae9c8c39d1f5961bf42bdab3034e8f6",
-                                "uncompressed-sha256": "e6c01405aef6a8a73b9632c288f06dfe385d402a9f99f3a3c477c588ba63f031"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "005ce2deb69583dbbfe4636699f19e50f97758ccdd976f80c248b2e6fb4fb08c",
+                                "uncompressed-sha256": "0c6176c5de4e8b67a82a3af45ee70a59b1cc223bfe506d3cea1a3a46b48e4f73"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "3b8ff361600cd32174d48d8087d400628b817690f22d73460ad5fb28ba8f177a",
-                                "uncompressed-sha256": "c8014328e32cc53708fdced7791f09bf8840af917dfa58be60e48f281b99146e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "e88329c5f2694e06cf573ab93446614f56356b1ca2caf9cf2eff0ac237a310cb",
+                                "uncompressed-sha256": "a9ab7360ee6e67698fdde05c168aa7269cf13803d03f8b48737f44dc44e0a7dd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "71804f0240f94ae0ccc426ab67e099f935e3ea965f1892b3dfb9f6a34f9704ae",
-                                "uncompressed-sha256": "fc617ef7dac4114edab54fa3f13fff2fcdb4debce76757cda2dea93382f148f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "15364d65581f201e89b04f0c773db75216c8fc858c122e16a03332fb43745c99",
+                                "uncompressed-sha256": "af8214114fbc59ca81b08b4ce51f128a22b9e61e74273c8094bf270ecb8ed9d1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-live.aarch64.iso.sig",
-                                "sha256": "0944a209d7091ff084fec7deb091fd031cad53c1e3d4bc94fc90f79fca741df1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-live.aarch64.iso.sig",
+                                "sha256": "81e524bac35331623ea54242d43fb595d256c47c6036a0ff3ff80f83ecd8ddf5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-live-kernel-aarch64.sig",
-                                "sha256": "1a654a618aca6ec8a7f38c0f83ea34971aa52925e07fa99a8b082cfc080a975f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-live-kernel-aarch64.sig",
+                                "sha256": "30437e6ccfa45657f7e1fb498537d942253bd8677a1c3b897f20a17226bb1d1e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "8072ce7b47f46b45b8a91032a38d571610052aa8ca90890c65d88b291208ba8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "d9ec4ae83c4f5d37b85f717d143b0c7acad4cd415d5c98fcbb170932339d09f5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "16936519593bde117cedc5a34d90834016a3fd542f77790a5a1e23f0d26d6de1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "e21fec1d835dd8263fac350b2e6d3023ca5f4784d857c50a31928ad16947c003"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "c07f24f922206d3c6620d8dcbdd50d64e8ce98e6b0dd787f5f8e74ed18d67c6b",
-                                "uncompressed-sha256": "e306d5f9a18e66dde95a8ea60e6ab1632d99487a12438663283bde439be07037"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "1a0c72f0b90f8d9ab6860c4b01d3dc6df5aef62b9286e1fb799d699551d569ec",
+                                "uncompressed-sha256": "b77795e8593cabd7355f76edcad8d1e4fa1502b2c20a46a8cc5c14177984ff49"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "67d835f909afe06f12cf1b43518dc930b908402e745eaa880b460025626d4181",
-                                "uncompressed-sha256": "c1d89d63b70ecd54be83e4061c54d551a5327d265fa29fd68b35ad67d87c4b5f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "6dcb1e6b7a4886cadf847c62d5d22a99f637c7508f87cadedbff11e2c5c21416",
+                                "uncompressed-sha256": "d095cbe9ce7d848f29480ca44019161f60acbf838a8ab79d4441182d09f13144"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/aarch64/fedora-coreos-36.20221014.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "f54ebd453d3ee5c5e2d77fa30193a4c101569205e3b7151eeb4cc58a6b165c7e",
-                                "uncompressed-sha256": "d17eaeff40d2ed944b8659c52991bbbf18252409ce62b985079e6cc47fb07dad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "2b1f4c4215d8f5c5b97002dd2e48be85953c8a0a4cc52c951ddf2f11204d5cb7",
+                                "uncompressed-sha256": "9517caf8d48ad9474563903e5bab1745118f62539935ea63614d97062737427e"
                             }
                         }
                     }
@@ -109,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-036a90c511827f07e"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-09c0afcc2f79ffb86"
                         },
                         "ap-east-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-03e2e08e60e568b9c"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-09028714404ea2f32"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-02b55e657338af497"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-06520a5f5d8e78479"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0df0292996af7e2e7"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-0a73ad79e9883f9e0"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-03891be095eb9464d"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-0b43c57a8baaff258"
                         },
                         "ap-south-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0ea66310feaf94608"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-0df53d760edc3dacb"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-034dadbf5a4285384"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-02f437f60ca8ebc62"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0c3a6a523e586b08a"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-0f3c8f23a909070df"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0251023c60d8ec093"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-09b1cb0ad0056a9cf"
                         },
                         "ca-central-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-057ea9d399f3f2125"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-05b5241744920ce3a"
                         },
                         "eu-central-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-05bb287d89acd213a"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-022e065fc2be7123f"
                         },
                         "eu-north-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-06f2628bb886a7c59"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-0981e5a3c1ec8b294"
                         },
                         "eu-south-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0a9a24df99a712d84"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-08ffe4f2f0d6e0291"
                         },
                         "eu-west-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-03a09d7d1c9c6d7d8"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-0e227fd980e115358"
                         },
                         "eu-west-2": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0a410342dbda412fb"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-0a0f3c26da8d539a3"
                         },
                         "eu-west-3": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0ccf7aa5f7e91a44c"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-07058ca7ffb1fb58f"
                         },
                         "me-central-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-03f44e00892d1893a"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-0ed8dc9983db4ff63"
                         },
                         "me-south-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-09bf9f526ed45daf9"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-0da0ff40d6706eab6"
                         },
                         "sa-east-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-06d606bc9d6ea61a5"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-0d67d8eb3be287c44"
                         },
                         "us-east-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0e1197667e37d709a"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-0e6230d4bbacd5ebc"
                         },
                         "us-east-2": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0a80fbe909923cd07"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-0f022dc70d7a2a121"
                         },
                         "us-west-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-06ddc197557635731"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-049b528199f1d281e"
                         },
                         "us-west-2": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0fb04186575f641d7"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-084f89b414e8fec2b"
                         }
                     }
                 }
@@ -207,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "9ff691cf7acac0e2b9629e38bbf03a4d37cf1bec8af84abf0592ebdefc1e7a1c",
-                                "uncompressed-sha256": "84d801060fdd27c784c98bc528632e141f3374a1088aacdacf18c898077d4f9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "a602051ec55530bc5f7861b53949ba5c8be6797ec1c345a16dab1d1eb890c4d6",
+                                "uncompressed-sha256": "4c0b3038d0206ea51532e08083d4f5098cd49f38b2d23b491e4d2d926f0325b1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "74b9093a9f67619ff1f42d941d50d69556a310a748fc16f1b8ef87fb98933c49",
-                                "uncompressed-sha256": "ae3643e2236bef019a90624e6df20568a2188187d4d089761f0f06a822f380f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "13cabebff131717f495f06b713438ac358d69bed2dce0cefaa72112c9fee2631",
+                                "uncompressed-sha256": "fe3577bd806b4c9d98d3d97f0aac851e695d48b2c97c148b5590c831a106b9a6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-live.s390x.iso.sig",
-                                "sha256": "28a186e05bb9498f7c853f8b329f2af1a3c6f4c4ec7e6f4988e8732cdcce16f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-live.s390x.iso.sig",
+                                "sha256": "84d8a9f32ef3a431bec9dc9cd6740f6a01d75c62964d10b7998087eb9eb57a5d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-live-kernel-s390x.sig",
-                                "sha256": "817ecfde938475c79dd93021ad1f87587768ae496d36663e6aa0608a383279ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-live-kernel-s390x.sig",
+                                "sha256": "9ac47b13ab5888eca1a665e6933e9831d2bb0a6468fd4348f51e77fb29aa8573"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "9bfe667d748839154ab35780e2c52770f15abbc809b7bf6bf83eaa84ee02fa4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "4c389db5d359262310a8d1f6213e9aa47d4a9e283b73ebb4f44323f841dcdf9a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "fa815e9daf93da7889476a0bdde9bb6a11ceda6c60b4732b7614d7fe45a144dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "b015a6ddbca1666a9d76e8ee71a9d4587e803c84584c5a7e64532712708dab66"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "b2a8b95284e76b016d14c8e3d27abb04a4d9d2f79f67fd632cbe92af3bed0829",
-                                "uncompressed-sha256": "80835e93c18c17bbc9d7f0ef4bfc80ff1ba5998f4e95fcc6963fd39a764cc012"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "21285536e2b394c62f128dd5339f73d4ae705cdd1120bba60292fdf141128e45",
+                                "uncompressed-sha256": "ebd76030b2f722664c7bb1e3eb9407a42c7b6eb84bb034ef7fc40156d6d2262f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "1756e378aa80282545385439b354ae41b356592dbb00eab4a875f9d06a637e2f",
-                                "uncompressed-sha256": "8d9f5d1503bdb5a8702e3e4c83d1210f241cff06e8577e165f8ec15f67b9385a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "faf2dbe964091827bf3da240113bea79be1e717a4edb537242d9ad70821c7eff",
+                                "uncompressed-sha256": "2fe709454bda5b86ffd22657762022d4376d0aa94b081e700054f7321287b649"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/s390x/fedora-coreos-36.20221014.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "47c937d0aa95bba062c3af3de13de1cbd12a487b0acefc699499dd81f25de24a",
-                                "uncompressed-sha256": "e2ec23bb8e6262f9222332d3a495593efd7c7c2af951f607abb61600add3de10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "d4a6645109398d4b512292304397a563d83b386169f347a8f2897365c1fd82db",
+                                "uncompressed-sha256": "7c36035ca4bd021dc83ce0bec3a1ba3c8f1cca1eab9aef787b8a3e41397b0c4a"
                             }
                         }
                     }
@@ -296,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "b12f3705ad036a266a7e133f772aa6ca5814f994d5351af90877193e6df307d6",
-                                "uncompressed-sha256": "e1522185a7422bcf36011de35273f9b909fb54df8c3ce9b121996192d5ffb398"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "b3eda806b02188e6fc711698121d7aaad71514c63bb21786704e5787991398b7",
+                                "uncompressed-sha256": "1a62274b3e03a71764195bfca91264350d28ea1ce8899e11b32c65a3358909f8"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "0de0d54b141313ddf5f865a972628954f095ed158777be5cd804428bbdcbac42",
-                                "uncompressed-sha256": "954cc2295f6606a0a6269e4c8b517c8e1f37194882f1df7a8424475350a8e44b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "88287e26b2afae452522ec00cd546a3c7ec1eab718421cc3990b5150f2977c20",
+                                "uncompressed-sha256": "0be3cda1185a8b17181eb252c2dc66dd9ceb04dfaa6c7d4036cf83f7ff46f27f"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "3a6f9ce1e6d5fbb93a30228f20105e17d37a9c4b4eec15b067e45bdddbb22293",
-                                "uncompressed-sha256": "b6a60b8ed9193e32498f9ab94a5bf02821ed18369f846cfa9370f236a085c16a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "ad735bdd450827c539b3339ab4ed37c697935d9ece44071cb918e1832ab56dbe",
+                                "uncompressed-sha256": "e99517e5988a74027e1529db382c1adc488431dcf7211b25b86ed82512f538e0"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "964fef40531f09fd1968464b7ce5e4846244ac4a8a562d0340557031c6b58027",
-                                "uncompressed-sha256": "bef984e9e7da4c0a7544b099d68d03bb90850f7015b0ff87e83feeac594243f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "68c5150206898240d46cf9809296c3e25584ea247a53a0aa6d3882a798facf24",
+                                "uncompressed-sha256": "724cd433c398c88cde794a0d1f25a71eba61f8e39ea7e99ccfc5d6c4d85e69cf"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "f861ba6da69c9a050fa1ecbeb69cc1914949dc640705160ea2ca6d7d4e390ead",
-                                "uncompressed-sha256": "0bab5a189eb92ec266241d96548ae010d5a210859c607d181f84d4add14d3216"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "1102f8e3ccf08689853b3a16cb5a53ce2d3bc66d44ea61f78ec6539c68cc4bfc",
+                                "uncompressed-sha256": "0887aaac5dc7bfce20b01a126eb82d63182c6f10c19e33aac53641f93074bb80"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a51347073e88b50dadd2795157cef88419999dae9b364d5cb7dd092d9a4111ca",
-                                "uncompressed-sha256": "dc04d63d91449d14a9fc86958924f21fd15c457d7ad91fd86b2d6eccbabc1d4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "ecd4d76dddd0935d7b0cff5973bce9f91a10b711332c82eade997c4ae8c5fcd9",
+                                "uncompressed-sha256": "462bfec8f8b8c9a4697d0abef0486ad196b69c25de6a3a423950487911b59a25"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "199e1ad363d21423e7c17ed160106f6dd7638639184b695e1a546495ad8d2c8a",
-                                "uncompressed-sha256": "029c936ff360ea284971aad3a6d6a659ac011dd1a43ff3f6c6f85448ed9575d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "3990e611348ce0597f3914e4c90d9401268c8173a45388bcb8a810df0cb479e3",
+                                "uncompressed-sha256": "9314beefa363c31f4ed299826796602cef2ce686b40aaf47cc65321f029260a3"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "69f8cdfc58518800502bf90d456ac76c5ae0d4b141d54818e9a9053b60393d56",
-                                "uncompressed-sha256": "6c4bde723083ac82f29e6665f0b1034e12ddfe6d5176c5ec8e0d82db50d04ea5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "2099f7ca425c8401f1da35cabdcfdb490f87e6f445222104d16450c677afa0c5",
+                                "uncompressed-sha256": "7c2020fd176f2d0000a8a353d71ab1c60f7ac3e8f7c5ffa73b0a5d45b6e11d2a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "47e1c7bf9cfa24859fe097e73ee647d53c973cdac7eef616c9b897aa1b48baba",
-                                "uncompressed-sha256": "e4cb0d496c1ec669f6211565ab5449c068ec5349e74f530aa9a2066b160e4eb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "501bf04fb9a7362adb7965ba2bf1b4b4c56621cbece95ff70e1aa103098db72d",
+                                "uncompressed-sha256": "0d056cb2c037e4afd9893ee3b2f93af69616233fd252364be392b7fdc7deb7be"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-live.x86_64.iso.sig",
-                                "sha256": "bdb928179705959a557fddfdd7ed34d57a194447a63aa5805e8e6055e866710f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-live.x86_64.iso.sig",
+                                "sha256": "9e6d7f82f612be54191c6509cf7e73b473b48af6a70d6795cc74a7587db0aff3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-live-kernel-x86_64.sig",
-                                "sha256": "8ba8c8895e42dd1efa08d338c930bcb8707663ab3a42433584b70c6dcdcb7dd8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-live-kernel-x86_64.sig",
+                                "sha256": "952baf3fe442e051a29b153db08161aedc63baaf4e920ad01f36ab886b3c4bf8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "f78a2258f7ff4d289ab4834b81bb42e4e499827cbefba8babdb1382ecf05129a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "7e8034f34d544067a736d36c075dfe2cea4ecbb09679c9a4a7335c5b56d7cf4d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "c02a7fef891e9580d2806be7e61484f65c59a968083e6eb5477559427e3dd3f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "823eb896391739e6a1083831294053bfff1dd8dc1db12fa58372848122f1119a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "92a7b419c2e2864bb423fc17123bbe0f86a56ef6fb00ad8a8a843db1b2a4b0de",
-                                "uncompressed-sha256": "86ab6a3ca1fe64ed04910cd28aae0029843978cb79ea6a45ed9e009a99bd3190"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "ef0fa96160f6e7eff028dc89e68fc54db8c853b5ae858ef69b458ea158b1da53",
+                                "uncompressed-sha256": "653b66facc1608c60a9698926647740d27b286d079562e295783ea0a21199c1f"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "c434dfdb0bc96d9b68c4b3bc52b5d2b21705164a00003a145c1c670f43f71940"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "e48ec5021f6075954031219f8ed1541ca5956cfa979c9bd865965c3230d9737a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "1f6f9316458f2d8d34ec15aa75c2ffb560d4190aea690c05368c78d769ad87f8",
-                                "uncompressed-sha256": "bc980b8aa6c898f20a6c370aa10d0566d9817ecc7c9dce4509cb2fd2bb3ef868"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "30b9c2dedc455222bf285995bd598ea36bb5d169a83aba31a574d8f53e0abe04",
+                                "uncompressed-sha256": "18ab7d221dc2d532cdd3ae96f6d5b21a811d39119323371875235c8499d82248"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "36fcbb2f0a88d96311abca715f89dbb1804a95ebdaf7c9e1f1773b38e24faadc",
-                                "uncompressed-sha256": "58e6b43a9ff157166b3d06723b17b0607916aaf4983751ac502608d8c02f4c84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "a9920e5eabcd1aacbaf8662a3d3298c2e5549ee055195ab27a801942899ca8a7",
+                                "uncompressed-sha256": "c83924970b0b07ed29b1b87971e5774a483b63e3dbf4b467b7d121f73cd1e526"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "5c47fd27784edc55f3e354857555ad6cfa15f9407a4c46b607425a23526bfc48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "32683ccf2eb23ea2eefa476a79cf230a4994bc6fd3938d29b16a7085448f89ab"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "d77213b8f94ee794471b908dfcd067a9e48d225e8abda704e293392935a2a191"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "0baff97c451b86a52ea485efd4cadf5a1e153c46a1526a731cfc881be5e56177"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221014.3.1/x86_64/fedora-coreos-36.20221014.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "1ef7132dab448ef30cf80be5212929675079f69a6e0f376e8afeb09a2838f6df",
-                                "uncompressed-sha256": "0587a2bb969ad17e2fcab14f1379570c32cf0c64e055ea2b5f85ef826877b640"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "a504101cdb08d2c7e6abbfab505eb9de8004ccd63f67f9ca326d02f4c9709120",
+                                "uncompressed-sha256": "3b6531814d9027b34a72651a6a403985ea010e75f001369bf4039b780e3050d4"
                             }
                         }
                     }
@@ -524,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0c8661ee1060c6926"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-0dc480332ca50c6c0"
                         },
                         "ap-east-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0f6195bf7148e3190"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-0ba8ba0155be404f7"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0414c64aee0ea1ac1"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-08a5a48791191f957"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0084007a62839cace"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-095baff1628883aea"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-077e4fa40ab8e6702"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-087426d7093931bf9"
                         },
                         "ap-south-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0fa8891216ee5689a"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-066aceaa77b563832"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-04b6f9378df4122fa"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-05f8e46596cf62682"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-00ea4d323a9581790"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-041b5ac6d1a09fd54"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0430b0c3736e4b7ed"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-09bf9b81f0fe71c3a"
                         },
                         "ca-central-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0062e38e2cfe0c039"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-03799a89027c854dd"
                         },
                         "eu-central-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-00ff0fbe23149b696"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-049a633dbb614a6b2"
                         },
                         "eu-north-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-08e2459371a6b45f6"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-08bd233e5011b623a"
                         },
                         "eu-south-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0eefac3c163e74187"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-0a89cc729a850577a"
                         },
                         "eu-west-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-032abea8c266c07f0"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-0edaa9c91f5aac890"
                         },
                         "eu-west-2": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-03a17bdc7ad5c45b6"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-03fd47202d909f586"
                         },
                         "eu-west-3": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-01812ebc51b11f001"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-08571b9fdc72b2c0f"
                         },
                         "me-central-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0c29b643b51916530"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-0ddd04962b978797a"
                         },
                         "me-south-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0f390f6f6cbf114c1"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-01b78c1a8e3cc6dce"
                         },
                         "sa-east-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0294c8d01b8c5ad18"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-025d2bd714f5dbfa7"
                         },
                         "us-east-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0103e7a695f6179f9"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-0a12a67a1cf7653ad"
                         },
                         "us-east-2": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-0e82145ef9134946b"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-0b4a4e7fb269f5a06"
                         },
                         "us-west-1": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-02364398b51982593"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-015abecf95012f975"
                         },
                         "us-west-2": {
-                            "release": "36.20221014.3.1",
-                            "image": "ami-02b29cd2f9aba628a"
+                            "release": "36.20221030.3.0",
+                            "image": "ami-002563ba6e9168794"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20221014.3.1",
+                    "release": "36.20221030.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-36-20221014-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-36-20221030-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-11-07T20:40:32Z",
+        "last-modified": "2022-11-15T15:38:06Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "f4c52bf5607eedde4d83676102d57f7b533cb255ba1ce51e2d06a00438586f2d",
-                                "uncompressed-sha256": "5e85bd5647c03c9b8c870d43fe3ce992adeb87c597b3ada5994888e7da21c377"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "3fd88fe15629724716410f9d396addc6e5c25055050af532b7e9dcbc99a0ac2a",
+                                "uncompressed-sha256": "665213154bb9e1c2313dc4914f3a74e42c4e081c565777393d6f3865df17e900"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-azure.aarch64.vhd.xz.sig",
-                                "sha256": "63dffac0b512f703314215fe26906e0008246b377ce92f129fcf8accdadc8d41",
-                                "uncompressed-sha256": "cfbd1bc2985fc23c9fae84136c427ff22b89a6e9ad443eb814cefae21a056d4e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "00a9c56aee88ba3bffa6aa9e83ae1ce4824e2652b5ab4f41c0091f4c79cd8cc6",
+                                "uncompressed-sha256": "55632497bb9a41e1592718492a4e00f4cdc6f26daf3728bb8e2ab059cbf94d8f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "d28e4553b708a59874ad6aefda3fa2cb0709a24d448048f1ff588380cf3cdb85",
-                                "uncompressed-sha256": "23f239eee86cb206fd573d91da9840d23d954499a092be4f88315605104fc3b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "dc8bdc110f7ca7f8349d3557056a8fb6cf7f114616ed6f95c54be0249c0d9934",
+                                "uncompressed-sha256": "9aef787ff8259f1d423d3b94b7983accca7dfcd59147794d29050919cc68e90e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-live.aarch64.iso.sig",
-                                "sha256": "6bc7f7afc04be6e3692c5af3b171674bd7606c1896d4dafde134ec53d71bfad6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-live.aarch64.iso.sig",
+                                "sha256": "a3ca77a1b4f14f7486cf710d5d961f7379b78e58a2e0db88ece9c87429bf2c20"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-live-kernel-aarch64.sig",
-                                "sha256": "30437e6ccfa45657f7e1fb498537d942253bd8677a1c3b897f20a17226bb1d1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-live-kernel-aarch64.sig",
+                                "sha256": "e5f22a13b48f397d17a0b50f7844d03a7f6e81a000b323db7baddc29570001ec"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-live-initramfs.aarch64.img.sig",
-                                "sha256": "079e8dd6dbeccce889b13f0a7310f58d269a627ac4070dde19b0ea8fa13c284d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "a7fc558d88f1de8518e1596cdf965528b235675e47049a86390e625acca6092d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-live-rootfs.aarch64.img.sig",
-                                "sha256": "40dc513cf846537e3f3b77442e46b814fa8ddcf2ad14324bbceb77e886bde240"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "eed6ee7582e68f184ccbbae63ef147619ae260434f63a55ddfd96bbd424831df"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-metal.aarch64.raw.xz.sig",
-                                "sha256": "9437f401568d17985c614b478dbf9915760b080463109780c5ffe09c811817d5",
-                                "uncompressed-sha256": "6fd6fc911c0f3bd5e107d762b5271df756bf848e8f1699f9c37409a9e19f0402"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "4bab44dba5bdc98bf2c77e642de6d746b5441d19cc0976c88159e30a6c5c3377",
+                                "uncompressed-sha256": "ea54144c3ab7567b64732ced93c01bbb599d3d87e5f3dd186837b25b9e50d041"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "a368ee6f9c68ce531e8029a63f5f77127a4ea9b674b289ea55dd7ccade247bc9",
-                                "uncompressed-sha256": "ed8d00491a931297c8c2d9e534bb087f338f0edba860a7966b7998a957699377"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "78fcdfabb338c6bf579a095add75c5ae8f367dd6babdb5a180fbea456549ce28",
+                                "uncompressed-sha256": "7fcc6e27c5e848a9a446b264b13494a8bcb05485d3dbd73528713c6ea935f8bb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/aarch64/fedora-coreos-36.20221030.2.3-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "5edb114f0279de0dc3b473756a834b42d71c1eea304c04bf05f3313c4b57711f",
-                                "uncompressed-sha256": "c6086be6e8b78f6fc8b02d8ef00adf2f001708951e5b2554fbc660afde30f7dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "2d9371e037ede77b006623a9845b0db5209a3d1da4cc9d8a03d4fcdbed10923a",
+                                "uncompressed-sha256": "b35ffea40b4dc6df79408a3bff614805d88f4d0c85c872de13e9ebdfbe9dd583"
                             }
                         }
                     }
@@ -109,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0b1971fbd87b7fb30"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0cd4732ebe74b0f63"
                         },
                         "ap-east-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0a9352d69d7b23cb8"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0165cd535b336f3c3"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-02ec72f808110e54d"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-013b04e8ab847770e"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0b27bd9a224bef9d5"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-03aad0efdfa3ccb2e"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0873f81fd993c0891"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0b66ae40faec4702d"
                         },
                         "ap-south-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-04916ab06624b5db9"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0b16c056f2fc2fd02"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0e92ac3a4bbfab9b9"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0f997b5468e461d2e"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-017a45a86a4222201"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-07c265e4d027e829c"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-087a5e3b711e7908c"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-082b38e3643e61945"
                         },
                         "ca-central-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0b594f3c560344565"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-03116601dbd201d8b"
                         },
                         "eu-central-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-04519e28b9136a3e9"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0fc335670602d8924"
                         },
                         "eu-north-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-08db1855fd430d02a"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-07ce290cc2ba1e62e"
                         },
                         "eu-south-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-07031852884616e9e"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0e039846dbd766a98"
                         },
                         "eu-west-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0cbbd336faec78a34"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-09c28b37a137d748a"
                         },
                         "eu-west-2": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-01e56ef0cfd91f020"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-04a7b9c1e1371d44c"
                         },
                         "eu-west-3": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0635c2769f99a05eb"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-00fbe5ea72643c8c0"
                         },
                         "me-central-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0354c9fecc63ed0a6"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-08f031e1722c3d1fa"
                         },
                         "me-south-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0bc3df67121c481bc"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0b547baba55dd9cbb"
                         },
                         "sa-east-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-058c87938eb7d3083"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-02887e1ecac556b7a"
                         },
                         "us-east-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0371d2fcbaf9e0a89"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0f1d063b0e1e01223"
                         },
                         "us-east-2": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0f3d047ee5ef5bbc3"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0c9a7d1e1a90fbcd3"
                         },
                         "us-west-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0a0a975155e4dc313"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0dffd52201b65b6d2"
                         },
                         "us-west-2": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0b1786312284fb83b"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0f66a72d1d55bd7cc"
                         }
                     }
                 }
@@ -207,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "a2f4b168599dec4155074487c62aada90bc62080fc797bb660b30563b2c931ee",
-                                "uncompressed-sha256": "790c833f645888ed1d5d3e72075ce2fad7e56f43462c9bd4e73aaaff5caf1f9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "d386b536f25650690589225f76ee708df87df239fac04aedbb523db6d6477732",
+                                "uncompressed-sha256": "50c9479f82b462e7a2498d51b9c6ee0b5e45e4addc7c1d12cec2706ac4c66901"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-metal4k.s390x.raw.xz.sig",
-                                "sha256": "c49d07bb7bc97dc7cfeb23f694b59a7ff108f16d51f15af7dfbd9531e1092609",
-                                "uncompressed-sha256": "4c5124954613c7b5bd21f10c584775aa0a73d6ce409cda3e376aabaa48dd1887"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "60c4a0e0637f44052481b1c1127ef3973af7012f883bf20b03a597f3937d8100",
+                                "uncompressed-sha256": "1f7cd7a17cbb8a86c95df73909582bfb500109d119c8ff8d25993f226e96cdff"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-live.s390x.iso.sig",
-                                "sha256": "98389f411dfe3cc1ee42a796e597e36bd7cf9ec93eabf9491d2918c94c687509"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-live.s390x.iso.sig",
+                                "sha256": "f9dd78778fd596750fc285ac055eefb561adffc27dac5a80cad77ab60588677f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-live-kernel-s390x.sig",
-                                "sha256": "9ac47b13ab5888eca1a665e6933e9831d2bb0a6468fd4348f51e77fb29aa8573"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-live-kernel-s390x.sig",
+                                "sha256": "75cd92f1654274d8b446969d2c966892e8af5b5398bc805ae243d7e6da09efd0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-live-initramfs.s390x.img.sig",
-                                "sha256": "16af8503d4a1a4206316c8a7d36b127efad7d033b18ce0b97f8b35844bf1dc87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "328584c97be42147b5d1ed26130082f7329be3e6ee2e115161170dacc613cba4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-live-rootfs.s390x.img.sig",
-                                "sha256": "39da15494be1d593ed9fc8f0aaf83ae27869700cabd1dc01232b81bb447bd46a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "e172b9fe21d78083c10c6e308ac0da09a57728f1b4d73094db39e3f08c6eeaba"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-metal.s390x.raw.xz.sig",
-                                "sha256": "f1bbd9972d50797797868f0fa13c4ae37af879b5a4e61edbe43e5cff59c03939",
-                                "uncompressed-sha256": "8ae8a96ab0a2b1f9831b61a613a6ca34e38a10275fb89252278b84b8a3efb492"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "7bb52c197a38a7a03310f2b8bd32afc3af0a5588d383a176b2afa1293d10c0ec",
+                                "uncompressed-sha256": "9b588b4c5935d6cdb319e733881aed45c1d5ef77162aa42a1a9ad09611bf5acc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "2fb1a5c4423851c75c61ff4ebf13e97a96f56891f31b00388706fb89d4dccecb",
-                                "uncompressed-sha256": "b305944b1331a1f688eff53683abf0e28d9d4dbbaf92691cb20bc6e3bdc9eb91"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "d5bc88236e4a82ef13a1313f5b24d53a2a131f3beb121344ef2867aa56da978a",
+                                "uncompressed-sha256": "c6e94d4f2e2f6750fea83c23ec2482da5f956428608cad38864361f7ceb48fa5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/s390x/fedora-coreos-36.20221030.2.3-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "3fdeccc35a0a2914903af8d6b0285161578dfc472b742c8a28ffd57d6fe43a46",
-                                "uncompressed-sha256": "b61d28a2787f9b75633b6b9606ef2a116bde38f11736c8bd06af05467203db8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "dcb55e3fbaa5b0d6c94570a9552e409c8e83eb9786236f4ca338079673688518",
+                                "uncompressed-sha256": "e40edaab4cf1926cd999fafdaf04c135199a80d115e584a94baf95d8f8b76ca8"
                             }
                         }
                     }
@@ -296,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "f57eabaaa209430539ceb1540dc77dfde8297ed18f874888d5a393702b4b4818",
-                                "uncompressed-sha256": "42930a90e3c8b770dbc78b99511ec4237222d479ae66997c51641cdc566b5299"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "69142d5ce440e918a49d8b40c7d517cc071ccee6bba441fcb70c06d3f5ab0932",
+                                "uncompressed-sha256": "c64044ad6266892ff4d233d11498917616b36cc05a61c6d187072b7490a3deae"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "0608a857ea984f4365b7dcae7134181405bbf1066374034ede79c0a6d6da86f6",
-                                "uncompressed-sha256": "4ea8e453f5a0a0be3357472ce4de2e22d2c87f3155373fc4951708889eeddbb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "4465459d63767cf10371f16e30493136663225173a3357a842f93429d18499ee",
+                                "uncompressed-sha256": "424192bb9c70acf365d35848a0051f7299904504c7c049200f5b7ca0ed6b6828"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-azure.x86_64.vhd.xz.sig",
-                                "sha256": "8f3cc9d67e3e0a6db5be942922c79f981fa7a4a86d319de9aeceb88e5f94ce22",
-                                "uncompressed-sha256": "1577bb9ec3cd7034de93ebe2e328d4df1aadac87ca9dc58d7342004cc615717e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "61131cb844634511631dd9dcf5557a377abce48723480ff5acf6adf982034c35",
+                                "uncompressed-sha256": "e40f996e8545335dec274772304b8e6d1c59f7cd80c6e598ec1bed6c8d1b6331"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "58fc312c0bbb730af78d95de581b4008ac03762c134dd48548ec194206db6a86",
-                                "uncompressed-sha256": "54265bc18180fd46442adf1cdd998884d031fbdfd22847ebfd61de3b4e986c91"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "2ddfc95da04bec61bf022719ef0c3cfa03674c59ad533a5491e1c823f68c9a6d",
+                                "uncompressed-sha256": "39c6381651609341a8ae5a2f318e87762eb05e39d31102fcd9d14b7190230b71"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "86feaaae8ae57fcb0b30495fe18cd1a19a42475191a1d64828991846149cfd1d",
-                                "uncompressed-sha256": "fe8d77087843366df031ced897922b4e406cc0b4f5ea739051bb45f54e2a14d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "a5ae2b62215d1069b0b662b18f0b4136d400a921a89430eada4461ac61c45c20",
+                                "uncompressed-sha256": "3869e2e85e0349304a6d5c39383ee81a3d1692768e4b7d5fd72bec611625315d"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "cd69c99637f19c1199d4d4141ca16cb88e5d3ab4fe5b5ba4fcdae27455dd0090",
-                                "uncompressed-sha256": "b0e778fbfa3f5fbbf40b010c0255c3ff64d30ccdb1371f0c1b521bf3a8935e08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "37ac18045c0d8a44037206571203acae133520be21cfbf228d56008b98aeb371",
+                                "uncompressed-sha256": "29e060f7dec1a8000eda79efc7d58b7fb5e6b835f6438a74ff4804ab3db9dd44"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-gcp.x86_64.tar.gz.sig",
-                                "sha256": "422f07354e7604a5e50e1d9ff3ba6a745f883c25b2eab468e12262fa30c98b0c",
-                                "uncompressed-sha256": "51afb7c6903d076fe6420d0d6dd10b9496fd3d6d1d61e6baecf14c4dbdd8eb20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "5fd31ded051203ca22a5eb35a17f37a9c4b612f688f37c4208ed30aee105e8f8",
+                                "uncompressed-sha256": "9dd8a25e86c956fabc3e91db9b2cddda8a096ef7944ebc00efbca0c02a3690b0"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "2ef5561acad05dab10e253776c7e8ee01bd2789314d88c2dd472fedf1cc871f0",
-                                "uncompressed-sha256": "b0d6f3edfa56ff6935902ccd156dd374faa8eb3ae174bda0f9fe354684976f7e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "28c1884e2f0bac281a3fc3851a6066bfa4781aad36057ca0ee72a29838b4ec24",
+                                "uncompressed-sha256": "4c7ad688572966ea4ab0c6f2fbfefe4020889012ad8889555c2bced9e294682c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "cd43c53040c2ee8bb8e45bfa2307e49de7d9058b21e03b1762aae9edc47ee5d1",
-                                "uncompressed-sha256": "34e44a5ff4238d082e80f4ca25135d538013669334d171ca7a5d420aadcc916a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "489e9fc51aaa9e8f57788208a7b071adf6475153c19b879193951549ec29a87c",
+                                "uncompressed-sha256": "f04e25d737105ff3c79eb1c7195ea09bb03ab811a0835bd8162eed4cc8c92ae2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-live.x86_64.iso.sig",
-                                "sha256": "734a5b469ec22b9644f332c8b8bab61a621457932cf8da215dc620577a974558"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-live.x86_64.iso.sig",
+                                "sha256": "3386d3be54b2cd456f530399bf0774577eb7be1cdaef31baf154007b611dd94e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-live-kernel-x86_64.sig",
-                                "sha256": "952baf3fe442e051a29b153db08161aedc63baaf4e920ad01f36ab886b3c4bf8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-live-kernel-x86_64.sig",
+                                "sha256": "2bd5f834349313d10a9dbeb41d9f71d985f7b9c4f7e2ba750a1dd6558f082ba9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-live-initramfs.x86_64.img.sig",
-                                "sha256": "3fadda34249317218ac3b7ec04db02a4a8cbbe72c760c6b0cc0fd5b182dc975f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "4f2de1752c7c08aa50021f19a05de4c3196ce212de764671dbeea2e15e5d6a3d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-live-rootfs.x86_64.img.sig",
-                                "sha256": "616203b8cd62a1d32ad64178ba356049139dc99d3298cba43c35897c9133a976"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "f92e60abcc7831df7ed1de93586ccf2906707902717ece97abfb51b65d8bfe08"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-metal.x86_64.raw.xz.sig",
-                                "sha256": "7fe2b4eb6dd19c947087483f55f1f6a17d657195f957178ac085c1ed4cc10f13",
-                                "uncompressed-sha256": "8c6c882f352d340be3146f245ba7418056e82ceb36a948aeacd9af106e3e56e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "801161dd4c0cc075584467b330cf124fccb811ce8e4fe8998b2c04b3062f56a1",
+                                "uncompressed-sha256": "d4b7d066be65ef1f331795753ea58f3187331f89f9b895e037d53772f04bb26b"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-nutanix.x86_64.qcow2.sig",
-                                "sha256": "dd2cd65c8b0a492537f1570de9c120c90fd5193c2432ee07366364b3e38297e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "b91966af45e197df8acfec2191f7a8221c1303109c29bb5c51e74fc6b80d49ce"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "93a10d9c9c0b8a581037634215cd86ee0f6ece31dd41a3da79168a4da9046812",
-                                "uncompressed-sha256": "82878e566564f16cde7f1dc757aacfe1ecf29e596ed6ea733a187e5afcc571c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "526aa0067c26294f4df3c39e1b5677187e9590e1f8ef38e3ef07a4dca7afe213",
+                                "uncompressed-sha256": "af22d3e8e2719852aa8fb857d26bcdb39b48651b4141a310b9bbec8ff402f9f1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "caf19caeaaed0b04224b4736e080d04e73e89c6d9d38c60fb4517094838e2cc7",
-                                "uncompressed-sha256": "04d224a27a97ce3ce517fb731e7037efb5051eb9646eb23bcdb351770c28f700"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "337252c938d772666f6c245d9f556f554a1bd796562fe0c8d4b79014f68b79e1",
+                                "uncompressed-sha256": "db609b8a134d0f4e7551136a415b2408a46013eee4f0828dfc8a854cb4cb3811"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-virtualbox.x86_64.ova.sig",
-                                "sha256": "a48da94ff8dc696d3b151e837a8f097c02d7a8058c6bdc87baa53c59fe51291e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "540cfedea2a260f35be6dd4267847403cd362cc6b86f31a6b0ce89b247b0e4c0"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-vmware.x86_64.ova.sig",
-                                "sha256": "7d13778acd01692048135266d032048783670cbabbc3c815609798d8c8510177"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "bd8606c2cb940d2c48234451c4d4cefefd5cbfdfae66f1cbf898c15614a0683c"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/36.20221030.2.3/x86_64/fedora-coreos-36.20221030.2.3-vultr.x86_64.raw.xz.sig",
-                                "sha256": "efcb7faf8239d7a68769938203710d62a9bd354345dcec40e6d1da3a13954a0a",
-                                "uncompressed-sha256": "aebe67a63ab93f1e8690dc379f179cf24cdfa8766cb9e15f6411fcfca123936b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "1f7b428e999d75e49d79d38e3012bf662d38a5bc239993159a4fea3ca1a5fd51",
+                                "uncompressed-sha256": "652b324756aa4f252038e58b2392808df0edf0aa99a537c56f2cf7519e0ff28f"
                             }
                         }
                     }
@@ -524,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0dee918920b4ba998"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-00a1bc3948e7ad1dc"
                         },
                         "ap-east-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-020eb0033dc290d20"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0ddf5cc3fbb322a93"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-02d613915c3a89548"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-045e30e32298d6a7e"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0c34b40e7180c1cd6"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0e3aba425260a1734"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-01a1a5ec96c2cfb38"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0e721e17aaa2f163d"
                         },
                         "ap-south-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-009a514f019018b53"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0d832ddbcdc20f345"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-04f77b491b4a4989a"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0ee76191fcf5e9385"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0588a8217098bd038"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-06a04637ba695e440"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-06f700f8797b0d6d0"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0c22c848a28c9c31c"
                         },
                         "ca-central-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0889518725a653994"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0d481b5731ec5766c"
                         },
                         "eu-central-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-036f66d64e0164b8c"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-05cb1e8bf8609e334"
                         },
                         "eu-north-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-012cc14c3a2562d91"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-00ac87cb194dde7c9"
                         },
                         "eu-south-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-052ea5640534bc798"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-05ce32fa7d80c1c90"
                         },
                         "eu-west-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0f67c3be09960a4de"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0e442817c9ef0fe47"
                         },
                         "eu-west-2": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0d0cf5fc29987a471"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0b7b9e1c2ab18f126"
                         },
                         "eu-west-3": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0135792a18fc0677b"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0eb3865b91026540b"
                         },
                         "me-central-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0399fc6453413a821"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-056287fc70b94f412"
                         },
                         "me-south-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-01b210886631f4342"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0062bdb66696f52dc"
                         },
                         "sa-east-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0ececaef6efe8a10b"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0e60ff82e6d321841"
                         },
                         "us-east-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0c3e3ffc34004bfc3"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-03a7141a04bf3bf97"
                         },
                         "us-east-2": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-01a26db2cfab08377"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-098f0f1c20560bd97"
                         },
                         "us-west-1": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0ec27dcf53d3a25b2"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-021f25631575cf6b9"
                         },
                         "us-west-2": {
-                            "release": "36.20221030.2.3",
-                            "image": "ami-0b631c8759a57190c"
+                            "release": "37.20221106.2.1",
+                            "image": "ami-0ab66d8b13bca9cd0"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20221030.2.3",
+                    "release": "37.20221106.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-36-20221030-2-3-gcp-x86-64"
+                    "name": "fedora-coreos-37-20221106-2-1-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-11-07T20:40:34Z"
+    "last-modified": "2022-11-15T15:38:07Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "37.20221031.1.0",
+      "version": "37.20221106.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "37.20221106.1.0",
+      "version": "37.20221111.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1667919600,
+          "start_epoch": 1668535200,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-11-02T18:50:22Z"
+    "last-modified": "2022-11-15T15:38:06Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "36.20221001.3.0",
+      "version": "36.20221014.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "36.20221014.3.1",
+      "version": "36.20221030.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1667419200,
+          "start_epoch": 1668535200,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-11-07T20:40:33Z"
+    "last-modified": "2022-11-15T15:38:07Z"
   },
   "releases": [
     {
@@ -77,19 +77,22 @@
       }
     },
     {
-      "version": "36.20221030.2.1",
+      "version": "36.20221030.2.3",
       "metadata": {
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
+        },
         "rollout": {
           "start_percentage": 1.0
         }
       }
     },
     {
-      "version": "36.20221030.2.3",
+      "version": "37.20221106.2.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1667919600,
+          "start_epoch": 1668535200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).