### PR TITLE
Roll out stable 37.20221225.3.0, testing 37.20230107.2.0, next 37.20230107.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-01-04T00:14:37Z",
+        "last-modified": "2023-01-10T15:34:46Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "d7488a72104312e62ce92c7e461d3346bc423e49af4550afa1cbba30f51ad5d7",
-                                "uncompressed-sha256": "7c476a755cc7b51b2956fc2b2e43114b6360785e697f17510642b82b95224176"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "977bbffd596e56b3eaf3f8d073325f09395d52ce36d1520b7abe7ec8856502ad",
+                                "uncompressed-sha256": "6195c6f9dc0c575132ce35d0af51bfbda7e15ef0e7452a59d0bb235268059a31"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-azure.aarch64.vhd.xz.sig",
-                                "sha256": "b06e5a039dca728a73cfde5c9757ae646082cdd95b62575fe25fb6d4defb99a5",
-                                "uncompressed-sha256": "97f16b275cf8d87897a072f206a28e8cadddf03687637a0edaa9771f44014b32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "8ef674a3c922651a43c28c8e78aab8f1b20e5d40a59904a027142765b9f239ab",
+                                "uncompressed-sha256": "b8dc2ed99c4189afaee729f1ab5bc50d72051020a01e0601a953cf65694e7c5b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "3d5dfe662642ce636d002f61e4a0c966d60dc1b9c4c843f469f21fbee142077f",
-                                "uncompressed-sha256": "bcc5eeba77303ceeff50e58c0edd8c18ec7162335959e634b6beeb5a72128cd5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "dc0767934ffc86678bf402cd7fb75f27c821d6b7949f8c0486493eef5c5905eb",
+                                "uncompressed-sha256": "0de960f5ebdee103c1e93a3cc5c1e21a0347d44baa120cfbe652d3b47abac01c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-live.aarch64.iso.sig",
-                                "sha256": "56dd391ffd55103e1d44c5681cab8993589214ed56fefaae7fd2ee5fe253ea77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-live.aarch64.iso.sig",
+                                "sha256": "25bb9c88a021b7c6362e88caa7ed55f7c0e941c2149590ab205ee13b2994441d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-live-kernel-aarch64.sig",
-                                "sha256": "6c87ccd2811cf5754df2756cc755f358180fb63bf981aa9b7754599b6f379339"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-live-kernel-aarch64.sig",
+                                "sha256": "3d2c34550d0039bd812c73e7d006804c027646fa26f6c0e32c71449702c018a4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-live-initramfs.aarch64.img.sig",
-                                "sha256": "c17adac49d2212c646c923ac0aedd5e04a94ab69693209ee81240e30d9ec4920"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "af2c12a04fe84d4da7bb798df5deb14dac2e8e05494a98940f7a6ec2e67c310f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-live-rootfs.aarch64.img.sig",
-                                "sha256": "e56d4e7554633dd81eb11904a71cb0e63a207fc79b95e7f677f6cb419cf46852"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "3112888c6ac53a5f290314938bbce9414fca0c28e04e11517cd97fce905a71dd"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-metal.aarch64.raw.xz.sig",
-                                "sha256": "24ec2426fd0b8dd0c5c5959f09f540e681965c28fcdd3d0de6d6424f06618447",
-                                "uncompressed-sha256": "2b6242036fbe05c9feef6bccc4a584ba099ed15ff90966f2b766a528c9484904"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "239e0458d88fcf2566da02df56e70fc67bf25215e884305c9176b79d76fab6ae",
+                                "uncompressed-sha256": "48ad530d85b17aba5822f2aedf7c82103cf763f562da57e91b1e5bc367c07dff"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "d23b6e40eb1ee682142e47cc1ebd8501da35592e6a9580409541c75a9ac8bb39",
-                                "uncompressed-sha256": "e24e6eef6a85bb585fc3adcff98a0244c954a65beb1f8679e1055b490e3e4d5c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "e3f178bf70eb41a92c39ed784df00db49044f42052244af02dbfff184bc028a7",
+                                "uncompressed-sha256": "574794dc6f129f818d166341b2065a9dca743c2848add5d3c3622aca3a609365"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/aarch64/fedora-coreos-37.20221225.1.2-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "f87c568777ead99f8abff8b12f550fc7cc26e2b1b834a63d457f75504e88c388",
-                                "uncompressed-sha256": "08f0b5d1e9be1afdf03027ada7cf1d3fc639d8e01f5d1e7110442889d211e036"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "e8ee9ba2d126f9d118c534d0c582fbf5ad1931bfbdaef389f41d1f6a37e5c8a9",
+                                "uncompressed-sha256": "5bdf2f385eea406d041c198b8f3799c301a7e0cf6469fce34374e0bc7beab9d0"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-07b584410223a63f3"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-031616548a4f71e02"
                         },
                         "ap-east-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0b22c7e11676f8ac8"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-000c208cde4a57b48"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0e3b7e360366642dc"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-00c9c78fcc15c4ba9"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-09ffd92de897ed686"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0c1fa501eb69225ef"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0ae7b3542e3946540"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0a7754001b6cf3920"
                         },
                         "ap-south-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0085f4ea473662316"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0e4a070ca764ed98a"
                         },
                         "ap-south-2": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-03043d0e0f7a32bc5"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-03325812083c7d390"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0d3d7a1fe2a02a097"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0d706511423d25297"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-004c1094eb94c8112"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0c930a946ce71fb20"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0cb194668ae424eeb"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-080c02c454272b5ba"
                         },
                         "ca-central-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0b11a90a4d323435e"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-07e24bad53c9ac450"
                         },
                         "eu-central-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-04384f431bb0cbd7a"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0237333533d79d03e"
                         },
                         "eu-central-2": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-05bba94ea39b16bc4"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0ba518ec82bdb195e"
                         },
                         "eu-north-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0bd1667bf08e215c3"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-023218ae084f9b49e"
                         },
                         "eu-south-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0dfa547ad318ebb81"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0ee54fd370f8e93f5"
                         },
                         "eu-south-2": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-04e9cb687a1538fe0"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-05be36bd4efefcd6e"
                         },
                         "eu-west-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-06bb8dcf1849bccdd"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0e956a74154eb10c6"
                         },
                         "eu-west-2": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-07d50bca3a9720b7f"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-07a38391084cf4fab"
                         },
                         "eu-west-3": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0efff50d55300e9a8"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-03d862d9420903c58"
                         },
                         "me-central-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-099007d26d9c3dae0"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0b20fd929ba573a26"
                         },
                         "me-south-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0de6baafb1aeae27d"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-020ed85bd66797a44"
                         },
                         "sa-east-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-02a906e10a5907196"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-00dfb820fa27c1eb9"
                         },
                         "us-east-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0378b2954174885d6"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-03d11b31ccdd1d308"
                         },
                         "us-east-2": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0fdf4521baad88b3b"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-01d9c7efecabc69d7"
                         },
                         "us-west-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0fae10c2670896879"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0e0015512020e32e2"
                         },
                         "us-west-2": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0846bf342d57ee561"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-04b669d9894c26f6c"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "9f68ee7a1a261463f5dd3fb6485938b89f4aa1c983980fea6a6e349c81de9833",
-                                "uncompressed-sha256": "4c7872120d7fc980cce5a842e53db9e5bd91f9132649a6d0a0ea404d09b57ae2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "cc19d50e1a750e1af099371177ea51697fe9fb9e275749c81e77675a56067430",
+                                "uncompressed-sha256": "b048b0e8c6ca2e9426da707704c174b15a2829f913f54ad1336f3c02c21e5d99"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-metal4k.s390x.raw.xz.sig",
-                                "sha256": "87d13ffbd73091301e9db4344328c69d69499257c24b9688585df12d2c87544a",
-                                "uncompressed-sha256": "f9078f91785624d6737f218e0b1455a2a3c6c6d900efa745bdb8a41902a1a758"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "1e75c223e300755f2db4d46f350b123a502e938e208346d96e145a84829e145b",
+                                "uncompressed-sha256": "539a9043b5066ddd20e250aa448b5fe0672bc28e14eb2694f3365b56f9e9173a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-live.s390x.iso.sig",
-                                "sha256": "7289b0aec51c2470839e1b44006d8f236ca5887890e057782d6aa26bf705a3a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-live.s390x.iso.sig",
+                                "sha256": "7097d815a360f3cb150fdc1dbf050998e5ac6c7b4120b69e8b0fc4829daa9089"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-live-kernel-s390x.sig",
-                                "sha256": "647edd9b580f1628ca8b68159accc5c41484c8b94572fdce7fc895c98f3d7168"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-live-kernel-s390x.sig",
+                                "sha256": "18caa65f5e5017964815b26ca094e5e5dd4dabacd116293b41718d53c7fc866a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-live-initramfs.s390x.img.sig",
-                                "sha256": "ecde2d7943caac3e2f89013434cc05292810867767637c1c2a0978d486f3bda7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "507f80ba39c50b387bdf0bc2993bff10dbd159b91f77cd3be3cf3acc525c5eae"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-live-rootfs.s390x.img.sig",
-                                "sha256": "2ecdd3ced8382466b19ac2de487e4cb51d507103f2bbd45b45fd8c6f0fadeb97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "46ed78025df2fcbe1bf1a6fd149dde9d26594332d6b347a1ba2fb921fba6168c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-metal.s390x.raw.xz.sig",
-                                "sha256": "18e1f0ec68cec5c1195a18859d6ff75bd1296b28780c66cbe36d778b313319fb",
-                                "uncompressed-sha256": "2dd729ebdcb2f3903d9e4781581cc4981ddf3beb8aea24cdcc55c3ff2c509255"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "71f26b4abd131fed27013d7953c4ce37fe5df458cffe3716882c9971ec5a72c2",
+                                "uncompressed-sha256": "be49f6e94637d54a3d00c8be1a0a62c1c60488bdbab4f6a92d38169b9e4e3bfa"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "f1e68f46cfa6bb4435c13ca2b84e875b012465496b43eb5b322e8e54c4286810",
-                                "uncompressed-sha256": "08f12f56193d6ff2c8a0e0ccb2c541d8ac512818fae580bbf7e5919899105d6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "4b3d22a17762a175a7406c39b2039c2069187640e865ab0c8a96a6db0843108b",
+                                "uncompressed-sha256": "6d23ad2a887ce7ccd34a17e9bb3d1cd67a1fb5db4775100fab8526eadde22dce"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/s390x/fedora-coreos-37.20221225.1.2-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "7671700e15af357da822e64bdd114f2c2edb5a346ec515d60128acaa8e78d699",
-                                "uncompressed-sha256": "a6c4347e8bc8027a42494b7b7402ebafaaecdb729d5995255b3f517d30ede34e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "8b0f9869977480958889bf9bd83341cd5e9bb1bbaadd2025bb28b989f7332bbb",
+                                "uncompressed-sha256": "628392eb3aff5f5024b492eddfc74c697312d1d32c62fd6232af022e569c8b8b"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "d2918b9a42e576ad991bc8ad8cc62c3d686a8c7da03def86dd0c000255de5a76",
-                                "uncompressed-sha256": "ea980fecb7dd572a1527cbec278c85e86ffead29d422d2a6e3f88b5189f153cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d9059b097084b134079238eca5a3bb4a29098db956153c9abaac12bd0b7425fe",
+                                "uncompressed-sha256": "e733d93bfafa858fef780228b79dd281ee6093eefb09c1192de31bc145f83e3f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "d46ec34ad97231b7d204e77bccf515b9497db0e554ce39d3cc085f80ce7eabb9",
-                                "uncompressed-sha256": "a4901ce3aececf9a1b16062d323d59559a7b48bca713fc52d40ddff770df0ca9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "b3070bcfe9a01c3ea3c36269dc6e8309e22a217e763a05782b778067c3a253cd",
+                                "uncompressed-sha256": "7aaf7ce448effa77df594ebe6ec7e0607cc51e9f052397e2352438d0ccf9c138"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-azure.x86_64.vhd.xz.sig",
-                                "sha256": "fd68f98fae1e5f13fe3090bdabfdd84ef9ff9bfcaa3818bab3b8e3d1a4426100",
-                                "uncompressed-sha256": "92ee715a4f9d8cacb40e6027d2397c06742a51d2fedffeb591da369eccfe43ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "87eb7c1a4c83574b242c3ffa4573f85a681179d0e00a3f1bb457913019c0c291",
+                                "uncompressed-sha256": "102e8f0f7d5481628ea189cfc86a7c681b1acc8c202365425da2ee5297e9b23e"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "cc9753efdeb67649f4bd32b14be97e858493188390329800548d975fd74482a2",
-                                "uncompressed-sha256": "b3fb9b96de578dd2c9d50cfab50ecd196cae46b4d65db7016f095afa5819b410"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "fa40a9ede72bf51e9b5a75d1f4ce5f919132fbfe7ad34af903042d40622db80d",
+                                "uncompressed-sha256": "d970686f51a344448bd7e39c97cea496fb07bac80c693d9cc3205ab655c48a92"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "23ea0a58cf3506909aa976d418c1ad07fafd8d92ae3e78e8f6813a01e538faea",
-                                "uncompressed-sha256": "e8d610753b374affbb594490c7b1a9f914974fe505f3a17b929ec730aa2e88a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "416270709aeb420155d82ad5bb3115c7fe772d19f4a06cd853647c24fab9613e",
+                                "uncompressed-sha256": "99e4242602401f198bd96f5b4a3437d61d69118da10143e7e8e9d7cf1eb39c5b"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "551ff53ecf9d6cc91f4f613b82d018d2899a5cf41ff9eb060aec8f5ca308b8c5",
-                                "uncompressed-sha256": "7d90f988092ebb4befe0f1460a675a2b6282558e865d0119ea3714312afbc2be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "bdcaafa4550d75a794d0fb4d281b9d3a04a96afe782b01ef5af642e719f4871e",
+                                "uncompressed-sha256": "05ff0c7c0dc32b7ffdf1d1936d06d7083f43923bcfc8b87cf2fe8d8980e7890c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-gcp.x86_64.tar.gz.sig",
-                                "sha256": "4187bd1924fe75d95c7880484f1714657ab8adc331169883d25d4a8f5910072a",
-                                "uncompressed-sha256": "4d84e919b02f685ddadc85c2c6d1790fc5ba1186f27c5145af6e9e5c23d378e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "70a0971133fa23d07122002b9dcc02c7bab885628942fbd6b53ea0a94a87b684",
+                                "uncompressed-sha256": "4977c955f66f2ebb58c4098b7616afc755d2c219a887173c6bf9813568ee84ed"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "0146b5ba3a428e4de3c38fae337c1281cbe89a511d95d55c660294a745a1a6ee",
-                                "uncompressed-sha256": "1102c60f03a96e724772ba2e330ce1355003f8ef78d5d4b571184ef7ab024b8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "41c192a0ab9452940b8d9f1a5142f955a311ee06f7d9deabb0ebe6354a4599e8",
+                                "uncompressed-sha256": "eaa7b09563e514bd7754ed81e27f5c8ec1ae9966806d4a483e29c064dca5c495"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "e2318bd2e14e2699f33fe03352439fad0b5de95a5421a1f58c64b1ac97418765",
-                                "uncompressed-sha256": "7b5e8025beb6ecb2cb6af5779296e8d017b8c40f4f97b3d38176f14113685b0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "35243714f2c3ea5d2089abe5e82b4786e5b4c4d6baddaf8faedfef3744298469",
+                                "uncompressed-sha256": "35ae03d85f63f65828705d04affc2fe07de10021e8a036ceb5206284a2faa399"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-live.x86_64.iso.sig",
-                                "sha256": "3a0b29f49e730b683125e7f230544394d0e9cf4610e28c7b2439d87d85e98ee9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-live.x86_64.iso.sig",
+                                "sha256": "7bc0590d084afc65787422fca9d3d5185b853f70596975302662231ffc105aa3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-live-kernel-x86_64.sig",
-                                "sha256": "9db5d790857d1d9e60d60e76c770e606a2cfd993a5a2c09ca30c4e54a4c23ef6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-live-kernel-x86_64.sig",
+                                "sha256": "b0948a50703d6db7e1e4a1a2e383ff9903eead429510b4f5c7db14539c6fc1c3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-live-initramfs.x86_64.img.sig",
-                                "sha256": "ffcc274001c91f0b6504d097de725835c7e1553664d2c210aa0dc36d66332b67"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "ae541cae9af8fcddc236a85ac0b733d1c9b952001704c3edfd65e9a7e03e8771"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-live-rootfs.x86_64.img.sig",
-                                "sha256": "306f2a4b22b5215a1260efcfdef70bbd18d659c522584d280a9a48c95825bcce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "1cc096cebc3f8470b0a4078ef764483ecbecb338f64fb23ce4365a174acce3cd"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-metal.x86_64.raw.xz.sig",
-                                "sha256": "bf5f39fdeb2725c962dd2a9d544dfa4ea545d344fe3e76b349352981f7b399b7",
-                                "uncompressed-sha256": "177322389c933134289ef3b7cc34702ad313c990956023f5efcc40795e387f8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "f98afc39685f47ecacf1b62ec3841b13c531f3255d4534b6a869d46f952dd798",
+                                "uncompressed-sha256": "ae584e47f489126ed91a44762f4ce310c931884a9636421e7625e16a16b2ce10"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-nutanix.x86_64.qcow2.sig",
-                                "sha256": "580a072f73129a67d4d644007c8ae2f9066fe364bf1d27e5b5fabff656cb6628"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "e22fff9dd16220f9e6fca65a8afab9fd5b4eebd74a7c4aec70bc0eac27126944"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "b87498f4e601814598954ca61963c88c1de97bcf904d29519b6265b61e5f720d",
-                                "uncompressed-sha256": "6f777a977b80d600e996d2c3e80b5c639f2674a385dfeac32bb178ddf11e1352"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "65b98843a0497aff65cb8f116d9213bdcb85abcb07301f5543e9dae5858f8a8f",
+                                "uncompressed-sha256": "ff22540ac617e16b7d9b681e1c39e63f7a0e6e31999d4c23299cd63722bf1722"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "539dc1b954b8dd68734d758b9066aabe2c7e0261d73b7980757425cf1681dbc5",
-                                "uncompressed-sha256": "628936ff95e04cd3fe4d917a16bf5a89086b769a40f21837da4a00b3470eafc6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "f0f95f17613250b53657a4791b4e99820ce70357d5c731596a44f5011176ad85",
+                                "uncompressed-sha256": "a2747687de8d9fd302c8e4ceeed1395783473e312e856c2244200cfc033df3d3"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-virtualbox.x86_64.ova.sig",
-                                "sha256": "17f03c8fa9fab02a86f302468d702218dd88604d9b4deb3cd8cb12ec17e74035"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "4977c4794e903c422e1ad72df29565db7cdd32ac552e8706a23bfdf4e482791c"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-vmware.x86_64.ova.sig",
-                                "sha256": "a4d9f562cbd84c6400abce840dab53901ca9aacd1cba365c3e03cc76dc4d5661"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "a7a69cc24123ec3f49852c9e85d92cad2710f790a5fb33748a47145e7b167f6e"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20221225.1.2/x86_64/fedora-coreos-37.20221225.1.2-vultr.x86_64.raw.xz.sig",
-                                "sha256": "36141e6d999bb677aa0a69de6ddfe6d975e6959aa99a844e1fabc1fa63d14302",
-                                "uncompressed-sha256": "e41247c5dad86a03996de6ec9dc6305cde9a029729635df4597f38516c66693d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "77d9d207f68b8234a3dcceb29d8212c7d0d30aaa0707182a35719856d9153c33",
+                                "uncompressed-sha256": "60e7369c6c8cbeef01e5479996f29c1bdc82bf77cc247c0b1b7f3cd5b551129c"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0a36107307c2837e7"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0e1766cfd6604d9b0"
                         },
                         "ap-east-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0610e95d423dd9b57"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-086bc91a0296bc84a"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-00849c32686cc9d45"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0d8f9f9dd6472af99"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-07ee953bfa3685a65"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-05f200e49fa4cc62a"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0f0f6a64182fe613b"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0c2e4f2850372240b"
                         },
                         "ap-south-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-05e1a7044b6c1e537"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0258c9e7041fd7323"
                         },
                         "ap-south-2": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-08188749948c82fc0"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0d9d423afabe0b660"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-070844e2ba3079c9f"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0f5f37e48067c36cd"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0647196a1471ef74d"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-050d7753fe78d1898"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0811e5aa61fe52469"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0714e70bfdca0d925"
                         },
                         "ca-central-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-007e51673fe3ccd66"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0baf00f6ade04e2b8"
                         },
                         "eu-central-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0f26ecffa8577f3c2"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0a52066b48bfe98d7"
                         },
                         "eu-central-2": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-066b1dfe86cf21ffc"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-06733da4ec013d976"
                         },
                         "eu-north-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-049313dd5fdbd5e02"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0a6dda563c1d2011b"
                         },
                         "eu-south-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0b03a973c12236146"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0ba424fd2560f1324"
                         },
                         "eu-south-2": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-03b22837f2b37f729"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-05db3ceefeccbde9a"
                         },
                         "eu-west-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0ab7f4bebb7941ab6"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-02fb2fb7b9455356a"
                         },
                         "eu-west-2": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0223474bb989e6de3"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0dd3b2a80b9172bb6"
                         },
                         "eu-west-3": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0cdcb929a9222a443"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-07b0a9094cae29aa7"
                         },
                         "me-central-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-08f2f1ca1d7ff637e"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0723224f5090ef79f"
                         },
                         "me-south-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-034d72d8100096e56"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0c66abd76a17b1b80"
                         },
                         "sa-east-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-08ab1b85b0930125f"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0c9ad65d0d8bcbd94"
                         },
                         "us-east-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0732dbadce25b01a6"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0702a19612def7895"
                         },
                         "us-east-2": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0c06a64572009d728"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0dafb13c17d44e66d"
                         },
                         "us-west-1": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-0f3e8584f2aadb552"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-0fe8b3641026b23d0"
                         },
                         "us-west-2": {
-                            "release": "37.20221225.1.2",
-                            "image": "ami-02b3f10ae98ce2b08"
+                            "release": "37.20230107.1.0",
+                            "image": "ami-03381a08b75a0d965"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221225.1.2",
+                    "release": "37.20230107.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-37-20221225-1-2-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230107-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,105 +1,105 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2022-12-27T14:02:06Z",
+        "last-modified": "2023-01-10T15:34:45Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "fe62456339eaabcc5c29fbb4dd6af7c6f6a65bca274757618abcfbb090534982",
-                                "uncompressed-sha256": "e0adb5659ae4992210348758cd97b301de5eba08376a89027534a5f7f25d2be0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "c5357b69e1fda577804e5cbaa35dfd3003f9589a186b3119007e73e170d8fa86",
+                                "uncompressed-sha256": "8d934f369ec3c5341c5864b3982bbd8d0a64b488fba7074c365f931cbba3564f"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "347f80b007efb54d85eeb4912c6c28c45d08545f6952ebb1ed9b25e9429c1264",
-                                "uncompressed-sha256": "654088b9f7c767eae6a3d19d905212c33f3ee64fdb67630217e6057d21e05fca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "d3aca8d6edc9f2a4a2645bf5e0268063a83d5e595716e1f4ab848319cd166573",
+                                "uncompressed-sha256": "e08def9d914ff7e32165d7937da18fbc3130f431a9bc2556593ce7547e1a1fd8"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "6db747d5a874d522d9f390a9f7a3235fddd11ec18bc465cc97c025306aa41996",
-                                "uncompressed-sha256": "a205bf80a9ecbdf012908ac2978a17c38e4dfe02b88fc7834c3bce626c24f980"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "bf608b2d4b2c5b49db43d02df0f513f4dc6b3c334240e7e078093e36508ed028",
+                                "uncompressed-sha256": "effa0ed1efddd8611ed779cae1f2a6884c877df6385bf11cd45132cad7b6ffb9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-live.aarch64.iso.sig",
-                                "sha256": "ffab61c8d1ee821403e5f2bc2a57ea11a02c0ceff4839a07500165ab53675776"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-live.aarch64.iso.sig",
+                                "sha256": "2b115c2b999fd6b428b5c1f6fe48c4ca9e809e51d972ef5477554abaa32adc5b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-live-kernel-aarch64.sig",
-                                "sha256": "5dfe9ad3814207d407e3d8c6b94641d40bb2c9c34808c57ab29f9dfdb18dbee2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-live-kernel-aarch64.sig",
+                                "sha256": "6c87ccd2811cf5754df2756cc755f358180fb63bf981aa9b7754599b6f379339"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "c15acfff16d9a0ba2afbb9579221c210d2da57611e685019ac930bdf14ece48d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "3add203626aac4765595a108ac1358ee12bf79d336ef25c4dc0e48e7fdc8ddad"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "88c72eca8a758333c0acd3fc1bb00d2889c2a59294f18826b34dc18f6f446c74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "ce70bc40fa306291f5f28d84ab274f1f0fdba23141b3364d8f2a30b94934ec6b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "38e3883c914d09b4ffdb4887dfddb307d40e25664252bf3a7bf505d6c3a92d03",
-                                "uncompressed-sha256": "722ed664750d4532a07a112c6c55f221cca7a5f5d9cb34dae5d3c09667783185"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "c525191d960e0ce2b4ff64dc15fc166b937449e505cc11d4fa283f7ea938828c",
+                                "uncompressed-sha256": "9ffd05e5cf57ab5a59934633655eefb79006cea6cf6169bdb230d3b57443097d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "731c27f2adb38909ebe47fb2d6782857b147a8b4902cf9bdcbbefb88d3dbb9a9",
-                                "uncompressed-sha256": "31535d99c8d7d0a97a78b288b66595182523bd8e0992112071a214d7a1b2d35f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "fa9e7a4512055b7b3047d535a399e9b0d5c524f6fc15694a4f652d6d5110dca8",
+                                "uncompressed-sha256": "93cb3c078ffb6f78b637734f8c1c07730fdbcfba63cb29e0e8bf39db520db942"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/aarch64/fedora-coreos-37.20221211.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "4eb34cc211849dfd717f45f6e31ed5e5072f6b5da80737f12a5133ff4e531ecd",
-                                "uncompressed-sha256": "faaf94578b5bef1b9774c2c87e5c7b0aaa6938cf47ad050c126d214e7b813eee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "8e45fa8997c611400b66ebebf8a50ae6df04024636207d3664ac868b159691fe",
+                                "uncompressed-sha256": "e495beefdd63b8ab6029406250a9a728cd72dd890a7ed0268f5cada3c250278a"
                             }
                         }
                     }
@@ -109,96 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-03a0b86c683c35b98"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-06d26d2f08d7b9062"
                         },
                         "ap-east-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-01404ebe20cb23ae9"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-060b6078e64de3e73"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0d5b4b244f6a71a16"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-001ac427fe7d89eeb"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0d4e3c5009bf4d80a"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-04dcf95e62d51c84f"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-08dad64e1a8608da8"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-023945e28656cbb1a"
                         },
                         "ap-south-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-01377ce596b438336"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-01add1e599b13c0cc"
+                        },
+                        "ap-south-2": {
+                            "release": "37.20221225.3.0",
+                            "image": "ami-03aced59e4f04fa49"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-02dc80aa15293e07f"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0c32fe3b7bf381af4"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-05496e177a0e376a9"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0c091f8157811fc19"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0f341ece569ade917"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0ed4da84e9cefe8ea"
                         },
                         "ca-central-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-090bbcf489464a32f"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0cde7a2b15ac01a69"
                         },
                         "eu-central-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0c003a8076785de75"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-033c41c6f9430716a"
+                        },
+                        "eu-central-2": {
+                            "release": "37.20221225.3.0",
+                            "image": "ami-073df58253f36a98b"
                         },
                         "eu-north-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0e120c4f5b9438389"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0ef19b714025349a6"
                         },
                         "eu-south-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-01d6df42c56df5ec4"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-007236bf9f80ca505"
+                        },
+                        "eu-south-2": {
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0ac1b59af953f2f25"
                         },
                         "eu-west-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-025b4b1e7a410e1a1"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-039ed07dc04136b0f"
                         },
                         "eu-west-2": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0ee1d2f93fb4e32f7"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-018d1cfe267918469"
                         },
                         "eu-west-3": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0e3be69fbf40c7acc"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-04480a3648d5dca71"
                         },
                         "me-central-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0a7540c0a1e8142fa"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-04781b16cf3af7765"
                         },
                         "me-south-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0ae02cf3aaf355b0a"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-036cb48cbb39c5cc4"
                         },
                         "sa-east-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-09cd6be561caa96df"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-004ec4afcc34c7e4b"
                         },
                         "us-east-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0720576e1729ac57d"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-03be86ff62fe082ad"
                         },
                         "us-east-2": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0120758d4b10c38a3"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-04d3ef399dbfcfd53"
                         },
                         "us-west-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-05284ff65020ba4a1"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-05abddf43d55a6e70"
                         },
                         "us-west-2": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0a2d0094dc160b84c"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0f60f80218c57cb91"
                         }
                     }
                 }
@@ -207,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "6ca226cabf7bb6d25eb9035a496a9b6285486755ad33a7559f31b85b8ce25bb7",
-                                "uncompressed-sha256": "d30d579ecf7e62be073003d70993c0e7c315e3d63dd63f7e9b105a6077fff2f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "0c9080b2fcaece3beea1306a37d3396475f72af0653a0416f5d3b997b563b564",
+                                "uncompressed-sha256": "b091f833aef129c187fdce48d7008453f3e9331a843d8fc96f01568863456965"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "082168fe9041133954e9047607cda3221a49b9398a99d160dd0ce155fe694bd1",
-                                "uncompressed-sha256": "83d79be78853cc9fe8757c6b7db3dd60b32f40437699a854fd72f170f47f9572"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "d3ed2090b69fb2a0b701d344aced64e6bf8ae1c348838fcdbe5164cb54e6c48f",
+                                "uncompressed-sha256": "9a6d1305b81cfa49ea75a1bd2164e3eeb811b3f5933c0cb5ba2ef5526ffdef48"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-live.s390x.iso.sig",
-                                "sha256": "779959533b590d1e2dab9b88b7fcf5273d24e937438773efc3f4cfde4289b6dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-live.s390x.iso.sig",
+                                "sha256": "02e9e5fb5987893298c05a17068caccf18fd48500073dfbe7af51248c82e3fa6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-live-kernel-s390x.sig",
-                                "sha256": "ee6449a981f58f8994372b906cb44c90fe1d7674238153ad0cb483012af9b4d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-live-kernel-s390x.sig",
+                                "sha256": "647edd9b580f1628ca8b68159accc5c41484c8b94572fdce7fc895c98f3d7168"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "f31a9914d0f2426ca2a950b06ab520e5e484f4744e97285b367d89bb22cea9f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "67d167c8269a0fc4de453777726c19cb4567332bffea899e4126daa378d6fe49"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "796ca664bc4987e4afb188a08c8bd0ae602e1ab7ba49089e877c576d2cc29e90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "ba8e85bef7ce86bf1be72f48a50d57c7a8de039f34472a5133301bf4d712aada"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "029a93255a718987dece42c331b91ba6454b6fbbf8df12eeebdc58fe0c486f1d",
-                                "uncompressed-sha256": "6f1a8bb376edbc3a615c8999d87f73052aef684e7123c260afd2abbb928d577a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "bcb637e382947c7e6dc7c8a4417eec4b112a5d9890b4dcd94411045f70934265",
+                                "uncompressed-sha256": "cecca0c48698ba3699033b9c0e2b89897bab36f613ef9c0cb21d02118cfffc72"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "7d748c3edc308f0ffdcd0d95e57cf321e6452d5308c8ce8c54db63c8d225a1b2",
-                                "uncompressed-sha256": "6e162438a766a3d65af686d9fead5c23be2ceee0ed1802a4c6ceba57ee675624"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "973a50d1181f68003a3dc35779342f3348fa622e5ceefd5af7fb18bdb4994077",
+                                "uncompressed-sha256": "f5392c5ca64630677ac94c38da80d88686f2319ec0d5b291f2f1656462ca2c62"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/s390x/fedora-coreos-37.20221211.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "08bba93a0894477ac70450fc9e2da25c4b4840ce2b59e6245da8c2c43f3253bb",
-                                "uncompressed-sha256": "c900eb578df87b3d1f779e2b4f098c16d80e788515e69725d9659730495ce90f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "bb61e903d78ef804fe5ba4af484f530f52f32ba30ba3ca8b96bdc582bf21e1e3",
+                                "uncompressed-sha256": "9fef2f0e4eaf56966b338744dc91d5d3fcdac3bdff657c57a2ef64632c997278"
                             }
                         }
                     }
@@ -296,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "d7bfda1a25306aa9b171d5fce8e6f1df3da96d75697b934389f4c2d24a95e46b",
-                                "uncompressed-sha256": "2c89474d395ea4e75aeef3f0e530930d397122c190c35dc33464352c1d45b5fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "db8c65aa46de008394ae9ac2e4cd2843db01800e92d9f44e4bbe4bd886426110",
+                                "uncompressed-sha256": "b6d8d6ee677370e5db0c626ca49840a84fe815a97186545aa6bfaeb6e186371a"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "daa4b1d1bf21d4d2d399790956ff5233f2987338420f3c93ef65937ba06c6a02",
-                                "uncompressed-sha256": "a156e381ae6fcdcba62758702c8911956ef8e0ebb378a5f19aea489d1d4827e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "c341e0a2ff198eb1020f4bb714be7bc459db45009577442f01485130b01bd8f4",
+                                "uncompressed-sha256": "40cb32cf1ed575f19942fdd8e1b4df9f7f9d32a135e5a06c4af3d5ec55312417"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "13ab85c7f72a70f3b2d09e02eb29e4887659c5bf2bc9b7257b2df3b0a387684c",
-                                "uncompressed-sha256": "f0bbb9d6cff63eed603a24504ccea043233916febb09a5c5c0ce8f93f79c6fe6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "c51b20b7db8111132c60570fe3d8692a4a3e9137a3481f141534bcda12842396",
+                                "uncompressed-sha256": "54e3acd8c4c4ffd2ef8950d508c70b42f2a7711c816286e91fa28e1b2fde1097"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "51957b9bbe057b2978dc92e4642de767d43738b193497a5df3ca4be970b84eeb",
-                                "uncompressed-sha256": "476f7c44496cbf963252f4fbb11e5aa4a4e62e7d2a76943c6e6deaa150b0c214"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "5c02b9b9d90a978a149e35cfff0ca0ca471ca5a01a7d923f729e672e56994297",
+                                "uncompressed-sha256": "9bf54797024fcb701a483e763d689721c2756a1d3aa58eeedb76787469fbfd25"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "d083c1274494cb39f67cdbbd22ce6d9588c8ef9023be0432d930f3ed6947795d",
-                                "uncompressed-sha256": "024c3c93a2319ccdf07756ae4dc7afe38eece54e5d1aae8508ab73dfd5658410"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "28b3c432b1bf5959230ae83b929a0a68cf247a245ad22940c4a0df9ed8cbf01d",
+                                "uncompressed-sha256": "a9b21a15a59a7a976cc41081b9f89d5d1c2faabd08d74e9b2eec2145494b15d7"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "7e23c26e74013888a69b1b66824635e16cbe6abc6e407801493bb3486c8cbfa7",
-                                "uncompressed-sha256": "6a8c71ca2cd6d9d7f823676feeb31e769a5fcf7a7858eecbd91aec9e26c8c56e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "2087f2f79e088ddd6fbeff110f38b862e3a9dc95a789d855ff9dd6142f841eb3",
+                                "uncompressed-sha256": "d15c867eff7741ab135aa9a2cbe65b52c5e9d3cbbbf95238c7d46ba8745216bd"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "b5c00f0cd30ab252d77d97604cf9c640ac571994b75a8957f198bb81b3ff760b",
-                                "uncompressed-sha256": "60ad53f48f9a41202d387ef0746d45bbfdf827093883ad156d123f248ef8e8aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "dc2e98e09b24bc2d7d10f69141c3d6a2c12572cfbdd8b9b76d2051296cb474c0",
+                                "uncompressed-sha256": "79a54ea1ad1708e85a959e5d7e3b662f69a068329941b179f42ab0fc3f2e6a1f"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "9a7a972456d61174c7794879b4a5feef4b00e22f8e87cf823f50ada3f079105d",
-                                "uncompressed-sha256": "c85d45a847a886a7995392fb37313bf4ddff761886fd4d4c051a8b227be4a59e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "0167dc052da1643d6abeb9cf8807ccec54c4d525a5a14bc2a69357c0c8dd5aad",
+                                "uncompressed-sha256": "d6f7de74dd6f1ee000bc1f50b2eef66bccd3f241527569562148677dc31c3924"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "9dc2f7292b43d154e8b299233ae6594768bff0afd6c8d16c91765f9423497a9c",
-                                "uncompressed-sha256": "251f67c02d298add7290bc667ef20186b0cc97dd4c70d3b7dc0e3f3d96ba6fc8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "d2b838ba58a2f18648d153c83e7a5a08a9ef933f075ee360acd0811c42fc95ad",
+                                "uncompressed-sha256": "34bc7b380d86e2dbf0d0bd6b8bd59c21d5b2b092776dc77fc947a8c270e61fe7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-live.x86_64.iso.sig",
-                                "sha256": "b5fee07dca9a8c9277d4a36e0e15921d037de002759e8ff1ae3dbc13f0ca953b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-live.x86_64.iso.sig",
+                                "sha256": "c6bd43780d601910b1ea222d9b8a2bffe360095a0e32cc4254d05a1727a59ab5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-live-kernel-x86_64.sig",
-                                "sha256": "fefdbc8ce0e52f8681a40680f777c8c2ea73088b9968a75889bd29b27a564783"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-live-kernel-x86_64.sig",
+                                "sha256": "9db5d790857d1d9e60d60e76c770e606a2cfd993a5a2c09ca30c4e54a4c23ef6"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "579834269b98e3352897ba54855eb44a731bcac6bf253781e84624e1f740c6a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "810439bc50e6ca986770d206dc1562930f4ddb0b23d83cef6158a4f2ff29aa1e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "3a137f5eec3dbf6ea5c560184645b8b15e4d9feb317cc3396e3a8c81ea26d05c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "342fea07af6f9853ae7db1a0c8961641cb381ca134c9ad31fdf0ca52aa05ebfd"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "ec56a9e1c50d432486b2da6bac148702f4afa05ef6e20f15964e87c28f989381",
-                                "uncompressed-sha256": "a50878d9e7d3e40cac754e2ebb8d21eb045aa92438b15f6f31058b21ac904fa2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "f7e3df1f2b835b594164fc698f1736f911142e746fc6e2f9cf8cc776bd9b1944",
+                                "uncompressed-sha256": "22106f90ecfd717d5cbab1a8a52af444fffd3e5593538141d4cfbd33fd84277e"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "b9be1189184363f0ce04505338505bbf99c9b1adca2239b149945791962fbce1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "5916c09d9917816b8a1222aeda54fb87a511bec58ab8b7631f04c8cc59a58012"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "4251e5fdba15ed55a8d670520aaca6a87bce4d0ce5dc0be1885696b61bf3271d",
-                                "uncompressed-sha256": "1c5a4bc176e03fe051a0f1550f740e51352b5645838d7209373c5c93bf476a64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "0a4ac2e8d0503f736d65ecb0489cb5034211c081dbb941671740ef547f634220",
+                                "uncompressed-sha256": "e00bf7d3c5686bebcc83bcc9936c08a9de77a9406a404c42f6293da4e3efdf3e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "28d438c8326967ce3ec68cb733f6ef5927c141921570144a16872e786f6965f7",
-                                "uncompressed-sha256": "2322c02c1a1bca4f7b7bfe2922f8f3b576a4456dafff8779150a8a2000be7e91"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "8bdf7ab04fe147680a18e7b28187f535cc05e41fe2e4b233f99cf1dcddf39c41",
+                                "uncompressed-sha256": "42cc6152fb4c84ebd0859bfc474452226649d3d65358f3ada707c9ec48ec78ad"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "24061db75ff3433a0bb7e90a8df13c4f04d779c9441c995ad78345b641ececcb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "b2543665e0fc2316a6e50bc1de82e5ae6e75b68dd7d7b471586dd1df5a90f888"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "369765d22aff376f7ba4fe8a11eb798e0138d335f8095f81e207d4c7e4f07ead"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "60a10066c38b73a45ea6c0daf6a678a90ad381858a30eda533e169f7d8beb3d1"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221211.3.0/x86_64/fedora-coreos-37.20221211.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "25da40dda3897bfab71e403c777be3b282e45abab790b7c2a37da2813dc343c0",
-                                "uncompressed-sha256": "216798649c9161611de7e74c51e2cb618096f1a57c2ead39ea60d4d0ee8fa435"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "bc532ddee639959e95029ccb9ad8a35753488873e75aea382e709797727dbf2e",
+                                "uncompressed-sha256": "fc44fda308921efceeebcfbf1602f0a55f1356bdeeaad8587e40a0bb867ab67f"
                             }
                         }
                     }
@@ -524,104 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-020b739766e2f887a"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0c6dd632c5ae88ae6"
                         },
                         "ap-east-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-09bae491486bb8683"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0562cc1ff70fd6ebf"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0cd413434211c8865"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0f56fb6fbf94c491a"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-08b8d3872a05a506d"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-079b35a9ea188726e"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-03378bb05039211de"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-03dfecc812169c6ca"
                         },
                         "ap-south-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-04f5be6459b4f075c"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-00a027d6ec9b5699d"
+                        },
+                        "ap-south-2": {
+                            "release": "37.20221225.3.0",
+                            "image": "ami-00714523e52d36d13"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0058b399576077b1b"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0e29fe54b08c44ef0"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0a566951f88b0b8e9"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-06b0a136ac9046081"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-042961caae8f7778a"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0cf19fddc0e08896d"
                         },
                         "ca-central-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0f372f8cb87ed5405"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0d592428317839f86"
                         },
                         "eu-central-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0c52e2d4dc1066f44"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0a30595d0b835938d"
+                        },
+                        "eu-central-2": {
+                            "release": "37.20221225.3.0",
+                            "image": "ami-04022ee1b2ad11264"
                         },
                         "eu-north-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0d26a78af394c2319"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0638138db7e47bf44"
                         },
                         "eu-south-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0277f4c1dc01290bd"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-083fd24555c0b7468"
+                        },
+                        "eu-south-2": {
+                            "release": "37.20221225.3.0",
+                            "image": "ami-03ace2588f245c49a"
                         },
                         "eu-west-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0199192023df17f1f"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0a515364f37cc3718"
                         },
                         "eu-west-2": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-06ac157e28822fa1c"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-031a782a2dd2a3434"
                         },
                         "eu-west-3": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-09e6b4a25c4505369"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0526431bcc8f76de1"
                         },
                         "me-central-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0810a10afa6a2f696"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-05877175bad9f86f4"
                         },
                         "me-south-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0f12eb6f8a509574c"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0977375da1606d0cf"
                         },
                         "sa-east-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-04f5fbc6c40a728db"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0a93326b2a7af3d9d"
                         },
                         "us-east-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0a3279828fb6dad65"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0ce26a467370cadf3"
                         },
                         "us-east-2": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-02138926287184a4e"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-02dfb61b98736d52e"
                         },
                         "us-west-1": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-0206818ee836371c8"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0cad4e17ef908f6bf"
                         },
                         "us-west-2": {
-                            "release": "37.20221211.3.0",
-                            "image": "ami-09de1409d37ba4886"
+                            "release": "37.20221225.3.0",
+                            "image": "ami-0c7b5a429d32199e1"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221211.3.0",
+                    "release": "37.20221225.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-37-20221211-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20221225-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-01-04T00:14:36Z",
+        "last-modified": "2023-01-10T15:34:46Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "fa6d0f8182a07e5c7cbfe2ea6187bf3855d68abcdb194be7799982c3498c695b",
-                                "uncompressed-sha256": "f0e056aec01c3a64703d44f5124798de60a903f55cc8046b1957646167147e6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "70c1f396d5f3766d6b7f58d2331b7dc1b8dd6da6bb2f1aa71d79b9be10c5567a",
+                                "uncompressed-sha256": "86c9a5e9d6d7b6892cdeb34c7d09e12f9038856ed716f5ec53007616082e4552"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-azure.aarch64.vhd.xz.sig",
-                                "sha256": "fe5265300029a9fa89d50f77fc3fce84df8c950fb2db05fc8569d38c550d1626",
-                                "uncompressed-sha256": "82e4d5c0b0fa139b18ccde13009b28c43fa064d7c7f78a60e146ef07034eb1cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "12aa8e6300363b22d7631bbafb16979c520376863ccb65c621bb2354572e80a0",
+                                "uncompressed-sha256": "472fc2e40babd6f9979750353438e74ea6379bbcb79761115fb24e69c15f026f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "c73050ca3be05869c596b88dbfb69846897da52a95ce701a02239df9d7e3ce6c",
-                                "uncompressed-sha256": "0d29d7012105d73d701cb279243d999c2506fad71d0970a54bcb5c055e743729"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "680ecf6fc81173b82669231a181746529ef1fc4929b5345d209b7e343240133f",
+                                "uncompressed-sha256": "18c9776655db10e8b928a1a3fd0eb5c0ac90f51a804e189488a0678871045d87"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-live.aarch64.iso.sig",
-                                "sha256": "7922dee4e3de0ecfb2ecef7b8cfd03f25b35c242bf4e877b10222d2f89516621"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-live.aarch64.iso.sig",
+                                "sha256": "e787f35849b36b31a20983e8e79f27f741132fb9382bc5c53bbeb331295fbc77"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-live-kernel-aarch64.sig",
-                                "sha256": "6c87ccd2811cf5754df2756cc755f358180fb63bf981aa9b7754599b6f379339"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-live-kernel-aarch64.sig",
+                                "sha256": "3d2c34550d0039bd812c73e7d006804c027646fa26f6c0e32c71449702c018a4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-live-initramfs.aarch64.img.sig",
-                                "sha256": "fae8c9fb219c8b79d064accb55883d853d838fdb9013cac7493fc6c67595d636"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "983487c79f759136c1608d18ea96645a5d795d93cce2fab906dadbc0dc16a90a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-live-rootfs.aarch64.img.sig",
-                                "sha256": "ff896309b4d957ca12824b22b79a9124d61d9a3095788f0e95633c133cc8670b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "e3392205fd4bc5de1d1c4669173dd7275f68ca2e46f32418e6ba0cd1f3056b13"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-metal.aarch64.raw.xz.sig",
-                                "sha256": "ee3c762b40d938234faea6bb872ffa814d09471aaa82c1b399de9623671396b6",
-                                "uncompressed-sha256": "ced1c7be990ec36f125c6f0c6f58cc479b6f937e7f4dc881dcafeae4da28b26e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "abc9eb6e8b5edf2b9712f564ce5119801cf5e535c3f6c808ae9dec18088da00b",
+                                "uncompressed-sha256": "eda373ed51c694480dcf1bf7f316e7e1d6174a4de95f7b40bb61fadbfde125a3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "49093f6b4c446f6da9b9f457ed5fd5aa989eea0f81f19b8e50f1e5af2b7f217d",
-                                "uncompressed-sha256": "c9b654b2a6c3679a63238b197f2e526e341d1805129858c5c45f019fef54cb70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "240502c9801f7353d60ab133e40ecc0d0f5851e45a1649ff93f7488a89675e17",
+                                "uncompressed-sha256": "abf669aac32714678383c2364af737ed475933e13f82066210ba78afe61bc542"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/aarch64/fedora-coreos-37.20221225.2.2-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "a9d6278feb86d6fe29e369c16f510f07bb486f8c34f8ea6dfb43456856d94eff",
-                                "uncompressed-sha256": "c7878f6783e3b2bdd38478d830b8ad5ff3bbda54cc2a294fc431d2bd1aa0b5bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "04ace3a9d5e2dc469c26389082a3dd6b38f4a87b64cd09b042dac2f0acf0603f",
+                                "uncompressed-sha256": "2f5575a5fe8624859d5d72a38bfbb91f5a2b51244f04a7a1d4bb282fa429714f"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-069f1704d7f776826"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-060c2a918bc07c55e"
                         },
                         "ap-east-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-054ae4e0f56fa8c6a"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0c726d9f96bc3228f"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-09d526e443e585029"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0eee85f00f2b1fbba"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-04d2fc60a419d658f"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0afebe8c52053c96f"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0c46975c6ddf3aab5"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0dc68b2ae8c5d4b9d"
                         },
                         "ap-south-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-085015ed7bb4e54e6"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-06ddb0393eba4e3b5"
                         },
                         "ap-south-2": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0ca8542c75783cda6"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0b6e6aaa1c85e4e15"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-094f99f0952655466"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-055c0e612c983997a"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-017ffa8084ad58d33"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0127f012e7e4260c6"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0353346982de7badc"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-04cecbb752d747454"
                         },
                         "ca-central-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-051fafacbd2a19e1d"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0c8192df9b1593c49"
                         },
                         "eu-central-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-07013b37fcc133300"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-047edf60becda6160"
                         },
                         "eu-central-2": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-02e7549eb94e680a6"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-00f94afe5e9e636e9"
                         },
                         "eu-north-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0707672350eaea33b"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0ae2c30a3fb3f0065"
                         },
                         "eu-south-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-07c59b726a290e102"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-09ae0dbe445eba9fc"
                         },
                         "eu-south-2": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0ce172cbec9dccd5a"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0fa81a9ae64f0a90f"
                         },
                         "eu-west-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-037d6795cec0e29f0"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-018c2f0a94261d638"
                         },
                         "eu-west-2": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-073613d9c876ea2a2"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0509f6fb413470ff4"
                         },
                         "eu-west-3": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0bebe192966bf9929"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0d2f183e57d050a4e"
                         },
                         "me-central-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0d77045585163774d"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0177df4bcf49073af"
                         },
                         "me-south-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-075e9015ec2892089"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-09fd1d71c48ac1ddd"
                         },
                         "sa-east-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-08263f7b8e8c5b19f"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0fa04f94cee25ad0f"
                         },
                         "us-east-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0c67a0b5b4e3099e6"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0591ed392b43faf6d"
                         },
                         "us-east-2": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0423978303848c390"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0a71738cedb156c54"
                         },
                         "us-west-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0a41166408b0fdebc"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0a6ae2f8bbe6708fe"
                         },
                         "us-west-2": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-074a13a39714293c0"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-05bcbb2da36937304"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "41f0b4b662b515de1c0587d7eb7e05b96f63489e0ac799e18c50fcfd2af50908",
-                                "uncompressed-sha256": "e6fa06f804f0f221647428881ca9aeab2d62be21163e344a11fc65681dd4d157"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "692472ec9bff9aff3d6da9e79e22e4ae107bc0e0acb8bb8f2753f8fda67370ab",
+                                "uncompressed-sha256": "3601f8228fbf8e4d8ed5c000ee1963574917bd34b49644dc70cbb79abd5e0350"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-metal4k.s390x.raw.xz.sig",
-                                "sha256": "911634b8a51fc832d76bfea41e4d87fb3dbb5a8df20a3e216bc906133d673f6d",
-                                "uncompressed-sha256": "162871dc301da8d54f578fb3177f128e8a2e97131d3cf14cd5ea6cc3a4d6654a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "dc5b148cf8de3e4abc0a2ced1f24678647c4c0135fdee43e2e764c03c449ff82",
+                                "uncompressed-sha256": "d198f5b6f592cd8f8e5ae5bd05e884e7f01f6e99d20ca114e0e2a027f0db7e4c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-live.s390x.iso.sig",
-                                "sha256": "bcd95e0a09386d911be6ecf6245a86f0cda38cd0dc83a104e27a4538017d5dd5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-live.s390x.iso.sig",
+                                "sha256": "60df51588f5563d3f5f0c0f0948c8a5f4a6da59f6bd54404da4b7dbb3d89b73e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-live-kernel-s390x.sig",
-                                "sha256": "647edd9b580f1628ca8b68159accc5c41484c8b94572fdce7fc895c98f3d7168"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-live-kernel-s390x.sig",
+                                "sha256": "18caa65f5e5017964815b26ca094e5e5dd4dabacd116293b41718d53c7fc866a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-live-initramfs.s390x.img.sig",
-                                "sha256": "17cf33eb2865f208fa18da0e8e01fb490e68f5d8e8a2bcaf8487c460cbf32027"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "9518b8b01016d5b65ec4d2dffe10532903b509a1f2bfb21181d4a410c7c7fb04"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-live-rootfs.s390x.img.sig",
-                                "sha256": "ee7ceb1bdd23a11d387534941230f8e0e8f0fcdf682703ff7d9f9fcce3f31a12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "9bfdd8bc12e769f7c1eaefcf5f5023eb9c4d2f9bc1df0b3a2470e88b774320d2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-metal.s390x.raw.xz.sig",
-                                "sha256": "0676617d250cb5ab6c157e520249ec56195370a9f3b5b09c81825bfc8432376a",
-                                "uncompressed-sha256": "d98b02d686c9b80ca2b95d978957c97eafb95bc171f1680ee112faa8cd4f6019"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "c480a0e890e0c676061351427416a21d9209a173202934b4b7337281c4abb274",
+                                "uncompressed-sha256": "15f3d8ba72be3aa6f86c2ce35ca5840562bf46e23d9fb757cc2144d3c1bd9614"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "07dda4e4f135216cea4a0f62aff5b355de827df3e78e0eeeec7b4dc535408877",
-                                "uncompressed-sha256": "7b2af55301072f405d54371c13dfd0bcd5c0b86b5dfe2cee54eb8462fe24cfd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "3d13ebc6617d3c968bb3ba0c2a4f543e9c0ed15e5b4c1705d0e5629ce202e13e",
+                                "uncompressed-sha256": "69df4328d011e255da9b7bc5a67cfa2cd4f6c21f849344aae503d7266acdd33f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/s390x/fedora-coreos-37.20221225.2.2-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "2fa5a3a0ea53fc57a8690772124fc6252cc93d7ea947d09f2cd59e00553997e2",
-                                "uncompressed-sha256": "93a24d6d3e2e2f44bf2ff9afbaf1c92a2d52e5c55a17ffa1a61a7d55fe4c9eec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "6272a9bab39c5de4b079d475276e7b2ce6577ffa98e77fc9ec657080e74cf28c",
+                                "uncompressed-sha256": "72d3db122336aabd94a8c97ba01ae6dcd5faa61f080c9deb975730105c7ff2a9"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "c8826b2786be719a4a4c11b5b1b636d49ad11a5a8dfed7f0d9552ad717f6d55f",
-                                "uncompressed-sha256": "ca1ee208eeeb8ff4930d105753637295b8058175ffc181ef8f6ff517a9626f68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "88514cf4f8fb06a5c916c778847c266367099ceb8150d07b7d58aaedb0ab9d57",
+                                "uncompressed-sha256": "5d0ac3d524b627e8c42cad30c75879ed273eedc6726fd4abaed78bac4f502c0e"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "dc807a4515e6d1f740a7855b44b7e60c8e2f9c67d8ea9a689727f9c0e19fe060",
-                                "uncompressed-sha256": "398b9770f41d01484871b943e120c433bc77c37b8d89cb61314da21e5d6438ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "c8ef492d10dcdf8a8f2e3e4f7205fb0c1770dc8c53792a5467a58f8cded95ac0",
+                                "uncompressed-sha256": "e425cacb0b2b2a5bff08ab8734cca84c107e949b94649d21f45e9bc1ccd9ecb6"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-azure.x86_64.vhd.xz.sig",
-                                "sha256": "2ab763d105bc1733263bd00f8c77b292c8300f79c39202567929cda44ab1294d",
-                                "uncompressed-sha256": "077fc32134290c1cf2d00f7f68d353acad5ec60b5d04bd2e7794936816e6c49e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "b494feb8fd10034b3626f7e115bcb58bc89ea37d654cd2459b447c4a7fb8abbb",
+                                "uncompressed-sha256": "4647aaa93a55aa64f384b19c81767935bc00e5c0e214dc243f996f136eac43ac"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "2616c41b3a6887830c6f0f67e636f1d59048c65a6b8760548c2f45fb00021f08",
-                                "uncompressed-sha256": "8ef48dc2c3b555898fd2d49faf04665644a25eb01b4953a5d0f248d17e660ea5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "5b633980f3225c3edfc32cc2af25a7b29c977a8b512ffa80b82dbae236f3a93e",
+                                "uncompressed-sha256": "6c9cdad689fb0a5360ac6a7844918bf3c10b4f2d1481ed12affc665844ba9acd"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "f88b286375485bda57894a4f8ec27b10c06386f4bbf3e921593ae1ca80b8c3dd",
-                                "uncompressed-sha256": "5f01c1632ac3a0db273ce589a952909365b15b989bef915e613f36f4054ab996"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "3d4e6e909a9ff8a3bc17b015378adac4e4d75a273568a5c4092ad025b7a69df8",
+                                "uncompressed-sha256": "e771cee285060d000e0a013b08c914a61ffd723aff2a93766530a64a9d554994"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a31d2645a1b312b2fc1e4b1a157cedccd3e124365f7c35b11a3f22fefb029b3b",
-                                "uncompressed-sha256": "d9620a7fb266f99710df74b90bc77aba3d0eb5789245863defe4a990de85152c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "600be01060d2799255984b58791bf819bdbd0a455483f38eef211574bebeb3f3",
+                                "uncompressed-sha256": "3e5b3c24953e58f40b4888ac79c1af2575eb1a54705241863b0eff8f229f21df"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-gcp.x86_64.tar.gz.sig",
-                                "sha256": "b5623b8c68a7883fe93c02c0e829502337a6173017328f6e905da423ff093c1c",
-                                "uncompressed-sha256": "fc73875d65f627f2db37a8d8fc3a72f3e56dec3d6bc518f2ee4d476e2351652f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "39a7b9414bde7aa5f5b7ad82bafaa4a049841fc88ae401da78e605bb2869b140",
+                                "uncompressed-sha256": "677d49d82bca06da57bcd0ef7866c1d7c0de25732c2cf9feb5a256cd68d71bdf"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "33487d9b13c5f9dce8c202a2373e98ab27940dfb0981fbf10afc5a83f9cf1f4e",
-                                "uncompressed-sha256": "4f8e03acf605118f62050b7ff99e1c50365dfaca32b9883686ea058c4d774ab3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "cdea8fbc3a761ad520b83e08622da3919733610a301f99973cad4e187e5016f0",
+                                "uncompressed-sha256": "f1b2e0ec81a5e9164c9ffb81bcf399a587a837d56ae90e9689a430e5fdec2115"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "989377a32d8b85f68815a8f868a7f5ef454a33d6bd3055bc9484e11f00594c48",
-                                "uncompressed-sha256": "dd93c3106290169bd3a7ef12c3fb38d182ce3f1f4d554314b8dfc26e8193f968"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "3d53003082eef8ab3d8b967b83da7f4bec9792b85f9f7ca619969569624fe3ff",
+                                "uncompressed-sha256": "baf5d3ad5cf574df37e377a09ef98bd9c64d606d171ccbe64b86ee6b7ac4dec8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-live.x86_64.iso.sig",
-                                "sha256": "eb3dc51dba9ec06decddeabfb59b05d43747b6accdc81414672f737f1d4f888e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-live.x86_64.iso.sig",
+                                "sha256": "523df98604b975a4117ef0a1169bd12f90b2f6bcce8426b9368f06868e7cbd86"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-live-kernel-x86_64.sig",
-                                "sha256": "9db5d790857d1d9e60d60e76c770e606a2cfd993a5a2c09ca30c4e54a4c23ef6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-live-kernel-x86_64.sig",
+                                "sha256": "b0948a50703d6db7e1e4a1a2e383ff9903eead429510b4f5c7db14539c6fc1c3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-live-initramfs.x86_64.img.sig",
-                                "sha256": "f2cceef2834fa2322fa59cebf0f20df50cd28dd242da5f4af3a5cd0c42ba5ab5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "49b0ea5521d1ea6bbdc7c21a18b6b730e3a84b1e5e6c62ed00f877091566dadc"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-live-rootfs.x86_64.img.sig",
-                                "sha256": "bb1691ab15b7d0b0cd15bad40b125fe55b226db33da5aa6e9d6b6c1e3d903ca4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "adbd977763ddb08bec466d252353adcd709bcec8ad4ca4ff42fcb6ed0529b816"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-metal.x86_64.raw.xz.sig",
-                                "sha256": "b205055f7d101e594ffd9362d874748fd92ef59ef83b81b3a8f4f60511e79c90",
-                                "uncompressed-sha256": "712e637dd2a7a0c9932c0cf4b388880dd5ffcc6e39f29e2ab8a06dcadac3c304"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "3b02e92be4f2831a42cf85f8bbcc9b14fa0c3a9b98a132293ca3d43fe0cbf612",
+                                "uncompressed-sha256": "4201616311b5c6a8a0b62ffda3cc23dab50a527e65dd90bf32cdbdf0b372ef70"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-nutanix.x86_64.qcow2.sig",
-                                "sha256": "c46b7156ff9ccfc4a9da77505558ba56bd6b86fb02afd09cb2b3ef391d38f432"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "95e2e70080638ee60b870408a341f3d438a19bd336b412f65c6f5b38def978aa"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "a748ccf538b67b4c52c029211013e7252c0b2516bf6f79872b3da022aa40bb93",
-                                "uncompressed-sha256": "6c63e1c057d18eb95f103ac1938191ded09d3a3a78f686e734bd94644e61e3eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "4589f0ce3bcf00c6b1e54886a1777cb190e7c6f4db711310924ecdffb9898ee6",
+                                "uncompressed-sha256": "45b9c1bf823b71cebb04a08d92c262fbf579c44bc8009db254770a8282cc3085"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "2c619535cf64fb07c977d1575ec79feff99880eebcb2159ab7c8af5c0a43dc32",
-                                "uncompressed-sha256": "23e610737a71f3cd128f2743934045c729c4e1056eb099cea3fcbb6d65ddb24e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "30f677d1cbea9ef2eabc7c7a2a0ebd775d95655daaebb9641556aadda830b73c",
+                                "uncompressed-sha256": "43f22151d60fa0860daf5d194a800151c170d28cbf24fcb2fe01ccfb05ad54b1"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-virtualbox.x86_64.ova.sig",
-                                "sha256": "a230b85bdf571b43a0c3af684650d82eead23555260d7c8681f56ac321a76b6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "b05fd2abf39708bdd6fc42f2ebf27d7ef2de29355f792a0abd05f4bb844627c0"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-vmware.x86_64.ova.sig",
-                                "sha256": "4b56ec21a1265078d67f1c7dc857d64805673ec5ac8f55cc2a02e6f212dfe3de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "6baeede9021d636e1189a06296684cb3fb5bce4347796aaec191a1821ff20898"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20221225.2.2/x86_64/fedora-coreos-37.20221225.2.2-vultr.x86_64.raw.xz.sig",
-                                "sha256": "6b91fe030f229554c754f8a4ff7539c6122d774dc9fd2b2e9f9ba46a4271ab07",
-                                "uncompressed-sha256": "dfb60dee623cf01b48225d8c4025715b63cad0f899e216be5802d3c5642a4860"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "94b841c9330de72dd14399c0949049ef411b3cee4b4f244aaae738977d9eb1af",
+                                "uncompressed-sha256": "3e7551fde411cca23b1a37573edda83c4b341754841194df7cf28ea6d9158de8"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0b464b4229abe3805"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0b30c2df012d49808"
                         },
                         "ap-east-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0f997da656c70087b"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-05747b06141fb8d21"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-06a95744516c380e7"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0a218a991a1d694dc"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0e5a0a72e51607c0a"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0f08fcbc43ea681d4"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-04328867094a28b20"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-083141b2e42f44882"
                         },
                         "ap-south-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0d0300c5221cfd449"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0e2ee812cf0a8bad7"
                         },
                         "ap-south-2": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-004ae258c9546a539"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0b838f33a18adbf11"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-02458b95fdde428b2"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0d2edecc650cd30c0"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0f9efe6fc359cf241"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0312986fcb192f380"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0ced3a3dfbf900a7a"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0c2a70329cedf464c"
                         },
                         "ca-central-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-01d73af31e938e268"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0fca7e57266127d17"
                         },
                         "eu-central-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-00a3379b21d4b1049"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-001e48360d4d408f1"
                         },
                         "eu-central-2": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0739e864f2bbc4908"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-01685214e3e5c51b3"
                         },
                         "eu-north-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0e06fa154f91134a8"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-014c9634de9f9dd51"
                         },
                         "eu-south-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-001feaf8ea597d33c"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-051c21d33881db603"
                         },
                         "eu-south-2": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-068a0e5304f267f5c"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0936ecf583f268236"
                         },
                         "eu-west-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0803a3f5a9432a5ec"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0086b2aba5d8ea2d0"
                         },
                         "eu-west-2": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-05538fa655c4f4212"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-035ca7c954d58f3f6"
                         },
                         "eu-west-3": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-04fa346673151d0fd"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-094f4089829255c3d"
                         },
                         "me-central-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0ac733d6c499b9ea7"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-0ad5c86b3a17d305b"
                         },
                         "me-south-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-082516f16a212b3fa"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-03ddbac6009359b07"
                         },
                         "sa-east-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-06e3425476bc58048"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-01a33f4da07a7805a"
                         },
                         "us-east-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0e798e92149adf79d"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-024044166849cbef4"
                         },
                         "us-east-2": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0009c774472d0d237"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-080076578edd81422"
                         },
                         "us-west-1": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-0494c82f940fc293d"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-02186c15db7772141"
                         },
                         "us-west-2": {
-                            "release": "37.20221225.2.2",
-                            "image": "ami-05a0b7848092eb33e"
+                            "release": "37.20230107.2.0",
+                            "image": "ami-02215a6cfae50fed5"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221225.2.2",
+                    "release": "37.20230107.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-37-20221225-2-2-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230107-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-01-04T00:14:38Z"
+    "last-modified": "2023-01-10T15:34:47Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "37.20221225.1.1",
+      "version": "37.20221225.1.2",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "37.20221225.1.2",
+      "version": "37.20230107.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1672927200,
+          "duration_minutes": 2880,
+          "start_epoch": 1673373600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2022-12-27T14:02:07Z"
+    "last-modified": "2023-01-10T15:34:45Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "37.20221127.3.0",
+      "version": "37.20221211.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "37.20221211.3.0",
+      "version": "37.20221225.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1672164000,
+          "start_epoch": 1673373600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-01-04T00:14:37Z"
+    "last-modified": "2023-01-10T15:34:46Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "37.20221225.2.1",
+      "version": "37.20221225.2.2",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "37.20221225.2.2",
+      "version": "37.20230107.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1672927200,
+          "duration_minutes": 2880,
+          "start_epoch": 1673373600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).