### PR TITLE
workflows/promote-config: don't promote snoozes in denylist

### DIFF
--- a/.github/workflows/promote-config.yml
+++ b/.github/workflows/promote-config.yml
@@ -61,6 +61,12 @@ jobs:
           git config user.name 'CoreOS Bot'
           git config user.email coreosbot@fedoraproject.org
           ../fcos-releng-auto/scripts/promote-config.sh ${src_stream}
+          # If we're promoting to a production stream then strip out
+          # the snoozes in the denylist because we don't want changes
+          # in the executed tests over time for those streams.
+          if [[ "${target_stream}" =~ stable|testing|next ]]; then
+            sed -E -i '/^\s+snooze/d' kola-denylist.yaml 
+          fi
           echo "commit_title=$(git log --pretty=format:%s -1 HEAD)" >> $GITHUB_ENV
       - name: Open pull request
         uses: peter-evans/create-pull-request@v4.2.3


### PR DESCRIPTION
For our production streams we don't want tests that weren't originally run for the original promotion to start running later (either on an ad-hoc build or for `stable` a few weeks later). Let's strip out the snooze lines when we do the promotion.