### PR TITLE
Pause rollouts of 37.20230107.1.0 and 37.20230107.2.0

### DIFF
--- a/updates/next.json
+++ b/updates/next.json
@@ -75,16 +75,6 @@
           "start_percentage": 1.0
         }
       }
-    },
-    {
-      "version": "37.20230107.1.0",
-      "metadata": {
-        "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1673373600,
-          "start_percentage": 0.0
-        }
-      }
     }
   ]
 }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -91,16 +91,6 @@
           "start_percentage": 1.0
         }
       }
-    },
-    {
-      "version": "37.20230107.2.0",
-      "metadata": {
-        "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1673373600,
-          "start_percentage": 0.0
-        }
-      }
     }
   ]
 }


### PR DESCRIPTION
The new 6.0.16 kernel has a bug preventing samba mounts from working:
- https://bugzilla.redhat.com/show_bug.cgi?id=2158496
- https://bugzilla.kernel.org/show_bug.cgi?id=216895

It is fixed by 6.0.18:

https://bodhi.fedoraproject.org/updates/FEDORA-2023-9dc8ecf7fa

Stop the rollout. We'll respin `testing` and `next` with the new kernel.