### PR TITLE
Roll out stable 37.20221106.3.0, testing 37.20221127.2.0, next 37.20221127.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-11-15T15:38:07Z",
+        "last-modified": "2022-11-29T08:58:13Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "5d49e0ec321bf8a5715075ecee863c9d394db7e712359d61ae7f950c1736c5d3",
-                                "uncompressed-sha256": "78410912dc92d627bc4b69ac49962fc572ec5e96ee9c552bc128398ed8643a2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "52ee5cdbee8fc5c2673e3c12faf0784646e8a522ccd7fbc748d14b17ce430aac",
+                                "uncompressed-sha256": "a1212f268bd905734e63125108e20acab9d09cc9d7a961edf845283980acab02"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "d954cceef97e09a933d08d23092c396407f79fe16c1412c830ee6b33764f8a0b",
-                                "uncompressed-sha256": "ad0df45b03e8b23fb713293a20e2a15a8dda1fe6fd045abb54abe526d66f2be8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "172cca47d23554ef65100a655f5279310e0ff6755c233f14b8f2e72fa9412049",
+                                "uncompressed-sha256": "65e16823e0ef8ec40ff1a6302473136c842d73938370118e42f4689fdd3e6875"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "347a0e10c4850d2c5b3ae74f2ed5701e7e0224ca230d077c78ba196bc9660434",
-                                "uncompressed-sha256": "005459cdffefeacae8af7356ed5fc1d8b698e84426362bd790f5cab532d22cef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "cf2681e454d66431be20a88af2100b6b435467dddfad89a22b184b63bbd91884",
+                                "uncompressed-sha256": "021abcc86936912c4e77239b9c900a58c3c847c6384c4895d72069aa0bd971ed"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-live.aarch64.iso.sig",
-                                "sha256": "f72322c4a494b6c45559226a9108d73e14f3a6ffd3c2369e50c18be82dd3289c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-live.aarch64.iso.sig",
+                                "sha256": "7f56df1c033e8bd7d7d2f440cbe0f0b2ecccc02ddcddb3e0c3ab961328f7d724"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-live-kernel-aarch64.sig",
-                                "sha256": "e5f22a13b48f397d17a0b50f7844d03a7f6e81a000b323db7baddc29570001ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-live-kernel-aarch64.sig",
+                                "sha256": "034552dae2f7f2f283951d6197fd2d0dc4a9f4dfaedcacd6beb2814846971586"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "9e1eda26e3b437808dccd08e78c9bd7ba67e3599acb9b748288a48cbb86c311f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "7c85f079c93b4e65eddfb6fa9b88edf1f1dc4a4b71632314a332763a1d0c0c09"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "25b1f64a7624c14e35e901dc80db9eacef3dab8b3b77ecd26fc63b564ead2e0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "d134e7017c8d31dafe0bae0726bc61737268f5cacc3309a002d88fe288a08075"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "acdd8122d8a12c379abbdd472b7be934306cccda2310b991d8721d385290eec7",
-                                "uncompressed-sha256": "c2591c3f235294d3b9aecef17f6dc5e1446d9f4cc6c395491e9e08ff930f5177"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "c3b8024a3a58a828cf17a10fd33957306f3ad367d3ee32931318d896229c8c1f",
+                                "uncompressed-sha256": "41c6baa42bb80e2a5198393a3547c2f51a705c86ba7cc81f717135b516f79727"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "4976e45e90b6f92afbd1c30bfda11ad264db378bdd9b5d9bf8626cf8b5f49194",
-                                "uncompressed-sha256": "6fd290c61877809e5a6ba8c765496f65fa624fec02a4cee8becda16b32c75701"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "303fbd997a49ee07b085f305de6d9e76a5a14074d9d49062112bb6d1f234f60b",
+                                "uncompressed-sha256": "deeb94db277f3147abba084203747f011c81e774b40f5cd4bbf91b486c4d9c5e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/aarch64/fedora-coreos-37.20221111.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "6a773e82fe7e17c208a1dc84830a49de94a5c8800adf808e0af8c34349e95a45",
-                                "uncompressed-sha256": "b862e914a28d01d5ecf719f8bb17f410bb18aede30f754f6c6993011fa68d9b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "0c1adc4bfafefbca2b60080e239b08bee36e16333ab26e6e101bd892689eef58",
+                                "uncompressed-sha256": "0acb76147186367864aa56eff8d5599d5534c9adbfdcb3b979cf440d42675cd1"
                             }
                         }
                     }
@@ -109,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0a92dab1342e5fbb3"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0b7a91478050d7e01"
                         },
                         "ap-east-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-07dfa1278e0f7dfa4"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0f1f0e1b5ef765e69"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-01f2c3b5dba7a9ea8"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-071f37b73b6423d28"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-08c225de7773a837b"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0990006a464d26a54"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0d3d213887853fdd6"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0e353adc728810d85"
                         },
                         "ap-south-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-03a3518e0793fc099"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-053a71075d21945b0"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0be25ce8f542096c0"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0023ddcee98045e88"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0bb889c951b0fdd72"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0b88d1a2e529d9ca0"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0ec8eeb40f1f7627c"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0bd103c2259e17e94"
                         },
                         "ca-central-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-084f604532069a024"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0c01bb2c8e743fd40"
                         },
                         "eu-central-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0aa44b5dcb2495e98"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0b316e33d04aa1008"
                         },
                         "eu-north-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0b92e506c5d33a518"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0a59d00b2a6016e08"
                         },
                         "eu-south-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-04067fa2789e8c95c"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0d705c727dfd08460"
                         },
                         "eu-west-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0d7a077a34d94ab30"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-03ae3cd946b4f8d4e"
                         },
                         "eu-west-2": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-08e2438d2d1835c0c"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-06c0c9636897fb614"
                         },
                         "eu-west-3": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-02266f7199d1efb87"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-04aec8f75c8eb6a5c"
                         },
                         "me-central-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0e67dfba9b2499776"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0dee3d64bd4bf423c"
                         },
                         "me-south-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0ee31a6cb48d2ce21"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0d26b8bce9cad7822"
                         },
                         "sa-east-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0c6eabbfcb0b935ae"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0c2ff8579a3465d95"
                         },
                         "us-east-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0422f0b5f52345f4e"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0484ebc0d3b1551f5"
                         },
                         "us-east-2": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0afcf8244a6c481ca"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-08e8a316ba8352bcf"
                         },
                         "us-west-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-00889b2cdb960363b"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0f418b98305b096b5"
                         },
                         "us-west-2": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-01b28424aa8656fd3"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-03a406c9798da2582"
                         }
                     }
                 }
@@ -207,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "6a013fc53eda04ff213abc298a0e47b4f71ffc2e30c53f437a13990e2ef7fbb1",
-                                "uncompressed-sha256": "fb234571fa1553d0a393e08218091b6d74001bd4d5293a57892d2fcac6c74e14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "534406d0328d05b82b8f1d3ba4088763ed5bd541f5ac44049c73607d06c52883",
+                                "uncompressed-sha256": "227405a891b2ca3cb92024035b3349356b6afcd8ae837b805e4495887f7f5334"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "1e65ed939def3755be423fe313cb3843444ba1719ab9def7615af87414bde8e0",
-                                "uncompressed-sha256": "533723ca04836b92d35a7f5d3cc07c7281fcd87701df3d76e3159d1456793277"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "6d51e6c7370fe4c6dab5cc890af53b3b0880ed9150003d7ba1eabac165e8ef85",
+                                "uncompressed-sha256": "5227fb8ad9f5f40f1626fd08b49a2221e4b0329733ae1d0cf416ebea26bfceb5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-live.s390x.iso.sig",
-                                "sha256": "4ac1cc28b4fa811bf00617115360d3035221743f5dba76a979c83fe1a384a3d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-live.s390x.iso.sig",
+                                "sha256": "a6790d77132a5e51c7c49d02150092dcdc4d27db10b465ae4c69faededaab1ad"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-live-kernel-s390x.sig",
-                                "sha256": "75cd92f1654274d8b446969d2c966892e8af5b5398bc805ae243d7e6da09efd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-live-kernel-s390x.sig",
+                                "sha256": "b3633b401b13e13ed7d361662e780f8d6782473b19a430dccb7882c03652ccfc"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "a1a6ac90c94f1426cf5617e066bbbad722ac6a1fa953fb1b1921c422b03770e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "3251766d174aa3c4dffd2614e22370a8a996f65d6a6aed167ac38021352eba18"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "2f07717b00a091186a7ec9774956b5dd1798e368cdbb27ad8d23edbd106330dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "88cf6af67deb5faab3d5491b99517c7016e23ae788d1d9dfcaad178534fa678c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "926c51de20ac2f9a1cd91bd2da08f6456169d3ae5acb1972ed7f96998b0043f3",
-                                "uncompressed-sha256": "bb36df255473e503c7ae567b1cb505f7fb2ecc0c3713f7f70bf08e0e90e3b9fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "01064c33b32e76bb7377502bca9be8a43e4eb8fd9c34f73288cd341e4f36ab7f",
+                                "uncompressed-sha256": "076cdffb6aaab253de053716c50a30e10e2264ef5f645b0f59a10a6d241382e5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "ffba64633e5189244e65144c2aa29153f07231c5df9a92a5edeae9009982ec26",
-                                "uncompressed-sha256": "78a598f410411008c63bc3ff8be2a4c2f3203de501ee1be92c3728b8c9b44773"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "d7a840310279a2a26e87d3d948d16c0e781fbb088736998f533cf4b17cef8637",
+                                "uncompressed-sha256": "ef64eeec3f832809a877f860da3690a13450ab28d7b04319348d2258348215b1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/s390x/fedora-coreos-37.20221111.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "79c776ecbd122ebd50cae0bf1f1f74569f59f05c164bc48a79c253da7df11a93",
-                                "uncompressed-sha256": "5c17468005fcf3aab082e42900e46b57546659518bd06ce56a888f32c25930fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "df6a5f635838d1f5e0acf7f84f2abb3a5b1c95f14f59f4d3d8b1dcbaa352b046",
+                                "uncompressed-sha256": "7d4357058a913d8dd8f555a62ac375ac47b2d696ea8fb0f3d4fb40847e578b72"
                             }
                         }
                     }
@@ -296,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "239931b4cf0021b73b695c524c9897196503475e17bcba979f5a6a42afdd6700",
-                                "uncompressed-sha256": "7e6eae3b31ce9475b84a6837076cf8908b9b9e55fcd10d5a509a497373431e88"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "6d14409dfd8c3443b007b429a96379cad76b90e8bff513f2ffeff6d840ee2337",
+                                "uncompressed-sha256": "85257d1bcd5b21a5c8d32adee2e6d6b79254dea373bbb69f90fa8633edd75430"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "b4e3d4c1fc65b5494cc2221dc13a6b3b92f3c99072f2a88020a9ebce8d38aab6",
-                                "uncompressed-sha256": "244e94e28e439da8eb3870896fd44e450d956fae4a979f918946b53440b02493"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "25176e4a665d80c27f8949a54a93e8936dfde1fa6d2d368e1082bc6b886c4277",
+                                "uncompressed-sha256": "938681af636ad4072922633ee3a5a8a521f9874bfdf22ea0e29e0c6cb71f90bf"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "803792fef65e4c82cee1ad412e9602c6ea240152dddf4ed0038aa32ac73b1f51",
-                                "uncompressed-sha256": "6efba7b901566420d62a150f4092ed28e285922aa67ee95e29e1a89c0e187d84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "7e835a6e7e9f84c19c112f7ed94f044bd1917144f0e28a6341eca41e434d78ac",
+                                "uncompressed-sha256": "fd1d79fd6e133925fb998610f06a5d55cd8a6ab1d2b89b1fc509c11207ea1817"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "67d676e99119906b96caaf265f957a2d5a63dfdc4d12cbcd7c53dc5cdd911dc1",
-                                "uncompressed-sha256": "2381e1745af17b133ef3ed9325c13e75a3a0ee81c15299b8c22ceeb040a45da1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "1cab59760860f988900c074c6649639cc49c0dde842870eca9466c574fe4fdef",
+                                "uncompressed-sha256": "36b78ee183a3595c8a97dc779ccbd921d464240142ae799c72eb7b23e367af2b"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "4727cf7dbbaefb0c8adff30d3b8f158902806902a9b0d3212cfc2b6e77c04103",
-                                "uncompressed-sha256": "51572c88822b8b65072a6c7f1b067ff3a6966648374d8b97984a64b5f991afd2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "651b97b78b917961cc78d32870377ef28930bcfa457a60e1951e886a2d4b2f42",
+                                "uncompressed-sha256": "5b23cddcdf77988f7709686aba017b4549cc55258bab1dcd3583d1a610b1d490"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "07c834465a6a29b632105d4068577a7efbb4aad61273a18a8f1b59548db65989",
-                                "uncompressed-sha256": "26e142f4803a24b5fcd4688aa71e38581c0ee3d32fd4497f08a1e3f8f89e6df5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "6d65db02eef86c1a5c6aa5930890778b93397ede7d324dff478b1d7d1ec63fa9",
+                                "uncompressed-sha256": "7961bea4eb7fec757ece1a8b9e5513c41f01aba9f0c57409dc5a1996c5262aa0"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "240c11d5c582e1468209b38670be4a50f7efd46ab937ef9a2d60bc1bc15e7824",
-                                "uncompressed-sha256": "02cf06d6dd55262f55b953916054ec7401f4bf9b0f77de65bf47cbaa93658b58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "1e24077807cb6ff270e3154f502e9dec787f381dfc6be1828fc2c2c4f078dc3c",
+                                "uncompressed-sha256": "ff689de04b80c83e5109c44d704d7a72bacb53f398f3b6dc49eb38e5c3d02863"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "08f3fc9b9ba81bb62b91dd133718e2f396b2aa9ee87d33da282ebacf7eb8239f",
-                                "uncompressed-sha256": "10c1afc46d47a06a7d2898c2dc22d67b64890d52cd927b043f9320d64fac92cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "ebc0069855a12b26d873459ce3125b51a8b12d85e5b2e3b3546eee2e23968824",
+                                "uncompressed-sha256": "689c3745c7de570230a8d8921f37ed29041169d467138cf45221aef929eb0d47"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "f08ea481142f8904cbe535dd1668f88990613d81992dbffb4642218a7dbeaeb8",
-                                "uncompressed-sha256": "85fe7cd0dbaf22e3ab592dd6a5a578b828953e3d61cba911b0863b7b87bb5d46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "49a82064618e9dee26c8d3329c5e6550874e75895a4f22fb331b420dc5b65fb1",
+                                "uncompressed-sha256": "d9bde61bfea0210693c83aefb767daa2f8a9c6bcf28d7b22df4eb1ba639f9e8f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-live.x86_64.iso.sig",
-                                "sha256": "8d1bf83aafe26d489181785cb7d892a56c5c439bbfba7125237006cfa7865abc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-live.x86_64.iso.sig",
+                                "sha256": "2a96c4b360859be6c9900be1226da33a2722a73954a4819a6b05aa92611d3474"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-live-kernel-x86_64.sig",
-                                "sha256": "2bd5f834349313d10a9dbeb41d9f71d985f7b9c4f7e2ba750a1dd6558f082ba9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-live-kernel-x86_64.sig",
+                                "sha256": "68077e35ec7c697edbea4b5d8e6eb230eafbf3ec6ad42590da02d42e4bb0c08f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "cc6ea008ae1004f7189f91e2a63f67dfa444b4d98f2e5971da82257f1ed3a524"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "a73571dfdb8533874301235c660273a90f60f1d76891ceb46dc4388b0942323a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "0de66c27349b3b12229baa933d5e41a0160c7ea48e5bd0331a3d617ecc092e62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "68177446703bfa6685620828f76af046c1bc4b2d964ab547be3e0dac45833095"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "497dc700075433f2eb42c707f187d507b36d243f13d2ac406e78dcd0cbb4bc99",
-                                "uncompressed-sha256": "a35c935b53088abd44bcbce3e31d394df54c21b6b74aa609330c28fc65de6f1f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "85922deea81d6edb4b3bcee71617b320f181c89930c620d54c3819a7eb2730c9",
+                                "uncompressed-sha256": "019c3b0bb1405a32d09a540138c6810bd185a435ce85cd616dd484d371a6c3c0"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "6fe9e9eadd1bdeac164b8b191f641b9153cd7cbacc8b8834902daa555487af2b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "33879ec4cb244d18812728f10919d05244aa9d2a0cff6bffdb54ab0a3bfe7d74"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "b0b444743be3ab2819b1441677df4e5b042b77f65c9154dd3506429ad03e79d2",
-                                "uncompressed-sha256": "da68dfada75807c348c7d1be92e761ef228e4f658259dcc5fb6946fd449ec982"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "73146bfe19e40219f02d6b9f553a60139a641b06e322f034e40a2981df78aed1",
+                                "uncompressed-sha256": "da2bbed4232fc892c47a0c7a99bf6ffd8885f6a22ce62ce0bee9d477f47faa26"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "aa1eef11464a096cea86513c54ccc573aee8880f28e69d719056b8419722ff56",
-                                "uncompressed-sha256": "d16b76c581bd74c9499f8e89d49ce72cc56f9ae32ba761369c2171e7d2aa1527"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "ccc0cea0ce92c58df94e97f9d084895c941a7c159b564d3fdc531813f7f60637",
+                                "uncompressed-sha256": "d9b9dbd340f193aea3fcef451c34a9da18c4c6d3f1736c56ac97e3803b1e60ab"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "4e942664c84dd472cc7516b9d0fe3d181341353192fb263df43b8d86db6063a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "fb482315473bb2b867eb2bef60a4d89e640de5c621d345581a0c1b9cecb5a34a"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "f4bd15c9cb87ba12f741b574b1096d3b52b7205dd924c17e2dada499985ac756"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "09ca33fa3d835fa876223a5dcbe14dc3dca7c88ddafdf9b67199bb710f410a59"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221111.1.0/x86_64/fedora-coreos-37.20221111.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "23e25c80a275b90dd205a6c31861555b01df4f53ee533c40e187bfa5ae72901c",
-                                "uncompressed-sha256": "ce2fa87f55fbcde117af9a0dd916e738469c784314b7d5fb37d730422c1742e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "92e36537378b91da9ce742018edec84dae58b612b1c0573739a87cf41108546c",
+                                "uncompressed-sha256": "0a458b175c6010f08b94ff9d3077db7c4b1fd9419313759cf39aeac83e973237"
                             }
                         }
                     }
@@ -524,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0d7b07c20c4a5548c"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0275c46e8b5fe8e75"
                         },
                         "ap-east-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0a0889b78c00a1bc1"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-03f22b9e68b2482e0"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-086e6afe795c65396"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-019f04935d310324e"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-03dee867ef15b89a5"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0c07fd79b132ff68e"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0977400ac6ce49a6f"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0343c28f386fe464c"
                         },
                         "ap-south-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-01872894d3469cf9a"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-09de33e51006ef754"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0ac8315e08bb1b4f7"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-00277bf40700e60dc"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-002c9a2cfbebe1580"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0b76075be0d38ba5d"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-06d8bf61cdf310875"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-03c3a5855099e2863"
                         },
                         "ca-central-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-03a7c3e75867d366c"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-08ed156a73e2a3f99"
                         },
                         "eu-central-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-03dba3c1e968e975d"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0270a9c74f9195928"
                         },
                         "eu-north-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-025e4ea1a5108b4fe"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0b3fab3032c010a46"
                         },
                         "eu-south-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-00cd7304ea8d2ca71"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-065196c444540f333"
                         },
                         "eu-west-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-02015c18c845a147d"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0bc787556d5e786f9"
                         },
                         "eu-west-2": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-062d48dde28ef10fd"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-050dd6e9d7391cea8"
                         },
                         "eu-west-3": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0476ffa43631f99a2"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-001546dce005b5c2e"
                         },
                         "me-central-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0b088c84f54e3fd79"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0a8a616e98df9ceb2"
                         },
                         "me-south-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-02d9ec5eb4ef0458f"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-06dbdb62c493a786a"
                         },
                         "sa-east-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0f39b573bbd7776e2"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-00b661f7a1682706e"
                         },
                         "us-east-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-025c5177ab8dd2d3c"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0ee1c05bffb4eb5b0"
                         },
                         "us-east-2": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-072f991cf8a65d37a"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-041c229112c49550a"
                         },
                         "us-west-1": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0f3d0906765ada69d"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-032be6d17c472fa82"
                         },
                         "us-west-2": {
-                            "release": "37.20221111.1.0",
-                            "image": "ami-0b770545fdbefec4b"
+                            "release": "37.20221127.1.0",
+                            "image": "ami-0ed3e48daf96ed375"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221111.1.0",
+                    "release": "37.20221127.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-37-20221111-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20221127-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,105 +1,105 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-11-15T15:38:05Z",
+        "last-modified": "2022-11-29T08:58:11Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "005ce2deb69583dbbfe4636699f19e50f97758ccdd976f80c248b2e6fb4fb08c",
-                                "uncompressed-sha256": "0c6176c5de4e8b67a82a3af45ee70a59b1cc223bfe506d3cea1a3a46b48e4f73"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "f684cebcb5f91d1224e10267f22b80857a9ee9bd817cd4ce16bb9ce02c06a983",
+                                "uncompressed-sha256": "166ab4c97ca13f39389e8b99817270212035247cdab4ebf23e2261f212eee348"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "e88329c5f2694e06cf573ab93446614f56356b1ca2caf9cf2eff0ac237a310cb",
-                                "uncompressed-sha256": "a9ab7360ee6e67698fdde05c168aa7269cf13803d03f8b48737f44dc44e0a7dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "1c30e715d796988e7e8ca8513518620c6500404600704301677c6437ae187b4c",
+                                "uncompressed-sha256": "4085094dab9f9528518f20f38138e0d28a5a0776b21f8c3c3aa5cd2363470191"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "15364d65581f201e89b04f0c773db75216c8fc858c122e16a03332fb43745c99",
-                                "uncompressed-sha256": "af8214114fbc59ca81b08b4ce51f128a22b9e61e74273c8094bf270ecb8ed9d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "3454d8eb27ed83e5a14a4dd3153d5879caa0cc38fdd0090b65e76b7e9a57932c",
+                                "uncompressed-sha256": "0709b5ab9ac9878a00358050b6d666ef25c7fb3e41e4fde7d80176cd3aeb79fc"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-live.aarch64.iso.sig",
-                                "sha256": "81e524bac35331623ea54242d43fb595d256c47c6036a0ff3ff80f83ecd8ddf5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-live.aarch64.iso.sig",
+                                "sha256": "eadd18db27620ad213d2a7429efcc14a98ea517e0ce5c019967ac81d4e747c7a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-live-kernel-aarch64.sig",
-                                "sha256": "30437e6ccfa45657f7e1fb498537d942253bd8677a1c3b897f20a17226bb1d1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-live-kernel-aarch64.sig",
+                                "sha256": "e5f22a13b48f397d17a0b50f7844d03a7f6e81a000b323db7baddc29570001ec"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "d9ec4ae83c4f5d37b85f717d143b0c7acad4cd415d5c98fcbb170932339d09f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "2d82b87e4ff1f86677ca6af3174e3b6e6fb47f6a7819cd2b49c2947b8369f854"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "e21fec1d835dd8263fac350b2e6d3023ca5f4784d857c50a31928ad16947c003"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "f513a085abe9f46774964b842de3f61c748ea943f1a82a9204959de6a6f6044e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "1a0c72f0b90f8d9ab6860c4b01d3dc6df5aef62b9286e1fb799d699551d569ec",
-                                "uncompressed-sha256": "b77795e8593cabd7355f76edcad8d1e4fa1502b2c20a46a8cc5c14177984ff49"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "c75ea9b0f1e1fb9e18f5d691d389859168eacf5040f1211f3ecb00b30258faa4",
+                                "uncompressed-sha256": "3ec02dbba0be4620960920e52f7df7d96ac6a805a32bb00b5279a13cbd157bc7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "6dcb1e6b7a4886cadf847c62d5d22a99f637c7508f87cadedbff11e2c5c21416",
-                                "uncompressed-sha256": "d095cbe9ce7d848f29480ca44019161f60acbf838a8ab79d4441182d09f13144"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "bbd5d68d1908af5299b14516c0ed1119ccd55c6d70a62f6ee5563a1a0f74ba8e",
+                                "uncompressed-sha256": "85b2f89a0a039aadfbde6f86d62b614181fc02d7c8e0a72bac04d1b6da09f18f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/aarch64/fedora-coreos-36.20221030.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "2b1f4c4215d8f5c5b97002dd2e48be85953c8a0a4cc52c951ddf2f11204d5cb7",
-                                "uncompressed-sha256": "9517caf8d48ad9474563903e5bab1745118f62539935ea63614d97062737427e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "e09ce232f553595f93237a646f619fc2ebd243a202468432799bbf4e654bbc32",
+                                "uncompressed-sha256": "47fe170d0a0a04f1806dd709c00b032bf435a1ccf2be1feaf72d02ea3768f4b1"
                             }
                         }
                     }
@@ -109,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-09c0afcc2f79ffb86"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-05e839284351f0945"
                         },
                         "ap-east-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-09028714404ea2f32"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0382ba5a7d891caa6"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-06520a5f5d8e78479"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-069b8f4ac34a79dba"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-0a73ad79e9883f9e0"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-056a99de9de703d3d"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-0b43c57a8baaff258"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-02c6719301df621ae"
                         },
                         "ap-south-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-0df53d760edc3dacb"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-025ef55912b61a95e"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-02f437f60ca8ebc62"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0ac076297f002e2b4"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-0f3c8f23a909070df"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0a5476e295781bad5"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-09b1cb0ad0056a9cf"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0d54786cf7bdc8e06"
                         },
                         "ca-central-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-05b5241744920ce3a"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-032ed973b7ab6c49a"
                         },
                         "eu-central-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-022e065fc2be7123f"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0a66d014ce67e339f"
                         },
                         "eu-north-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-0981e5a3c1ec8b294"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-097ae94fc2cc12f07"
                         },
                         "eu-south-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-08ffe4f2f0d6e0291"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-086376fb611c03465"
                         },
                         "eu-west-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-0e227fd980e115358"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-04957cadbc3d4a73f"
                         },
                         "eu-west-2": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-0a0f3c26da8d539a3"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-01137a01d6fb41cee"
                         },
                         "eu-west-3": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-07058ca7ffb1fb58f"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-00766e638a5d292b8"
                         },
                         "me-central-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-0ed8dc9983db4ff63"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-06febca420b0dc553"
                         },
                         "me-south-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-0da0ff40d6706eab6"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-01dd2fcd029fc69d2"
                         },
                         "sa-east-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-0d67d8eb3be287c44"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-08a9aa4a187b7bae2"
                         },
                         "us-east-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-0e6230d4bbacd5ebc"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-005e127a70943bda1"
                         },
                         "us-east-2": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-0f022dc70d7a2a121"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0f7170e81979db815"
                         },
                         "us-west-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-049b528199f1d281e"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0d590da423855a2e9"
                         },
                         "us-west-2": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-084f89b414e8fec2b"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-00347b3d6fad87f35"
                         }
                     }
                 }
@@ -207,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "a602051ec55530bc5f7861b53949ba5c8be6797ec1c345a16dab1d1eb890c4d6",
-                                "uncompressed-sha256": "4c0b3038d0206ea51532e08083d4f5098cd49f38b2d23b491e4d2d926f0325b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "560c4818b41de3748a474ea83c1fd3a7d3a212e3fc7860cde2be1cf475b54217",
+                                "uncompressed-sha256": "969011000060cfba5826688a09544b8dfc31916f38f8273a57098e4d37f17105"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "13cabebff131717f495f06b713438ac358d69bed2dce0cefaa72112c9fee2631",
-                                "uncompressed-sha256": "fe3577bd806b4c9d98d3d97f0aac851e695d48b2c97c148b5590c831a106b9a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "1ea65cecd3b27b5e0b240ffd279b021aebab4caae350a72e5306d78e4a3518e4",
+                                "uncompressed-sha256": "b16fedbdd9fcaf1e93edd833225ec66803f081cc675d99d8e7344e7a816db053"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-live.s390x.iso.sig",
-                                "sha256": "84d8a9f32ef3a431bec9dc9cd6740f6a01d75c62964d10b7998087eb9eb57a5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-live.s390x.iso.sig",
+                                "sha256": "103f18b97793bed076d158629ce33ec045258870c7ec5ea5aa42e2b609a62c2c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-live-kernel-s390x.sig",
-                                "sha256": "9ac47b13ab5888eca1a665e6933e9831d2bb0a6468fd4348f51e77fb29aa8573"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-live-kernel-s390x.sig",
+                                "sha256": "75cd92f1654274d8b446969d2c966892e8af5b5398bc805ae243d7e6da09efd0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "4c389db5d359262310a8d1f6213e9aa47d4a9e283b73ebb4f44323f841dcdf9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "9f80bb576d03e4fbfb27472965e075c451183bea996e5f8c68c3eb670870a727"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "b015a6ddbca1666a9d76e8ee71a9d4587e803c84584c5a7e64532712708dab66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "e743390f558a11832fde3b15cfa653b7d58698200ba5758ce430d3f6125aa055"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "21285536e2b394c62f128dd5339f73d4ae705cdd1120bba60292fdf141128e45",
-                                "uncompressed-sha256": "ebd76030b2f722664c7bb1e3eb9407a42c7b6eb84bb034ef7fc40156d6d2262f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "be590caf468c573e7cda299e4d4da9cb8a95691a7c51ceec8891a4ac4dec87d8",
+                                "uncompressed-sha256": "89404d13304df7ccbae51189933f8da4f58919993942cbec81353f951393434f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "faf2dbe964091827bf3da240113bea79be1e717a4edb537242d9ad70821c7eff",
-                                "uncompressed-sha256": "2fe709454bda5b86ffd22657762022d4376d0aa94b081e700054f7321287b649"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "ff44e41edb08d632563769c5822e74d1fc10c6befdfb35f93304f30962bae523",
+                                "uncompressed-sha256": "65e77460fcf528cecaf6a5e9e03873950c564cc05c42bdbc11ab3c270662f525"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/s390x/fedora-coreos-36.20221030.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "d4a6645109398d4b512292304397a563d83b386169f347a8f2897365c1fd82db",
-                                "uncompressed-sha256": "7c36035ca4bd021dc83ce0bec3a1ba3c8f1cca1eab9aef787b8a3e41397b0c4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "4554257ea072e604cb5d58bfcea5b28ebdb51cefbacb456945578809b7dc3621",
+                                "uncompressed-sha256": "3499acd5c2fcb8d3d94daf328f6ba001b027d6b2c204fae5dd97a667f8ddb718"
                             }
                         }
                     }
@@ -296,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "b3eda806b02188e6fc711698121d7aaad71514c63bb21786704e5787991398b7",
-                                "uncompressed-sha256": "1a62274b3e03a71764195bfca91264350d28ea1ce8899e11b32c65a3358909f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "90955fedff08c081e617df343aef97e111b737db644ff6421708bf4db63b0780",
+                                "uncompressed-sha256": "5ae2a1185c1ea7187fa0fefd1ba757285e2a59113646cad6173c604133115bd6"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "88287e26b2afae452522ec00cd546a3c7ec1eab718421cc3990b5150f2977c20",
-                                "uncompressed-sha256": "0be3cda1185a8b17181eb252c2dc66dd9ceb04dfaa6c7d4036cf83f7ff46f27f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "df8019c840e9a542284c10b540e12ef2edd2fd93124f2e8389dc116044368a03",
+                                "uncompressed-sha256": "8ad2e70d942af67b90f1a632d014a78cd192218da251631e323293c70cabf37e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "ad735bdd450827c539b3339ab4ed37c697935d9ece44071cb918e1832ab56dbe",
-                                "uncompressed-sha256": "e99517e5988a74027e1529db382c1adc488431dcf7211b25b86ed82512f538e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "5a2b6349912b7e8623b4dba534749de562943df83694ed820752a22be9ff15e2",
+                                "uncompressed-sha256": "19fdd919effdcb38a26e2ed735de89e61fa0eedad32e77ddf073528a388d5c02"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "68c5150206898240d46cf9809296c3e25584ea247a53a0aa6d3882a798facf24",
-                                "uncompressed-sha256": "724cd433c398c88cde794a0d1f25a71eba61f8e39ea7e99ccfc5d6c4d85e69cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "95f4d18591529f1d0a1ed2df17cbbac29f1c6382f47addb17769935ef29eeba4",
+                                "uncompressed-sha256": "66b3c6b1d35d8769f50cc395335c77ea8fa36793421796201d215b5bf3a9b54f"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "1102f8e3ccf08689853b3a16cb5a53ce2d3bc66d44ea61f78ec6539c68cc4bfc",
-                                "uncompressed-sha256": "0887aaac5dc7bfce20b01a126eb82d63182c6f10c19e33aac53641f93074bb80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "b9cfb2ff914b3281cc62357e36a59644bd31f4ccd63bbce0c1233e6c2f5f36d5",
+                                "uncompressed-sha256": "3d42e49a375e0c44a306fa52937ef9a1f92aa483e7ffb188eaed60d2640c9ee2"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "ecd4d76dddd0935d7b0cff5973bce9f91a10b711332c82eade997c4ae8c5fcd9",
-                                "uncompressed-sha256": "462bfec8f8b8c9a4697d0abef0486ad196b69c25de6a3a423950487911b59a25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "8125bfa0acaf6e0a2b81e8d04c7ec3bd50df80b9ca10a603655bcad881cea6cd",
+                                "uncompressed-sha256": "f24ddcdae099c42363a9ac2e10569724898d5d8632edf8c7c69d2b9f8a2a0e4b"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "3990e611348ce0597f3914e4c90d9401268c8173a45388bcb8a810df0cb479e3",
-                                "uncompressed-sha256": "9314beefa363c31f4ed299826796602cef2ce686b40aaf47cc65321f029260a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "e9d6f09954a3f237ace2703ba3468e4d17606a349fe911405847b2451bc5a089",
+                                "uncompressed-sha256": "aca08005d45b276182e064a7f1bd940607cc4487dea99c9e4caefd882ac7c509"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "2099f7ca425c8401f1da35cabdcfdb490f87e6f445222104d16450c677afa0c5",
-                                "uncompressed-sha256": "7c2020fd176f2d0000a8a353d71ab1c60f7ac3e8f7c5ffa73b0a5d45b6e11d2a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "9e10f6ddc0406cc9d0d4dba5d12f168718ad8813fd7982f479791435d067e64f",
+                                "uncompressed-sha256": "06e2a972e3f508202fa2daefc6dfcc8a24670df3e08244f8037ba264402e9e61"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "501bf04fb9a7362adb7965ba2bf1b4b4c56621cbece95ff70e1aa103098db72d",
-                                "uncompressed-sha256": "0d056cb2c037e4afd9893ee3b2f93af69616233fd252364be392b7fdc7deb7be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "55dcc73474a426fd94849b33719aec0f5e87a95eab7471c536328fbf4e6ac9a5",
+                                "uncompressed-sha256": "1ace69cda38363350c365f8bdc1e80c02cef8ba9d1c7ad35807be0b8850ff25a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-live.x86_64.iso.sig",
-                                "sha256": "9e6d7f82f612be54191c6509cf7e73b473b48af6a70d6795cc74a7587db0aff3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-live.x86_64.iso.sig",
+                                "sha256": "98377fd880a6877fce084e7fd7aeb9c89011f3dabd4e1638da616c6f9f8da516"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-live-kernel-x86_64.sig",
-                                "sha256": "952baf3fe442e051a29b153db08161aedc63baaf4e920ad01f36ab886b3c4bf8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-live-kernel-x86_64.sig",
+                                "sha256": "2bd5f834349313d10a9dbeb41d9f71d985f7b9c4f7e2ba750a1dd6558f082ba9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "7e8034f34d544067a736d36c075dfe2cea4ecbb09679c9a4a7335c5b56d7cf4d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "f0a3913a79194676f7d5195cd20d01022d907722418e7e98f8cf4f90af5030ca"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "823eb896391739e6a1083831294053bfff1dd8dc1db12fa58372848122f1119a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "0b7907919444f2df75c320d7a046263d53b50220e9d5dab24a5a21d803e3cef1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "ef0fa96160f6e7eff028dc89e68fc54db8c853b5ae858ef69b458ea158b1da53",
-                                "uncompressed-sha256": "653b66facc1608c60a9698926647740d27b286d079562e295783ea0a21199c1f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "6e1ec4fcea431b60460d8587d6031d815de799a7c6a7224703c17e2cacb1885d",
+                                "uncompressed-sha256": "62a8185bcba391e0871f0dc785554f07321acb4ae66f9713fcbe8c7ac65984ad"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "e48ec5021f6075954031219f8ed1541ca5956cfa979c9bd865965c3230d9737a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "412d1c0652a5881f938d481dbdf4f70d9ace3da8a5e7f3cd95631af221a7d096"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "30b9c2dedc455222bf285995bd598ea36bb5d169a83aba31a574d8f53e0abe04",
-                                "uncompressed-sha256": "18ab7d221dc2d532cdd3ae96f6d5b21a811d39119323371875235c8499d82248"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "2480976b8a11c5b13c26e54bdf7efc3a2e0a01b0cad7ac1ab8ed5edd55b6d8b4",
+                                "uncompressed-sha256": "89e12d6f1e53ba45663f3c893cc105b9a536dda242531177ebdd3f0b513783b6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "a9920e5eabcd1aacbaf8662a3d3298c2e5549ee055195ab27a801942899ca8a7",
-                                "uncompressed-sha256": "c83924970b0b07ed29b1b87971e5774a483b63e3dbf4b467b7d121f73cd1e526"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "278f78ca722cbd4f7e93444cc3ef0bff27fc624bffb6e9e61ff01ad71998d6a6",
+                                "uncompressed-sha256": "71dea1c576f8dc9579a752b371d7fcec4cb9fa084e8a4cab2e57bb5153803f8a"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "32683ccf2eb23ea2eefa476a79cf230a4994bc6fd3938d29b16a7085448f89ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "95bdaa36b3aa193b4a1a2ee65371bdf8c217f558667fadf716a557c937f650b5"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "0baff97c451b86a52ea485efd4cadf5a1e153c46a1526a731cfc881be5e56177"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "47b94104fc46bcbe822d8fad05ebaee3934e922d19f4e3f3409b46ac39774b34"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20221030.3.0/x86_64/fedora-coreos-36.20221030.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "a504101cdb08d2c7e6abbfab505eb9de8004ccd63f67f9ca326d02f4c9709120",
-                                "uncompressed-sha256": "3b6531814d9027b34a72651a6a403985ea010e75f001369bf4039b780e3050d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "bb6919950f8d912ed1b55b30f355765b2254b047388e4e31837e33be8924bee6",
+                                "uncompressed-sha256": "4d0720bc4285f977e3a74d7ef6f7058f7c0ef3415b24a106479903997a61c261"
                             }
                         }
                     }
@@ -524,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-0dc480332ca50c6c0"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0fce48024bb4a50eb"
                         },
                         "ap-east-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-0ba8ba0155be404f7"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-08668920cd59acd3e"
                         },
                         "ap-northeast-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-08a5a48791191f957"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0211fd9c2b5e003de"
                         },
                         "ap-northeast-2": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-095baff1628883aea"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-04b4e734efc08a798"
                         },
                         "ap-northeast-3": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-087426d7093931bf9"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-03ba14a45ea3a62bf"
                         },
                         "ap-south-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-066aceaa77b563832"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-08ec8de4a8cdf7362"
                         },
                         "ap-southeast-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-05f8e46596cf62682"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0c1cda043f0d6fce9"
                         },
                         "ap-southeast-2": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-041b5ac6d1a09fd54"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-00c065e530e784b88"
                         },
                         "ap-southeast-3": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-09bf9b81f0fe71c3a"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-09d46f81ce2463bc8"
                         },
                         "ca-central-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-03799a89027c854dd"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0a106814a50c57036"
                         },
                         "eu-central-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-049a633dbb614a6b2"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0991068fb5349de54"
                         },
                         "eu-north-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-08bd233e5011b623a"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0df1fadcc045d9be2"
                         },
                         "eu-south-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-0a89cc729a850577a"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0a2dafe5018e0ba3e"
                         },
                         "eu-west-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-0edaa9c91f5aac890"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0742512d2326b86c1"
                         },
                         "eu-west-2": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-03fd47202d909f586"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0bfa8325895d6b9b6"
                         },
                         "eu-west-3": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-08571b9fdc72b2c0f"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-01a103da43908c038"
                         },
                         "me-central-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-0ddd04962b978797a"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-07ac7fc63829eb78d"
                         },
                         "me-south-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-01b78c1a8e3cc6dce"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0b7620d17f9573397"
                         },
                         "sa-east-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-025d2bd714f5dbfa7"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0394322dcd05e7add"
                         },
                         "us-east-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-0a12a67a1cf7653ad"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-074ffe616eec21f4f"
                         },
                         "us-east-2": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-0b4a4e7fb269f5a06"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0e88e6ebe5fc4dad6"
                         },
                         "us-west-1": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-015abecf95012f975"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0382fd712f1f1a651"
                         },
                         "us-west-2": {
-                            "release": "36.20221030.3.0",
-                            "image": "ami-002563ba6e9168794"
+                            "release": "37.20221106.3.0",
+                            "image": "ami-0f37270dc88b615d0"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "36.20221030.3.0",
+                    "release": "37.20221106.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-36-20221030-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20221106-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-11-15T15:38:06Z",
+        "last-modified": "2022-11-29T08:58:12Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "3fd88fe15629724716410f9d396addc6e5c25055050af532b7e9dcbc99a0ac2a",
-                                "uncompressed-sha256": "665213154bb9e1c2313dc4914f3a74e42c4e081c565777393d6f3865df17e900"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "ac4c289a1a693c247c3dba2ecc89970e168120a08d5cb1a228f9394bb25c9ef2",
+                                "uncompressed-sha256": "6b36313602075829cb2382e7223baee2d8d2d01ee0b691929906e7424a75f462"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "00a9c56aee88ba3bffa6aa9e83ae1ce4824e2652b5ab4f41c0091f4c79cd8cc6",
-                                "uncompressed-sha256": "55632497bb9a41e1592718492a4e00f4cdc6f26daf3728bb8e2ab059cbf94d8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "04ba58a3434560b7bf09727a5f1d7cb161c381e92efaaba049e5e5044e9d2b6f",
+                                "uncompressed-sha256": "68c2e7bc28bda6e26c97c6251ab6e2cec7c101f143c0c48d92a72f99ba61d3b5"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "dc8bdc110f7ca7f8349d3557056a8fb6cf7f114616ed6f95c54be0249c0d9934",
-                                "uncompressed-sha256": "9aef787ff8259f1d423d3b94b7983accca7dfcd59147794d29050919cc68e90e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "11de77f637f09c9df3dc11760413e82506489f2b88bdd9e6d51013a93061a745",
+                                "uncompressed-sha256": "59b2ff257e52d813bd991dc8e5fe27cbcd6e938359812e25e865936d239b5e48"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-live.aarch64.iso.sig",
-                                "sha256": "a3ca77a1b4f14f7486cf710d5d961f7379b78e58a2e0db88ece9c87429bf2c20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-live.aarch64.iso.sig",
+                                "sha256": "6e3afba0ee981a36a7e96ac0449f2b288720a822c63ed2d11778b9225b71811f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-live-kernel-aarch64.sig",
-                                "sha256": "e5f22a13b48f397d17a0b50f7844d03a7f6e81a000b323db7baddc29570001ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-live-kernel-aarch64.sig",
+                                "sha256": "034552dae2f7f2f283951d6197fd2d0dc4a9f4dfaedcacd6beb2814846971586"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "a7fc558d88f1de8518e1596cdf965528b235675e47049a86390e625acca6092d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "a0ddda00d2ccc836b756ddb4dc23c441dc0ccf64b62b37b87aa4c3f946e87227"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "eed6ee7582e68f184ccbbae63ef147619ae260434f63a55ddfd96bbd424831df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "060a3a56b1a7419cbdcf8d4a4c63f85552e9772c1fca6727de58848ddca83281"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "4bab44dba5bdc98bf2c77e642de6d746b5441d19cc0976c88159e30a6c5c3377",
-                                "uncompressed-sha256": "ea54144c3ab7567b64732ced93c01bbb599d3d87e5f3dd186837b25b9e50d041"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "abef83a85271e8b3567123d4908f93db34e3c17596e35da33932a59f69890d30",
+                                "uncompressed-sha256": "dd0339f06743c55f56bf0a8a121f06eef5722829ca10612b9a08f29cf5e6c858"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "78fcdfabb338c6bf579a095add75c5ae8f367dd6babdb5a180fbea456549ce28",
-                                "uncompressed-sha256": "7fcc6e27c5e848a9a446b264b13494a8bcb05485d3dbd73528713c6ea935f8bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "33c7a9dfd447e942ba7b8b520c5ea7f3c5c92832bb0982836b1e8c3c1350446c",
+                                "uncompressed-sha256": "b4a6368bdacfad352415d7003e7ee22b3bbab0f9453047d2385c8ecb8039bfd1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/aarch64/fedora-coreos-37.20221106.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "2d9371e037ede77b006623a9845b0db5209a3d1da4cc9d8a03d4fcdbed10923a",
-                                "uncompressed-sha256": "b35ffea40b4dc6df79408a3bff614805d88f4d0c85c872de13e9ebdfbe9dd583"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "e6ad530c954074b19a7d8106786c9bec393efb089b9534029c50e859d61ef9c7",
+                                "uncompressed-sha256": "9edecac4f1f53336d8496fc61c67fa6b922c5757297d7296543f8c010a841d0b"
                             }
                         }
                     }
@@ -109,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0cd4732ebe74b0f63"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0cc31fc51e0e2df7f"
                         },
                         "ap-east-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0165cd535b336f3c3"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-03224e41726557c61"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-013b04e8ab847770e"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0c2dc9e05351aed61"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-03aad0efdfa3ccb2e"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0a4e8d03bdb99f909"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0b66ae40faec4702d"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0cbe5b5f9698dbf12"
                         },
                         "ap-south-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0b16c056f2fc2fd02"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-043fb0dc9226c0351"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0f997b5468e461d2e"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-09b76c9a69b7f281f"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-07c265e4d027e829c"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0db6cd70c907a6c61"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-082b38e3643e61945"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-039cfc9c5357b09af"
                         },
                         "ca-central-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-03116601dbd201d8b"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0ebd173c70e19b79f"
                         },
                         "eu-central-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0fc335670602d8924"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-05a8c3acfd5981abe"
                         },
                         "eu-north-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-07ce290cc2ba1e62e"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-05358be7ebac6aba1"
                         },
                         "eu-south-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0e039846dbd766a98"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-09e114389d23320da"
                         },
                         "eu-west-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-09c28b37a137d748a"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-09c433ac28385f1e8"
                         },
                         "eu-west-2": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-04a7b9c1e1371d44c"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-029ca2b70d1233545"
                         },
                         "eu-west-3": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-00fbe5ea72643c8c0"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-09b0847067dc57164"
                         },
                         "me-central-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-08f031e1722c3d1fa"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0dd152c9e7305904c"
                         },
                         "me-south-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0b547baba55dd9cbb"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-001923c7cf5fda98b"
                         },
                         "sa-east-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-02887e1ecac556b7a"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0bf14ba991e0153df"
                         },
                         "us-east-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0f1d063b0e1e01223"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0b10692b4588039fa"
                         },
                         "us-east-2": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0c9a7d1e1a90fbcd3"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-031bc195eb75ecb01"
                         },
                         "us-west-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0dffd52201b65b6d2"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-03200ca70d279b34d"
                         },
                         "us-west-2": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0f66a72d1d55bd7cc"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-05ed39ec9eb87dcf0"
                         }
                     }
                 }
@@ -207,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "d386b536f25650690589225f76ee708df87df239fac04aedbb523db6d6477732",
-                                "uncompressed-sha256": "50c9479f82b462e7a2498d51b9c6ee0b5e45e4addc7c1d12cec2706ac4c66901"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "b996393c7ff87ea9bfc93b2e4dee55fc1d145d362d45776d0d5de06bacaf5ccd",
+                                "uncompressed-sha256": "3cd54d2bbd59d93c0bae1e7f31d8fee16db7d310eab893fb7a74b9ebe545e804"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "60c4a0e0637f44052481b1c1127ef3973af7012f883bf20b03a597f3937d8100",
-                                "uncompressed-sha256": "1f7cd7a17cbb8a86c95df73909582bfb500109d119c8ff8d25993f226e96cdff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "d09e1201ebbd87a70c206c5d8f5e195680eec4170be69f41fadb91de90085a5e",
+                                "uncompressed-sha256": "150f07fc54fe639e04a12820f216ee1d12a91ced191dbe653feaba304d470b28"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-live.s390x.iso.sig",
-                                "sha256": "f9dd78778fd596750fc285ac055eefb561adffc27dac5a80cad77ab60588677f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-live.s390x.iso.sig",
+                                "sha256": "67b8054c20fcb30c09f03559ed91e6838bb4519ad5bdc191dc7579382c4b2abb"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-live-kernel-s390x.sig",
-                                "sha256": "75cd92f1654274d8b446969d2c966892e8af5b5398bc805ae243d7e6da09efd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-live-kernel-s390x.sig",
+                                "sha256": "b3633b401b13e13ed7d361662e780f8d6782473b19a430dccb7882c03652ccfc"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "328584c97be42147b5d1ed26130082f7329be3e6ee2e115161170dacc613cba4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "ae27ec17a4b5d3b1f62de5aefe9abf8090942cccac931d0be60d5f154ddd82a3"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "e172b9fe21d78083c10c6e308ac0da09a57728f1b4d73094db39e3f08c6eeaba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "7f86ff16eef8d814b708335d5d4b618ad6eaf994ab1ef28e89e078025266cc8b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "7bb52c197a38a7a03310f2b8bd32afc3af0a5588d383a176b2afa1293d10c0ec",
-                                "uncompressed-sha256": "9b588b4c5935d6cdb319e733881aed45c1d5ef77162aa42a1a9ad09611bf5acc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "87d24f6b046e4391a54352a14ddd2a54e766388bff62df2038a63201ac951fed",
+                                "uncompressed-sha256": "34eed3f9daa4b01137368a5d2b66e8897fa4ef922e2963669d75414a64e9b248"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "d5bc88236e4a82ef13a1313f5b24d53a2a131f3beb121344ef2867aa56da978a",
-                                "uncompressed-sha256": "c6e94d4f2e2f6750fea83c23ec2482da5f956428608cad38864361f7ceb48fa5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "7a056b366157960267e2d5ea03167eadfc341dac6d32c1e65975936a2e17d280",
+                                "uncompressed-sha256": "7af873996661f238fa22b3b96db8a3566a4603e083366391e505068729edebf0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/s390x/fedora-coreos-37.20221106.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "dcb55e3fbaa5b0d6c94570a9552e409c8e83eb9786236f4ca338079673688518",
-                                "uncompressed-sha256": "e40edaab4cf1926cd999fafdaf04c135199a80d115e584a94baf95d8f8b76ca8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "82544b0f59b0d1672a819186c3b1d26a8fb05b1303ebc8a3add88f1afb84de3f",
+                                "uncompressed-sha256": "da8d64fc834171cd6ae87735b5f451e5b7646fc74ffb566c04a41656074bfb82"
                             }
                         }
                     }
@@ -296,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "69142d5ce440e918a49d8b40c7d517cc071ccee6bba441fcb70c06d3f5ab0932",
-                                "uncompressed-sha256": "c64044ad6266892ff4d233d11498917616b36cc05a61c6d187072b7490a3deae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "25f709cb407acd3c64663248a8d7bdd8e2692cf5a396e1c48761458b3f7c8c44",
+                                "uncompressed-sha256": "11cad3512a35c3f02f3f2aa2219c6b822a6bff23e824c07b8d63b8b46d15fe6e"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "4465459d63767cf10371f16e30493136663225173a3357a842f93429d18499ee",
-                                "uncompressed-sha256": "424192bb9c70acf365d35848a0051f7299904504c7c049200f5b7ca0ed6b6828"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "3f37ca9adfca680553b8f8815706a54a5ea180dd15b92d1d59721d8f84aa6130",
+                                "uncompressed-sha256": "884e101a38e12ee1c3f79179298620b2a5ab05454d0bbf724f07aedcfc5b0c66"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "61131cb844634511631dd9dcf5557a377abce48723480ff5acf6adf982034c35",
-                                "uncompressed-sha256": "e40f996e8545335dec274772304b8e6d1c59f7cd80c6e598ec1bed6c8d1b6331"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "b3be81891e4737f1f33854287e29158e5453ed6f857197727edc1254bdc3aa91",
+                                "uncompressed-sha256": "f3f82901f94f2ff88e57bd936e0f691b225eeed157c3b9d4854aabcbbf2b4441"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "2ddfc95da04bec61bf022719ef0c3cfa03674c59ad533a5491e1c823f68c9a6d",
-                                "uncompressed-sha256": "39c6381651609341a8ae5a2f318e87762eb05e39d31102fcd9d14b7190230b71"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "4e9f3a2439ab0bd57065314c794f8a73c0a5bd5454aff5155bc80fcf9db29b6f",
+                                "uncompressed-sha256": "0f623ebd51397b2db3d88d4c962b49f6aedbc466e94c9080837e9c741cd92494"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "a5ae2b62215d1069b0b662b18f0b4136d400a921a89430eada4461ac61c45c20",
-                                "uncompressed-sha256": "3869e2e85e0349304a6d5c39383ee81a3d1692768e4b7d5fd72bec611625315d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "a2259a2ad455ccf432ece8e3adb43373e456e2719077415e10f881ace0fa4acd",
+                                "uncompressed-sha256": "d8738d093b2784d9f3eaa1a70b0d6adf221c6216e83139fbdadd3acd39a1ebb5"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "37ac18045c0d8a44037206571203acae133520be21cfbf228d56008b98aeb371",
-                                "uncompressed-sha256": "29e060f7dec1a8000eda79efc7d58b7fb5e6b835f6438a74ff4804ab3db9dd44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "ae8297a3f1df3dae8beb272ad5a9598e6542dd48e21cc9af501251f10cfc082d",
+                                "uncompressed-sha256": "a3d8dbefb3930d964bf115a81d5f664094647ad4c54e5f3f2e0b2846ad0fb03c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "5fd31ded051203ca22a5eb35a17f37a9c4b612f688f37c4208ed30aee105e8f8",
-                                "uncompressed-sha256": "9dd8a25e86c956fabc3e91db9b2cddda8a096ef7944ebc00efbca0c02a3690b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f864fd859c94d7a15b44f617b3034a064076c4217695b61e9d75a91749c672b4",
+                                "uncompressed-sha256": "dc64b98af202c1aea26e5a04a5f7355e9ece934e6fc33eaf453215ea30e6b20c"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "28c1884e2f0bac281a3fc3851a6066bfa4781aad36057ca0ee72a29838b4ec24",
-                                "uncompressed-sha256": "4c7ad688572966ea4ab0c6f2fbfefe4020889012ad8889555c2bced9e294682c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "a343e91cec4b25f10d3bd30bf5ee10501078630b3ca13aaa9ad827caea8169db",
+                                "uncompressed-sha256": "683d5cff0c1a478b96e7a47cb46bdddff8e32b0d7e098afcb06d8efd8f8b79d7"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "489e9fc51aaa9e8f57788208a7b071adf6475153c19b879193951549ec29a87c",
-                                "uncompressed-sha256": "f04e25d737105ff3c79eb1c7195ea09bb03ab811a0835bd8162eed4cc8c92ae2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "92b6fe39c81179d1dd861686e713fd4107d6f8462f1486c2d826c585cecfc267",
+                                "uncompressed-sha256": "06b898c8091dea699e81d3488491be1872018f8538329211f711512de75acd3f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-live.x86_64.iso.sig",
-                                "sha256": "3386d3be54b2cd456f530399bf0774577eb7be1cdaef31baf154007b611dd94e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-live.x86_64.iso.sig",
+                                "sha256": "841b19a2dbf0bab5fc430a0e938777cc643e308cbd93c48b1110f63356dfb0d5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-live-kernel-x86_64.sig",
-                                "sha256": "2bd5f834349313d10a9dbeb41d9f71d985f7b9c4f7e2ba750a1dd6558f082ba9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-live-kernel-x86_64.sig",
+                                "sha256": "68077e35ec7c697edbea4b5d8e6eb230eafbf3ec6ad42590da02d42e4bb0c08f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "4f2de1752c7c08aa50021f19a05de4c3196ce212de764671dbeea2e15e5d6a3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "a85caf3acb171fd979f6fb0cbefc7d8d1d9873fb968873982fb88f433c9b6545"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "f92e60abcc7831df7ed1de93586ccf2906707902717ece97abfb51b65d8bfe08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "1bc690a3a17649df2b208c71cc380cae3f87415295ebaa7e25026581a69405c9"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "801161dd4c0cc075584467b330cf124fccb811ce8e4fe8998b2c04b3062f56a1",
-                                "uncompressed-sha256": "d4b7d066be65ef1f331795753ea58f3187331f89f9b895e037d53772f04bb26b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "c1fb90940b53010edea63d1fd329df2521b2d4aa973512845d50271735c8a076",
+                                "uncompressed-sha256": "c7b7b37ec3461b941f888ad0280b5a1e0a0da11833c50905811ea91118b6d5c3"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "b91966af45e197df8acfec2191f7a8221c1303109c29bb5c51e74fc6b80d49ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "88f422bb41a36155b3f3705e3afde08ed5e09a3a9c03a899c94696448f3f530a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "526aa0067c26294f4df3c39e1b5677187e9590e1f8ef38e3ef07a4dca7afe213",
-                                "uncompressed-sha256": "af22d3e8e2719852aa8fb857d26bcdb39b48651b4141a310b9bbec8ff402f9f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "ec1eabc22b0910871a4ae0cd90685c5b2a6067fd4ab0369194c215cc495fbe54",
+                                "uncompressed-sha256": "20601e865a0ebe8fcd5b18626b28f4793b3c2d184581b3c5a84aaded89397608"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "337252c938d772666f6c245d9f556f554a1bd796562fe0c8d4b79014f68b79e1",
-                                "uncompressed-sha256": "db609b8a134d0f4e7551136a415b2408a46013eee4f0828dfc8a854cb4cb3811"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "5309c5f6b1584b53b9cc260fec1c182df5e55222fceb44c1fabe6a0292a942b8",
+                                "uncompressed-sha256": "60d5dc463eb0bf16f5110a0b25df021eadd17257b3b32a05f00cd19b39a8ce62"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "540cfedea2a260f35be6dd4267847403cd362cc6b86f31a6b0ce89b247b0e4c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "e756f34e9e360620025ac358c3b1200db9e7e4c8ae5584d178f663fa3638ee97"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "bd8606c2cb940d2c48234451c4d4cefefd5cbfdfae66f1cbf898c15614a0683c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "ce68b8db2e2b18190752b751e75ad473b7d0fb1a02d8b818ad450648e53ff8ce"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221106.2.1/x86_64/fedora-coreos-37.20221106.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "1f7b428e999d75e49d79d38e3012bf662d38a5bc239993159a4fea3ca1a5fd51",
-                                "uncompressed-sha256": "652b324756aa4f252038e58b2392808df0edf0aa99a537c56f2cf7519e0ff28f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "4f2d10cd6830abc2feace5e6e0514219894c1caf79ba3a4fe0de6c5fc776ec72",
+                                "uncompressed-sha256": "e081ea72e787b78b3959fbd154443bfa23973bd688f15a9bae0dc6c6355287a8"
                             }
                         }
                     }
@@ -524,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-00a1bc3948e7ad1dc"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-05226625167306621"
                         },
                         "ap-east-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0ddf5cc3fbb322a93"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-00d75de7e7cd75c25"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-045e30e32298d6a7e"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0f822e4292f03a0a1"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0e3aba425260a1734"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-09b8b7a3064ba93d6"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0e721e17aaa2f163d"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0fc78580e033f5734"
                         },
                         "ap-south-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0d832ddbcdc20f345"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0278db46cf58fc0b2"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0ee76191fcf5e9385"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0113ca0917f63013e"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-06a04637ba695e440"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0d18e71a90e4e8056"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0c22c848a28c9c31c"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0c79ec261c2eab195"
                         },
                         "ca-central-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0d481b5731ec5766c"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-09b3e1434b463386e"
                         },
                         "eu-central-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-05cb1e8bf8609e334"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-02574d7c4c20ace57"
                         },
                         "eu-north-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-00ac87cb194dde7c9"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-070dec5d5b629ec9e"
                         },
                         "eu-south-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-05ce32fa7d80c1c90"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0f87c493de063b1a4"
                         },
                         "eu-west-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0e442817c9ef0fe47"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-05cd41ea74c7f785a"
                         },
                         "eu-west-2": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0b7b9e1c2ab18f126"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-09cd725f3048dbf40"
                         },
                         "eu-west-3": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0eb3865b91026540b"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0d718530e6e972333"
                         },
                         "me-central-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-056287fc70b94f412"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-084d590704817447c"
                         },
                         "me-south-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0062bdb66696f52dc"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0f7e38dadea31ce8f"
                         },
                         "sa-east-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0e60ff82e6d321841"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0ce563999e962e8a4"
                         },
                         "us-east-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-03a7141a04bf3bf97"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0900908c3a2a5a865"
                         },
                         "us-east-2": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-098f0f1c20560bd97"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-06ac33742165f624b"
                         },
                         "us-west-1": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-021f25631575cf6b9"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-083b15ec2d71e0a76"
                         },
                         "us-west-2": {
-                            "release": "37.20221106.2.1",
-                            "image": "ami-0ab66d8b13bca9cd0"
+                            "release": "37.20221127.2.0",
+                            "image": "ami-0caef838d356c6de5"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221106.2.1",
+                    "release": "37.20221127.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-37-20221106-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-37-20221127-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-11-15T15:38:07Z"
+    "last-modified": "2022-11-29T08:58:14Z"
   },
   "releases": [
     {
@@ -61,23 +61,23 @@
       }
     },
     {
-      "version": "37.20221106.1.0",
+      "version": "37.20221111.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        },
+        "barrier": {
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1333#issuecomment-1319168915"
         }
       }
     },
     {
-      "version": "37.20221111.1.0",
+      "version": "37.20221127.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1668535200,
+          "start_epoch": 1669734000,
           "start_percentage": 0.0
-        },
-        "barrier": {
-          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1333#issuecomment-1319168915"
         }
       }
     }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -63,6 +63,9 @@
     {
       "version": "36.20221030.3.0",
       "metadata": {
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
+        },
         "rollout": {
           "start_percentage": 1.0
         }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-11-15T15:38:06Z"
+    "last-modified": "2022-11-29T08:58:12Z"
   },
   "releases": [
     {
@@ -61,7 +61,7 @@
       }
     },
     {
-      "version": "36.20221014.3.1",
+      "version": "36.20221030.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -69,11 +69,11 @@
       }
     },
     {
-      "version": "36.20221030.3.0",
+      "version": "37.20221106.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1668535200,
+          "start_epoch": 1669734000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-11-15T15:38:07Z"
+    "last-modified": "2022-11-29T08:58:13Z"
   },
   "releases": [
     {
@@ -81,9 +81,6 @@
       "metadata": {
         "barrier": {
           "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
-        },
-        "rollout": {
-          "start_percentage": 1.0
         }
       }
     },
@@ -91,8 +88,16 @@
       "version": "37.20221106.2.1",
       "metadata": {
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "37.20221127.2.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1668535200,
+          "start_epoch": 1669734000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @cverna via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).