### PR TITLE
Roll out testing 37.20221225.2.2, next 37.20221225.1.2

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2022-12-27T14:02:09Z",
+        "last-modified": "2023-01-04T00:14:37Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "447eed2f1442eecea927d43efb3ce1b1d66532b5468767987d628dca7b28756f",
-                                "uncompressed-sha256": "c97d289d7f0b1c3dd614563b5d0b369684de786797d8ea7e53c40a3968193cff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "d7488a72104312e62ce92c7e461d3346bc423e49af4550afa1cbba30f51ad5d7",
+                                "uncompressed-sha256": "7c476a755cc7b51b2956fc2b2e43114b6360785e697f17510642b82b95224176"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "8c7f11ecee7684fd8823a72ba26791aa6d3524f8dc0c7952b04428917d7439cd",
-                                "uncompressed-sha256": "cc51bbad612b2421a5ec54b5b235f27a3b87b0d814ff04472aa785a967252f25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-azure.aarch64.vhd.xz.sig",
+                                "sha256": "b06e5a039dca728a73cfde5c9757ae646082cdd95b62575fe25fb6d4defb99a5",
+                                "uncompressed-sha256": "97f16b275cf8d87897a072f206a28e8cadddf03687637a0edaa9771f44014b32"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "a92a6d48bc754722f0e33d85dafaef1747bcf5d6c3380f5e5b6151ea25b97298",
-                                "uncompressed-sha256": "1c6fa9700b699bcaf4063657270843a33cbbc502da96929634112fe6183a4806"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "3d5dfe662642ce636d002f61e4a0c966d60dc1b9c4c843f469f21fbee142077f",
+                                "uncompressed-sha256": "bcc5eeba77303ceeff50e58c0edd8c18ec7162335959e634b6beeb5a72128cd5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-live.aarch64.iso.sig",
-                                "sha256": "7104a8b9773af6f7a3ac51f766c9a285d34a73cece43ae9b3294075b25c9c792"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-live.aarch64.iso.sig",
+                                "sha256": "56dd391ffd55103e1d44c5681cab8993589214ed56fefaae7fd2ee5fe253ea77"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-live-kernel-aarch64.sig",
                                 "sha256": "6c87ccd2811cf5754df2756cc755f358180fb63bf981aa9b7754599b6f379339"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "56941de9c9c3fe1b62c3c65062da4a23a20fe545be1c801d47a13faf511bfcd9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-live-initramfs.aarch64.img.sig",
+                                "sha256": "c17adac49d2212c646c923ac0aedd5e04a94ab69693209ee81240e30d9ec4920"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "588b53a2c0330b174e67a1473afd466b79953eaccc38153877aaa11e52e30688"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-live-rootfs.aarch64.img.sig",
+                                "sha256": "e56d4e7554633dd81eb11904a71cb0e63a207fc79b95e7f677f6cb419cf46852"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "abf7f324120d05a135e3b9b43162da8275d895ea3ae065a83fc6f91d9d054d29",
-                                "uncompressed-sha256": "57517409e8a788e88780dd44dbac800bc05d20ab2717ff33408c743fe80b7d25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-metal.aarch64.raw.xz.sig",
+                                "sha256": "24ec2426fd0b8dd0c5c5959f09f540e681965c28fcdd3d0de6d6424f06618447",
+                                "uncompressed-sha256": "2b6242036fbe05c9feef6bccc4a584ba099ed15ff90966f2b766a528c9484904"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "f98e852053391f710a6835f105eaffb33a2a661a76b902937d30e6087a4e0c9c",
-                                "uncompressed-sha256": "d717d622855f36d6ea4063a0f300b76e2e24c69c1c228391fbe1aebf5401349b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "d23b6e40eb1ee682142e47cc1ebd8501da35592e6a9580409541c75a9ac8bb39",
+                                "uncompressed-sha256": "e24e6eef6a85bb585fc3adcff98a0244c954a65beb1f8679e1055b490e3e4d5c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/aarch64/fedora-coreos-37.20221225.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "110a1366bb31069c44f26946bedbadd67e53c8941f67ed996c5e2509564f515c",
-                                "uncompressed-sha256": "c7f6060ba96ad5e6e61faf629cf4d5b0f37ce9f07aea937154110d8cbe0d7e4d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "f87c568777ead99f8abff8b12f550fc7cc26e2b1b834a63d457f75504e88c388",
+                                "uncompressed-sha256": "08f0b5d1e9be1afdf03027ada7cf1d3fc639d8e01f5d1e7110442889d211e036"
                             }
                         }
                     }
@@ -109,96 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-0d8c0d8c3ecfc121a"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-07b584410223a63f3"
                         },
                         "ap-east-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-0435898c05daa468f"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0b22c7e11676f8ac8"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-01b3dd0355a278969"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0e3b7e360366642dc"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-0a71f360a1926b2dd"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-09ffd92de897ed686"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-02cdf9f41d585a783"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0ae7b3542e3946540"
                         },
                         "ap-south-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-077e36d70f70c0eed"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0085f4ea473662316"
+                        },
+                        "ap-south-2": {
+                            "release": "37.20221225.1.2",
+                            "image": "ami-03043d0e0f7a32bc5"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-07af683970595656d"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0d3d7a1fe2a02a097"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-0c5ac7b443418e70e"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-004c1094eb94c8112"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-0b52a49f986154550"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0cb194668ae424eeb"
                         },
                         "ca-central-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-02b53ef3949145908"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0b11a90a4d323435e"
                         },
                         "eu-central-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-09517dfb16f619297"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-04384f431bb0cbd7a"
+                        },
+                        "eu-central-2": {
+                            "release": "37.20221225.1.2",
+                            "image": "ami-05bba94ea39b16bc4"
                         },
                         "eu-north-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-0305e311f30346feb"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0bd1667bf08e215c3"
                         },
                         "eu-south-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-0955b1a84a705950b"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0dfa547ad318ebb81"
+                        },
+                        "eu-south-2": {
+                            "release": "37.20221225.1.2",
+                            "image": "ami-04e9cb687a1538fe0"
                         },
                         "eu-west-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-031f22d0858726ff3"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-06bb8dcf1849bccdd"
                         },
                         "eu-west-2": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-0d576642cbe87302e"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-07d50bca3a9720b7f"
                         },
                         "eu-west-3": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-0be0246df90ff3cf6"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0efff50d55300e9a8"
                         },
                         "me-central-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-01574e8a48552676b"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-099007d26d9c3dae0"
                         },
                         "me-south-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-04489c0edef6ef10d"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0de6baafb1aeae27d"
                         },
                         "sa-east-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-0400ae06567874264"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-02a906e10a5907196"
                         },
                         "us-east-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-03f7d6f5c8a072bbf"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0378b2954174885d6"
                         },
                         "us-east-2": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-04e526724b6a72438"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0fdf4521baad88b3b"
                         },
                         "us-west-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-0d0e7156abd9fafc8"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0fae10c2670896879"
                         },
                         "us-west-2": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-0748a331bef45c9c2"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0846bf342d57ee561"
                         }
                     }
                 }
@@ -207,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "0c2bd364d10d9bdfa2ee51c54eaf9146e3f9cc0eb7e27883ee4ead3ca74965a3",
-                                "uncompressed-sha256": "bfafe3a27678d50ebe9d0b8ef69543ef6ce2f6e8ae0a74d5d6f57ffaa5cce7ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "9f68ee7a1a261463f5dd3fb6485938b89f4aa1c983980fea6a6e349c81de9833",
+                                "uncompressed-sha256": "4c7872120d7fc980cce5a842e53db9e5bd91f9132649a6d0a0ea404d09b57ae2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "2e66ce0b6e0900c9e943985dda6b30e58fbeddf38f4c1da56ae02bdf29c868aa",
-                                "uncompressed-sha256": "79a4b9e594d97afd310c475b9bbfaf70d9630d6a5831fbc6dcee4b49d6835297"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-metal4k.s390x.raw.xz.sig",
+                                "sha256": "87d13ffbd73091301e9db4344328c69d69499257c24b9688585df12d2c87544a",
+                                "uncompressed-sha256": "f9078f91785624d6737f218e0b1455a2a3c6c6d900efa745bdb8a41902a1a758"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-live.s390x.iso.sig",
-                                "sha256": "b0c8eba700950a1916d0f700cd4408657527061c0f44e6d13068097cb05119bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-live.s390x.iso.sig",
+                                "sha256": "7289b0aec51c2470839e1b44006d8f236ca5887890e057782d6aa26bf705a3a7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-live-kernel-s390x.sig",
                                 "sha256": "647edd9b580f1628ca8b68159accc5c41484c8b94572fdce7fc895c98f3d7168"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "05673cb6c22c9f54bdcc9e7179c35a5713268bf43ce12df2aa7fccbb8ef9610c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-live-initramfs.s390x.img.sig",
+                                "sha256": "ecde2d7943caac3e2f89013434cc05292810867767637c1c2a0978d486f3bda7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "9247847da95d605f440b2c696ef4c2669ab77a799b003512e6b850e3eda23231"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-live-rootfs.s390x.img.sig",
+                                "sha256": "2ecdd3ced8382466b19ac2de487e4cb51d507103f2bbd45b45fd8c6f0fadeb97"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "882c2c63d489b324a9ad8797262efa1b603e89d5865f268777acfa93e7be686c",
-                                "uncompressed-sha256": "af11460611af0f17d4ef42708e6af5933391b033ec858580599c9da427529d01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-metal.s390x.raw.xz.sig",
+                                "sha256": "18e1f0ec68cec5c1195a18859d6ff75bd1296b28780c66cbe36d778b313319fb",
+                                "uncompressed-sha256": "2dd729ebdcb2f3903d9e4781581cc4981ddf3beb8aea24cdcc55c3ff2c509255"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "9f2471f4bfb50d219002c280a9203bef7eeb3ea7ce37fd492c1c47e53e0c1c7b",
-                                "uncompressed-sha256": "6541deccaf963184a164a005c4eb03e068e9dfc92bfbd2d707c7f9d3f6ab46b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "f1e68f46cfa6bb4435c13ca2b84e875b012465496b43eb5b322e8e54c4286810",
+                                "uncompressed-sha256": "08f12f56193d6ff2c8a0e0ccb2c541d8ac512818fae580bbf7e5919899105d6c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/s390x/fedora-coreos-37.20221225.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "99a9fb43a38e3688937aadf0512d07f0d6ced5b6591f71f284c4250c066d3f84",
-                                "uncompressed-sha256": "bb4db38b164d9b115eeddd3a45df10e45513fd8a5a4663752a795385df74092a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "7671700e15af357da822e64bdd114f2c2edb5a346ec515d60128acaa8e78d699",
+                                "uncompressed-sha256": "a6c4347e8bc8027a42494b7b7402ebafaaecdb729d5995255b3f517d30ede34e"
                             }
                         }
                     }
@@ -296,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "cfa4a91757597dbc9bf2bf5f1ad79358830c0540938a8a5825d2649fbbe70e36",
-                                "uncompressed-sha256": "54bb2423f7b6b4b27675a5425b833d1f586cfd2107cccc7d38a37bc3e505a060"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d2918b9a42e576ad991bc8ad8cc62c3d686a8c7da03def86dd0c000255de5a76",
+                                "uncompressed-sha256": "ea980fecb7dd572a1527cbec278c85e86ffead29d422d2a6e3f88b5189f153cc"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "6f0779bdd633a16f49600f2cfb6e92c7f8670a2d97e7752a346bea9e24edf792",
-                                "uncompressed-sha256": "a71149e0dcd87fab5fda4d9e6f5ff2980546596b63eacb13080f8c67a5128abb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "d46ec34ad97231b7d204e77bccf515b9497db0e554ce39d3cc085f80ce7eabb9",
+                                "uncompressed-sha256": "a4901ce3aececf9a1b16062d323d59559a7b48bca713fc52d40ddff770df0ca9"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "be89eb05196a2b004b87d41524d74dd971fa70a4d9d5ddebd71b7627241548b9",
-                                "uncompressed-sha256": "a2df7a069131b7485e3251f3d8ad6c308d67e721d829f34b5b130c5cfbaa1ded"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "fd68f98fae1e5f13fe3090bdabfdd84ef9ff9bfcaa3818bab3b8e3d1a4426100",
+                                "uncompressed-sha256": "92ee715a4f9d8cacb40e6027d2397c06742a51d2fedffeb591da369eccfe43ca"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "29801f0d576a5c3ee4155859c6e7d83fe012d8ce20966d9116a551160145de8b",
-                                "uncompressed-sha256": "0541c9de1ba0f47fde4e518a0f96a1a764c9f904f9037ce336e0f8ac6f7756db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "cc9753efdeb67649f4bd32b14be97e858493188390329800548d975fd74482a2",
+                                "uncompressed-sha256": "b3fb9b96de578dd2c9d50cfab50ecd196cae46b4d65db7016f095afa5819b410"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "48f101868572026131ca5fed11393174441159bab40c9eb1b9682fa129f976c6",
-                                "uncompressed-sha256": "adfe3cff999d86b40b99f13f2bc9d33016eeea0328fac8010f25a184cb779df0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "23ea0a58cf3506909aa976d418c1ad07fafd8d92ae3e78e8f6813a01e538faea",
+                                "uncompressed-sha256": "e8d610753b374affbb594490c7b1a9f914974fe505f3a17b929ec730aa2e88a5"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a4de1357609cf627bd745194f4d746fcf92e7f3aacbc91513d40d46f9855fb86",
-                                "uncompressed-sha256": "0d34acf34a67b5bdf7b7925b15cbfea339d69ecd7a95a37588aac42e4ccd8335"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "551ff53ecf9d6cc91f4f613b82d018d2899a5cf41ff9eb060aec8f5ca308b8c5",
+                                "uncompressed-sha256": "7d90f988092ebb4befe0f1460a675a2b6282558e865d0119ea3714312afbc2be"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "2b44f23f30c5909a2ec5dcca4dd7f1cc5e6b7567790831e5267b75d81a9d1e5c",
-                                "uncompressed-sha256": "5c21d27ddb4b306735d9eac8f0162e89e9a760354e7deebf685f39919ca36321"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "4187bd1924fe75d95c7880484f1714657ab8adc331169883d25d4a8f5910072a",
+                                "uncompressed-sha256": "4d84e919b02f685ddadc85c2c6d1790fc5ba1186f27c5145af6e9e5c23d378e5"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "0ddceb30eee9470331155b211b59f3c265b1ef9199649dcb91902aba14ea030c",
-                                "uncompressed-sha256": "591bb67c3a93b2968a9ca5e0faa5aa8cee83da893c2c2fcd2f83654a1ad42a96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "0146b5ba3a428e4de3c38fae337c1281cbe89a511d95d55c660294a745a1a6ee",
+                                "uncompressed-sha256": "1102c60f03a96e724772ba2e330ce1355003f8ef78d5d4b571184ef7ab024b8c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "34c83385efdb7a88ab6d6030cf9bda884cbe2130b7bf94e6f037cae236fa5eed",
-                                "uncompressed-sha256": "01458a0ab35de1ed05b6e7e8ac206bbbf95dba0715776aa8ccdfbc83c16b49b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "e2318bd2e14e2699f33fe03352439fad0b5de95a5421a1f58c64b1ac97418765",
+                                "uncompressed-sha256": "7b5e8025beb6ecb2cb6af5779296e8d017b8c40f4f97b3d38176f14113685b0a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-live.x86_64.iso.sig",
-                                "sha256": "16af5ba0c5a2235f875f99b05880f49bb033ef05f0bde2262a1347e86e6491bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-live.x86_64.iso.sig",
+                                "sha256": "3a0b29f49e730b683125e7f230544394d0e9cf4610e28c7b2439d87d85e98ee9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-live-kernel-x86_64.sig",
                                 "sha256": "9db5d790857d1d9e60d60e76c770e606a2cfd993a5a2c09ca30c4e54a4c23ef6"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "475aef98231e0d7c343e14115d19aba054d3ce2bc6129dc61171a053ad4c0d9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "ffcc274001c91f0b6504d097de725835c7e1553664d2c210aa0dc36d66332b67"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "b253c9a9fde90a2ab5200f125fa74e58bb84a1e728801e99218842ae6b7689c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-live-rootfs.x86_64.img.sig",
+                                "sha256": "306f2a4b22b5215a1260efcfdef70bbd18d659c522584d280a9a48c95825bcce"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "6262016c2a514a8ba6dd44be1edd017201945061bc5864151a3068d8373100ca",
-                                "uncompressed-sha256": "dd1ea785388413254ef1d6fc84949171a96c460bf0cfd5f4d4a68798b182983f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "bf5f39fdeb2725c962dd2a9d544dfa4ea545d344fe3e76b349352981f7b399b7",
+                                "uncompressed-sha256": "177322389c933134289ef3b7cc34702ad313c990956023f5efcc40795e387f8e"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "9f13b4f2ddf506cff5de64dda610c3ebba8252d684d88d996a1a4fd97aa98531"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-nutanix.x86_64.qcow2.sig",
+                                "sha256": "580a072f73129a67d4d644007c8ae2f9066fe364bf1d27e5b5fabff656cb6628"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "bd386fa67fc4ee60baab2fbcea47852efe4067360e46bb29c0a12e51d2f43ae1",
-                                "uncompressed-sha256": "a74c751e617dea46af2ae0e2e21355f682e64d12acbb7be607380c7e04d90b4e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "b87498f4e601814598954ca61963c88c1de97bcf904d29519b6265b61e5f720d",
+                                "uncompressed-sha256": "6f777a977b80d600e996d2c3e80b5c639f2674a385dfeac32bb178ddf11e1352"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "568d7edc538a67011e47a84170544e3b5cd5aafc564d5236ca3f85c4a4995233",
-                                "uncompressed-sha256": "47205a9cc9f34c61a1eace97418aa8fd9047f7c43bc48cb2bae07510c247f3bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "539dc1b954b8dd68734d758b9066aabe2c7e0261d73b7980757425cf1681dbc5",
+                                "uncompressed-sha256": "628936ff95e04cd3fe4d917a16bf5a89086b769a40f21837da4a00b3470eafc6"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "bc999ac4c57e5a19a8453f3d1fbae3231979e3bc78ae030177c99408d09fcf6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-virtualbox.x86_64.ova.sig",
+                                "sha256": "17f03c8fa9fab02a86f302468d702218dd88604d9b4deb3cd8cb12ec17e74035"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "7a45e004029532425fbe32e91db1510ee1ee32419153cf70bc8b7163adfefa43"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-vmware.x86_64.ova.sig",
+                                "sha256": "a4d9f562cbd84c6400abce840dab53901ca9aacd1cba365c3e03cc76dc4d5661"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.1/x86_64/fedora-coreos-37.20221225.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "d5aaaf15562bcc93ce9cb856d70b19ce9cc1547b881571dedd662b7d58497958",
-                                "uncompressed-sha256": "f9ec24ff2a0e677b67e154824d6084642bcb8af5ff4edd623c09abe672f72a8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-vultr.x86_64.raw.xz.sig",
+                                "sha256": "36141e6d999bb677aa0a69de6ddfe6d975e6959aa99a844e1fabc1fa63d14302",
+                                "uncompressed-sha256": "e41247c5dad86a03996de6ec9dc6305cde9a029729635df4597f38516c66693d"
                             }
                         }
                     }
@@ -524,104 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-0c1764372f7190155"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0a36107307c2837e7"
                         },
                         "ap-east-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-0f1ef8ba7957a4bc0"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0610e95d423dd9b57"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-016d34bedbfb62893"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-00849c32686cc9d45"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-040ee73ba69141b2e"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-07ee953bfa3685a65"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-0676c1913b6750cc0"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0f0f6a64182fe613b"
                         },
                         "ap-south-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-041b00cc70ce08896"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-05e1a7044b6c1e537"
+                        },
+                        "ap-south-2": {
+                            "release": "37.20221225.1.2",
+                            "image": "ami-08188749948c82fc0"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-01c57b59da2bcd0f2"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-070844e2ba3079c9f"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-06a7cc42312ec89be"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0647196a1471ef74d"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-0711e410d2921f653"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0811e5aa61fe52469"
                         },
                         "ca-central-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-057b10b4881ffcdbf"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-007e51673fe3ccd66"
                         },
                         "eu-central-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-01bdae15bac3c8acc"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0f26ecffa8577f3c2"
+                        },
+                        "eu-central-2": {
+                            "release": "37.20221225.1.2",
+                            "image": "ami-066b1dfe86cf21ffc"
                         },
                         "eu-north-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-05724ec13270bc1be"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-049313dd5fdbd5e02"
                         },
                         "eu-south-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-016cda76ee5a63059"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0b03a973c12236146"
+                        },
+                        "eu-south-2": {
+                            "release": "37.20221225.1.2",
+                            "image": "ami-03b22837f2b37f729"
                         },
                         "eu-west-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-054dbbea3a07e2de4"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0ab7f4bebb7941ab6"
                         },
                         "eu-west-2": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-09696c06e47a42c66"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0223474bb989e6de3"
                         },
                         "eu-west-3": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-00f6e7c34132f206a"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0cdcb929a9222a443"
                         },
                         "me-central-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-08d7c1ac96df08b3a"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-08f2f1ca1d7ff637e"
                         },
                         "me-south-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-004f48a82aca02f0e"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-034d72d8100096e56"
                         },
                         "sa-east-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-06ff1700c7523556d"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-08ab1b85b0930125f"
                         },
                         "us-east-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-0b97443c130890465"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0732dbadce25b01a6"
                         },
                         "us-east-2": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-0f6505433741a8568"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0c06a64572009d728"
                         },
                         "us-west-1": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-05943fcf6c8ffbf1b"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-0f3e8584f2aadb552"
                         },
                         "us-west-2": {
-                            "release": "37.20221225.1.1",
-                            "image": "ami-02b3e94e40101accd"
+                            "release": "37.20221225.1.2",
+                            "image": "ami-02b3f10ae98ce2b08"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221225.1.1",
+                    "release": "37.20221225.1.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-37-20221225-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-37-20221225-1-2-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2022-12-27T14:02:07Z",
+        "last-modified": "2023-01-04T00:14:36Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "10f5f1923d5922d24c0b3bf35c656062eaa7495efad2a42a22e41af4399b7cf7",
-                                "uncompressed-sha256": "4b63445e02cea7fa9ddcde498a47c631fd677c865bc1b9cc34395f407812c8c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "fa6d0f8182a07e5c7cbfe2ea6187bf3855d68abcdb194be7799982c3498c695b",
+                                "uncompressed-sha256": "f0e056aec01c3a64703d44f5124798de60a903f55cc8046b1957646167147e6b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "7e88ebab79c9fd563ead760c2149affb3b83dced3aef5f34221813a25a3503ab",
-                                "uncompressed-sha256": "e29557f65342b2603870291280ac70cd95f7aed8125506d10fb646c39f60e4f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-azure.aarch64.vhd.xz.sig",
+                                "sha256": "fe5265300029a9fa89d50f77fc3fce84df8c950fb2db05fc8569d38c550d1626",
+                                "uncompressed-sha256": "82e4d5c0b0fa139b18ccde13009b28c43fa064d7c7f78a60e146ef07034eb1cc"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "2479f86a1eb6f6f0644e939ba0227076931b591fe61778ead938922506719066",
-                                "uncompressed-sha256": "58b7ec7e4062a7768b5850fd86b965ea713136c2aee08468b294965a9bc4589a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "c73050ca3be05869c596b88dbfb69846897da52a95ce701a02239df9d7e3ce6c",
+                                "uncompressed-sha256": "0d29d7012105d73d701cb279243d999c2506fad71d0970a54bcb5c055e743729"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-live.aarch64.iso.sig",
-                                "sha256": "083a0691f2d476e6f9bfce35e52d29615aceec21866ecb4db966257519dba317"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-live.aarch64.iso.sig",
+                                "sha256": "7922dee4e3de0ecfb2ecef7b8cfd03f25b35c242bf4e877b10222d2f89516621"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-live-kernel-aarch64.sig",
                                 "sha256": "6c87ccd2811cf5754df2756cc755f358180fb63bf981aa9b7754599b6f379339"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "210f320139ecedacaed6bb87a9c99a861e0b5761f97143b8a877f7411077020e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-live-initramfs.aarch64.img.sig",
+                                "sha256": "fae8c9fb219c8b79d064accb55883d853d838fdb9013cac7493fc6c67595d636"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "45c12850f85532fbf018c097f2b8ff58ae605f5663e9a346652615d1d3dc5bcb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-live-rootfs.aarch64.img.sig",
+                                "sha256": "ff896309b4d957ca12824b22b79a9124d61d9a3095788f0e95633c133cc8670b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "505fd2c62808d4235f027af77de64e246f065e16a3472dd0e85f9b7c6f256c8a",
-                                "uncompressed-sha256": "6d92b2e8880c8dfdc7ca425dedd9dc4f73ab5a9742cc692d5d7282099fcce0e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-metal.aarch64.raw.xz.sig",
+                                "sha256": "ee3c762b40d938234faea6bb872ffa814d09471aaa82c1b399de9623671396b6",
+                                "uncompressed-sha256": "ced1c7be990ec36f125c6f0c6f58cc479b6f937e7f4dc881dcafeae4da28b26e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "bbf5146245e0a8d409681901d3fb6476dcbbf6020939beec60a0a5062c0a5621",
-                                "uncompressed-sha256": "e9e2d4852fe01fbd642cba66d9138b6cee386c6db0561d60099143ac12f5bf80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "49093f6b4c446f6da9b9f457ed5fd5aa989eea0f81f19b8e50f1e5af2b7f217d",
+                                "uncompressed-sha256": "c9b654b2a6c3679a63238b197f2e526e341d1805129858c5c45f019fef54cb70"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/aarch64/fedora-coreos-37.20221225.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "7dd398097daebf94c5cc6322aacf65cf7761f2a9cc7fab2f541dc1b8ccb76b24",
-                                "uncompressed-sha256": "0ee652abd22e27dadaddb6842d1d799c3927556f7d1d7a2daac33aea512966d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "a9d6278feb86d6fe29e369c16f510f07bb486f8c34f8ea6dfb43456856d94eff",
+                                "uncompressed-sha256": "c7878f6783e3b2bdd38478d830b8ad5ff3bbda54cc2a294fc431d2bd1aa0b5bc"
                             }
                         }
                     }
@@ -109,96 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-02a7886543df74446"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-069f1704d7f776826"
                         },
                         "ap-east-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-07a4ae39b8da2f137"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-054ae4e0f56fa8c6a"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0a0f10a8c9dcd09dd"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-09d526e443e585029"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0b80d673e4dfdf8f8"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-04d2fc60a419d658f"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0f30020c2317f2541"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0c46975c6ddf3aab5"
                         },
                         "ap-south-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0c95448b64bd707aa"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-085015ed7bb4e54e6"
+                        },
+                        "ap-south-2": {
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0ca8542c75783cda6"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0cb51c55616095ab4"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-094f99f0952655466"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0379fbf6aba455c72"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-017ffa8084ad58d33"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0a98c3dbc2e6bc5e6"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0353346982de7badc"
                         },
                         "ca-central-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-005fa508c1f35c8c7"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-051fafacbd2a19e1d"
                         },
                         "eu-central-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-06772ddd37cabd688"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-07013b37fcc133300"
+                        },
+                        "eu-central-2": {
+                            "release": "37.20221225.2.2",
+                            "image": "ami-02e7549eb94e680a6"
                         },
                         "eu-north-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-00cbd470041bc50de"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0707672350eaea33b"
                         },
                         "eu-south-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0cddeb93a864e1e81"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-07c59b726a290e102"
+                        },
+                        "eu-south-2": {
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0ce172cbec9dccd5a"
                         },
                         "eu-west-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-06ed9ef7fc4c4e1bf"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-037d6795cec0e29f0"
                         },
                         "eu-west-2": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0d868fa350ffd48a4"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-073613d9c876ea2a2"
                         },
                         "eu-west-3": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0dba2076c75ec9d39"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0bebe192966bf9929"
                         },
                         "me-central-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0469d1cae3956ad0b"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0d77045585163774d"
                         },
                         "me-south-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-039c4af36a4580434"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-075e9015ec2892089"
                         },
                         "sa-east-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-09eabe5cb19acd70d"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-08263f7b8e8c5b19f"
                         },
                         "us-east-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0b13e5bfe66bf4df8"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0c67a0b5b4e3099e6"
                         },
                         "us-east-2": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0e5e4b08cf7ae3c13"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0423978303848c390"
                         },
                         "us-west-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-045144f607c10406f"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0a41166408b0fdebc"
                         },
                         "us-west-2": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0bb236bf794e71d43"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-074a13a39714293c0"
                         }
                     }
                 }
@@ -207,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "8791b5fce8787c796885c7aa90eb9726859fbce574460eb4f6ee91c7f9ced8fc",
-                                "uncompressed-sha256": "04362b927917a565c55143134f713fbe127383f3021c04a16606fdcca9d4cba0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "41f0b4b662b515de1c0587d7eb7e05b96f63489e0ac799e18c50fcfd2af50908",
+                                "uncompressed-sha256": "e6fa06f804f0f221647428881ca9aeab2d62be21163e344a11fc65681dd4d157"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "78ac87d9b054091da2636490d853b2a0b66a8dd93e049fb6ffb42ddc77066827",
-                                "uncompressed-sha256": "0be50227c6d3e582d5bdca63770b60bf9d517d7ad2ffdc35208a49ec234f4fc3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-metal4k.s390x.raw.xz.sig",
+                                "sha256": "911634b8a51fc832d76bfea41e4d87fb3dbb5a8df20a3e216bc906133d673f6d",
+                                "uncompressed-sha256": "162871dc301da8d54f578fb3177f128e8a2e97131d3cf14cd5ea6cc3a4d6654a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-live.s390x.iso.sig",
-                                "sha256": "4000a72582bcc27112985ad262842d16d30faa6598a9c294833723e71f296d41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-live.s390x.iso.sig",
+                                "sha256": "bcd95e0a09386d911be6ecf6245a86f0cda38cd0dc83a104e27a4538017d5dd5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-live-kernel-s390x.sig",
                                 "sha256": "647edd9b580f1628ca8b68159accc5c41484c8b94572fdce7fc895c98f3d7168"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "f5c91baadbd46f01ea95c69db52e53d5e06ccc46b46a4ea2f7bf5d5fcf8e49d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-live-initramfs.s390x.img.sig",
+                                "sha256": "17cf33eb2865f208fa18da0e8e01fb490e68f5d8e8a2bcaf8487c460cbf32027"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "cfa993d8a21ab878028ddcbf051ffb2bb585a894ea28a56a86e50e54bbbcc5e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-live-rootfs.s390x.img.sig",
+                                "sha256": "ee7ceb1bdd23a11d387534941230f8e0e8f0fcdf682703ff7d9f9fcce3f31a12"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "70e1006a788e8328f25049b84652dd897b4d8fb552161525b3424cbee3c0b62d",
-                                "uncompressed-sha256": "9b696dbb137a254c9815b8d6a8cfa474c5dc75ac5ed4a3791e1563aed9e8d780"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-metal.s390x.raw.xz.sig",
+                                "sha256": "0676617d250cb5ab6c157e520249ec56195370a9f3b5b09c81825bfc8432376a",
+                                "uncompressed-sha256": "d98b02d686c9b80ca2b95d978957c97eafb95bc171f1680ee112faa8cd4f6019"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "9b65263a307378cd20cab5f80f4ecc006c7086e4616784ef7a758d09dffb7900",
-                                "uncompressed-sha256": "97930ae03e9907341d059983e9c1f119323bb2bcb84c198f0303dd878cdade8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "07dda4e4f135216cea4a0f62aff5b355de827df3e78e0eeeec7b4dc535408877",
+                                "uncompressed-sha256": "7b2af55301072f405d54371c13dfd0bcd5c0b86b5dfe2cee54eb8462fe24cfd0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/s390x/fedora-coreos-37.20221225.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "a5df712d9785a37192c75fd187dbf926425da25287722bf4de5c7cd882990a6f",
-                                "uncompressed-sha256": "ab4611c1bb40a007f04297b8f5346bf0513cf09c8a303545566294a2768e3eb6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "2fa5a3a0ea53fc57a8690772124fc6252cc93d7ea947d09f2cd59e00553997e2",
+                                "uncompressed-sha256": "93a24d6d3e2e2f44bf2ff9afbaf1c92a2d52e5c55a17ffa1a61a7d55fe4c9eec"
                             }
                         }
                     }
@@ -296,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "3de7a3dbce88a0d3c4f246d890ca2f1ed17e1e60622c56a874925f2990f1f5a1",
-                                "uncompressed-sha256": "75958bb813a29f31e50ae4ae9fe26dccceb4b3bbfec10ed8cd437d0d2596eda0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "c8826b2786be719a4a4c11b5b1b636d49ad11a5a8dfed7f0d9552ad717f6d55f",
+                                "uncompressed-sha256": "ca1ee208eeeb8ff4930d105753637295b8058175ffc181ef8f6ff517a9626f68"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "5b1e087a6f89299f28c95a97519b59cf2bd654b430ca63d5853450ce77f2ac09",
-                                "uncompressed-sha256": "7df3544c6c41c70fc893ebad8562e72c052c37d9b92870d58f33c5b50119efcf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "dc807a4515e6d1f740a7855b44b7e60c8e2f9c67d8ea9a689727f9c0e19fe060",
+                                "uncompressed-sha256": "398b9770f41d01484871b943e120c433bc77c37b8d89cb61314da21e5d6438ad"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "349abfb721e6510a116832a41d332ac2b3e803f0bc33ba1f4305e9d2e9e70abc",
-                                "uncompressed-sha256": "f10781585306a60945326a41b65c7b4dd47b4480cc89442e71585fae155cb689"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "2ab763d105bc1733263bd00f8c77b292c8300f79c39202567929cda44ab1294d",
+                                "uncompressed-sha256": "077fc32134290c1cf2d00f7f68d353acad5ec60b5d04bd2e7794936816e6c49e"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "1a677a42ead2475e41d883eb61358ed937bfb42aa5ac57e08f2a1960f87fa33a",
-                                "uncompressed-sha256": "79c903d7073f1377dcd6f9d4b090328218674e7385f16243e633685d4169d7ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "2616c41b3a6887830c6f0f67e636f1d59048c65a6b8760548c2f45fb00021f08",
+                                "uncompressed-sha256": "8ef48dc2c3b555898fd2d49faf04665644a25eb01b4953a5d0f248d17e660ea5"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "f44d1689971bdd5c1c4fcd48eb0cc3d907e238a7d5da5d18ab1ae3bae09a125c",
-                                "uncompressed-sha256": "9514d531c74fe004bfb98d80ede738522afc1d0446f1f02c95aea4a1cd658d76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "f88b286375485bda57894a4f8ec27b10c06386f4bbf3e921593ae1ca80b8c3dd",
+                                "uncompressed-sha256": "5f01c1632ac3a0db273ce589a952909365b15b989bef915e613f36f4054ab996"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "c45075f8ea889192e8c9eb20c8d5e7d99b3849519b690130048cbb287b46334f",
-                                "uncompressed-sha256": "86b05770cfc6f17dcd3e0d9d7a42a03c56ce5ead0fd21005d61fb0ad30da292e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "a31d2645a1b312b2fc1e4b1a157cedccd3e124365f7c35b11a3f22fefb029b3b",
+                                "uncompressed-sha256": "d9620a7fb266f99710df74b90bc77aba3d0eb5789245863defe4a990de85152c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "893c87a626d50f669af65cceee2dc6b69d6a4495304c8088f56ab65d621fd7f5",
-                                "uncompressed-sha256": "8f5e7e600c649358c57fa969cae680b472dc687844199f5de8550ba152040d0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "b5623b8c68a7883fe93c02c0e829502337a6173017328f6e905da423ff093c1c",
+                                "uncompressed-sha256": "fc73875d65f627f2db37a8d8fc3a72f3e56dec3d6bc518f2ee4d476e2351652f"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "1470206e920813c3f8dcec6f8a4600f66a5b1ec4ce91ba38df537f345d46e08f",
-                                "uncompressed-sha256": "bac609623ece6b3b61175ce1b19c6a072e1f6d8832a4b2ccfff26717431f0a3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "33487d9b13c5f9dce8c202a2373e98ab27940dfb0981fbf10afc5a83f9cf1f4e",
+                                "uncompressed-sha256": "4f8e03acf605118f62050b7ff99e1c50365dfaca32b9883686ea058c4d774ab3"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "cf875e2f464f1291080772c8bf5f03eca7e94bf4b71457a6592d85da5c0a94f3",
-                                "uncompressed-sha256": "97cea9338c914bff71b4fe51584aabae795773c2c22172171a35586bd2c379b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "989377a32d8b85f68815a8f868a7f5ef454a33d6bd3055bc9484e11f00594c48",
+                                "uncompressed-sha256": "dd93c3106290169bd3a7ef12c3fb38d182ce3f1f4d554314b8dfc26e8193f968"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-live.x86_64.iso.sig",
-                                "sha256": "d261df277f4827013eb1e602c6b0d066668cafaf9456e0690429d8e2733ad375"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-live.x86_64.iso.sig",
+                                "sha256": "eb3dc51dba9ec06decddeabfb59b05d43747b6accdc81414672f737f1d4f888e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-live-kernel-x86_64.sig",
                                 "sha256": "9db5d790857d1d9e60d60e76c770e606a2cfd993a5a2c09ca30c4e54a4c23ef6"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "4c32707a2d012940a18ce29047c79c1d26333172c0198f0da45984c0d231f841"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "f2cceef2834fa2322fa59cebf0f20df50cd28dd242da5f4af3a5cd0c42ba5ab5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "c3928929b6e9b699246cbd897726e7e9eb8c7255c8db3914f193d2ef5bdb0c59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-live-rootfs.x86_64.img.sig",
+                                "sha256": "bb1691ab15b7d0b0cd15bad40b125fe55b226db33da5aa6e9d6b6c1e3d903ca4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "9e4717040f13ba7dedb05eab365e96f021c11a6b067dc86da961d39900ce0cdc",
-                                "uncompressed-sha256": "f92562eb30c3e2d98f35c45f10d1a47a616788bcab9e4627e777db413cd2f738"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "b205055f7d101e594ffd9362d874748fd92ef59ef83b81b3a8f4f60511e79c90",
+                                "uncompressed-sha256": "712e637dd2a7a0c9932c0cf4b388880dd5ffcc6e39f29e2ab8a06dcadac3c304"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "15714c1afc22d59beb17d2cd65228902c06a200c96a846cc8c4e6be9f9f28224"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-nutanix.x86_64.qcow2.sig",
+                                "sha256": "c46b7156ff9ccfc4a9da77505558ba56bd6b86fb02afd09cb2b3ef391d38f432"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "224211f8d6a961ae0ba6571858944a3870cca97e0f170af3a91d68093247dcea",
-                                "uncompressed-sha256": "02060d97301ef4924dd268c56e17ddaff9d7deec9ce75bf489de652f9c1b4233"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "a748ccf538b67b4c52c029211013e7252c0b2516bf6f79872b3da022aa40bb93",
+                                "uncompressed-sha256": "6c63e1c057d18eb95f103ac1938191ded09d3a3a78f686e734bd94644e61e3eb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "baa1043e4ad75f4f31abc91c2da87d3e91aee1cd161d96faccee3c682565c0b8",
-                                "uncompressed-sha256": "82600d7f7c4f09eab3abf9ee889c71553cb6bbf9553131df1ae1ea831209f0fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "2c619535cf64fb07c977d1575ec79feff99880eebcb2159ab7c8af5c0a43dc32",
+                                "uncompressed-sha256": "23e610737a71f3cd128f2743934045c729c4e1056eb099cea3fcbb6d65ddb24e"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "8e0aae16c422270875ca86ab11a176f7200a1c9e5a8e939f5e9fde4ae8001848"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-virtualbox.x86_64.ova.sig",
+                                "sha256": "a230b85bdf571b43a0c3af684650d82eead23555260d7c8681f56ac321a76b6b"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "c2670982b98ccf7af819905c192c7c9f91e745563da4aa898bdbc46474f9a940"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-vmware.x86_64.ova.sig",
+                                "sha256": "4b56ec21a1265078d67f1c7dc857d64805673ec5ac8f55cc2a02e6f212dfe3de"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.1/x86_64/fedora-coreos-37.20221225.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "fc0605e0cf70b2734c45fb914798d3e642a32c94fac21d9274a525560c6bfc9d",
-                                "uncompressed-sha256": "79157388b7e5875971b24cbdedf0c4122cb04cced871b0cf4b11c9eb63eebaf7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-vultr.x86_64.raw.xz.sig",
+                                "sha256": "6b91fe030f229554c754f8a4ff7539c6122d774dc9fd2b2e9f9ba46a4271ab07",
+                                "uncompressed-sha256": "dfb60dee623cf01b48225d8c4025715b63cad0f899e216be5802d3c5642a4860"
                             }
                         }
                     }
@@ -524,104 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0b20912315bf60c8e"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0b464b4229abe3805"
                         },
                         "ap-east-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0c4596ee43e642044"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0f997da656c70087b"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0762cc3c26f53375b"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-06a95744516c380e7"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-06fa650547319abcb"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0e5a0a72e51607c0a"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0226956235a0eaf43"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-04328867094a28b20"
                         },
                         "ap-south-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-03e1196d888976893"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0d0300c5221cfd449"
+                        },
+                        "ap-south-2": {
+                            "release": "37.20221225.2.2",
+                            "image": "ami-004ae258c9546a539"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-05d5f9e071853fcb3"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-02458b95fdde428b2"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-029c01a5032a838f8"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0f9efe6fc359cf241"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-030165d695da9bcd7"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0ced3a3dfbf900a7a"
                         },
                         "ca-central-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0f5a59a97c29df3ce"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-01d73af31e938e268"
                         },
                         "eu-central-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0aa33a8e1752ecd51"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-00a3379b21d4b1049"
+                        },
+                        "eu-central-2": {
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0739e864f2bbc4908"
                         },
                         "eu-north-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0e939746d98dfd882"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0e06fa154f91134a8"
                         },
                         "eu-south-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0dfda847443311d2b"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-001feaf8ea597d33c"
+                        },
+                        "eu-south-2": {
+                            "release": "37.20221225.2.2",
+                            "image": "ami-068a0e5304f267f5c"
                         },
                         "eu-west-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-07aa241ffb9145e68"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0803a3f5a9432a5ec"
                         },
                         "eu-west-2": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0c9d116a2ca5e6920"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-05538fa655c4f4212"
                         },
                         "eu-west-3": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-051e661eda565ff7a"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-04fa346673151d0fd"
                         },
                         "me-central-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0b2949f311331a2d8"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0ac733d6c499b9ea7"
                         },
                         "me-south-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-08724c16120812aff"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-082516f16a212b3fa"
                         },
                         "sa-east-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-07c22c617ffabe6d2"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-06e3425476bc58048"
                         },
                         "us-east-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0979e14ecc1b00ae7"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0e798e92149adf79d"
                         },
                         "us-east-2": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-04816c8c5fbec5368"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0009c774472d0d237"
                         },
                         "us-west-1": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-0e0ee354758cbc448"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-0494c82f940fc293d"
                         },
                         "us-west-2": {
-                            "release": "37.20221225.2.1",
-                            "image": "ami-03282e46d87b0d2ee"
+                            "release": "37.20221225.2.2",
+                            "image": "ami-05a0b7848092eb33e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221225.2.1",
+                    "release": "37.20221225.2.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-37-20221225-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-37-20221225-2-2-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2022-12-27T14:02:09Z"
+    "last-modified": "2023-01-04T00:14:38Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "37.20221211.1.0",
+      "version": "37.20221225.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "37.20221225.1.1",
+      "version": "37.20221225.1.2",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1672164000,
+          "duration_minutes": 1440,
+          "start_epoch": 1672927200,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2022-12-27T14:02:08Z"
+    "last-modified": "2023-01-04T00:14:37Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "37.20221211.2.0",
+      "version": "37.20221225.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "37.20221225.2.1",
+      "version": "37.20221225.2.2",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1672164000,
+          "duration_minutes": 1440,
+          "start_epoch": 1672927200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).