### PR TITLE
Roll out stable 37.20221211.3.0, testing 37.20221225.2.1, next 37.20221225.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-12-14T14:40:04Z",
+        "last-modified": "2022-12-27T14:02:09Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "a461294cb9292685276bf85868ca57bdbeab325c05a09bed3955d9404286c508",
-                                "uncompressed-sha256": "477d30b27308edc10e39cfff4aa7a622c5a899e820393780312f32eeb193483e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "447eed2f1442eecea927d43efb3ce1b1d66532b5468767987d628dca7b28756f",
+                                "uncompressed-sha256": "c97d289d7f0b1c3dd614563b5d0b369684de786797d8ea7e53c40a3968193cff"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "f4d85959eb46106f7344465179c0f5a117dddf7c974fe1230ed7e33f18f40953",
-                                "uncompressed-sha256": "34202c009ed92043c82e075bda1610b63707396a9a82d374c5cdf3a8b406f220"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "8c7f11ecee7684fd8823a72ba26791aa6d3524f8dc0c7952b04428917d7439cd",
+                                "uncompressed-sha256": "cc51bbad612b2421a5ec54b5b235f27a3b87b0d814ff04472aa785a967252f25"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "bec38364c19c7af8f4af06ef92cb956f6595e184ef2e4a06c1f919edff655c6f",
-                                "uncompressed-sha256": "3239352ee4e4c3ba94464391d12753db8b02b644ffcefdd66b153072046f5de8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a92a6d48bc754722f0e33d85dafaef1747bcf5d6c3380f5e5b6151ea25b97298",
+                                "uncompressed-sha256": "1c6fa9700b699bcaf4063657270843a33cbbc502da96929634112fe6183a4806"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-live.aarch64.iso.sig",
-                                "sha256": "6a6cb7e4a6b99ee64a84ca1b8ea90457ec4df162302678f784cd5557e6e2447e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-live.aarch64.iso.sig",
+                                "sha256": "7104a8b9773af6f7a3ac51f766c9a285d34a73cece43ae9b3294075b25c9c792"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-live-kernel-aarch64.sig",
-                                "sha256": "5dfe9ad3814207d407e3d8c6b94641d40bb2c9c34808c57ab29f9dfdb18dbee2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-live-kernel-aarch64.sig",
+                                "sha256": "6c87ccd2811cf5754df2756cc755f358180fb63bf981aa9b7754599b6f379339"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "3ac5edf6620032202441d1300651063d38183352d896a62df8ab0fe03253e508"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "56941de9c9c3fe1b62c3c65062da4a23a20fe545be1c801d47a13faf511bfcd9"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "c0e83d6f012bed70784995a2a2c931b062cddb44776813a4cecdb5704dac49cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "588b53a2c0330b174e67a1473afd466b79953eaccc38153877aaa11e52e30688"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "3cd693df32e7e84e192ca37039638e18b6efaa80477c27c1a1931a6cd048ae8c",
-                                "uncompressed-sha256": "63fb10dcada2736c44a3eb18318702d25de14cddc7780a65dba32e757c1656ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "abf7f324120d05a135e3b9b43162da8275d895ea3ae065a83fc6f91d9d054d29",
+                                "uncompressed-sha256": "57517409e8a788e88780dd44dbac800bc05d20ab2717ff33408c743fe80b7d25"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "c2aaeb681bde6f928b9b8fcf1a8991bb36fc50227fe068f39229fe4387978645",
-                                "uncompressed-sha256": "1df417d80e5c16c3268cbd827ab0628e271c5e1db057542d7ff11d922c25c9ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "f98e852053391f710a6835f105eaffb33a2a661a76b902937d30e6087a4e0c9c",
+                                "uncompressed-sha256": "d717d622855f36d6ea4063a0f300b76e2e24c69c1c228391fbe1aebf5401349b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/aarch64/fedora-coreos-37.20221211.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "7ddc173097e2ac739a3ee33199ab2c5126422f8ce85973c635ef612f09f77efe",
-                                "uncompressed-sha256": "896cd0f3851c0cf46224bea33e990b0836a950634fc863f3240109da0a428d73"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "110a1366bb31069c44f26946bedbadd67e53c8941f67ed996c5e2509564f515c",
+                                "uncompressed-sha256": "c7f6060ba96ad5e6e61faf629cf4d5b0f37ce9f07aea937154110d8cbe0d7e4d"
                             }
                         }
                     }
@@ -109,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0bf775cca4087696e"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-0d8c0d8c3ecfc121a"
                         },
                         "ap-east-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-078f4ad996cb61966"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-0435898c05daa468f"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0ec1109f294f0b16f"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-01b3dd0355a278969"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-02d2a4aedb2267bf7"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-0a71f360a1926b2dd"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0cabc319d35f4f83c"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-02cdf9f41d585a783"
                         },
                         "ap-south-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-052f6e168258b8515"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-077e36d70f70c0eed"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-088d819d5b7768e6b"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-07af683970595656d"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0a8d313cd17a95612"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-0c5ac7b443418e70e"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0cd8c7046878f6670"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-0b52a49f986154550"
                         },
                         "ca-central-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0a225c56bfb41ca10"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-02b53ef3949145908"
                         },
                         "eu-central-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-06f9734b6015e6a03"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-09517dfb16f619297"
                         },
                         "eu-north-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-007ff4038943a6d2b"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-0305e311f30346feb"
                         },
                         "eu-south-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-09c5c1e7915a30574"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-0955b1a84a705950b"
                         },
                         "eu-west-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0e62e5e309a0e769b"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-031f22d0858726ff3"
                         },
                         "eu-west-2": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-08ca81e1cd4a53157"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-0d576642cbe87302e"
                         },
                         "eu-west-3": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0687130b3f6e69edd"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-0be0246df90ff3cf6"
                         },
                         "me-central-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-069fd57c39a4553dd"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-01574e8a48552676b"
                         },
                         "me-south-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0a833ae53271125f0"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-04489c0edef6ef10d"
                         },
                         "sa-east-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-086bb0a30e304c0f1"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-0400ae06567874264"
                         },
                         "us-east-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-06455c2d58fe38ed0"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-03f7d6f5c8a072bbf"
                         },
                         "us-east-2": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0adb19060aa393a69"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-04e526724b6a72438"
                         },
                         "us-west-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-09299b5ebd9e7322f"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-0d0e7156abd9fafc8"
                         },
                         "us-west-2": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-044f2a3a900abf76e"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-0748a331bef45c9c2"
                         }
                     }
                 }
@@ -207,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "e15d7758412cd8535fd7efeffffd1192194b6b869c8ac7ef15574c7ae816715a",
-                                "uncompressed-sha256": "5dfa0d082aab551dd7b9f0d9cd258f99cb9a56213726ff1f0d6e3acaeee15983"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "0c2bd364d10d9bdfa2ee51c54eaf9146e3f9cc0eb7e27883ee4ead3ca74965a3",
+                                "uncompressed-sha256": "bfafe3a27678d50ebe9d0b8ef69543ef6ce2f6e8ae0a74d5d6f57ffaa5cce7ef"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "b09f0af561c4e82ab355ec0a6b55439eaaebe9a7bb61c6953ad9d4d4cff891af",
-                                "uncompressed-sha256": "3b899fb7c87d3b567531e27100be79e862cff473c262b89a18559e987cd0297a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "2e66ce0b6e0900c9e943985dda6b30e58fbeddf38f4c1da56ae02bdf29c868aa",
+                                "uncompressed-sha256": "79a4b9e594d97afd310c475b9bbfaf70d9630d6a5831fbc6dcee4b49d6835297"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-live.s390x.iso.sig",
-                                "sha256": "e682d90ce1b7c1a850955f7d2922042c6385b9640076427ad624c89cbb7f4422"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-live.s390x.iso.sig",
+                                "sha256": "b0c8eba700950a1916d0f700cd4408657527061c0f44e6d13068097cb05119bb"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-live-kernel-s390x.sig",
-                                "sha256": "ee6449a981f58f8994372b906cb44c90fe1d7674238153ad0cb483012af9b4d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-live-kernel-s390x.sig",
+                                "sha256": "647edd9b580f1628ca8b68159accc5c41484c8b94572fdce7fc895c98f3d7168"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "ad21146d397639ef1b49f6bd914b8917249b56ba8036d66ea4b2a8dec5bbb50e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "05673cb6c22c9f54bdcc9e7179c35a5713268bf43ce12df2aa7fccbb8ef9610c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "948d97766a792afbcf934535aa0707c65fa96e61d5079b1eabf975bcbc31ac66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "9247847da95d605f440b2c696ef4c2669ab77a799b003512e6b850e3eda23231"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "6e3f17498c2eae97aa6bed36352eac4aa078ee03c00b6ce4a445f830df104004",
-                                "uncompressed-sha256": "9d1b24b76670deed13f80b95754f0cc028e7eda00856408c54404b8b35a8fa5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "882c2c63d489b324a9ad8797262efa1b603e89d5865f268777acfa93e7be686c",
+                                "uncompressed-sha256": "af11460611af0f17d4ef42708e6af5933391b033ec858580599c9da427529d01"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "95cfddc416c49eacd366efee96264644b4f5016665c9d5aed42e0375d4b816d6",
-                                "uncompressed-sha256": "8a4a33f8cbe793f757d4926a6a73f6dc603fd2ed07244c074d113ccbc7546067"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "9f2471f4bfb50d219002c280a9203bef7eeb3ea7ce37fd492c1c47e53e0c1c7b",
+                                "uncompressed-sha256": "6541deccaf963184a164a005c4eb03e068e9dfc92bfbd2d707c7f9d3f6ab46b7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/s390x/fedora-coreos-37.20221211.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "2e23b315c5d2fe409cec0247bbe8cca7a3fc960c9c186fe5801a65e5957765f7",
-                                "uncompressed-sha256": "e38d48e1d98d7777e177ee31695fc2e5a72e8532351555b3f940e87eb9a8cf19"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "99a9fb43a38e3688937aadf0512d07f0d6ced5b6591f71f284c4250c066d3f84",
+                                "uncompressed-sha256": "bb4db38b164d9b115eeddd3a45df10e45513fd8a5a4663752a795385df74092a"
                             }
                         }
                     }
@@ -296,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "73fe7b395fb6537385e1bef315a1172280144b963c8fd88207a92415219b1531",
-                                "uncompressed-sha256": "75f170010ebf456a2b5139aec2cb9ea9738c955e4d8d6507fb4a69446e9ec76e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "cfa4a91757597dbc9bf2bf5f1ad79358830c0540938a8a5825d2649fbbe70e36",
+                                "uncompressed-sha256": "54bb2423f7b6b4b27675a5425b833d1f586cfd2107cccc7d38a37bc3e505a060"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "d9cd562b09c3d439ce3eca055d1ec5c9d91ce499d2ae71bb68cd2a4c3745c68a",
-                                "uncompressed-sha256": "1e0adf9733d8fb58120ddf4cdff046a1c07e7190060141f24b0477c26a7f69fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "6f0779bdd633a16f49600f2cfb6e92c7f8670a2d97e7752a346bea9e24edf792",
+                                "uncompressed-sha256": "a71149e0dcd87fab5fda4d9e6f5ff2980546596b63eacb13080f8c67a5128abb"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "337e73298e690fd4672939252d7371089ba59fc422c16b488e48338f68a6f3df",
-                                "uncompressed-sha256": "ebb0564a8362601bb2ac88ae61f0d1543c22806d6d111a2572257f581b4fffe0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "be89eb05196a2b004b87d41524d74dd971fa70a4d9d5ddebd71b7627241548b9",
+                                "uncompressed-sha256": "a2df7a069131b7485e3251f3d8ad6c308d67e721d829f34b5b130c5cfbaa1ded"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "7338b70d929c0d4dd8e9f5e95726e93e43aafacaf92601101fe7d0f3d1e4ecdf",
-                                "uncompressed-sha256": "ed8ff7a15896e5402f0f18b998880a1bbd0ad3aa576ca6ba2f96c0db73e67142"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "29801f0d576a5c3ee4155859c6e7d83fe012d8ce20966d9116a551160145de8b",
+                                "uncompressed-sha256": "0541c9de1ba0f47fde4e518a0f96a1a764c9f904f9037ce336e0f8ac6f7756db"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "219a96b218bf2723fe7fb1f8958ec250522a7fffadb4ce090ec333af9c18565e",
-                                "uncompressed-sha256": "b0f39775a1dc7737a67b1a50b9fbe8e23d00ddec34bde38b667ec9083ab68854"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "48f101868572026131ca5fed11393174441159bab40c9eb1b9682fa129f976c6",
+                                "uncompressed-sha256": "adfe3cff999d86b40b99f13f2bc9d33016eeea0328fac8010f25a184cb779df0"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a577cdfe1b02872ea58ada5cbfb97e7024567d99b94d5f2bc9d65f2b986f4e96",
-                                "uncompressed-sha256": "1246c56938b6fd974b45c23aa9cd9e4f455593177c712f2b2069fd9cde79a6b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "a4de1357609cf627bd745194f4d746fcf92e7f3aacbc91513d40d46f9855fb86",
+                                "uncompressed-sha256": "0d34acf34a67b5bdf7b7925b15cbfea339d69ecd7a95a37588aac42e4ccd8335"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "604302ee742816cd7bc02e1cfda6d286d773ebafc126d94a32d4b92b9ca10b0e",
-                                "uncompressed-sha256": "968b50c3132896657c9088c16c2614afdf28a29f1abf192caed23d55ff13d181"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "2b44f23f30c5909a2ec5dcca4dd7f1cc5e6b7567790831e5267b75d81a9d1e5c",
+                                "uncompressed-sha256": "5c21d27ddb4b306735d9eac8f0162e89e9a760354e7deebf685f39919ca36321"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "d837083ca37d1846efeb76f86fa41e6ffab94ba496f7a998df4a0ecb9c776671",
-                                "uncompressed-sha256": "3392cc3f1eb69bce46a1bdf566247a4862c242b917696adf9f30286791612372"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "0ddceb30eee9470331155b211b59f3c265b1ef9199649dcb91902aba14ea030c",
+                                "uncompressed-sha256": "591bb67c3a93b2968a9ca5e0faa5aa8cee83da893c2c2fcd2f83654a1ad42a96"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "59ce9eca7e0a84eb50458b6254c304d8ca581b62d02832a9b37f2106f631ad7a",
-                                "uncompressed-sha256": "ab4c77412f0ad8a0a2a1cbf585c3892411a016521c47f899dc74eeccede466b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "34c83385efdb7a88ab6d6030cf9bda884cbe2130b7bf94e6f037cae236fa5eed",
+                                "uncompressed-sha256": "01458a0ab35de1ed05b6e7e8ac206bbbf95dba0715776aa8ccdfbc83c16b49b4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-live.x86_64.iso.sig",
-                                "sha256": "b3387e0e6c150351b7679a8465521d38f46d815b10e74b385e570d87e9178e3e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-live.x86_64.iso.sig",
+                                "sha256": "16af5ba0c5a2235f875f99b05880f49bb033ef05f0bde2262a1347e86e6491bc"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-live-kernel-x86_64.sig",
-                                "sha256": "fefdbc8ce0e52f8681a40680f777c8c2ea73088b9968a75889bd29b27a564783"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-live-kernel-x86_64.sig",
+                                "sha256": "9db5d790857d1d9e60d60e76c770e606a2cfd993a5a2c09ca30c4e54a4c23ef6"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "f72e7753bd46026675b39f967047664eb69c6ecb01283872237ef93641e0814b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "475aef98231e0d7c343e14115d19aba054d3ce2bc6129dc61171a053ad4c0d9c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "392ae12286ad6ee69766c105621359ce281f725613a5561326e088db4c3fb093"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "b253c9a9fde90a2ab5200f125fa74e58bb84a1e728801e99218842ae6b7689c4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "2ac6d9336f342f6d96cb36ad60a666fdf59f3a0f7363f9bba9129550fe7f8743",
-                                "uncompressed-sha256": "ca32b0d39108e5600e3e9a50b310bf3bb1162e645ef63be87c703a00647630ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "6262016c2a514a8ba6dd44be1edd017201945061bc5864151a3068d8373100ca",
+                                "uncompressed-sha256": "dd1ea785388413254ef1d6fc84949171a96c460bf0cfd5f4d4a68798b182983f"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "bb39e090a5ca3afc4e5b35e29e124bb7805b4eeeb914eca2353c82f21f65574b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "9f13b4f2ddf506cff5de64dda610c3ebba8252d684d88d996a1a4fd97aa98531"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "a9d30e015f903998d8d36b739bed7f1b40b99ac37615e9270151e48f4573c5c6",
-                                "uncompressed-sha256": "104721423a09b4eca3f29450c2726b79f9d8cd1b1bd6508aa24b7c6f665f63dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "bd386fa67fc4ee60baab2fbcea47852efe4067360e46bb29c0a12e51d2f43ae1",
+                                "uncompressed-sha256": "a74c751e617dea46af2ae0e2e21355f682e64d12acbb7be607380c7e04d90b4e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "a326b4f7a76fef5b36967fff8adea10ecce8901424208c1c88a8edff4e50ee32",
-                                "uncompressed-sha256": "175d431aeb16f65f59f0cfe75f8fc758eac8b0ece6aa8fb615f3423d9b09cb91"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "568d7edc538a67011e47a84170544e3b5cd5aafc564d5236ca3f85c4a4995233",
+                                "uncompressed-sha256": "47205a9cc9f34c61a1eace97418aa8fd9047f7c43bc48cb2bae07510c247f3bf"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "9a39bcfa575363cf5b803178770a568f1dacef8d2e43fd9c0812de3a18230a01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "bc999ac4c57e5a19a8453f3d1fbae3231979e3bc78ae030177c99408d09fcf6c"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "1c8f81e2eb83ca24383d26f5f4f447eb4a98787603ff0d4ee6fb3cf92c739799"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "7a45e004029532425fbe32e91db1510ee1ee32419153cf70bc8b7163adfefa43"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221211.1.0/x86_64/fedora-coreos-37.20221211.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "babd5d0a03ad2fc2772fd3ca856fc38da0018a5bcceea479befb2415fae73c11",
-                                "uncompressed-sha256": "81e246daafa0995faeb519da3aa8c533c7951c900b190313de0a53e9995b5561"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "d5aaaf15562bcc93ce9cb856d70b19ce9cc1547b881571dedd662b7d58497958",
+                                "uncompressed-sha256": "f9ec24ff2a0e677b67e154824d6084642bcb8af5ff4edd623c09abe672f72a8c"
                             }
                         }
                     }
@@ -524,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0d82d5fdc1e3ed912"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-0c1764372f7190155"
                         },
                         "ap-east-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-017300d08f00afcc0"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-0f1ef8ba7957a4bc0"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0779059f5b5c7201e"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-016d34bedbfb62893"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-035d8e4be04737c1a"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-040ee73ba69141b2e"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0623d34a26d09260c"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-0676c1913b6750cc0"
                         },
                         "ap-south-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-029e8affd1c18c345"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-041b00cc70ce08896"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-05fbda5d1d3cc5d8c"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-01c57b59da2bcd0f2"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0671f100476c72844"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-06a7cc42312ec89be"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-095743fab41ccbb80"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-0711e410d2921f653"
                         },
                         "ca-central-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0c6a97098cb8ded33"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-057b10b4881ffcdbf"
                         },
                         "eu-central-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0bcd1dc752c82a1ae"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-01bdae15bac3c8acc"
                         },
                         "eu-north-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0714ba0c3a4c6ba3e"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-05724ec13270bc1be"
                         },
                         "eu-south-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0e747daa229aa0915"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-016cda76ee5a63059"
                         },
                         "eu-west-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0d3b4761af34b1f9d"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-054dbbea3a07e2de4"
                         },
                         "eu-west-2": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-03fb3eb870249b053"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-09696c06e47a42c66"
                         },
                         "eu-west-3": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-04c9d9246609aa385"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-00f6e7c34132f206a"
                         },
                         "me-central-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0191f183708f9d9d3"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-08d7c1ac96df08b3a"
                         },
                         "me-south-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0d87e308c0dff61ac"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-004f48a82aca02f0e"
                         },
                         "sa-east-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0e95d699f61e3e80d"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-06ff1700c7523556d"
                         },
                         "us-east-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0d39fcfd4e6ba30eb"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-0b97443c130890465"
                         },
                         "us-east-2": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0afd2306bde311151"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-0f6505433741a8568"
                         },
                         "us-west-1": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-04b16f23848a7250c"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-05943fcf6c8ffbf1b"
                         },
                         "us-west-2": {
-                            "release": "37.20221211.1.0",
-                            "image": "ami-0b12eef15b3ca66b8"
+                            "release": "37.20221225.1.1",
+                            "image": "ami-02b3e94e40101accd"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221211.1.0",
+                    "release": "37.20221225.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-37-20221211-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20221225-1-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,105 +1,105 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-12-14T14:40:02Z",
+        "last-modified": "2022-12-27T14:02:06Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "0db088733cac56ebf05e831521f1cca85fcedca4ec0ceab0ea2e82c21df4094d",
-                                "uncompressed-sha256": "0f9f232990fcaa753369ee01f1c7b89a1128e848ecbe3d9d8cafe3220ebc136c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "fe62456339eaabcc5c29fbb4dd6af7c6f6a65bca274757618abcfbb090534982",
+                                "uncompressed-sha256": "e0adb5659ae4992210348758cd97b301de5eba08376a89027534a5f7f25d2be0"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "b2be538986f711985dabeb618dcf9476745cc86df5e8841c1164365268a08978",
-                                "uncompressed-sha256": "c99bec6a134fdf3610da92b2ec265a33318508cf8a2ef8bafad181215ad39a0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "347f80b007efb54d85eeb4912c6c28c45d08545f6952ebb1ed9b25e9429c1264",
+                                "uncompressed-sha256": "654088b9f7c767eae6a3d19d905212c33f3ee64fdb67630217e6057d21e05fca"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "349506644f69a3474027a7276a9c73c1cbfc859249709b79a6104dc7fc49edd5",
-                                "uncompressed-sha256": "5cbe91cc77f1121150f35fd0fe9f03978a54f2774082b210bd554bc1b2310ab1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "6db747d5a874d522d9f390a9f7a3235fddd11ec18bc465cc97c025306aa41996",
+                                "uncompressed-sha256": "a205bf80a9ecbdf012908ac2978a17c38e4dfe02b88fc7834c3bce626c24f980"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live.aarch64.iso.sig",
-                                "sha256": "6e0a3bace39d4cc3f6d3e662c71465ccc7ddd9a4e0e232694562216e1c164dd8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-live.aarch64.iso.sig",
+                                "sha256": "ffab61c8d1ee821403e5f2bc2a57ea11a02c0ceff4839a07500165ab53675776"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live-kernel-aarch64.sig",
-                                "sha256": "034552dae2f7f2f283951d6197fd2d0dc4a9f4dfaedcacd6beb2814846971586"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-live-kernel-aarch64.sig",
+                                "sha256": "5dfe9ad3814207d407e3d8c6b94641d40bb2c9c34808c57ab29f9dfdb18dbee2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "8722b6d92c9d8a2a3acdbcc109a066e6021a9b6c3a0b1cce2dd20877d009fca9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "c15acfff16d9a0ba2afbb9579221c210d2da57611e685019ac930bdf14ece48d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "5c9c3381369ca6ad6656bc8608240c7d8c5c155412e823b769efddd522ca6aae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "88c72eca8a758333c0acd3fc1bb00d2889c2a59294f18826b34dc18f6f446c74"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "cad5adf20101d03813a944bf89a23db380598608f7317e61b1c884c5ac02a0af",
-                                "uncompressed-sha256": "1b94ce12bf7628d65e7d5a47bc762de359f55f4fd38a0d2ad6e8e0aef5c3d50e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "38e3883c914d09b4ffdb4887dfddb307d40e25664252bf3a7bf505d6c3a92d03",
+                                "uncompressed-sha256": "722ed664750d4532a07a112c6c55f221cca7a5f5d9cb34dae5d3c09667783185"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "77e7329d7eda5a82e1c9c0e7eaba9abd0c3ac45458fef750103e4bf867959e78",
-                                "uncompressed-sha256": "8e61bf86b3a49c222006fc7aeb6d5836e8a56c9a44afa29fd5b4651d5eb284fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "731c27f2adb38909ebe47fb2d6782857b147a8b4902cf9bdcbbefb88d3dbb9a9",
+                                "uncompressed-sha256": "31535d99c8d7d0a97a78b288b66595182523bd8e0992112071a214d7a1b2d35f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/aarch64/fedora-coreos-37.20221127.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "566819b697250ab60db0d32ee9e1ab6949e01ea1e99339e6ef236b06eb6ad531",
-                                "uncompressed-sha256": "ae6bc140166de8046e8f6213f781074c39dd127a384b1301dabf025199ef6c68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "4eb34cc211849dfd717f45f6e31ed5e5072f6b5da80737f12a5133ff4e531ecd",
+                                "uncompressed-sha256": "faaf94578b5bef1b9774c2c87e5c7b0aaa6938cf47ad050c126d214e7b813eee"
                             }
                         }
                     }
@@ -109,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0cf70bcd15eb97f9f"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-03a0b86c683c35b98"
                         },
                         "ap-east-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0eedbb9b46cb012c8"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-01404ebe20cb23ae9"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0c665c7562f2c62fa"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0d5b4b244f6a71a16"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0c4268493fe404f07"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0d4e3c5009bf4d80a"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0fdaa1084fa96fcf1"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-08dad64e1a8608da8"
                         },
                         "ap-south-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-07f22503fd2de4b09"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-01377ce596b438336"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0eb59fedf8032d46b"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-02dc80aa15293e07f"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0ad1c05af2d57479f"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-05496e177a0e376a9"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-08587b5a8c34f081e"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0f341ece569ade917"
                         },
                         "ca-central-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-07faeb56deea10fed"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-090bbcf489464a32f"
                         },
                         "eu-central-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0e02c0d2f176711ec"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0c003a8076785de75"
                         },
                         "eu-north-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-07478e30242b2d845"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0e120c4f5b9438389"
                         },
                         "eu-south-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-06c1f9cb92c099cc8"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-01d6df42c56df5ec4"
                         },
                         "eu-west-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0727d1ac18ed8876b"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-025b4b1e7a410e1a1"
                         },
                         "eu-west-2": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-097349b7c6c4ccc4d"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0ee1d2f93fb4e32f7"
                         },
                         "eu-west-3": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0c4e2a15183f0e53a"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0e3be69fbf40c7acc"
                         },
                         "me-central-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-05d786ea872565d71"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0a7540c0a1e8142fa"
                         },
                         "me-south-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0a6cfa1e63fcab55e"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0ae02cf3aaf355b0a"
                         },
                         "sa-east-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0dca77a4dc4fc8357"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-09cd6be561caa96df"
                         },
                         "us-east-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0ccee6825d912eac6"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0720576e1729ac57d"
                         },
                         "us-east-2": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0bda223034d8e6700"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0120758d4b10c38a3"
                         },
                         "us-west-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0de120e10478a5964"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-05284ff65020ba4a1"
                         },
                         "us-west-2": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0c7dc08a47cda7250"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0a2d0094dc160b84c"
                         }
                     }
                 }
@@ -207,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "377b69e89025c0da16066596cd0a596cfbfe917fb43881f3017b0d2314b227d8",
-                                "uncompressed-sha256": "046c45e681d3d062c2d121a50e163e66af7c8a06882976cb64d1f3d3c6f63ba4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "6ca226cabf7bb6d25eb9035a496a9b6285486755ad33a7559f31b85b8ce25bb7",
+                                "uncompressed-sha256": "d30d579ecf7e62be073003d70993c0e7c315e3d63dd63f7e9b105a6077fff2f9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "035691f8bf819eea01a42da8361321e192da837155de63893260b964cc314492",
-                                "uncompressed-sha256": "29c86a31dddf52b97e1739745f777c4ec32e4c884c8b57c57b125e85f8e9e3a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "082168fe9041133954e9047607cda3221a49b9398a99d160dd0ce155fe694bd1",
+                                "uncompressed-sha256": "83d79be78853cc9fe8757c6b7db3dd60b32f40437699a854fd72f170f47f9572"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live.s390x.iso.sig",
-                                "sha256": "d98f55301b01fa630abc3aaefbd8ec757682ebcd18d50d4e3eb7f3950f944d0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-live.s390x.iso.sig",
+                                "sha256": "779959533b590d1e2dab9b88b7fcf5273d24e937438773efc3f4cfde4289b6dd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live-kernel-s390x.sig",
-                                "sha256": "b3633b401b13e13ed7d361662e780f8d6782473b19a430dccb7882c03652ccfc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-live-kernel-s390x.sig",
+                                "sha256": "ee6449a981f58f8994372b906cb44c90fe1d7674238153ad0cb483012af9b4d8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "762402f4a08598f6adbca5484dfbbaed923d8582c257897f8a0e432a601f73d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "f31a9914d0f2426ca2a950b06ab520e5e484f4744e97285b367d89bb22cea9f8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "3e41e1f48389f7e7567012c4abc3b6fc32f1442bd32d6b58d170b7c5dac6b511"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "796ca664bc4987e4afb188a08c8bd0ae602e1ab7ba49089e877c576d2cc29e90"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "3cae2d0b5e143a5761282fd3481eb8339a9bca1bb6e9aaf8b97aea277dc7cca7",
-                                "uncompressed-sha256": "dc0159e3d30fd53cb579b96bca9948e35cd870065a261f0fe21415c1fe983313"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "029a93255a718987dece42c331b91ba6454b6fbbf8df12eeebdc58fe0c486f1d",
+                                "uncompressed-sha256": "6f1a8bb376edbc3a615c8999d87f73052aef684e7123c260afd2abbb928d577a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "c1a12e21bbdb14d3f024479ff618e33cc6cb6b06ef95904811d42939b013872b",
-                                "uncompressed-sha256": "fcd1044b60940a7205176cc6d023b6d80fda05484ee2c45717a4364d67d6a743"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "7d748c3edc308f0ffdcd0d95e57cf321e6452d5308c8ce8c54db63c8d225a1b2",
+                                "uncompressed-sha256": "6e162438a766a3d65af686d9fead5c23be2ceee0ed1802a4c6ceba57ee675624"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/s390x/fedora-coreos-37.20221127.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "35a435c978faea0640f840490a38536e713c75bdd78db95d52371577cc52d3cf",
-                                "uncompressed-sha256": "35bb5793af2abe06b48a2cf831fa07a352229d7806401fb75080fcbb6aee84c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "08bba93a0894477ac70450fc9e2da25c4b4840ce2b59e6245da8c2c43f3253bb",
+                                "uncompressed-sha256": "c900eb578df87b3d1f779e2b4f098c16d80e788515e69725d9659730495ce90f"
                             }
                         }
                     }
@@ -296,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "299a63c19cf3e9958c4338dcb566c5e60aa040d57f28cafd72518e618999663c",
-                                "uncompressed-sha256": "33a0718312875a8b4a1f835dcbc8d7287dba328cf01dc5175f9349476aefc377"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d7bfda1a25306aa9b171d5fce8e6f1df3da96d75697b934389f4c2d24a95e46b",
+                                "uncompressed-sha256": "2c89474d395ea4e75aeef3f0e530930d397122c190c35dc33464352c1d45b5fa"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "50a6421ed0d9a6f9fcb81b07591628c9eba27b941c02e70d05b3c2f20438d745",
-                                "uncompressed-sha256": "ce2a80ae7ab6d935a4cb329df522429e04922119fb47f7c2edbcb2b2f6634711"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "daa4b1d1bf21d4d2d399790956ff5233f2987338420f3c93ef65937ba06c6a02",
+                                "uncompressed-sha256": "a156e381ae6fcdcba62758702c8911956ef8e0ebb378a5f19aea489d1d4827e1"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "678ecf7591f03b8738b4f2df4d0ee5892c69c1bcfe52503cd80c6fce69ae1970",
-                                "uncompressed-sha256": "6c0ceac7007c830def84e8f95de331275e2cd3a80b8c90adf8d3f16eefe76f84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "13ab85c7f72a70f3b2d09e02eb29e4887659c5bf2bc9b7257b2df3b0a387684c",
+                                "uncompressed-sha256": "f0bbb9d6cff63eed603a24504ccea043233916febb09a5c5c0ce8f93f79c6fe6"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "f6fcc890a25d1161db9bef32b2f0b7e0b6c44de2c963144237e16fcad8c41698",
-                                "uncompressed-sha256": "1537468c7225b19f8660f1fa94253c9cd55083914e4db2c86f28d714e1f5e761"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "51957b9bbe057b2978dc92e4642de767d43738b193497a5df3ca4be970b84eeb",
+                                "uncompressed-sha256": "476f7c44496cbf963252f4fbb11e5aa4a4e62e7d2a76943c6e6deaa150b0c214"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c82b57c6a97fa6eaaaca3f875ca838de8e0f79448b4aa0598ed8c944a9af3771",
-                                "uncompressed-sha256": "8ccefefa1c177a23d20302bb4e20d12db0536ce3f4192b53eb2cd56df3f46559"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "d083c1274494cb39f67cdbbd22ce6d9588c8ef9023be0432d930f3ed6947795d",
+                                "uncompressed-sha256": "024c3c93a2319ccdf07756ae4dc7afe38eece54e5d1aae8508ab73dfd5658410"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "e20c1463de7bd1105f1552076fd7d32ec04e7e8e163f7f24204b270566d80008",
-                                "uncompressed-sha256": "655526ddc02ff9661e047b7e51000ed43429dab5bb624cd9a137c8c31188fb22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "7e23c26e74013888a69b1b66824635e16cbe6abc6e407801493bb3486c8cbfa7",
+                                "uncompressed-sha256": "6a8c71ca2cd6d9d7f823676feeb31e769a5fcf7a7858eecbd91aec9e26c8c56e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "9dfb540736b5d68580e143e14eecdabff39c57b693cdb521baf9d97997dd0333",
-                                "uncompressed-sha256": "3998a22a7e17dd14252384d4f0d0f854993893189ab3ba97142f7a9b4d7c4735"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "b5c00f0cd30ab252d77d97604cf9c640ac571994b75a8957f198bb81b3ff760b",
+                                "uncompressed-sha256": "60ad53f48f9a41202d387ef0746d45bbfdf827093883ad156d123f248ef8e8aa"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "68bdcbd670456a171e1cad32a9011626dd38b3f4126479c588fb30b6c7177d74",
-                                "uncompressed-sha256": "c9fe59158c024ba294b1f787d3e7b6a034474ef216d5ee79343d2214a0065f49"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "9a7a972456d61174c7794879b4a5feef4b00e22f8e87cf823f50ada3f079105d",
+                                "uncompressed-sha256": "c85d45a847a886a7995392fb37313bf4ddff761886fd4d4c051a8b227be4a59e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "4df1725fbc0d6ba108a35184149eef7bbd530b9a0642508c58ebe99035499fe0",
-                                "uncompressed-sha256": "5e60edb7ec4a943fbf4b99f0266e7b5dcaffefd2cb672a04e7c612433317a8a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "9dc2f7292b43d154e8b299233ae6594768bff0afd6c8d16c91765f9423497a9c",
+                                "uncompressed-sha256": "251f67c02d298add7290bc667ef20186b0cc97dd4c70d3b7dc0e3f3d96ba6fc8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live.x86_64.iso.sig",
-                                "sha256": "8d9ff0d3a1ce973ea2564eb8b1391802148c0c21c3534728c562a69f8f3d0cce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-live.x86_64.iso.sig",
+                                "sha256": "b5fee07dca9a8c9277d4a36e0e15921d037de002759e8ff1ae3dbc13f0ca953b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live-kernel-x86_64.sig",
-                                "sha256": "68077e35ec7c697edbea4b5d8e6eb230eafbf3ec6ad42590da02d42e4bb0c08f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-live-kernel-x86_64.sig",
+                                "sha256": "fefdbc8ce0e52f8681a40680f777c8c2ea73088b9968a75889bd29b27a564783"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "1717235ca2799b6ab7fbbd86eee3b5325010b59dd7b92e089ae8a7ae6e3a0736"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "579834269b98e3352897ba54855eb44a731bcac6bf253781e84624e1f740c6a1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "00e98f13f5c9d781e93d9dda37b85be64dcc030fed75b1ae777f7fa695979c01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "3a137f5eec3dbf6ea5c560184645b8b15e4d9feb317cc3396e3a8c81ea26d05c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f08644d5a6124f2953dc1f8bb4262be8ae8770861edf3edf1d686cdda56d6ef9",
-                                "uncompressed-sha256": "39516813e72e91158af4192b976deed00fe36af1922dc5fff57056cab78a97d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "ec56a9e1c50d432486b2da6bac148702f4afa05ef6e20f15964e87c28f989381",
+                                "uncompressed-sha256": "a50878d9e7d3e40cac754e2ebb8d21eb045aa92438b15f6f31058b21ac904fa2"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "75b2a23d8946ce3c1158e22ee56074091b49dfd5502d66daa12dff3e128678b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "b9be1189184363f0ce04505338505bbf99c9b1adca2239b149945791962fbce1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "505df7e9116955f6bca9c8281e4094806d345fbf0c561223d749408051eb26d7",
-                                "uncompressed-sha256": "30ebcbda79fa61515852e396adc1bbc0e4d32f91ee5f319e2e0103afc031a201"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "4251e5fdba15ed55a8d670520aaca6a87bce4d0ce5dc0be1885696b61bf3271d",
+                                "uncompressed-sha256": "1c5a4bc176e03fe051a0f1550f740e51352b5645838d7209373c5c93bf476a64"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "4368f11d4fb7ccd12ce59f3acf56e88e84e1fa9c71e8958bb6c82708c43568fc",
-                                "uncompressed-sha256": "d022a66f7a5e331c77bba7167d495e1992fb0731c24689330c40f43de100b4f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "28d438c8326967ce3ec68cb733f6ef5927c141921570144a16872e786f6965f7",
+                                "uncompressed-sha256": "2322c02c1a1bca4f7b7bfe2922f8f3b576a4456dafff8779150a8a2000be7e91"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "2183f5e0d56b186888627499f5c9db8f53795bb726b81bbdd78c59630bcb40ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "24061db75ff3433a0bb7e90a8df13c4f04d779c9441c995ad78345b641ececcb"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "90d5909a53ac0549fa8daf7dd6cade89910f4e6cc266be61f8ce0a0ad1b4f73e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "369765d22aff376f7ba4fe8a11eb798e0138d335f8095f81e207d4c7e4f07ead"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221127.3.0/x86_64/fedora-coreos-37.20221127.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "772228b152b422314fdd0ec381e28f0aacaa0d4873c00c370d059f8701493bab",
-                                "uncompressed-sha256": "eceecb2315eba83d345f5f85fe77a0565a03b5a1742c701bacc55787c9a5cb3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "25da40dda3897bfab71e403c777be3b282e45abab790b7c2a37da2813dc343c0",
+                                "uncompressed-sha256": "216798649c9161611de7e74c51e2cb618096f1a57c2ead39ea60d4d0ee8fa435"
                             }
                         }
                     }
@@ -524,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-08be015d5bb663054"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-020b739766e2f887a"
                         },
                         "ap-east-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-06202a1413694ae57"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-09bae491486bb8683"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-031ab495179c8c4b2"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0cd413434211c8865"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-033b28ce4c883b454"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-08b8d3872a05a506d"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-05df54cacf5c0f449"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-03378bb05039211de"
                         },
                         "ap-south-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-015c7f5a6509ddb03"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-04f5be6459b4f075c"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-08adf686546982642"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0058b399576077b1b"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0699a95f69bb040b5"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0a566951f88b0b8e9"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-01075e94bdecac8e2"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-042961caae8f7778a"
                         },
                         "ca-central-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-067a4936d2519b72b"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0f372f8cb87ed5405"
                         },
                         "eu-central-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-094fe1584439e91dd"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0c52e2d4dc1066f44"
                         },
                         "eu-north-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-072747595f0c8e23d"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0d26a78af394c2319"
                         },
                         "eu-south-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-072e4b3a048ad8d43"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0277f4c1dc01290bd"
                         },
                         "eu-west-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0907c7277f49cef80"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0199192023df17f1f"
                         },
                         "eu-west-2": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-088cd193293ffa46d"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-06ac157e28822fa1c"
                         },
                         "eu-west-3": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0d987d085ef4e5397"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-09e6b4a25c4505369"
                         },
                         "me-central-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0ef9b1d7d483308f4"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0810a10afa6a2f696"
                         },
                         "me-south-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0dde7ea2ef172feb3"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0f12eb6f8a509574c"
                         },
                         "sa-east-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0bdb0448216a5fd04"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-04f5fbc6c40a728db"
                         },
                         "us-east-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0e15bde3da645fa47"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0a3279828fb6dad65"
                         },
                         "us-east-2": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-042e292bcd953e03a"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-02138926287184a4e"
                         },
                         "us-west-1": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-0029dbfa5dfecb227"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-0206818ee836371c8"
                         },
                         "us-west-2": {
-                            "release": "37.20221127.3.0",
-                            "image": "ami-070ac896f6520472e"
+                            "release": "37.20221211.3.0",
+                            "image": "ami-09de1409d37ba4886"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221127.3.0",
+                    "release": "37.20221211.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-37-20221127-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20221211-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-12-14T14:40:03Z",
+        "last-modified": "2022-12-27T14:02:07Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "1affce1ca4d1efbf4736099f79c1b0a88809485b71eba08e09967979fd1c341a",
-                                "uncompressed-sha256": "4f802dab54e30df29d6eec1b2b0ab1dd21f96873a68f915680b580bf430e6b72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "10f5f1923d5922d24c0b3bf35c656062eaa7495efad2a42a22e41af4399b7cf7",
+                                "uncompressed-sha256": "4b63445e02cea7fa9ddcde498a47c631fd677c865bc1b9cc34395f407812c8c7"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "0be58a472986116db3e3fb1574b7b865052d4966a34437c6b8b594f7f00fa016",
-                                "uncompressed-sha256": "834de354f0646253f9df2a0d4de2f156f03fd73ff3502f15caf3e7e02c6186b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "7e88ebab79c9fd563ead760c2149affb3b83dced3aef5f34221813a25a3503ab",
+                                "uncompressed-sha256": "e29557f65342b2603870291280ac70cd95f7aed8125506d10fb646c39f60e4f7"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "261014706211baefe31684627fe0279290a3ea15db483256d72051d06238a340",
-                                "uncompressed-sha256": "a554e77b83160346ae3117f8fab5dc7698bfbaf832eb91159007426bedfe1bab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "2479f86a1eb6f6f0644e939ba0227076931b591fe61778ead938922506719066",
+                                "uncompressed-sha256": "58b7ec7e4062a7768b5850fd86b965ea713136c2aee08468b294965a9bc4589a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-live.aarch64.iso.sig",
-                                "sha256": "e1d9bcec6ed58865aa91079d315347fc89270af3df2483c7215864f238283515"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-live.aarch64.iso.sig",
+                                "sha256": "083a0691f2d476e6f9bfce35e52d29615aceec21866ecb4db966257519dba317"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-live-kernel-aarch64.sig",
-                                "sha256": "5dfe9ad3814207d407e3d8c6b94641d40bb2c9c34808c57ab29f9dfdb18dbee2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-live-kernel-aarch64.sig",
+                                "sha256": "6c87ccd2811cf5754df2756cc755f358180fb63bf981aa9b7754599b6f379339"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "636e70107496b71088fa959aa47e606f84438b1b80b845d6b730b04b85f9b7ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "210f320139ecedacaed6bb87a9c99a861e0b5761f97143b8a877f7411077020e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "9e1bb8cb6d4e1aa73eb7d76ea658d809dc621e90692a49500cb0440db45a8839"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "45c12850f85532fbf018c097f2b8ff58ae605f5663e9a346652615d1d3dc5bcb"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "9c2d3c527ee6a98c416c784d0d70011e1ce0bc685a3212627def5b9109239141",
-                                "uncompressed-sha256": "94b76938e9ae173873ca7559498741eca71cc40942f158d0365f0e278f50d469"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "505fd2c62808d4235f027af77de64e246f065e16a3472dd0e85f9b7c6f256c8a",
+                                "uncompressed-sha256": "6d92b2e8880c8dfdc7ca425dedd9dc4f73ab5a9742cc692d5d7282099fcce0e2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "3cbb4d67f638353cacedb14304e590b31444a5b0f649cc1568302d0d8728ea80",
-                                "uncompressed-sha256": "400228e0d7130b30393cbeb6c1f4619eeec735ee97aa6d9736e86345aa6fb14b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "bbf5146245e0a8d409681901d3fb6476dcbbf6020939beec60a0a5062c0a5621",
+                                "uncompressed-sha256": "e9e2d4852fe01fbd642cba66d9138b6cee386c6db0561d60099143ac12f5bf80"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/aarch64/fedora-coreos-37.20221211.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "9581c33e1bacb18531ab99ceaf4bd3ca3f5f716aadbe37f5f9254e3a9af1b59a",
-                                "uncompressed-sha256": "c60d682f7beca4fde66bc5dd0482c1cf93edcc30742607e3e3eb8cb0fa85da05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "7dd398097daebf94c5cc6322aacf65cf7761f2a9cc7fab2f541dc1b8ccb76b24",
+                                "uncompressed-sha256": "0ee652abd22e27dadaddb6842d1d799c3927556f7d1d7a2daac33aea512966d5"
                             }
                         }
                     }
@@ -109,96 +109,96 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0bb1f77342e661c8e"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-02a7886543df74446"
                         },
                         "ap-east-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-04c9e9f036d7c7a9a"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-07a4ae39b8da2f137"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0377866d61d8bd75e"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0a0f10a8c9dcd09dd"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0478d790c9dc5a12f"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0b80d673e4dfdf8f8"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0ed9be1f0876a006b"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0f30020c2317f2541"
                         },
                         "ap-south-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0749db449be5a655a"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0c95448b64bd707aa"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-00a7869c0bde13b98"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0cb51c55616095ab4"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-03a5c3aea5da00371"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0379fbf6aba455c72"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-064bd1b83adb16288"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0a98c3dbc2e6bc5e6"
                         },
                         "ca-central-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0db74985b6273a0e5"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-005fa508c1f35c8c7"
                         },
                         "eu-central-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0193a3627e558a7af"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-06772ddd37cabd688"
                         },
                         "eu-north-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-09ba4e514bb6d52e1"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-00cbd470041bc50de"
                         },
                         "eu-south-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-082c802be14f476be"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0cddeb93a864e1e81"
                         },
                         "eu-west-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0e2d2faba7b4c557f"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-06ed9ef7fc4c4e1bf"
                         },
                         "eu-west-2": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-001fcad7a35ef891b"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0d868fa350ffd48a4"
                         },
                         "eu-west-3": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-07cab7ecd54c40f51"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0dba2076c75ec9d39"
                         },
                         "me-central-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0de52055c04e25ff4"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0469d1cae3956ad0b"
                         },
                         "me-south-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-04f5644411dfc98dd"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-039c4af36a4580434"
                         },
                         "sa-east-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0d6e1bd5e84115ae9"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-09eabe5cb19acd70d"
                         },
                         "us-east-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-05f4209c9943f3bac"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0b13e5bfe66bf4df8"
                         },
                         "us-east-2": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-03b85f87ce030034a"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0e5e4b08cf7ae3c13"
                         },
                         "us-west-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-01ce29099a5f094e7"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-045144f607c10406f"
                         },
                         "us-west-2": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0b9d0d5ee9b2b61c8"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0bb236bf794e71d43"
                         }
                     }
                 }
@@ -207,85 +207,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "4a0a42fa56a0897eeb4dc7109536d59e69911875a525d2e7aa19a3dee48deca1",
-                                "uncompressed-sha256": "904a12616c5206738c4d74079e170959739e6a2b03f247dc8c36b690c94b32c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "8791b5fce8787c796885c7aa90eb9726859fbce574460eb4f6ee91c7f9ced8fc",
+                                "uncompressed-sha256": "04362b927917a565c55143134f713fbe127383f3021c04a16606fdcca9d4cba0"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "4cb51f2b84d87f2a4d2c6bafbc8ee44207e0e528f2acee2a58813a5e0a8a054e",
-                                "uncompressed-sha256": "05e7d8b552900ec8b1c1edda8435f320d6ce23d9b6eb46dc606b6dc0787b1601"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "78ac87d9b054091da2636490d853b2a0b66a8dd93e049fb6ffb42ddc77066827",
+                                "uncompressed-sha256": "0be50227c6d3e582d5bdca63770b60bf9d517d7ad2ffdc35208a49ec234f4fc3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-live.s390x.iso.sig",
-                                "sha256": "d210f1dda857bf8f4b81bc2bb6bf7e9c0645a64320b785ff7cfa14931e914964"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-live.s390x.iso.sig",
+                                "sha256": "4000a72582bcc27112985ad262842d16d30faa6598a9c294833723e71f296d41"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-live-kernel-s390x.sig",
-                                "sha256": "ee6449a981f58f8994372b906cb44c90fe1d7674238153ad0cb483012af9b4d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-live-kernel-s390x.sig",
+                                "sha256": "647edd9b580f1628ca8b68159accc5c41484c8b94572fdce7fc895c98f3d7168"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "fb18c0f3646f7aa8d512d14475a2114ca24a77838ff73d1ece4d8eb64caab722"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "f5c91baadbd46f01ea95c69db52e53d5e06ccc46b46a4ea2f7bf5d5fcf8e49d3"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "f8a7c83eb51ee5f8f6f74808c916463ea085592508cba9f82d262fdd21de1a32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "cfa993d8a21ab878028ddcbf051ffb2bb585a894ea28a56a86e50e54bbbcc5e2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "68f238a1bc478241d6fa4a1b0244146c310eb7532b0ad7e7b1f7e3189866195f",
-                                "uncompressed-sha256": "c1e37c14c4657a1987db2773c00a624674c9e0013f9721d36d53291b56f8b566"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "70e1006a788e8328f25049b84652dd897b4d8fb552161525b3424cbee3c0b62d",
+                                "uncompressed-sha256": "9b696dbb137a254c9815b8d6a8cfa474c5dc75ac5ed4a3791e1563aed9e8d780"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "680ce8b2bebe1245165ddd3be65aa884a7b10904e45c53aac1f018b603178693",
-                                "uncompressed-sha256": "5086f6879e7127da5dc817fd684b377a58a6f6cf354589caf348f49d83835bcb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "9b65263a307378cd20cab5f80f4ecc006c7086e4616784ef7a758d09dffb7900",
+                                "uncompressed-sha256": "97930ae03e9907341d059983e9c1f119323bb2bcb84c198f0303dd878cdade8a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/s390x/fedora-coreos-37.20221211.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "6d2a83e5b596c003fdd03f91029ef1ff53e582dcb73dde92b35d2a55bda819a7",
-                                "uncompressed-sha256": "c2a6af03b44d432a36dbae5256808d4fbc4983a33ed0b7895aa717f9f24610d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "a5df712d9785a37192c75fd187dbf926425da25287722bf4de5c7cd882990a6f",
+                                "uncompressed-sha256": "ab4611c1bb40a007f04297b8f5346bf0513cf09c8a303545566294a2768e3eb6"
                             }
                         }
                     }
@@ -296,225 +296,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "093a14e3bccf6e32a171a1af3294cba39ab5e8a9d2c6307ae84022d1fbf840a4",
-                                "uncompressed-sha256": "cea4a21439c88ab3f5a154b184153e7f39c2690ab38c9181714a38e71a7c72c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "3de7a3dbce88a0d3c4f246d890ca2f1ed17e1e60622c56a874925f2990f1f5a1",
+                                "uncompressed-sha256": "75958bb813a29f31e50ae4ae9fe26dccceb4b3bbfec10ed8cd437d0d2596eda0"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "8be0de2d952331ed225bd5fb93687d040dd0c5e1b1cc5d5cedaa77ae7e721c98",
-                                "uncompressed-sha256": "2138c3dc900b72793eff27eebe3afa4c253bbeb433daae23fb2bfee3159267fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "5b1e087a6f89299f28c95a97519b59cf2bd654b430ca63d5853450ce77f2ac09",
+                                "uncompressed-sha256": "7df3544c6c41c70fc893ebad8562e72c052c37d9b92870d58f33c5b50119efcf"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "e65919686904fe1c982e0097db807dcbd7a45277617c04793a0df1016e7fb066",
-                                "uncompressed-sha256": "52a02b0b5ded2d9bfc9e1fa3370cf33990c889fe6069290382ae9d2124778542"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "349abfb721e6510a116832a41d332ac2b3e803f0bc33ba1f4305e9d2e9e70abc",
+                                "uncompressed-sha256": "f10781585306a60945326a41b65c7b4dd47b4480cc89442e71585fae155cb689"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "6e80eb48c147c48a9be36895a170a601a73e9cbb58128db97bee1d16e106b237",
-                                "uncompressed-sha256": "49363063ecdd03c2ff5999d21f2bf4839050ede7807931a744b2a4e25341e634"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "1a677a42ead2475e41d883eb61358ed937bfb42aa5ac57e08f2a1960f87fa33a",
+                                "uncompressed-sha256": "79c903d7073f1377dcd6f9d4b090328218674e7385f16243e633685d4169d7ca"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "d3e43169f2dcbcc61ad8c4bcd3cf2989103d9797ca8fc837e6c3db028efc5ba9",
-                                "uncompressed-sha256": "0485ea7641c4de38d7d3c22159555987377e998beeaa9539fdfff279425d03ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "f44d1689971bdd5c1c4fcd48eb0cc3d907e238a7d5da5d18ab1ae3bae09a125c",
+                                "uncompressed-sha256": "9514d531c74fe004bfb98d80ede738522afc1d0446f1f02c95aea4a1cd658d76"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "bec4188648b15b22b571c772f0d6f8114ef492a9d9c934868eea98456b68ab55",
-                                "uncompressed-sha256": "e3e598c03da85a935ac5211d496421f6daee67ed55d252d92c54eee00c0841ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "c45075f8ea889192e8c9eb20c8d5e7d99b3849519b690130048cbb287b46334f",
+                                "uncompressed-sha256": "86b05770cfc6f17dcd3e0d9d7a42a03c56ce5ead0fd21005d61fb0ad30da292e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "ed76593d9b310a462a8e89a9a0854e0f9c717248d59e97628903158c3306faaa",
-                                "uncompressed-sha256": "cd7226b504ae2421219c7443dc2c8ef384ada6b7733a28c4e5e13b15ad89318b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "893c87a626d50f669af65cceee2dc6b69d6a4495304c8088f56ab65d621fd7f5",
+                                "uncompressed-sha256": "8f5e7e600c649358c57fa969cae680b472dc687844199f5de8550ba152040d0d"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "7204137b63506e4dda2f3db9a4df64902376f14595d5271ff3a17eebefbdb2c6",
-                                "uncompressed-sha256": "bf405da8c30e5b07b5494b90babb4a03719b6dc24f14c1765a344a19d1248e7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "1470206e920813c3f8dcec6f8a4600f66a5b1ec4ce91ba38df537f345d46e08f",
+                                "uncompressed-sha256": "bac609623ece6b3b61175ce1b19c6a072e1f6d8832a4b2ccfff26717431f0a3d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "a01b01a652cc8964f3cae365c101888f85d14302814a80967849061ed25f7c9b",
-                                "uncompressed-sha256": "8a16a5b1f98aa5d8effd82e1acf0783814d21d97862e61e65d23708fc2b229e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "cf875e2f464f1291080772c8bf5f03eca7e94bf4b71457a6592d85da5c0a94f3",
+                                "uncompressed-sha256": "97cea9338c914bff71b4fe51584aabae795773c2c22172171a35586bd2c379b4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-live.x86_64.iso.sig",
-                                "sha256": "b49b007316add92a34d85449ea8734b52596c79e52baa1c7e8e6eee0ee095186"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-live.x86_64.iso.sig",
+                                "sha256": "d261df277f4827013eb1e602c6b0d066668cafaf9456e0690429d8e2733ad375"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-live-kernel-x86_64.sig",
-                                "sha256": "fefdbc8ce0e52f8681a40680f777c8c2ea73088b9968a75889bd29b27a564783"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-live-kernel-x86_64.sig",
+                                "sha256": "9db5d790857d1d9e60d60e76c770e606a2cfd993a5a2c09ca30c4e54a4c23ef6"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "bacdc4faa4b4d79d616a5a9e03bb5626c8610790288b83f941cb4948ea0a95bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "4c32707a2d012940a18ce29047c79c1d26333172c0198f0da45984c0d231f841"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "f8a75799acd04501161401210809ab5f6df92a7b4185fcdb5beb18c1dcd97801"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "c3928929b6e9b699246cbd897726e7e9eb8c7255c8db3914f193d2ef5bdb0c59"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "14ce0743539e93f6b3a43baf4fd73b548af6da41e178a1a6cac178cb905e35cc",
-                                "uncompressed-sha256": "f05d70c382628b4db0c6dee1ce85f3bacbdc87aacbbe3e1c9b1a408fc9e9df10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "9e4717040f13ba7dedb05eab365e96f021c11a6b067dc86da961d39900ce0cdc",
+                                "uncompressed-sha256": "f92562eb30c3e2d98f35c45f10d1a47a616788bcab9e4627e777db413cd2f738"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "3bbb6fb7e8480e9bb083c0a99305847a5334db980bad02750d3453b50614a591"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "15714c1afc22d59beb17d2cd65228902c06a200c96a846cc8c4e6be9f9f28224"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "d5ae1e5b7483bd3290e945d4144bb61a4830af14b776186803be8709fa6eb6a7",
-                                "uncompressed-sha256": "a47464dfdbf04731ea28b6fd032f63687c0791e3e4b6efea7356ca4fb81fb2fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "224211f8d6a961ae0ba6571858944a3870cca97e0f170af3a91d68093247dcea",
+                                "uncompressed-sha256": "02060d97301ef4924dd268c56e17ddaff9d7deec9ce75bf489de652f9c1b4233"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "d9a1ff23cb2c30aa1325c5cd66aee114de80f392155d9e2963008dd5d00ceb86",
-                                "uncompressed-sha256": "59bf0a3955c866be5c1eac3ddb4a3ea8365716c33ca31fdf4f0569ac3b614b2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "baa1043e4ad75f4f31abc91c2da87d3e91aee1cd161d96faccee3c682565c0b8",
+                                "uncompressed-sha256": "82600d7f7c4f09eab3abf9ee889c71553cb6bbf9553131df1ae1ea831209f0fb"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "13396e2d3633a39d0f9b8478fe02a592be083f1f161257b59f7fddaeac431562"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "8e0aae16c422270875ca86ab11a176f7200a1c9e5a8e939f5e9fde4ae8001848"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "7773c1223689a97f04307142d12ea6f0f2dca683756d591f45a42471a3c2678f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "c2670982b98ccf7af819905c192c7c9f91e745563da4aa898bdbc46474f9a940"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221211.2.0/x86_64/fedora-coreos-37.20221211.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "8537f780b2d8977c0472dc03fe6e8195d8f129652f77762a6fc74c4c4886f1a0",
-                                "uncompressed-sha256": "1feba3b0bb744aaf545c5d439324d072922d898bb3ac0a30347d019a87172d40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "fc0605e0cf70b2734c45fb914798d3e642a32c94fac21d9274a525560c6bfc9d",
+                                "uncompressed-sha256": "79157388b7e5875971b24cbdedf0c4122cb04cced871b0cf4b11c9eb63eebaf7"
                             }
                         }
                     }
@@ -524,104 +524,104 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0a3d77437119cda72"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0b20912315bf60c8e"
                         },
                         "ap-east-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-05407b1d35901ed38"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0c4596ee43e642044"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0b02fc86305e2d1f2"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0762cc3c26f53375b"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-089bcb745691345d1"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-06fa650547319abcb"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-03a34f785c226a501"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0226956235a0eaf43"
                         },
                         "ap-south-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-053f31b8fa9f0059d"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-03e1196d888976893"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-030b73c74523e91c4"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-05d5f9e071853fcb3"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0457aea3b46f1e1e2"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-029c01a5032a838f8"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-014a05fc23983e395"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-030165d695da9bcd7"
                         },
                         "ca-central-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-073c868283d59d4bc"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0f5a59a97c29df3ce"
                         },
                         "eu-central-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0bdd1bcd76c5117a2"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0aa33a8e1752ecd51"
                         },
                         "eu-north-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-08dd3b654533c54bb"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0e939746d98dfd882"
                         },
                         "eu-south-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0efb3d6e876ef4a76"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0dfda847443311d2b"
                         },
                         "eu-west-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-049423c97952c826a"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-07aa241ffb9145e68"
                         },
                         "eu-west-2": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0159cb0a54b6456ea"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0c9d116a2ca5e6920"
                         },
                         "eu-west-3": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-029d862c0a5f9a1c2"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-051e661eda565ff7a"
                         },
                         "me-central-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0f3ffb2abb68acc35"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0b2949f311331a2d8"
                         },
                         "me-south-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-01d5c179b6770ed34"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-08724c16120812aff"
                         },
                         "sa-east-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-08985003e37be796c"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-07c22c617ffabe6d2"
                         },
                         "us-east-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-09f985b285d005e22"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0979e14ecc1b00ae7"
                         },
                         "us-east-2": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0218df03f197d028b"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-04816c8c5fbec5368"
                         },
                         "us-west-1": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0386f59feed2904cf"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-0e0ee354758cbc448"
                         },
                         "us-west-2": {
-                            "release": "37.20221211.2.0",
-                            "image": "ami-0a8511e6d9ea1dfaf"
+                            "release": "37.20221225.2.1",
+                            "image": "ami-03282e46d87b0d2ee"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221211.2.0",
+                    "release": "37.20221225.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-37-20221211-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20221225-2-1-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-12-14T14:40:04Z"
+    "last-modified": "2022-12-27T14:02:09Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "37.20221127.1.0",
+      "version": "37.20221211.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "37.20221211.1.0",
+      "version": "37.20221225.1.1",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2160,
-          "start_epoch": 1671033600,
+          "duration_minutes": 2880,
+          "start_epoch": 1672164000,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-12-14T14:40:03Z"
+    "last-modified": "2022-12-27T14:02:07Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "37.20221106.3.0",
+      "version": "37.20221127.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "37.20221127.3.0",
+      "version": "37.20221211.3.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2160,
-          "start_epoch": 1671033600,
+          "duration_minutes": 2880,
+          "start_epoch": 1672164000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-12-14T14:40:04Z"
+    "last-modified": "2022-12-27T14:02:08Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "37.20221127.2.0",
+      "version": "37.20221211.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "37.20221211.2.0",
+      "version": "37.20221225.2.1",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2160,
-          "start_epoch": 1671033600,
+          "duration_minutes": 2880,
+          "start_epoch": 1672164000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @ravanelli via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).