### PR TITLE
Roll out stable 37.20221127.3.0, testing 37.20221211.2.0, next 37.20221211.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-11-29T08:58:13Z",
+        "last-modified": "2022-12-14T14:40:04Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "52ee5cdbee8fc5c2673e3c12faf0784646e8a522ccd7fbc748d14b17ce430aac",
-                                "uncompressed-sha256": "a1212f268bd905734e63125108e20acab9d09cc9d7a961edf845283980acab02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "a461294cb9292685276bf85868ca57bdbeab325c05a09bed3955d9404286c508",
+                                "uncompressed-sha256": "477d30b27308edc10e39cfff4aa7a622c5a899e820393780312f32eeb193483e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "172cca47d23554ef65100a655f5279310e0ff6755c233f14b8f2e72fa9412049",
-                                "uncompressed-sha256": "65e16823e0ef8ec40ff1a6302473136c842d73938370118e42f4689fdd3e6875"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "f4d85959eb46106f7344465179c0f5a117dddf7c974fe1230ed7e33f18f40953",
+                                "uncompressed-sha256": "34202c009ed92043c82e075bda1610b63707396a9a82d374c5cdf3a8b406f220"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "cf2681e454d66431be20a88af2100b6b435467dddfad89a22b184b63bbd91884",
-                                "uncompressed-sha256": "021abcc86936912c4e77239b9c900a58c3c847c6384c4895d72069aa0bd971ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "bec38364c19c7af8f4af06ef92cb956f6595e184ef2e4a06c1f919edff655c6f",
+                                "uncompressed-sha256": "3239352ee4e4c3ba94464391d12753db8b02b644ffcefdd66b153072046f5de8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-live.aarch64.iso.sig",
-                                "sha256": "7f56df1c033e8bd7d7d2f440cbe0f0b2ecccc02ddcddb3e0c3ab961328f7d724"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-live.aarch64.iso.sig",
+                                "sha256": "6a6cb7e4a6b99ee64a84ca1b8ea90457ec4df162302678f784cd5557e6e2447e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-live-kernel-aarch64.sig",
-                                "sha256": "034552dae2f7f2f283951d6197fd2d0dc4a9f4dfaedcacd6beb2814846971586"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-live-kernel-aarch64.sig",
+                                "sha256": "5dfe9ad3814207d407e3d8c6b94641d40bb2c9c34808c57ab29f9dfdb18dbee2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "7c85f079c93b4e65eddfb6fa9b88edf1f1dc4a4b71632314a332763a1d0c0c09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "3ac5edf6620032202441d1300651063d38183352d896a62df8ab0fe03253e508"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "d134e7017c8d31dafe0bae0726bc61737268f5cacc3309a002d88fe288a08075"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "c0e83d6f012bed70784995a2a2c931b062cddb44776813a4cecdb5704dac49cb"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "c3b8024a3a58a828cf17a10fd33957306f3ad367d3ee32931318d896229c8c1f",
-                                "uncompressed-sha256": "41c6baa42bb80e2a5198393a3547c2f51a705c86ba7cc81f717135b516f79727"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "3cd693df32e7e84e192ca37039638e18b6efaa80477c27c1a1931a6cd048ae8c",
+                                "uncompressed-sha256": "63fb10dcada2736c44a3eb18318702d25de14cddc7780a65dba32e757c1656ea"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "303fbd997a49ee07b085f305de6d9e76a5a14074d9d49062112bb6d1f234f60b",
-                                "uncompressed-sha256": "deeb94db277f3147abba084203747f011c81e774b40f5cd4bbf91b486c4d9c5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c2aaeb681bde6f928b9b8fcf1a8991bb36fc50227fe068f39229fe4387978645",
+                                "uncompressed-sha256": "1df417d80e5c16c3268cbd827ab0628e271c5e1db057542d7ff11d922c25c9ac"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/aarch64/fedora-coreos-37.20221127.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "0c1adc4bfafefbca2b60080e239b08bee36e16333ab26e6e101bd892689eef58",
-                                "uncompressed-sha256": "0acb76147186367864aa56eff8d5599d5534c9adbfdcb3b979cf440d42675cd1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "7ddc173097e2ac739a3ee33199ab2c5126422f8ce85973c635ef612f09f77efe",
+                                "uncompressed-sha256": "896cd0f3851c0cf46224bea33e990b0836a950634fc863f3240109da0a428d73"
                             }
                         }
                     }
@@ -109,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0b7a91478050d7e01"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0bf775cca4087696e"
                         },
                         "ap-east-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0f1f0e1b5ef765e69"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-078f4ad996cb61966"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-071f37b73b6423d28"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0ec1109f294f0b16f"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0990006a464d26a54"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-02d2a4aedb2267bf7"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0e353adc728810d85"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0cabc319d35f4f83c"
                         },
                         "ap-south-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-053a71075d21945b0"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-052f6e168258b8515"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0023ddcee98045e88"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-088d819d5b7768e6b"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0b88d1a2e529d9ca0"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0a8d313cd17a95612"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0bd103c2259e17e94"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0cd8c7046878f6670"
                         },
                         "ca-central-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0c01bb2c8e743fd40"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0a225c56bfb41ca10"
                         },
                         "eu-central-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0b316e33d04aa1008"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-06f9734b6015e6a03"
                         },
                         "eu-north-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0a59d00b2a6016e08"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-007ff4038943a6d2b"
                         },
                         "eu-south-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0d705c727dfd08460"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-09c5c1e7915a30574"
                         },
                         "eu-west-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-03ae3cd946b4f8d4e"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0e62e5e309a0e769b"
                         },
                         "eu-west-2": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-06c0c9636897fb614"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-08ca81e1cd4a53157"
                         },
                         "eu-west-3": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-04aec8f75c8eb6a5c"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0687130b3f6e69edd"
                         },
                         "me-central-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0dee3d64bd4bf423c"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-069fd57c39a4553dd"
                         },
                         "me-south-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0d26b8bce9cad7822"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0a833ae53271125f0"
                         },
                         "sa-east-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0c2ff8579a3465d95"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-086bb0a30e304c0f1"
                         },
                         "us-east-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0484ebc0d3b1551f5"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-06455c2d58fe38ed0"
                         },
                         "us-east-2": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-08e8a316ba8352bcf"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0adb19060aa393a69"
                         },
                         "us-west-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0f418b98305b096b5"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-09299b5ebd9e7322f"
                         },
                         "us-west-2": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-03a406c9798da2582"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-044f2a3a900abf76e"
                         }
                     }
                 }
@@ -207,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "534406d0328d05b82b8f1d3ba4088763ed5bd541f5ac44049c73607d06c52883",
-                                "uncompressed-sha256": "227405a891b2ca3cb92024035b3349356b6afcd8ae837b805e4495887f7f5334"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "e15d7758412cd8535fd7efeffffd1192194b6b869c8ac7ef15574c7ae816715a",
+                                "uncompressed-sha256": "5dfa0d082aab551dd7b9f0d9cd258f99cb9a56213726ff1f0d6e3acaeee15983"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "6d51e6c7370fe4c6dab5cc890af53b3b0880ed9150003d7ba1eabac165e8ef85",
-                                "uncompressed-sha256": "5227fb8ad9f5f40f1626fd08b49a2221e4b0329733ae1d0cf416ebea26bfceb5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "b09f0af561c4e82ab355ec0a6b55439eaaebe9a7bb61c6953ad9d4d4cff891af",
+                                "uncompressed-sha256": "3b899fb7c87d3b567531e27100be79e862cff473c262b89a18559e987cd0297a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-live.s390x.iso.sig",
-                                "sha256": "a6790d77132a5e51c7c49d02150092dcdc4d27db10b465ae4c69faededaab1ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-live.s390x.iso.sig",
+                                "sha256": "e682d90ce1b7c1a850955f7d2922042c6385b9640076427ad624c89cbb7f4422"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-live-kernel-s390x.sig",
-                                "sha256": "b3633b401b13e13ed7d361662e780f8d6782473b19a430dccb7882c03652ccfc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-live-kernel-s390x.sig",
+                                "sha256": "ee6449a981f58f8994372b906cb44c90fe1d7674238153ad0cb483012af9b4d8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "3251766d174aa3c4dffd2614e22370a8a996f65d6a6aed167ac38021352eba18"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "ad21146d397639ef1b49f6bd914b8917249b56ba8036d66ea4b2a8dec5bbb50e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "88cf6af67deb5faab3d5491b99517c7016e23ae788d1d9dfcaad178534fa678c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "948d97766a792afbcf934535aa0707c65fa96e61d5079b1eabf975bcbc31ac66"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "01064c33b32e76bb7377502bca9be8a43e4eb8fd9c34f73288cd341e4f36ab7f",
-                                "uncompressed-sha256": "076cdffb6aaab253de053716c50a30e10e2264ef5f645b0f59a10a6d241382e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "6e3f17498c2eae97aa6bed36352eac4aa078ee03c00b6ce4a445f830df104004",
+                                "uncompressed-sha256": "9d1b24b76670deed13f80b95754f0cc028e7eda00856408c54404b8b35a8fa5b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "d7a840310279a2a26e87d3d948d16c0e781fbb088736998f533cf4b17cef8637",
-                                "uncompressed-sha256": "ef64eeec3f832809a877f860da3690a13450ab28d7b04319348d2258348215b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "95cfddc416c49eacd366efee96264644b4f5016665c9d5aed42e0375d4b816d6",
+                                "uncompressed-sha256": "8a4a33f8cbe793f757d4926a6a73f6dc603fd2ed07244c074d113ccbc7546067"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/s390x/fedora-coreos-37.20221127.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "df6a5f635838d1f5e0acf7f84f2abb3a5b1c95f14f59f4d3d8b1dcbaa352b046",
-                                "uncompressed-sha256": "7d4357058a913d8dd8f555a62ac375ac47b2d696ea8fb0f3d4fb40847e578b72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "2e23b315c5d2fe409cec0247bbe8cca7a3fc960c9c186fe5801a65e5957765f7",
+                                "uncompressed-sha256": "e38d48e1d98d7777e177ee31695fc2e5a72e8532351555b3f940e87eb9a8cf19"
                             }
                         }
                     }
@@ -296,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "6d14409dfd8c3443b007b429a96379cad76b90e8bff513f2ffeff6d840ee2337",
-                                "uncompressed-sha256": "85257d1bcd5b21a5c8d32adee2e6d6b79254dea373bbb69f90fa8633edd75430"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "73fe7b395fb6537385e1bef315a1172280144b963c8fd88207a92415219b1531",
+                                "uncompressed-sha256": "75f170010ebf456a2b5139aec2cb9ea9738c955e4d8d6507fb4a69446e9ec76e"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "25176e4a665d80c27f8949a54a93e8936dfde1fa6d2d368e1082bc6b886c4277",
-                                "uncompressed-sha256": "938681af636ad4072922633ee3a5a8a521f9874bfdf22ea0e29e0c6cb71f90bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "d9cd562b09c3d439ce3eca055d1ec5c9d91ce499d2ae71bb68cd2a4c3745c68a",
+                                "uncompressed-sha256": "1e0adf9733d8fb58120ddf4cdff046a1c07e7190060141f24b0477c26a7f69fa"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7e835a6e7e9f84c19c112f7ed94f044bd1917144f0e28a6341eca41e434d78ac",
-                                "uncompressed-sha256": "fd1d79fd6e133925fb998610f06a5d55cd8a6ab1d2b89b1fc509c11207ea1817"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "337e73298e690fd4672939252d7371089ba59fc422c16b488e48338f68a6f3df",
+                                "uncompressed-sha256": "ebb0564a8362601bb2ac88ae61f0d1543c22806d6d111a2572257f581b4fffe0"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "1cab59760860f988900c074c6649639cc49c0dde842870eca9466c574fe4fdef",
-                                "uncompressed-sha256": "36b78ee183a3595c8a97dc779ccbd921d464240142ae799c72eb7b23e367af2b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "7338b70d929c0d4dd8e9f5e95726e93e43aafacaf92601101fe7d0f3d1e4ecdf",
+                                "uncompressed-sha256": "ed8ff7a15896e5402f0f18b998880a1bbd0ad3aa576ca6ba2f96c0db73e67142"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "651b97b78b917961cc78d32870377ef28930bcfa457a60e1951e886a2d4b2f42",
-                                "uncompressed-sha256": "5b23cddcdf77988f7709686aba017b4549cc55258bab1dcd3583d1a610b1d490"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "219a96b218bf2723fe7fb1f8958ec250522a7fffadb4ce090ec333af9c18565e",
+                                "uncompressed-sha256": "b0f39775a1dc7737a67b1a50b9fbe8e23d00ddec34bde38b667ec9083ab68854"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "6d65db02eef86c1a5c6aa5930890778b93397ede7d324dff478b1d7d1ec63fa9",
-                                "uncompressed-sha256": "7961bea4eb7fec757ece1a8b9e5513c41f01aba9f0c57409dc5a1996c5262aa0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "a577cdfe1b02872ea58ada5cbfb97e7024567d99b94d5f2bc9d65f2b986f4e96",
+                                "uncompressed-sha256": "1246c56938b6fd974b45c23aa9cd9e4f455593177c712f2b2069fd9cde79a6b4"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "1e24077807cb6ff270e3154f502e9dec787f381dfc6be1828fc2c2c4f078dc3c",
-                                "uncompressed-sha256": "ff689de04b80c83e5109c44d704d7a72bacb53f398f3b6dc49eb38e5c3d02863"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "604302ee742816cd7bc02e1cfda6d286d773ebafc126d94a32d4b92b9ca10b0e",
+                                "uncompressed-sha256": "968b50c3132896657c9088c16c2614afdf28a29f1abf192caed23d55ff13d181"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "ebc0069855a12b26d873459ce3125b51a8b12d85e5b2e3b3546eee2e23968824",
-                                "uncompressed-sha256": "689c3745c7de570230a8d8921f37ed29041169d467138cf45221aef929eb0d47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "d837083ca37d1846efeb76f86fa41e6ffab94ba496f7a998df4a0ecb9c776671",
+                                "uncompressed-sha256": "3392cc3f1eb69bce46a1bdf566247a4862c242b917696adf9f30286791612372"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "49a82064618e9dee26c8d3329c5e6550874e75895a4f22fb331b420dc5b65fb1",
-                                "uncompressed-sha256": "d9bde61bfea0210693c83aefb767daa2f8a9c6bcf28d7b22df4eb1ba639f9e8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "59ce9eca7e0a84eb50458b6254c304d8ca581b62d02832a9b37f2106f631ad7a",
+                                "uncompressed-sha256": "ab4c77412f0ad8a0a2a1cbf585c3892411a016521c47f899dc74eeccede466b4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-live.x86_64.iso.sig",
-                                "sha256": "2a96c4b360859be6c9900be1226da33a2722a73954a4819a6b05aa92611d3474"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-live.x86_64.iso.sig",
+                                "sha256": "b3387e0e6c150351b7679a8465521d38f46d815b10e74b385e570d87e9178e3e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-live-kernel-x86_64.sig",
-                                "sha256": "68077e35ec7c697edbea4b5d8e6eb230eafbf3ec6ad42590da02d42e4bb0c08f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-live-kernel-x86_64.sig",
+                                "sha256": "fefdbc8ce0e52f8681a40680f777c8c2ea73088b9968a75889bd29b27a564783"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "a73571dfdb8533874301235c660273a90f60f1d76891ceb46dc4388b0942323a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "f72e7753bd46026675b39f967047664eb69c6ecb01283872237ef93641e0814b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "68177446703bfa6685620828f76af046c1bc4b2d964ab547be3e0dac45833095"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "392ae12286ad6ee69766c105621359ce281f725613a5561326e088db4c3fb093"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "85922deea81d6edb4b3bcee71617b320f181c89930c620d54c3819a7eb2730c9",
-                                "uncompressed-sha256": "019c3b0bb1405a32d09a540138c6810bd185a435ce85cd616dd484d371a6c3c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "2ac6d9336f342f6d96cb36ad60a666fdf59f3a0f7363f9bba9129550fe7f8743",
+                                "uncompressed-sha256": "ca32b0d39108e5600e3e9a50b310bf3bb1162e645ef63be87c703a00647630ca"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "33879ec4cb244d18812728f10919d05244aa9d2a0cff6bffdb54ab0a3bfe7d74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "bb39e090a5ca3afc4e5b35e29e124bb7805b4eeeb914eca2353c82f21f65574b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "73146bfe19e40219f02d6b9f553a60139a641b06e322f034e40a2981df78aed1",
-                                "uncompressed-sha256": "da2bbed4232fc892c47a0c7a99bf6ffd8885f6a22ce62ce0bee9d477f47faa26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "a9d30e015f903998d8d36b739bed7f1b40b99ac37615e9270151e48f4573c5c6",
+                                "uncompressed-sha256": "104721423a09b4eca3f29450c2726b79f9d8cd1b1bd6508aa24b7c6f665f63dd"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "ccc0cea0ce92c58df94e97f9d084895c941a7c159b564d3fdc531813f7f60637",
-                                "uncompressed-sha256": "d9b9dbd340f193aea3fcef451c34a9da18c4c6d3f1736c56ac97e3803b1e60ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "a326b4f7a76fef5b36967fff8adea10ecce8901424208c1c88a8edff4e50ee32",
+                                "uncompressed-sha256": "175d431aeb16f65f59f0cfe75f8fc758eac8b0ece6aa8fb615f3423d9b09cb91"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "fb482315473bb2b867eb2bef60a4d89e640de5c621d345581a0c1b9cecb5a34a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "9a39bcfa575363cf5b803178770a568f1dacef8d2e43fd9c0812de3a18230a01"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "09ca33fa3d835fa876223a5dcbe14dc3dca7c88ddafdf9b67199bb710f410a59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "1c8f81e2eb83ca24383d26f5f4f447eb4a98787603ff0d4ee6fb3cf92c739799"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221127.1.0/x86_64/fedora-coreos-37.20221127.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "92e36537378b91da9ce742018edec84dae58b612b1c0573739a87cf41108546c",
-                                "uncompressed-sha256": "0a458b175c6010f08b94ff9d3077db7c4b1fd9419313759cf39aeac83e973237"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "babd5d0a03ad2fc2772fd3ca856fc38da0018a5bcceea479befb2415fae73c11",
+                                "uncompressed-sha256": "81e246daafa0995faeb519da3aa8c533c7951c900b190313de0a53e9995b5561"
                             }
                         }
                     }
@@ -524,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0275c46e8b5fe8e75"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0d82d5fdc1e3ed912"
                         },
                         "ap-east-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-03f22b9e68b2482e0"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-017300d08f00afcc0"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-019f04935d310324e"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0779059f5b5c7201e"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0c07fd79b132ff68e"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-035d8e4be04737c1a"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0343c28f386fe464c"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0623d34a26d09260c"
                         },
                         "ap-south-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-09de33e51006ef754"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-029e8affd1c18c345"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-00277bf40700e60dc"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-05fbda5d1d3cc5d8c"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0b76075be0d38ba5d"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0671f100476c72844"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-03c3a5855099e2863"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-095743fab41ccbb80"
                         },
                         "ca-central-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-08ed156a73e2a3f99"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0c6a97098cb8ded33"
                         },
                         "eu-central-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0270a9c74f9195928"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0bcd1dc752c82a1ae"
                         },
                         "eu-north-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0b3fab3032c010a46"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0714ba0c3a4c6ba3e"
                         },
                         "eu-south-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-065196c444540f333"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0e747daa229aa0915"
                         },
                         "eu-west-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0bc787556d5e786f9"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0d3b4761af34b1f9d"
                         },
                         "eu-west-2": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-050dd6e9d7391cea8"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-03fb3eb870249b053"
                         },
                         "eu-west-3": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-001546dce005b5c2e"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-04c9d9246609aa385"
                         },
                         "me-central-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0a8a616e98df9ceb2"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0191f183708f9d9d3"
                         },
                         "me-south-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-06dbdb62c493a786a"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0d87e308c0dff61ac"
                         },
                         "sa-east-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-00b661f7a1682706e"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0e95d699f61e3e80d"
                         },
                         "us-east-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0ee1c05bffb4eb5b0"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0d39fcfd4e6ba30eb"
                         },
                         "us-east-2": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-041c229112c49550a"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0afd2306bde311151"
                         },
                         "us-west-1": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-032be6d17c472fa82"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-04b16f23848a7250c"
                         },
                         "us-west-2": {
-                            "release": "37.20221127.1.0",
-                            "image": "ami-0ed3e48daf96ed375"
+                            "release": "37.20221211.1.0",
+                            "image": "ami-0b12eef15b3ca66b8"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221127.1.0",
+                    "release": "37.20221211.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-37-20221127-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20221211-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,105 +1,105 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-11-29T08:58:11Z",
+        "last-modified": "2022-12-14T14:40:02Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "f684cebcb5f91d1224e10267f22b80857a9ee9bd817cd4ce16bb9ce02c06a983",
-                                "uncompressed-sha256": "166ab4c97ca13f39389e8b99817270212035247cdab4ebf23e2261f212eee348"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "0db088733cac56ebf05e831521f1cca85fcedca4ec0ceab0ea2e82c21df4094d",
+                                "uncompressed-sha256": "0f9f232990fcaa753369ee01f1c7b89a1128e848ecbe3d9d8cafe3220ebc136c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "1c30e715d796988e7e8ca8513518620c6500404600704301677c6437ae187b4c",
-                                "uncompressed-sha256": "4085094dab9f9528518f20f38138e0d28a5a0776b21f8c3c3aa5cd2363470191"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "b2be538986f711985dabeb618dcf9476745cc86df5e8841c1164365268a08978",
+                                "uncompressed-sha256": "c99bec6a134fdf3610da92b2ec265a33318508cf8a2ef8bafad181215ad39a0c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "3454d8eb27ed83e5a14a4dd3153d5879caa0cc38fdd0090b65e76b7e9a57932c",
-                                "uncompressed-sha256": "0709b5ab9ac9878a00358050b6d666ef25c7fb3e41e4fde7d80176cd3aeb79fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "349506644f69a3474027a7276a9c73c1cbfc859249709b79a6104dc7fc49edd5",
+                                "uncompressed-sha256": "5cbe91cc77f1121150f35fd0fe9f03978a54f2774082b210bd554bc1b2310ab1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-live.aarch64.iso.sig",
-                                "sha256": "eadd18db27620ad213d2a7429efcc14a98ea517e0ce5c019967ac81d4e747c7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live.aarch64.iso.sig",
+                                "sha256": "6e0a3bace39d4cc3f6d3e662c71465ccc7ddd9a4e0e232694562216e1c164dd8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-live-kernel-aarch64.sig",
-                                "sha256": "e5f22a13b48f397d17a0b50f7844d03a7f6e81a000b323db7baddc29570001ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live-kernel-aarch64.sig",
+                                "sha256": "034552dae2f7f2f283951d6197fd2d0dc4a9f4dfaedcacd6beb2814846971586"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "2d82b87e4ff1f86677ca6af3174e3b6e6fb47f6a7819cd2b49c2947b8369f854"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "8722b6d92c9d8a2a3acdbcc109a066e6021a9b6c3a0b1cce2dd20877d009fca9"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "f513a085abe9f46774964b842de3f61c748ea943f1a82a9204959de6a6f6044e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "5c9c3381369ca6ad6656bc8608240c7d8c5c155412e823b769efddd522ca6aae"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "c75ea9b0f1e1fb9e18f5d691d389859168eacf5040f1211f3ecb00b30258faa4",
-                                "uncompressed-sha256": "3ec02dbba0be4620960920e52f7df7d96ac6a805a32bb00b5279a13cbd157bc7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "cad5adf20101d03813a944bf89a23db380598608f7317e61b1c884c5ac02a0af",
+                                "uncompressed-sha256": "1b94ce12bf7628d65e7d5a47bc762de359f55f4fd38a0d2ad6e8e0aef5c3d50e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "bbd5d68d1908af5299b14516c0ed1119ccd55c6d70a62f6ee5563a1a0f74ba8e",
-                                "uncompressed-sha256": "85b2f89a0a039aadfbde6f86d62b614181fc02d7c8e0a72bac04d1b6da09f18f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "77e7329d7eda5a82e1c9c0e7eaba9abd0c3ac45458fef750103e4bf867959e78",
+                                "uncompressed-sha256": "8e61bf86b3a49c222006fc7aeb6d5836e8a56c9a44afa29fd5b4651d5eb284fe"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/aarch64/fedora-coreos-37.20221106.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "e09ce232f553595f93237a646f619fc2ebd243a202468432799bbf4e654bbc32",
-                                "uncompressed-sha256": "47fe170d0a0a04f1806dd709c00b032bf435a1ccf2be1feaf72d02ea3768f4b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "566819b697250ab60db0d32ee9e1ab6949e01ea1e99339e6ef236b06eb6ad531",
+                                "uncompressed-sha256": "ae6bc140166de8046e8f6213f781074c39dd127a384b1301dabf025199ef6c68"
                             }
                         }
                     }
@@ -109,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-05e839284351f0945"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0cf70bcd15eb97f9f"
                         },
                         "ap-east-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0382ba5a7d891caa6"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0eedbb9b46cb012c8"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-069b8f4ac34a79dba"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0c665c7562f2c62fa"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-056a99de9de703d3d"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0c4268493fe404f07"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-02c6719301df621ae"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0fdaa1084fa96fcf1"
                         },
                         "ap-south-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-025ef55912b61a95e"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-07f22503fd2de4b09"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0ac076297f002e2b4"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0eb59fedf8032d46b"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0a5476e295781bad5"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0ad1c05af2d57479f"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0d54786cf7bdc8e06"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-08587b5a8c34f081e"
                         },
                         "ca-central-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-032ed973b7ab6c49a"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-07faeb56deea10fed"
                         },
                         "eu-central-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0a66d014ce67e339f"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0e02c0d2f176711ec"
                         },
                         "eu-north-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-097ae94fc2cc12f07"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-07478e30242b2d845"
                         },
                         "eu-south-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-086376fb611c03465"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-06c1f9cb92c099cc8"
                         },
                         "eu-west-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-04957cadbc3d4a73f"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0727d1ac18ed8876b"
                         },
                         "eu-west-2": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-01137a01d6fb41cee"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-097349b7c6c4ccc4d"
                         },
                         "eu-west-3": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-00766e638a5d292b8"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0c4e2a15183f0e53a"
                         },
                         "me-central-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-06febca420b0dc553"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-05d786ea872565d71"
                         },
                         "me-south-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-01dd2fcd029fc69d2"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0a6cfa1e63fcab55e"
                         },
                         "sa-east-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-08a9aa4a187b7bae2"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0dca77a4dc4fc8357"
                         },
                         "us-east-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-005e127a70943bda1"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0ccee6825d912eac6"
                         },
                         "us-east-2": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0f7170e81979db815"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0bda223034d8e6700"
                         },
                         "us-west-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0d590da423855a2e9"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0de120e10478a5964"
                         },
                         "us-west-2": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-00347b3d6fad87f35"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0c7dc08a47cda7250"
                         }
                     }
                 }
@@ -207,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "560c4818b41de3748a474ea83c1fd3a7d3a212e3fc7860cde2be1cf475b54217",
-                                "uncompressed-sha256": "969011000060cfba5826688a09544b8dfc31916f38f8273a57098e4d37f17105"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "377b69e89025c0da16066596cd0a596cfbfe917fb43881f3017b0d2314b227d8",
+                                "uncompressed-sha256": "046c45e681d3d062c2d121a50e163e66af7c8a06882976cb64d1f3d3c6f63ba4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "1ea65cecd3b27b5e0b240ffd279b021aebab4caae350a72e5306d78e4a3518e4",
-                                "uncompressed-sha256": "b16fedbdd9fcaf1e93edd833225ec66803f081cc675d99d8e7344e7a816db053"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "035691f8bf819eea01a42da8361321e192da837155de63893260b964cc314492",
+                                "uncompressed-sha256": "29c86a31dddf52b97e1739745f777c4ec32e4c884c8b57c57b125e85f8e9e3a7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-live.s390x.iso.sig",
-                                "sha256": "103f18b97793bed076d158629ce33ec045258870c7ec5ea5aa42e2b609a62c2c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live.s390x.iso.sig",
+                                "sha256": "d98f55301b01fa630abc3aaefbd8ec757682ebcd18d50d4e3eb7f3950f944d0e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-live-kernel-s390x.sig",
-                                "sha256": "75cd92f1654274d8b446969d2c966892e8af5b5398bc805ae243d7e6da09efd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live-kernel-s390x.sig",
+                                "sha256": "b3633b401b13e13ed7d361662e780f8d6782473b19a430dccb7882c03652ccfc"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "9f80bb576d03e4fbfb27472965e075c451183bea996e5f8c68c3eb670870a727"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "762402f4a08598f6adbca5484dfbbaed923d8582c257897f8a0e432a601f73d5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "e743390f558a11832fde3b15cfa653b7d58698200ba5758ce430d3f6125aa055"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "3e41e1f48389f7e7567012c4abc3b6fc32f1442bd32d6b58d170b7c5dac6b511"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "be590caf468c573e7cda299e4d4da9cb8a95691a7c51ceec8891a4ac4dec87d8",
-                                "uncompressed-sha256": "89404d13304df7ccbae51189933f8da4f58919993942cbec81353f951393434f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "3cae2d0b5e143a5761282fd3481eb8339a9bca1bb6e9aaf8b97aea277dc7cca7",
+                                "uncompressed-sha256": "dc0159e3d30fd53cb579b96bca9948e35cd870065a261f0fe21415c1fe983313"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "ff44e41edb08d632563769c5822e74d1fc10c6befdfb35f93304f30962bae523",
-                                "uncompressed-sha256": "65e77460fcf528cecaf6a5e9e03873950c564cc05c42bdbc11ab3c270662f525"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "c1a12e21bbdb14d3f024479ff618e33cc6cb6b06ef95904811d42939b013872b",
+                                "uncompressed-sha256": "fcd1044b60940a7205176cc6d023b6d80fda05484ee2c45717a4364d67d6a743"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/s390x/fedora-coreos-37.20221106.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "4554257ea072e604cb5d58bfcea5b28ebdb51cefbacb456945578809b7dc3621",
-                                "uncompressed-sha256": "3499acd5c2fcb8d3d94daf328f6ba001b027d6b2c204fae5dd97a667f8ddb718"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "35a435c978faea0640f840490a38536e713c75bdd78db95d52371577cc52d3cf",
+                                "uncompressed-sha256": "35bb5793af2abe06b48a2cf831fa07a352229d7806401fb75080fcbb6aee84c7"
                             }
                         }
                     }
@@ -296,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "90955fedff08c081e617df343aef97e111b737db644ff6421708bf4db63b0780",
-                                "uncompressed-sha256": "5ae2a1185c1ea7187fa0fefd1ba757285e2a59113646cad6173c604133115bd6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "299a63c19cf3e9958c4338dcb566c5e60aa040d57f28cafd72518e618999663c",
+                                "uncompressed-sha256": "33a0718312875a8b4a1f835dcbc8d7287dba328cf01dc5175f9349476aefc377"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "df8019c840e9a542284c10b540e12ef2edd2fd93124f2e8389dc116044368a03",
-                                "uncompressed-sha256": "8ad2e70d942af67b90f1a632d014a78cd192218da251631e323293c70cabf37e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "50a6421ed0d9a6f9fcb81b07591628c9eba27b941c02e70d05b3c2f20438d745",
+                                "uncompressed-sha256": "ce2a80ae7ab6d935a4cb329df522429e04922119fb47f7c2edbcb2b2f6634711"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "5a2b6349912b7e8623b4dba534749de562943df83694ed820752a22be9ff15e2",
-                                "uncompressed-sha256": "19fdd919effdcb38a26e2ed735de89e61fa0eedad32e77ddf073528a388d5c02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "678ecf7591f03b8738b4f2df4d0ee5892c69c1bcfe52503cd80c6fce69ae1970",
+                                "uncompressed-sha256": "6c0ceac7007c830def84e8f95de331275e2cd3a80b8c90adf8d3f16eefe76f84"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "95f4d18591529f1d0a1ed2df17cbbac29f1c6382f47addb17769935ef29eeba4",
-                                "uncompressed-sha256": "66b3c6b1d35d8769f50cc395335c77ea8fa36793421796201d215b5bf3a9b54f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "f6fcc890a25d1161db9bef32b2f0b7e0b6c44de2c963144237e16fcad8c41698",
+                                "uncompressed-sha256": "1537468c7225b19f8660f1fa94253c9cd55083914e4db2c86f28d714e1f5e761"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "b9cfb2ff914b3281cc62357e36a59644bd31f4ccd63bbce0c1233e6c2f5f36d5",
-                                "uncompressed-sha256": "3d42e49a375e0c44a306fa52937ef9a1f92aa483e7ffb188eaed60d2640c9ee2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "c82b57c6a97fa6eaaaca3f875ca838de8e0f79448b4aa0598ed8c944a9af3771",
+                                "uncompressed-sha256": "8ccefefa1c177a23d20302bb4e20d12db0536ce3f4192b53eb2cd56df3f46559"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "8125bfa0acaf6e0a2b81e8d04c7ec3bd50df80b9ca10a603655bcad881cea6cd",
-                                "uncompressed-sha256": "f24ddcdae099c42363a9ac2e10569724898d5d8632edf8c7c69d2b9f8a2a0e4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e20c1463de7bd1105f1552076fd7d32ec04e7e8e163f7f24204b270566d80008",
+                                "uncompressed-sha256": "655526ddc02ff9661e047b7e51000ed43429dab5bb624cd9a137c8c31188fb22"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "e9d6f09954a3f237ace2703ba3468e4d17606a349fe911405847b2451bc5a089",
-                                "uncompressed-sha256": "aca08005d45b276182e064a7f1bd940607cc4487dea99c9e4caefd882ac7c509"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "9dfb540736b5d68580e143e14eecdabff39c57b693cdb521baf9d97997dd0333",
+                                "uncompressed-sha256": "3998a22a7e17dd14252384d4f0d0f854993893189ab3ba97142f7a9b4d7c4735"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "9e10f6ddc0406cc9d0d4dba5d12f168718ad8813fd7982f479791435d067e64f",
-                                "uncompressed-sha256": "06e2a972e3f508202fa2daefc6dfcc8a24670df3e08244f8037ba264402e9e61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "68bdcbd670456a171e1cad32a9011626dd38b3f4126479c588fb30b6c7177d74",
+                                "uncompressed-sha256": "c9fe59158c024ba294b1f787d3e7b6a034474ef216d5ee79343d2214a0065f49"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "55dcc73474a426fd94849b33719aec0f5e87a95eab7471c536328fbf4e6ac9a5",
-                                "uncompressed-sha256": "1ace69cda38363350c365f8bdc1e80c02cef8ba9d1c7ad35807be0b8850ff25a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "4df1725fbc0d6ba108a35184149eef7bbd530b9a0642508c58ebe99035499fe0",
+                                "uncompressed-sha256": "5e60edb7ec4a943fbf4b99f0266e7b5dcaffefd2cb672a04e7c612433317a8a8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-live.x86_64.iso.sig",
-                                "sha256": "98377fd880a6877fce084e7fd7aeb9c89011f3dabd4e1638da616c6f9f8da516"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live.x86_64.iso.sig",
+                                "sha256": "8d9ff0d3a1ce973ea2564eb8b1391802148c0c21c3534728c562a69f8f3d0cce"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-live-kernel-x86_64.sig",
-                                "sha256": "2bd5f834349313d10a9dbeb41d9f71d985f7b9c4f7e2ba750a1dd6558f082ba9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live-kernel-x86_64.sig",
+                                "sha256": "68077e35ec7c697edbea4b5d8e6eb230eafbf3ec6ad42590da02d42e4bb0c08f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "f0a3913a79194676f7d5195cd20d01022d907722418e7e98f8cf4f90af5030ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "1717235ca2799b6ab7fbbd86eee3b5325010b59dd7b92e089ae8a7ae6e3a0736"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "0b7907919444f2df75c320d7a046263d53b50220e9d5dab24a5a21d803e3cef1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "00e98f13f5c9d781e93d9dda37b85be64dcc030fed75b1ae777f7fa695979c01"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "6e1ec4fcea431b60460d8587d6031d815de799a7c6a7224703c17e2cacb1885d",
-                                "uncompressed-sha256": "62a8185bcba391e0871f0dc785554f07321acb4ae66f9713fcbe8c7ac65984ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "f08644d5a6124f2953dc1f8bb4262be8ae8770861edf3edf1d686cdda56d6ef9",
+                                "uncompressed-sha256": "39516813e72e91158af4192b976deed00fe36af1922dc5fff57056cab78a97d8"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "412d1c0652a5881f938d481dbdf4f70d9ace3da8a5e7f3cd95631af221a7d096"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "75b2a23d8946ce3c1158e22ee56074091b49dfd5502d66daa12dff3e128678b3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "2480976b8a11c5b13c26e54bdf7efc3a2e0a01b0cad7ac1ab8ed5edd55b6d8b4",
-                                "uncompressed-sha256": "89e12d6f1e53ba45663f3c893cc105b9a536dda242531177ebdd3f0b513783b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "505df7e9116955f6bca9c8281e4094806d345fbf0c561223d749408051eb26d7",
+                                "uncompressed-sha256": "30ebcbda79fa61515852e396adc1bbc0e4d32f91ee5f319e2e0103afc031a201"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "278f78ca722cbd4f7e93444cc3ef0bff27fc624bffb6e9e61ff01ad71998d6a6",
-                                "uncompressed-sha256": "71dea1c576f8dc9579a752b371d7fcec4cb9fa084e8a4cab2e57bb5153803f8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "4368f11d4fb7ccd12ce59f3acf56e88e84e1fa9c71e8958bb6c82708c43568fc",
+                                "uncompressed-sha256": "d022a66f7a5e331c77bba7167d495e1992fb0731c24689330c40f43de100b4f8"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "95bdaa36b3aa193b4a1a2ee65371bdf8c217f558667fadf716a557c937f650b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "2183f5e0d56b186888627499f5c9db8f53795bb726b81bbdd78c59630bcb40ec"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "47b94104fc46bcbe822d8fad05ebaee3934e922d19f4e3f3409b46ac39774b34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "90d5909a53ac0549fa8daf7dd6cade89910f4e6cc266be61f8ce0a0ad1b4f73e"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221106.3.0/x86_64/fedora-coreos-37.20221106.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "bb6919950f8d912ed1b55b30f355765b2254b047388e4e31837e33be8924bee6",
-                                "uncompressed-sha256": "4d0720bc4285f977e3a74d7ef6f7058f7c0ef3415b24a106479903997a61c261"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "772228b152b422314fdd0ec381e28f0aacaa0d4873c00c370d059f8701493bab",
+                                "uncompressed-sha256": "eceecb2315eba83d345f5f85fe77a0565a03b5a1742c701bacc55787c9a5cb3a"
                             }
                         }
                     }
@@ -524,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0fce48024bb4a50eb"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-08be015d5bb663054"
                         },
                         "ap-east-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-08668920cd59acd3e"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-06202a1413694ae57"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0211fd9c2b5e003de"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-031ab495179c8c4b2"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-04b4e734efc08a798"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-033b28ce4c883b454"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-03ba14a45ea3a62bf"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-05df54cacf5c0f449"
                         },
                         "ap-south-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-08ec8de4a8cdf7362"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-015c7f5a6509ddb03"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0c1cda043f0d6fce9"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-08adf686546982642"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-00c065e530e784b88"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0699a95f69bb040b5"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-09d46f81ce2463bc8"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-01075e94bdecac8e2"
                         },
                         "ca-central-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0a106814a50c57036"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-067a4936d2519b72b"
                         },
                         "eu-central-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0991068fb5349de54"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-094fe1584439e91dd"
                         },
                         "eu-north-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0df1fadcc045d9be2"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-072747595f0c8e23d"
                         },
                         "eu-south-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0a2dafe5018e0ba3e"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-072e4b3a048ad8d43"
                         },
                         "eu-west-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0742512d2326b86c1"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0907c7277f49cef80"
                         },
                         "eu-west-2": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0bfa8325895d6b9b6"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-088cd193293ffa46d"
                         },
                         "eu-west-3": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-01a103da43908c038"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0d987d085ef4e5397"
                         },
                         "me-central-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-07ac7fc63829eb78d"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0ef9b1d7d483308f4"
                         },
                         "me-south-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0b7620d17f9573397"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0dde7ea2ef172feb3"
                         },
                         "sa-east-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0394322dcd05e7add"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0bdb0448216a5fd04"
                         },
                         "us-east-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-074ffe616eec21f4f"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0e15bde3da645fa47"
                         },
                         "us-east-2": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0e88e6ebe5fc4dad6"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-042e292bcd953e03a"
                         },
                         "us-west-1": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0382fd712f1f1a651"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-0029dbfa5dfecb227"
                         },
                         "us-west-2": {
-                            "release": "37.20221106.3.0",
-                            "image": "ami-0f37270dc88b615d0"
+                            "release": "37.20221127.3.0",
+                            "image": "ami-070ac896f6520472e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221106.3.0",
+                    "release": "37.20221127.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-37-20221106-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20221127-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-11-29T08:58:12Z",
+        "last-modified": "2022-12-14T14:40:03Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "ac4c289a1a693c247c3dba2ecc89970e168120a08d5cb1a228f9394bb25c9ef2",
-                                "uncompressed-sha256": "6b36313602075829cb2382e7223baee2d8d2d01ee0b691929906e7424a75f462"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "1affce1ca4d1efbf4736099f79c1b0a88809485b71eba08e09967979fd1c341a",
+                                "uncompressed-sha256": "4f802dab54e30df29d6eec1b2b0ab1dd21f96873a68f915680b580bf430e6b72"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "04ba58a3434560b7bf09727a5f1d7cb161c381e92efaaba049e5e5044e9d2b6f",
-                                "uncompressed-sha256": "68c2e7bc28bda6e26c97c6251ab6e2cec7c101f143c0c48d92a72f99ba61d3b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "0be58a472986116db3e3fb1574b7b865052d4966a34437c6b8b594f7f00fa016",
+                                "uncompressed-sha256": "834de354f0646253f9df2a0d4de2f156f03fd73ff3502f15caf3e7e02c6186b3"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "11de77f637f09c9df3dc11760413e82506489f2b88bdd9e6d51013a93061a745",
-                                "uncompressed-sha256": "59b2ff257e52d813bd991dc8e5fe27cbcd6e938359812e25e865936d239b5e48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "261014706211baefe31684627fe0279290a3ea15db483256d72051d06238a340",
+                                "uncompressed-sha256": "a554e77b83160346ae3117f8fab5dc7698bfbaf832eb91159007426bedfe1bab"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-live.aarch64.iso.sig",
-                                "sha256": "6e3afba0ee981a36a7e96ac0449f2b288720a822c63ed2d11778b9225b71811f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-live.aarch64.iso.sig",
+                                "sha256": "e1d9bcec6ed58865aa91079d315347fc89270af3df2483c7215864f238283515"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-live-kernel-aarch64.sig",
-                                "sha256": "034552dae2f7f2f283951d6197fd2d0dc4a9f4dfaedcacd6beb2814846971586"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-live-kernel-aarch64.sig",
+                                "sha256": "5dfe9ad3814207d407e3d8c6b94641d40bb2c9c34808c57ab29f9dfdb18dbee2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "a0ddda00d2ccc836b756ddb4dc23c441dc0ccf64b62b37b87aa4c3f946e87227"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "636e70107496b71088fa959aa47e606f84438b1b80b845d6b730b04b85f9b7ce"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "060a3a56b1a7419cbdcf8d4a4c63f85552e9772c1fca6727de58848ddca83281"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "9e1bb8cb6d4e1aa73eb7d76ea658d809dc621e90692a49500cb0440db45a8839"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "abef83a85271e8b3567123d4908f93db34e3c17596e35da33932a59f69890d30",
-                                "uncompressed-sha256": "dd0339f06743c55f56bf0a8a121f06eef5722829ca10612b9a08f29cf5e6c858"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "9c2d3c527ee6a98c416c784d0d70011e1ce0bc685a3212627def5b9109239141",
+                                "uncompressed-sha256": "94b76938e9ae173873ca7559498741eca71cc40942f158d0365f0e278f50d469"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "33c7a9dfd447e942ba7b8b520c5ea7f3c5c92832bb0982836b1e8c3c1350446c",
-                                "uncompressed-sha256": "b4a6368bdacfad352415d7003e7ee22b3bbab0f9453047d2385c8ecb8039bfd1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "3cbb4d67f638353cacedb14304e590b31444a5b0f649cc1568302d0d8728ea80",
+                                "uncompressed-sha256": "400228e0d7130b30393cbeb6c1f4619eeec735ee97aa6d9736e86345aa6fb14b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/aarch64/fedora-coreos-37.20221127.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "e6ad530c954074b19a7d8106786c9bec393efb089b9534029c50e859d61ef9c7",
-                                "uncompressed-sha256": "9edecac4f1f53336d8496fc61c67fa6b922c5757297d7296543f8c010a841d0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "9581c33e1bacb18531ab99ceaf4bd3ca3f5f716aadbe37f5f9254e3a9af1b59a",
+                                "uncompressed-sha256": "c60d682f7beca4fde66bc5dd0482c1cf93edcc30742607e3e3eb8cb0fa85da05"
                             }
                         }
                     }
@@ -109,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0cc31fc51e0e2df7f"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0bb1f77342e661c8e"
                         },
                         "ap-east-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-03224e41726557c61"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-04c9e9f036d7c7a9a"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0c2dc9e05351aed61"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0377866d61d8bd75e"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0a4e8d03bdb99f909"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0478d790c9dc5a12f"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0cbe5b5f9698dbf12"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0ed9be1f0876a006b"
                         },
                         "ap-south-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-043fb0dc9226c0351"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0749db449be5a655a"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-09b76c9a69b7f281f"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-00a7869c0bde13b98"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0db6cd70c907a6c61"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-03a5c3aea5da00371"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-039cfc9c5357b09af"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-064bd1b83adb16288"
                         },
                         "ca-central-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0ebd173c70e19b79f"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0db74985b6273a0e5"
                         },
                         "eu-central-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-05a8c3acfd5981abe"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0193a3627e558a7af"
                         },
                         "eu-north-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-05358be7ebac6aba1"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-09ba4e514bb6d52e1"
                         },
                         "eu-south-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-09e114389d23320da"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-082c802be14f476be"
                         },
                         "eu-west-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-09c433ac28385f1e8"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0e2d2faba7b4c557f"
                         },
                         "eu-west-2": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-029ca2b70d1233545"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-001fcad7a35ef891b"
                         },
                         "eu-west-3": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-09b0847067dc57164"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-07cab7ecd54c40f51"
                         },
                         "me-central-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0dd152c9e7305904c"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0de52055c04e25ff4"
                         },
                         "me-south-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-001923c7cf5fda98b"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-04f5644411dfc98dd"
                         },
                         "sa-east-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0bf14ba991e0153df"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0d6e1bd5e84115ae9"
                         },
                         "us-east-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0b10692b4588039fa"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-05f4209c9943f3bac"
                         },
                         "us-east-2": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-031bc195eb75ecb01"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-03b85f87ce030034a"
                         },
                         "us-west-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-03200ca70d279b34d"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-01ce29099a5f094e7"
                         },
                         "us-west-2": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-05ed39ec9eb87dcf0"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0b9d0d5ee9b2b61c8"
                         }
                     }
                 }
@@ -207,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "b996393c7ff87ea9bfc93b2e4dee55fc1d145d362d45776d0d5de06bacaf5ccd",
-                                "uncompressed-sha256": "3cd54d2bbd59d93c0bae1e7f31d8fee16db7d310eab893fb7a74b9ebe545e804"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "4a0a42fa56a0897eeb4dc7109536d59e69911875a525d2e7aa19a3dee48deca1",
+                                "uncompressed-sha256": "904a12616c5206738c4d74079e170959739e6a2b03f247dc8c36b690c94b32c7"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "d09e1201ebbd87a70c206c5d8f5e195680eec4170be69f41fadb91de90085a5e",
-                                "uncompressed-sha256": "150f07fc54fe639e04a12820f216ee1d12a91ced191dbe653feaba304d470b28"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "4cb51f2b84d87f2a4d2c6bafbc8ee44207e0e528f2acee2a58813a5e0a8a054e",
+                                "uncompressed-sha256": "05e7d8b552900ec8b1c1edda8435f320d6ce23d9b6eb46dc606b6dc0787b1601"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-live.s390x.iso.sig",
-                                "sha256": "67b8054c20fcb30c09f03559ed91e6838bb4519ad5bdc191dc7579382c4b2abb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-live.s390x.iso.sig",
+                                "sha256": "d210f1dda857bf8f4b81bc2bb6bf7e9c0645a64320b785ff7cfa14931e914964"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-live-kernel-s390x.sig",
-                                "sha256": "b3633b401b13e13ed7d361662e780f8d6782473b19a430dccb7882c03652ccfc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-live-kernel-s390x.sig",
+                                "sha256": "ee6449a981f58f8994372b906cb44c90fe1d7674238153ad0cb483012af9b4d8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "ae27ec17a4b5d3b1f62de5aefe9abf8090942cccac931d0be60d5f154ddd82a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "fb18c0f3646f7aa8d512d14475a2114ca24a77838ff73d1ece4d8eb64caab722"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "7f86ff16eef8d814b708335d5d4b618ad6eaf994ab1ef28e89e078025266cc8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "f8a7c83eb51ee5f8f6f74808c916463ea085592508cba9f82d262fdd21de1a32"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "87d24f6b046e4391a54352a14ddd2a54e766388bff62df2038a63201ac951fed",
-                                "uncompressed-sha256": "34eed3f9daa4b01137368a5d2b66e8897fa4ef922e2963669d75414a64e9b248"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "68f238a1bc478241d6fa4a1b0244146c310eb7532b0ad7e7b1f7e3189866195f",
+                                "uncompressed-sha256": "c1e37c14c4657a1987db2773c00a624674c9e0013f9721d36d53291b56f8b566"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "7a056b366157960267e2d5ea03167eadfc341dac6d32c1e65975936a2e17d280",
-                                "uncompressed-sha256": "7af873996661f238fa22b3b96db8a3566a4603e083366391e505068729edebf0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "680ce8b2bebe1245165ddd3be65aa884a7b10904e45c53aac1f018b603178693",
+                                "uncompressed-sha256": "5086f6879e7127da5dc817fd684b377a58a6f6cf354589caf348f49d83835bcb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/s390x/fedora-coreos-37.20221127.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "82544b0f59b0d1672a819186c3b1d26a8fb05b1303ebc8a3add88f1afb84de3f",
-                                "uncompressed-sha256": "da8d64fc834171cd6ae87735b5f451e5b7646fc74ffb566c04a41656074bfb82"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "6d2a83e5b596c003fdd03f91029ef1ff53e582dcb73dde92b35d2a55bda819a7",
+                                "uncompressed-sha256": "c2a6af03b44d432a36dbae5256808d4fbc4983a33ed0b7895aa717f9f24610d0"
                             }
                         }
                     }
@@ -296,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "25f709cb407acd3c64663248a8d7bdd8e2692cf5a396e1c48761458b3f7c8c44",
-                                "uncompressed-sha256": "11cad3512a35c3f02f3f2aa2219c6b822a6bff23e824c07b8d63b8b46d15fe6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "093a14e3bccf6e32a171a1af3294cba39ab5e8a9d2c6307ae84022d1fbf840a4",
+                                "uncompressed-sha256": "cea4a21439c88ab3f5a154b184153e7f39c2690ab38c9181714a38e71a7c72c8"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "3f37ca9adfca680553b8f8815706a54a5ea180dd15b92d1d59721d8f84aa6130",
-                                "uncompressed-sha256": "884e101a38e12ee1c3f79179298620b2a5ab05454d0bbf724f07aedcfc5b0c66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "8be0de2d952331ed225bd5fb93687d040dd0c5e1b1cc5d5cedaa77ae7e721c98",
+                                "uncompressed-sha256": "2138c3dc900b72793eff27eebe3afa4c253bbeb433daae23fb2bfee3159267fd"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "b3be81891e4737f1f33854287e29158e5453ed6f857197727edc1254bdc3aa91",
-                                "uncompressed-sha256": "f3f82901f94f2ff88e57bd936e0f691b225eeed157c3b9d4854aabcbbf2b4441"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e65919686904fe1c982e0097db807dcbd7a45277617c04793a0df1016e7fb066",
+                                "uncompressed-sha256": "52a02b0b5ded2d9bfc9e1fa3370cf33990c889fe6069290382ae9d2124778542"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "4e9f3a2439ab0bd57065314c794f8a73c0a5bd5454aff5155bc80fcf9db29b6f",
-                                "uncompressed-sha256": "0f623ebd51397b2db3d88d4c962b49f6aedbc466e94c9080837e9c741cd92494"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "6e80eb48c147c48a9be36895a170a601a73e9cbb58128db97bee1d16e106b237",
+                                "uncompressed-sha256": "49363063ecdd03c2ff5999d21f2bf4839050ede7807931a744b2a4e25341e634"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "a2259a2ad455ccf432ece8e3adb43373e456e2719077415e10f881ace0fa4acd",
-                                "uncompressed-sha256": "d8738d093b2784d9f3eaa1a70b0d6adf221c6216e83139fbdadd3acd39a1ebb5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "d3e43169f2dcbcc61ad8c4bcd3cf2989103d9797ca8fc837e6c3db028efc5ba9",
+                                "uncompressed-sha256": "0485ea7641c4de38d7d3c22159555987377e998beeaa9539fdfff279425d03ea"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "ae8297a3f1df3dae8beb272ad5a9598e6542dd48e21cc9af501251f10cfc082d",
-                                "uncompressed-sha256": "a3d8dbefb3930d964bf115a81d5f664094647ad4c54e5f3f2e0b2846ad0fb03c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "bec4188648b15b22b571c772f0d6f8114ef492a9d9c934868eea98456b68ab55",
+                                "uncompressed-sha256": "e3e598c03da85a935ac5211d496421f6daee67ed55d252d92c54eee00c0841ae"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "f864fd859c94d7a15b44f617b3034a064076c4217695b61e9d75a91749c672b4",
-                                "uncompressed-sha256": "dc64b98af202c1aea26e5a04a5f7355e9ece934e6fc33eaf453215ea30e6b20c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "ed76593d9b310a462a8e89a9a0854e0f9c717248d59e97628903158c3306faaa",
+                                "uncompressed-sha256": "cd7226b504ae2421219c7443dc2c8ef384ada6b7733a28c4e5e13b15ad89318b"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a343e91cec4b25f10d3bd30bf5ee10501078630b3ca13aaa9ad827caea8169db",
-                                "uncompressed-sha256": "683d5cff0c1a478b96e7a47cb46bdddff8e32b0d7e098afcb06d8efd8f8b79d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "7204137b63506e4dda2f3db9a4df64902376f14595d5271ff3a17eebefbdb2c6",
+                                "uncompressed-sha256": "bf405da8c30e5b07b5494b90babb4a03719b6dc24f14c1765a344a19d1248e7a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "92b6fe39c81179d1dd861686e713fd4107d6f8462f1486c2d826c585cecfc267",
-                                "uncompressed-sha256": "06b898c8091dea699e81d3488491be1872018f8538329211f711512de75acd3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "a01b01a652cc8964f3cae365c101888f85d14302814a80967849061ed25f7c9b",
+                                "uncompressed-sha256": "8a16a5b1f98aa5d8effd82e1acf0783814d21d97862e61e65d23708fc2b229e9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-live.x86_64.iso.sig",
-                                "sha256": "841b19a2dbf0bab5fc430a0e938777cc643e308cbd93c48b1110f63356dfb0d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-live.x86_64.iso.sig",
+                                "sha256": "b49b007316add92a34d85449ea8734b52596c79e52baa1c7e8e6eee0ee095186"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-live-kernel-x86_64.sig",
-                                "sha256": "68077e35ec7c697edbea4b5d8e6eb230eafbf3ec6ad42590da02d42e4bb0c08f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-live-kernel-x86_64.sig",
+                                "sha256": "fefdbc8ce0e52f8681a40680f777c8c2ea73088b9968a75889bd29b27a564783"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "a85caf3acb171fd979f6fb0cbefc7d8d1d9873fb968873982fb88f433c9b6545"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "bacdc4faa4b4d79d616a5a9e03bb5626c8610790288b83f941cb4948ea0a95bd"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "1bc690a3a17649df2b208c71cc380cae3f87415295ebaa7e25026581a69405c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "f8a75799acd04501161401210809ab5f6df92a7b4185fcdb5beb18c1dcd97801"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "c1fb90940b53010edea63d1fd329df2521b2d4aa973512845d50271735c8a076",
-                                "uncompressed-sha256": "c7b7b37ec3461b941f888ad0280b5a1e0a0da11833c50905811ea91118b6d5c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "14ce0743539e93f6b3a43baf4fd73b548af6da41e178a1a6cac178cb905e35cc",
+                                "uncompressed-sha256": "f05d70c382628b4db0c6dee1ce85f3bacbdc87aacbbe3e1c9b1a408fc9e9df10"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "88f422bb41a36155b3f3705e3afde08ed5e09a3a9c03a899c94696448f3f530a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "3bbb6fb7e8480e9bb083c0a99305847a5334db980bad02750d3453b50614a591"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "ec1eabc22b0910871a4ae0cd90685c5b2a6067fd4ab0369194c215cc495fbe54",
-                                "uncompressed-sha256": "20601e865a0ebe8fcd5b18626b28f4793b3c2d184581b3c5a84aaded89397608"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "d5ae1e5b7483bd3290e945d4144bb61a4830af14b776186803be8709fa6eb6a7",
+                                "uncompressed-sha256": "a47464dfdbf04731ea28b6fd032f63687c0791e3e4b6efea7356ca4fb81fb2fe"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "5309c5f6b1584b53b9cc260fec1c182df5e55222fceb44c1fabe6a0292a942b8",
-                                "uncompressed-sha256": "60d5dc463eb0bf16f5110a0b25df021eadd17257b3b32a05f00cd19b39a8ce62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "d9a1ff23cb2c30aa1325c5cd66aee114de80f392155d9e2963008dd5d00ceb86",
+                                "uncompressed-sha256": "59bf0a3955c866be5c1eac3ddb4a3ea8365716c33ca31fdf4f0569ac3b614b2e"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "e756f34e9e360620025ac358c3b1200db9e7e4c8ae5584d178f663fa3638ee97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "13396e2d3633a39d0f9b8478fe02a592be083f1f161257b59f7fddaeac431562"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "ce68b8db2e2b18190752b751e75ad473b7d0fb1a02d8b818ad450648e53ff8ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "7773c1223689a97f04307142d12ea6f0f2dca683756d591f45a42471a3c2678f"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221127.2.0/x86_64/fedora-coreos-37.20221127.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "4f2d10cd6830abc2feace5e6e0514219894c1caf79ba3a4fe0de6c5fc776ec72",
-                                "uncompressed-sha256": "e081ea72e787b78b3959fbd154443bfa23973bd688f15a9bae0dc6c6355287a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "8537f780b2d8977c0472dc03fe6e8195d8f129652f77762a6fc74c4c4886f1a0",
+                                "uncompressed-sha256": "1feba3b0bb744aaf545c5d439324d072922d898bb3ac0a30347d019a87172d40"
                             }
                         }
                     }
@@ -524,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-05226625167306621"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0a3d77437119cda72"
                         },
                         "ap-east-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-00d75de7e7cd75c25"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-05407b1d35901ed38"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0f822e4292f03a0a1"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0b02fc86305e2d1f2"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-09b8b7a3064ba93d6"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-089bcb745691345d1"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0fc78580e033f5734"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-03a34f785c226a501"
                         },
                         "ap-south-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0278db46cf58fc0b2"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-053f31b8fa9f0059d"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0113ca0917f63013e"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-030b73c74523e91c4"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0d18e71a90e4e8056"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0457aea3b46f1e1e2"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0c79ec261c2eab195"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-014a05fc23983e395"
                         },
                         "ca-central-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-09b3e1434b463386e"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-073c868283d59d4bc"
                         },
                         "eu-central-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-02574d7c4c20ace57"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0bdd1bcd76c5117a2"
                         },
                         "eu-north-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-070dec5d5b629ec9e"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-08dd3b654533c54bb"
                         },
                         "eu-south-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0f87c493de063b1a4"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0efb3d6e876ef4a76"
                         },
                         "eu-west-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-05cd41ea74c7f785a"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-049423c97952c826a"
                         },
                         "eu-west-2": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-09cd725f3048dbf40"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0159cb0a54b6456ea"
                         },
                         "eu-west-3": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0d718530e6e972333"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-029d862c0a5f9a1c2"
                         },
                         "me-central-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-084d590704817447c"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0f3ffb2abb68acc35"
                         },
                         "me-south-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0f7e38dadea31ce8f"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-01d5c179b6770ed34"
                         },
                         "sa-east-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0ce563999e962e8a4"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-08985003e37be796c"
                         },
                         "us-east-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0900908c3a2a5a865"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-09f985b285d005e22"
                         },
                         "us-east-2": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-06ac33742165f624b"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0218df03f197d028b"
                         },
                         "us-west-1": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-083b15ec2d71e0a76"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0386f59feed2904cf"
                         },
                         "us-west-2": {
-                            "release": "37.20221127.2.0",
-                            "image": "ami-0caef838d356c6de5"
+                            "release": "37.20221211.2.0",
+                            "image": "ami-0a8511e6d9ea1dfaf"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221127.2.0",
+                    "release": "37.20221211.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-37-20221127-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20221211-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-11-29T08:58:14Z"
+    "last-modified": "2022-12-14T14:40:04Z"
   },
   "releases": [
     {
@@ -63,9 +63,6 @@
     {
       "version": "37.20221111.1.0",
       "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        },
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1333#issuecomment-1319168915"
         }
@@ -75,8 +72,16 @@
       "version": "37.20221127.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1669734000,
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "37.20221211.1.0",
+      "metadata": {
+        "rollout": {
+          "duration_minutes": 2160,
+          "start_epoch": 1671033600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-11-29T08:58:12Z"
+    "last-modified": "2022-12-14T14:40:03Z"
   },
   "releases": [
     {
@@ -65,9 +65,6 @@
       "metadata": {
         "barrier": {
           "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
-        },
-        "rollout": {
-          "start_percentage": 1.0
         }
       }
     },
@@ -75,8 +72,16 @@
       "version": "37.20221106.3.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1669734000,
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "37.20221127.3.0",
+      "metadata": {
+        "rollout": {
+          "duration_minutes": 2160,
+          "start_epoch": 1671033600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-11-29T08:58:13Z"
+    "last-modified": "2022-12-14T14:40:04Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "37.20221106.2.1",
+      "version": "37.20221127.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "37.20221127.2.0",
+      "version": "37.20221211.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1669734000,
+          "duration_minutes": 2160,
+          "start_epoch": 1671033600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).