### PR TITLE
updates/{next,testing,stable}: drop unnecessary f36 barrier

### DIFF
--- a/updates/next.json
+++ b/updates/next.json
@@ -45,14 +45,6 @@
       }
     },
     {
-      "version": "36.20220418.1.0",
-      "metadata": {
-        "barrier": {
-          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
-        }
-      }
-    },
-    {
       "version": "36.20220906.1.0",
       "metadata": {
         "barrier": {

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -53,14 +53,6 @@
       }
     },
     {
-      "version": "36.20220505.3.2",
-      "metadata": {
-        "barrier": {
-          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
-        }
-      }
-    },
-    {
       "version": "36.20221030.3.0",
       "metadata": {
         "barrier": {

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -69,14 +69,6 @@
       }
     },
     {
-      "version": "36.20220505.2.0",
-      "metadata": {
-        "barrier": {
-          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
-        }
-      }
-    },
-    {
       "version": "36.20221030.2.3",
       "metadata": {
         "barrier": {


### PR DESCRIPTION
We don't need two barriers here. It seems like there was confusion on this that lead us here. Let's clean that up.