### PR TITLE
Roll out testing 37.20230110.2.0, next 37.20230110.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-01-10T15:34:46Z",
+        "last-modified": "2023-01-12T05:15:17Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "977bbffd596e56b3eaf3f8d073325f09395d52ce36d1520b7abe7ec8856502ad",
-                                "uncompressed-sha256": "6195c6f9dc0c575132ce35d0af51bfbda7e15ef0e7452a59d0bb235268059a31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "2051a66e33b18b9330d24f27c100992d0832d53efd81f385e34114fd29cb6e48",
+                                "uncompressed-sha256": "dccd2744ae561dde0431fb2a21779a5ca1d34f22d52530e11531b2bcd5f72f17"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "8ef674a3c922651a43c28c8e78aab8f1b20e5d40a59904a027142765b9f239ab",
-                                "uncompressed-sha256": "b8dc2ed99c4189afaee729f1ab5bc50d72051020a01e0601a953cf65694e7c5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "b0b8830530b5a9bd1a056c70c4249dea7ae52b8b9446a2495bb3ff998747572e",
+                                "uncompressed-sha256": "3cf82b24547a2bd4be09c2e058f505b05171ab33a41277af628121ee870d1d8b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "dc0767934ffc86678bf402cd7fb75f27c821d6b7949f8c0486493eef5c5905eb",
-                                "uncompressed-sha256": "0de960f5ebdee103c1e93a3cc5c1e21a0347d44baa120cfbe652d3b47abac01c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "ebfb67026d9d687ff270d6f645be70bbe80a55d420c9b5846c83186371df4202",
+                                "uncompressed-sha256": "93d62392f51097ba9aacf3dceb7925e26f4f8d986640b779f7b73d8db6fb5a8b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-live.aarch64.iso.sig",
-                                "sha256": "25bb9c88a021b7c6362e88caa7ed55f7c0e941c2149590ab205ee13b2994441d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-live.aarch64.iso.sig",
+                                "sha256": "83c239bda7f6b4f93fb87b99d44fe081f46c97dbc53d1283284c7408d4aca722"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-live-kernel-aarch64.sig",
-                                "sha256": "3d2c34550d0039bd812c73e7d006804c027646fa26f6c0e32c71449702c018a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-live-kernel-aarch64.sig",
+                                "sha256": "a2ef50a7dac3de0f10a256f32a4a03cbaa89b985cf0dc350d8028146daa57d6e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "af2c12a04fe84d4da7bb798df5deb14dac2e8e05494a98940f7a6ec2e67c310f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "37dffd210262c500c606d8ae6aee77da3612d2ca860a5ea83ea1dff659afc3a1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "3112888c6ac53a5f290314938bbce9414fca0c28e04e11517cd97fce905a71dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "da0368d3c88efa5ee67a4ee7f5761387d228869bccb1239e82d953dc93dd7bfd"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "239e0458d88fcf2566da02df56e70fc67bf25215e884305c9176b79d76fab6ae",
-                                "uncompressed-sha256": "48ad530d85b17aba5822f2aedf7c82103cf763f562da57e91b1e5bc367c07dff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "a2a968de8896070aa69baa3f330002b1a988b75ce19ab97a9a700371a45a10ec",
+                                "uncompressed-sha256": "a6660d617c9a9029d05575bac283e0abd6078cd93f23d43fec2a2e1f9ebfd306"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "e3f178bf70eb41a92c39ed784df00db49044f42052244af02dbfff184bc028a7",
-                                "uncompressed-sha256": "574794dc6f129f818d166341b2065a9dca743c2848add5d3c3622aca3a609365"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c5aa2728063c8f2e837ab9b54e32a5452a80fa0be8d5b85b5eb7d30db7aa473a",
+                                "uncompressed-sha256": "0e8e5cceeb3217fde2cf1d86c7348782fd2b51e726141e71e96c667f6651ab33"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/aarch64/fedora-coreos-37.20230107.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "e8ee9ba2d126f9d118c534d0c582fbf5ad1931bfbdaef389f41d1f6a37e5c8a9",
-                                "uncompressed-sha256": "5bdf2f385eea406d041c198b8f3799c301a7e0cf6469fce34374e0bc7beab9d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "06e3a515a769514a0f807308238d86270db6ec3bd7b1e5635e56dfde64b71bad",
+                                "uncompressed-sha256": "bbcdcc2758959761563d4361f84b86aa26e5d927dd9cc168de70e4fc736970a7"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-031616548a4f71e02"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-095fe626f72365dae"
                         },
                         "ap-east-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-000c208cde4a57b48"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0fc1b43f52c2f23a3"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-00c9c78fcc15c4ba9"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0d6ef9e2dd37c4565"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0c1fa501eb69225ef"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-05e4222b3d84461e1"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0a7754001b6cf3920"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0e70709fe1d53249b"
                         },
                         "ap-south-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0e4a070ca764ed98a"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-03fd7d2c2c4211864"
                         },
                         "ap-south-2": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-03325812083c7d390"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0a76bcfc665042a97"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0d706511423d25297"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-067d409aab2cd908d"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0c930a946ce71fb20"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0b9589a2c0b680969"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-080c02c454272b5ba"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-07d67e6b26bf74003"
                         },
                         "ca-central-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-07e24bad53c9ac450"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0b9f832e9c7e42c90"
                         },
                         "eu-central-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0237333533d79d03e"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-094044767dd7052a5"
                         },
                         "eu-central-2": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0ba518ec82bdb195e"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-02c1d232f7c94cedb"
                         },
                         "eu-north-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-023218ae084f9b49e"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0eb4e8d1ac1299db8"
                         },
                         "eu-south-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0ee54fd370f8e93f5"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-09a518edf00960006"
                         },
                         "eu-south-2": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-05be36bd4efefcd6e"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-03c06e933e6af5b7e"
                         },
                         "eu-west-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0e956a74154eb10c6"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0ce70de66007c4514"
                         },
                         "eu-west-2": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-07a38391084cf4fab"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-098b7a7302c4c908d"
                         },
                         "eu-west-3": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-03d862d9420903c58"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-05e23601195443a8d"
                         },
                         "me-central-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0b20fd929ba573a26"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0bfaec78b366bfc83"
                         },
                         "me-south-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-020ed85bd66797a44"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-02b6e82c123cf4a68"
                         },
                         "sa-east-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-00dfb820fa27c1eb9"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-036a7a30c1d5f6076"
                         },
                         "us-east-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-03d11b31ccdd1d308"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0254f671bafb0df7f"
                         },
                         "us-east-2": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-01d9c7efecabc69d7"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-04f07a1323f5ea598"
                         },
                         "us-west-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0e0015512020e32e2"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-02021af6ef82291d4"
                         },
                         "us-west-2": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-04b669d9894c26f6c"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0bde92d55487d7cae"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "cc19d50e1a750e1af099371177ea51697fe9fb9e275749c81e77675a56067430",
-                                "uncompressed-sha256": "b048b0e8c6ca2e9426da707704c174b15a2829f913f54ad1336f3c02c21e5d99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "56518e6b9e9b9d537828fc343b8270c0a2f1de8d00f52daed343991f8d9ae78e",
+                                "uncompressed-sha256": "42b51d16650c2a1fa83735f360b599420883aa7d9c263417aacda357260f7508"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "1e75c223e300755f2db4d46f350b123a502e938e208346d96e145a84829e145b",
-                                "uncompressed-sha256": "539a9043b5066ddd20e250aa448b5fe0672bc28e14eb2694f3365b56f9e9173a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "e3d82efa859714922259e16901f13d973730a0b641861bed24fe19b15f18ebfb",
+                                "uncompressed-sha256": "f32e875b73c30415810e5e6300bff130ab90b001f5b4ec4de41fe726b581e2e2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-live.s390x.iso.sig",
-                                "sha256": "7097d815a360f3cb150fdc1dbf050998e5ac6c7b4120b69e8b0fc4829daa9089"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-live.s390x.iso.sig",
+                                "sha256": "28bc5cbe4a05d4f1cdb977388cce7091457a3cfd3ff17cc1382c10e6d71b6494"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-live-kernel-s390x.sig",
-                                "sha256": "18caa65f5e5017964815b26ca094e5e5dd4dabacd116293b41718d53c7fc866a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-live-kernel-s390x.sig",
+                                "sha256": "495f557b4b78e633c1830eaebe75ef93f6d2f6f30ef9a4423b3646fd9f0a5383"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "507f80ba39c50b387bdf0bc2993bff10dbd159b91f77cd3be3cf3acc525c5eae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "6e954d359d3bbfdc18a662ccccdd00b5a11acfafaf10a374378d5590426e96c0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "46ed78025df2fcbe1bf1a6fd149dde9d26594332d6b347a1ba2fb921fba6168c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "ca08862cbfe4d9ba9cf60d69665a68974bdaf4513bda78d333e08b585b0f17e5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "71f26b4abd131fed27013d7953c4ce37fe5df458cffe3716882c9971ec5a72c2",
-                                "uncompressed-sha256": "be49f6e94637d54a3d00c8be1a0a62c1c60488bdbab4f6a92d38169b9e4e3bfa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "c20e565451eec98de3780a27af0c575c0b17e450b01d956f1e1b8e04bdca1cde",
+                                "uncompressed-sha256": "e55931b9ff134844c40688f5fb8f473866cef8805af51900f17d50c148cbbf7e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "4b3d22a17762a175a7406c39b2039c2069187640e865ab0c8a96a6db0843108b",
-                                "uncompressed-sha256": "6d23ad2a887ce7ccd34a17e9bb3d1cd67a1fb5db4775100fab8526eadde22dce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "73a22d3b7d2ad112f8f8c83d0c86e49a331435bbb2a9f60a6acfb6a209d9903e",
+                                "uncompressed-sha256": "6172ffbf24b5f1596a21a262044827d0ef13e8693b3a18de56530deb10d49525"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/s390x/fedora-coreos-37.20230107.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "8b0f9869977480958889bf9bd83341cd5e9bb1bbaadd2025bb28b989f7332bbb",
-                                "uncompressed-sha256": "628392eb3aff5f5024b492eddfc74c697312d1d32c62fd6232af022e569c8b8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "9c6c86951bcd8c7927e51836cde04089047f89c811a8fcd84a058de097079102",
+                                "uncompressed-sha256": "8186bc3393ed95005794a709ef0d338eb0ce2679d909238cf9d9891d74721a73"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "d9059b097084b134079238eca5a3bb4a29098db956153c9abaac12bd0b7425fe",
-                                "uncompressed-sha256": "e733d93bfafa858fef780228b79dd281ee6093eefb09c1192de31bc145f83e3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "e5c810c0da4e9e3f4e680086ee2f75699b378f897f15f1e7b5b01998ad521b94",
+                                "uncompressed-sha256": "6d411eb6ee9f1d8d27020062d42ca28b71224cdcebbf081be9a2c9336ceac160"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "b3070bcfe9a01c3ea3c36269dc6e8309e22a217e763a05782b778067c3a253cd",
-                                "uncompressed-sha256": "7aaf7ce448effa77df594ebe6ec7e0607cc51e9f052397e2352438d0ccf9c138"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "87156ab342b0714cc24fe5e56ae4998d6e3625f79dc3d661f30c0cd2fbddbaf9",
+                                "uncompressed-sha256": "7522aa170210243b5bbd8452d684e591bd19ca6b8d5c0483d1a1436d10438972"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "87eb7c1a4c83574b242c3ffa4573f85a681179d0e00a3f1bb457913019c0c291",
-                                "uncompressed-sha256": "102e8f0f7d5481628ea189cfc86a7c681b1acc8c202365425da2ee5297e9b23e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "8e9d23fc9175a5cff0da5ec09f81ddf77cf914a1ba66b94ad0d4a3699f77dd0a",
+                                "uncompressed-sha256": "b2c729c4c54db4f82c2b5d258411eb2de86ef05a4b3ef47cc10588bb7a4aa071"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "fa40a9ede72bf51e9b5a75d1f4ce5f919132fbfe7ad34af903042d40622db80d",
-                                "uncompressed-sha256": "d970686f51a344448bd7e39c97cea496fb07bac80c693d9cc3205ab655c48a92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "0a3bb54035f982baaa28e7c62762fbdd4840c9265fc6b8187251161ebebee5a7",
+                                "uncompressed-sha256": "6a9aeeaaa51d5c1e94297f7b792c16dfce83a163795c77747c347d72ba06c156"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "416270709aeb420155d82ad5bb3115c7fe772d19f4a06cd853647c24fab9613e",
-                                "uncompressed-sha256": "99e4242602401f198bd96f5b4a3437d61d69118da10143e7e8e9d7cf1eb39c5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "b05bd786099ba9439c474b4a7733598bacda0d4146060dae828b5d26456ff0c6",
+                                "uncompressed-sha256": "1dfd86f50984e2449ae8b5f80fbf05be45e36ac079a5726185deb3a1c0c93974"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "bdcaafa4550d75a794d0fb4d281b9d3a04a96afe782b01ef5af642e719f4871e",
-                                "uncompressed-sha256": "05ff0c7c0dc32b7ffdf1d1936d06d7083f43923bcfc8b87cf2fe8d8980e7890c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "6106ac5d0a548d5319d787edb8a083e4cd002e5ece503ae698b1dbc12addceef",
+                                "uncompressed-sha256": "94323c963c882c0ace24aaae5650fd6ba499d1e33bcf271cbc300f12142212e1"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "70a0971133fa23d07122002b9dcc02c7bab885628942fbd6b53ea0a94a87b684",
-                                "uncompressed-sha256": "4977c955f66f2ebb58c4098b7616afc755d2c219a887173c6bf9813568ee84ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "3e5b468577f42745a7fb8c295da64d22e5cda35a81bd62f3dc56f7e9a3c1a0f2",
+                                "uncompressed-sha256": "1e02b8754d66e16b49c457e1f4f25be787457a83ab838adb9af63cbf8860cd7e"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "41c192a0ab9452940b8d9f1a5142f955a311ee06f7d9deabb0ebe6354a4599e8",
-                                "uncompressed-sha256": "eaa7b09563e514bd7754ed81e27f5c8ec1ae9966806d4a483e29c064dca5c495"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "f71badb35543f647d217139bb13beb1082dfd166689f0dde152617d9af5ca8c0",
+                                "uncompressed-sha256": "3856379fbd6a3a463c3083f3711bd6f3e4c4f5f3e2638834e53066eb44df5872"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "35243714f2c3ea5d2089abe5e82b4786e5b4c4d6baddaf8faedfef3744298469",
-                                "uncompressed-sha256": "35ae03d85f63f65828705d04affc2fe07de10021e8a036ceb5206284a2faa399"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "f5c903429b3b785faff9cf7ff2a6c67b1f780478856ddc03c6f65f376209b9f0",
+                                "uncompressed-sha256": "11864ee80ea5c4a8e2c7407e06165a9b846265ec992ff18b3fafb82a9af0ad47"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-live.x86_64.iso.sig",
-                                "sha256": "7bc0590d084afc65787422fca9d3d5185b853f70596975302662231ffc105aa3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-live.x86_64.iso.sig",
+                                "sha256": "97f4ac88856aaef253df68a41529fd8f3ee3baf401837907c3a376f3087c6e9e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-live-kernel-x86_64.sig",
-                                "sha256": "b0948a50703d6db7e1e4a1a2e383ff9903eead429510b4f5c7db14539c6fc1c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-live-kernel-x86_64.sig",
+                                "sha256": "d76b102cc1b5fc711adfea30dae7d07948179d8837ee470797064de14017e15f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "ae541cae9af8fcddc236a85ac0b733d1c9b952001704c3edfd65e9a7e03e8771"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "13eeec1a465c967d79f90b3cddf6d08ae453edda644b9649f68fac5ce6f711db"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "1cc096cebc3f8470b0a4078ef764483ecbecb338f64fb23ce4365a174acce3cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "55edac2cc74e7354e44c7ca34d6399789a6fe39475fbbcb51828d58f42f9121c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f98afc39685f47ecacf1b62ec3841b13c531f3255d4534b6a869d46f952dd798",
-                                "uncompressed-sha256": "ae584e47f489126ed91a44762f4ce310c931884a9636421e7625e16a16b2ce10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "f8a13cb62aa42d11419c2f66454bd3ca7203ef91f5580e13f6d76a9d9c68de58",
+                                "uncompressed-sha256": "32d3101a67c59d480a13f504432a19091600704a0360f24e9157b8ff719a5721"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "e22fff9dd16220f9e6fca65a8afab9fd5b4eebd74a7c4aec70bc0eac27126944"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "699157915db97f8c3bdc1f27ad3460054284a99cfde67085403e758f61cd459a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "65b98843a0497aff65cb8f116d9213bdcb85abcb07301f5543e9dae5858f8a8f",
-                                "uncompressed-sha256": "ff22540ac617e16b7d9b681e1c39e63f7a0e6e31999d4c23299cd63722bf1722"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "e770b416c03aa058575e42c9c8f0338469023e6a33ca71ab77051dcb57d581c5",
+                                "uncompressed-sha256": "dbc4cbc96395e51e386adb4e424f5c611c9b441473365664b1bfbe6b3b6adbce"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "f0f95f17613250b53657a4791b4e99820ce70357d5c731596a44f5011176ad85",
-                                "uncompressed-sha256": "a2747687de8d9fd302c8e4ceeed1395783473e312e856c2244200cfc033df3d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "7f2d3e6d0134cc0c43e0087cee00d21a3629cf137efe7a8fa12ecb1eff8d5c07",
+                                "uncompressed-sha256": "7a842dd2a8a905ee75a2656d26e1a9f5574613bf4d9aba9ba32aeffbff18172b"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "4977c4794e903c422e1ad72df29565db7cdd32ac552e8706a23bfdf4e482791c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "e64e88b1804bc3081771542cb9efc4bf665497eae7c46e87dec23543c6c5d664"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "a7a69cc24123ec3f49852c9e85d92cad2710f790a5fb33748a47145e7b167f6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "dd14da3e63e3e0a7a9bb6cf86d50075f6fa691deb001d354fcf05be721a7afa8"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230107.1.0/x86_64/fedora-coreos-37.20230107.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "77d9d207f68b8234a3dcceb29d8212c7d0d30aaa0707182a35719856d9153c33",
-                                "uncompressed-sha256": "60e7369c6c8cbeef01e5479996f29c1bdc82bf77cc247c0b1b7f3cd5b551129c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "adbe5454999ae8582c3d6b91a36f16984ef42d032e639c5fd6a47aff9e8a6e60",
+                                "uncompressed-sha256": "971dec4c1819c0b7912033f8a098460b1ac42c623cab395a46bf4159856152af"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0e1766cfd6604d9b0"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0e57b47ea594474fe"
                         },
                         "ap-east-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-086bc91a0296bc84a"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-08a562e0bc13d47cd"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0d8f9f9dd6472af99"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-07cb1da511e817ac2"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-05f200e49fa4cc62a"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-02e83b8ccf74b5a3a"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0c2e4f2850372240b"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-03907ae5ffc10f9e5"
                         },
                         "ap-south-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0258c9e7041fd7323"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0bbffa0b6a4182f21"
                         },
                         "ap-south-2": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0d9d423afabe0b660"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0bbcde3faf558630a"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0f5f37e48067c36cd"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-05fc2b20a89684357"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-050d7753fe78d1898"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-06dd96a18123af9b8"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0714e70bfdca0d925"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0b7c888375b620cef"
                         },
                         "ca-central-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0baf00f6ade04e2b8"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-03e510230371c134f"
                         },
                         "eu-central-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0a52066b48bfe98d7"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-03ad598b815ade5b3"
                         },
                         "eu-central-2": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-06733da4ec013d976"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0ef50629d68bdeb08"
                         },
                         "eu-north-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0a6dda563c1d2011b"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-020dd9fb02f9dab37"
                         },
                         "eu-south-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0ba424fd2560f1324"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-078bb1c98ddfc83ec"
                         },
                         "eu-south-2": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-05db3ceefeccbde9a"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-023b9e6c285e30cfd"
                         },
                         "eu-west-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-02fb2fb7b9455356a"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0ea1b80890576bf2b"
                         },
                         "eu-west-2": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0dd3b2a80b9172bb6"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0d8c53259d5762892"
                         },
                         "eu-west-3": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-07b0a9094cae29aa7"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0e102dda4366fff0b"
                         },
                         "me-central-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0723224f5090ef79f"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-04e2f29306394df0f"
                         },
                         "me-south-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0c66abd76a17b1b80"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0c4882222359c08b6"
                         },
                         "sa-east-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0c9ad65d0d8bcbd94"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-069ae89b080c06eae"
                         },
                         "us-east-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0702a19612def7895"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0ae2c6206508f3b0e"
                         },
                         "us-east-2": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0dafb13c17d44e66d"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-08a62aa175ca3074a"
                         },
                         "us-west-1": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-0fe8b3641026b23d0"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0f02bbce67965c16e"
                         },
                         "us-west-2": {
-                            "release": "37.20230107.1.0",
-                            "image": "ami-03381a08b75a0d965"
+                            "release": "37.20230110.1.0",
+                            "image": "ami-0c0620e4b43f4e325"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230107.1.0",
+                    "release": "37.20230110.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-37-20230107-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230110-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-01-10T15:34:46Z",
+        "last-modified": "2023-01-12T05:15:16Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "70c1f396d5f3766d6b7f58d2331b7dc1b8dd6da6bb2f1aa71d79b9be10c5567a",
-                                "uncompressed-sha256": "86c9a5e9d6d7b6892cdeb34c7d09e12f9038856ed716f5ec53007616082e4552"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "d1c9d37fafca2f388b59f5b6e8d92ca4f85d49eaa115706089597e9934a98c38",
+                                "uncompressed-sha256": "8944c374114a62f5ba94fab1dc3d606ec411b6d037fdb16cc3cafc389cdfa4db"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "12aa8e6300363b22d7631bbafb16979c520376863ccb65c621bb2354572e80a0",
-                                "uncompressed-sha256": "472fc2e40babd6f9979750353438e74ea6379bbcb79761115fb24e69c15f026f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "96e5ab3eb9b3ee47d6f3fb98ef05c88acca96efeedbeae9ce909614773e1e636",
+                                "uncompressed-sha256": "838636623e4d1f89a25015bf7baf00315318d762af3c787a12bfb91435872f23"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "680ecf6fc81173b82669231a181746529ef1fc4929b5345d209b7e343240133f",
-                                "uncompressed-sha256": "18c9776655db10e8b928a1a3fd0eb5c0ac90f51a804e189488a0678871045d87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "99b89768bef6dd1240c690d66f2bccefb5b07473fa353cad94d9a56666f34ece",
+                                "uncompressed-sha256": "bee5758159137c81a08778cff92b0c2f5affaec6b68681efd6209e29f1aac7c6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-live.aarch64.iso.sig",
-                                "sha256": "e787f35849b36b31a20983e8e79f27f741132fb9382bc5c53bbeb331295fbc77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-live.aarch64.iso.sig",
+                                "sha256": "2745ffbea8f77c7db26ad53b73a80b4bb6acbc0afd85f6a018ae62c8bec850dd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-live-kernel-aarch64.sig",
-                                "sha256": "3d2c34550d0039bd812c73e7d006804c027646fa26f6c0e32c71449702c018a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-live-kernel-aarch64.sig",
+                                "sha256": "a2ef50a7dac3de0f10a256f32a4a03cbaa89b985cf0dc350d8028146daa57d6e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "983487c79f759136c1608d18ea96645a5d795d93cce2fab906dadbc0dc16a90a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "afff55a72f9aa1a9736557c0206d28b9e43373a82ca02876f528683775dad5db"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "e3392205fd4bc5de1d1c4669173dd7275f68ca2e46f32418e6ba0cd1f3056b13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "694974163ce4f1c6f001cab87b8e7ae2502d01a5658c1af6e4f31ee78a8df5c5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "abc9eb6e8b5edf2b9712f564ce5119801cf5e535c3f6c808ae9dec18088da00b",
-                                "uncompressed-sha256": "eda373ed51c694480dcf1bf7f316e7e1d6174a4de95f7b40bb61fadbfde125a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "9a60bec313dc6104d5333186975651d996167335c079bca7549a7c4635f98df7",
+                                "uncompressed-sha256": "9f1a9a3c1c74207fadb9ac2001c6ac2b13ec6652a9ec65d505a95a5b1028f319"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "240502c9801f7353d60ab133e40ecc0d0f5851e45a1649ff93f7488a89675e17",
-                                "uncompressed-sha256": "abf669aac32714678383c2364af737ed475933e13f82066210ba78afe61bc542"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "004d159f781e024690fd377af77102f43ac145858235c323329c88bcf2702f1a",
+                                "uncompressed-sha256": "2a7f614f22953f35dbe7c71166cca90d1c27a83292b8eb661cbb3ee6b685a3b0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/aarch64/fedora-coreos-37.20230107.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "04ace3a9d5e2dc469c26389082a3dd6b38f4a87b64cd09b042dac2f0acf0603f",
-                                "uncompressed-sha256": "2f5575a5fe8624859d5d72a38bfbb91f5a2b51244f04a7a1d4bb282fa429714f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "5a09a75091ea24bc656e3d6d41c32af72d73bcf32ffc29fa7d06bf1d0d287039",
+                                "uncompressed-sha256": "a31ece55a78cb1fc2a4b3b3c2fa9c6269151fb9127b9c97c8c93b3ccfc6d9b22"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-060c2a918bc07c55e"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-009c05ead6fa732d7"
                         },
                         "ap-east-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0c726d9f96bc3228f"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0e6e277487a1d68cd"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0eee85f00f2b1fbba"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0be998e42d8e9cad5"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0afebe8c52053c96f"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0940b847996723fea"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0dc68b2ae8c5d4b9d"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0616a86428bfefc6a"
                         },
                         "ap-south-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-06ddb0393eba4e3b5"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-034836539386412ca"
                         },
                         "ap-south-2": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0b6e6aaa1c85e4e15"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0f67e3a4dce747fcf"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-055c0e612c983997a"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-055bc40cd628cc3f7"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0127f012e7e4260c6"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-09ac6e6294a4569f1"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-04cecbb752d747454"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0173f5e6b6b3e9477"
                         },
                         "ca-central-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0c8192df9b1593c49"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-09e8a8eb0907a444b"
                         },
                         "eu-central-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-047edf60becda6160"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-08ed726e001eb8291"
                         },
                         "eu-central-2": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-00f94afe5e9e636e9"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0000b9598de36696b"
                         },
                         "eu-north-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0ae2c30a3fb3f0065"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-001ac96c41d87479c"
                         },
                         "eu-south-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-09ae0dbe445eba9fc"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0408ffb2102172775"
                         },
                         "eu-south-2": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0fa81a9ae64f0a90f"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0137e46c937d68b34"
                         },
                         "eu-west-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-018c2f0a94261d638"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-03c6da4fb80437ab9"
                         },
                         "eu-west-2": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0509f6fb413470ff4"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0ae44818e4ef4352c"
                         },
                         "eu-west-3": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0d2f183e57d050a4e"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0ac447fd22ad35a88"
                         },
                         "me-central-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0177df4bcf49073af"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-007b4f36fddac9ebc"
                         },
                         "me-south-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-09fd1d71c48ac1ddd"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-03ec80f2fb5734052"
                         },
                         "sa-east-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0fa04f94cee25ad0f"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0f5bb1ac31d8ffd9d"
                         },
                         "us-east-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0591ed392b43faf6d"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0f876c8337d89cc6f"
                         },
                         "us-east-2": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0a71738cedb156c54"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-06754f411091c0487"
                         },
                         "us-west-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0a6ae2f8bbe6708fe"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-00bc1fb74eceac0b7"
                         },
                         "us-west-2": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-05bcbb2da36937304"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0edf3af6072f6843e"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "692472ec9bff9aff3d6da9e79e22e4ae107bc0e0acb8bb8f2753f8fda67370ab",
-                                "uncompressed-sha256": "3601f8228fbf8e4d8ed5c000ee1963574917bd34b49644dc70cbb79abd5e0350"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "225002322510dddcd9279477e2644971f2dbd990eb7ec83325ecdb8e84773c4f",
+                                "uncompressed-sha256": "58873607cf5273fc70f33f208fa09f75e22eac8472ff99a555f81a2f07b96782"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "dc5b148cf8de3e4abc0a2ced1f24678647c4c0135fdee43e2e764c03c449ff82",
-                                "uncompressed-sha256": "d198f5b6f592cd8f8e5ae5bd05e884e7f01f6e99d20ca114e0e2a027f0db7e4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "369d9cddde94c2baa0de1063f4b6cc028c858a0de240e1cf58666c1dfc875275",
+                                "uncompressed-sha256": "720ffe6330dc04b12fc82bb6e13876720c649fd369188f062bb60602b1b92ac1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-live.s390x.iso.sig",
-                                "sha256": "60df51588f5563d3f5f0c0f0948c8a5f4a6da59f6bd54404da4b7dbb3d89b73e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-live.s390x.iso.sig",
+                                "sha256": "598a8e3f4253e676fd6116c90168e576b43b66055ecbdc166f266b8f833b5db8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-live-kernel-s390x.sig",
-                                "sha256": "18caa65f5e5017964815b26ca094e5e5dd4dabacd116293b41718d53c7fc866a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-live-kernel-s390x.sig",
+                                "sha256": "495f557b4b78e633c1830eaebe75ef93f6d2f6f30ef9a4423b3646fd9f0a5383"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "9518b8b01016d5b65ec4d2dffe10532903b509a1f2bfb21181d4a410c7c7fb04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "1508ce066cf79e4ee5eaeb787bd1e70e04d79f2d14aa3dd6636ff54cb9b14c87"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "9bfdd8bc12e769f7c1eaefcf5f5023eb9c4d2f9bc1df0b3a2470e88b774320d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "06f478ec8c8306e2ac1e219baaaea0312aaf2736b81e4264321c349918749f08"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "c480a0e890e0c676061351427416a21d9209a173202934b4b7337281c4abb274",
-                                "uncompressed-sha256": "15f3d8ba72be3aa6f86c2ce35ca5840562bf46e23d9fb757cc2144d3c1bd9614"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "83cbc44d5b26db66bc71677a85de3032c967eb8fdcc8acde2689e430247961f1",
+                                "uncompressed-sha256": "f7662088e8017856615d2d9330ff70ff73797f990f171dcc3bab7ec5a6b84844"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "3d13ebc6617d3c968bb3ba0c2a4f543e9c0ed15e5b4c1705d0e5629ce202e13e",
-                                "uncompressed-sha256": "69df4328d011e255da9b7bc5a67cfa2cd4f6c21f849344aae503d7266acdd33f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "3edac2624589c198060b5add23f58e407735214d1d9ad79ae05bdd9c28fb02c6",
+                                "uncompressed-sha256": "bbe84a90e8c3304b2f8299b69d2d99ca160490de26b322cdacb659efb52d5310"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/s390x/fedora-coreos-37.20230107.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "6272a9bab39c5de4b079d475276e7b2ce6577ffa98e77fc9ec657080e74cf28c",
-                                "uncompressed-sha256": "72d3db122336aabd94a8c97ba01ae6dcd5faa61f080c9deb975730105c7ff2a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "f38962d365d0c44a43ef3a32c1afa887a71d8ea69dd254d5465371dae1a973d0",
+                                "uncompressed-sha256": "85480e9bc54f4a99d5e132553891963731d7a5d8d0582f496b2671548b41a72d"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "88514cf4f8fb06a5c916c778847c266367099ceb8150d07b7d58aaedb0ab9d57",
-                                "uncompressed-sha256": "5d0ac3d524b627e8c42cad30c75879ed273eedc6726fd4abaed78bac4f502c0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "2a9d404e0c6faf29829547ba33126fba414a974e9a0f2a2cf6214316cbaba0dd",
+                                "uncompressed-sha256": "f6df0dce1ac83e85ae16e13fb66a018cc75481ca76902eefc2458858e13571f1"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "c8ef492d10dcdf8a8f2e3e4f7205fb0c1770dc8c53792a5467a58f8cded95ac0",
-                                "uncompressed-sha256": "e425cacb0b2b2a5bff08ab8734cca84c107e949b94649d21f45e9bc1ccd9ecb6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "13699e5c5ec9dbfab85da658d4e69cfeea8362f6d8cc0eb7d25dfb47ac5a9cad",
+                                "uncompressed-sha256": "c4704a2a1acc1ffd094d2f7d9af0b3ac7dfaebb6a1b2a3f46fc21b71b20e8df7"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "b494feb8fd10034b3626f7e115bcb58bc89ea37d654cd2459b447c4a7fb8abbb",
-                                "uncompressed-sha256": "4647aaa93a55aa64f384b19c81767935bc00e5c0e214dc243f996f136eac43ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "da122eb914ee303ea3744ff48c4841ae1dc00659a748623956e01e9f75661eb2",
+                                "uncompressed-sha256": "f33cd8e12178b4bb56faf11ab0b07ecd4218e067094795e8ccf56443dcecf774"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "5b633980f3225c3edfc32cc2af25a7b29c977a8b512ffa80b82dbae236f3a93e",
-                                "uncompressed-sha256": "6c9cdad689fb0a5360ac6a7844918bf3c10b4f2d1481ed12affc665844ba9acd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "b7bbeaef0b58dcf7903c5d69028c649cb299583f7f71ceca631486806f777a3d",
+                                "uncompressed-sha256": "7f284ec090124cd9d123e7b7435b176b37852061d02c740995ba72582a234252"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "3d4e6e909a9ff8a3bc17b015378adac4e4d75a273568a5c4092ad025b7a69df8",
-                                "uncompressed-sha256": "e771cee285060d000e0a013b08c914a61ffd723aff2a93766530a64a9d554994"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "775ebaf861dd0150e42f85e996a8bf56e33c1e630cba38fcd6d8244c5d6a1c57",
+                                "uncompressed-sha256": "9f72ae5f768c0bbc7257ef80f8aaf8fca7310cf39db58b5ba69e199d0f899869"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "600be01060d2799255984b58791bf819bdbd0a455483f38eef211574bebeb3f3",
-                                "uncompressed-sha256": "3e5b3c24953e58f40b4888ac79c1af2575eb1a54705241863b0eff8f229f21df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "6d62210d1997320b74d1e15eac0a12986a745b67900ce0432bb0df4e6d9b2445",
+                                "uncompressed-sha256": "5d7a97fb0871f480453f3c63ad529d961fbc356a936149d05a5e05e12725bdfb"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "39a7b9414bde7aa5f5b7ad82bafaa4a049841fc88ae401da78e605bb2869b140",
-                                "uncompressed-sha256": "677d49d82bca06da57bcd0ef7866c1d7c0de25732c2cf9feb5a256cd68d71bdf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "503c42022ecfc1ce23f35ad32bcb2ccf84d7a66363c56d341c3ea10181f8c958",
+                                "uncompressed-sha256": "b457552fb66b78dcdfbb190bd13b31c0d5f65aa2fe33fe89036dedd122d68d2b"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "cdea8fbc3a761ad520b83e08622da3919733610a301f99973cad4e187e5016f0",
-                                "uncompressed-sha256": "f1b2e0ec81a5e9164c9ffb81bcf399a587a837d56ae90e9689a430e5fdec2115"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "185fd81b5d6222888201c8f0837644916ee95a9ee42bcd3c4f280956df33d167",
+                                "uncompressed-sha256": "59724677c259a30459cd8667cca2d128bebbe2b06188dc77e143ecef974afbc3"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "3d53003082eef8ab3d8b967b83da7f4bec9792b85f9f7ca619969569624fe3ff",
-                                "uncompressed-sha256": "baf5d3ad5cf574df37e377a09ef98bd9c64d606d171ccbe64b86ee6b7ac4dec8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "0b5a0af36680bbbfa5edfb16d45aadfd2a29e242336873638505f8ed5c8b4821",
+                                "uncompressed-sha256": "315371c738c3ecb9422922ff5fed96376243b7729757a1c3e21e1c3ab282e27d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-live.x86_64.iso.sig",
-                                "sha256": "523df98604b975a4117ef0a1169bd12f90b2f6bcce8426b9368f06868e7cbd86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-live.x86_64.iso.sig",
+                                "sha256": "08422c5998f7bfb10788b2a49b4b45421a205db0d3be8ab2a681e38962aead59"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-live-kernel-x86_64.sig",
-                                "sha256": "b0948a50703d6db7e1e4a1a2e383ff9903eead429510b4f5c7db14539c6fc1c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-live-kernel-x86_64.sig",
+                                "sha256": "d76b102cc1b5fc711adfea30dae7d07948179d8837ee470797064de14017e15f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "49b0ea5521d1ea6bbdc7c21a18b6b730e3a84b1e5e6c62ed00f877091566dadc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "70e40dae9cbfdf930fd370ba57c76bf31fb6cd7854cbc4622f363067a51a6f3c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "adbd977763ddb08bec466d252353adcd709bcec8ad4ca4ff42fcb6ed0529b816"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "1b8f37046c12341f1690abcd4004fcd72c22080b88ca8ffd0800a8c6f3d10dd3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "3b02e92be4f2831a42cf85f8bbcc9b14fa0c3a9b98a132293ca3d43fe0cbf612",
-                                "uncompressed-sha256": "4201616311b5c6a8a0b62ffda3cc23dab50a527e65dd90bf32cdbdf0b372ef70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "29451cb7287c71c4eb65df58eeb4d00bf53a28df511e50d7d867523314d3f142",
+                                "uncompressed-sha256": "b7a8de2cf6a41ab5cbd937f179f6ea6202f8fa7ba88389f9ad2664b99cf5cf7e"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "95e2e70080638ee60b870408a341f3d438a19bd336b412f65c6f5b38def978aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "2865ad3702811fa782de4fa03060615aff5f4e297fa5f8f9d2a89c0299e75ca4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "4589f0ce3bcf00c6b1e54886a1777cb190e7c6f4db711310924ecdffb9898ee6",
-                                "uncompressed-sha256": "45b9c1bf823b71cebb04a08d92c262fbf579c44bc8009db254770a8282cc3085"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "36ac1d902459604f13b61f97ad47bd82a31f755ab4dff2b2deaab9aa22c05eba",
+                                "uncompressed-sha256": "a1d0833bb8465a142788007fdb16e3644c5bbe558296c5ccf36edf67cbfbfa7c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "30f677d1cbea9ef2eabc7c7a2a0ebd775d95655daaebb9641556aadda830b73c",
-                                "uncompressed-sha256": "43f22151d60fa0860daf5d194a800151c170d28cbf24fcb2fe01ccfb05ad54b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "05997cfaba9f80e9d17ccf44085a0a9b66c20a20d6b8e7e3a2917e7cd46a6c94",
+                                "uncompressed-sha256": "8f46e0a0b459b86ed3d2dcb452d43e229c7612c5794c7527a4d66da7c8fd07a0"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "b05fd2abf39708bdd6fc42f2ebf27d7ef2de29355f792a0abd05f4bb844627c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "c78c7a700d87e060d4fe8fdae74d9f5073cbb43441dc161585a76c5904adde43"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "6baeede9021d636e1189a06296684cb3fb5bce4347796aaec191a1821ff20898"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "9ad63de0be5fa0da75993e5ce3439e78bb4ff406f2e4fbea35ff1d3e2e503536"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230107.2.0/x86_64/fedora-coreos-37.20230107.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "94b841c9330de72dd14399c0949049ef411b3cee4b4f244aaae738977d9eb1af",
-                                "uncompressed-sha256": "3e7551fde411cca23b1a37573edda83c4b341754841194df7cf28ea6d9158de8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "df8e77a427c457c6733931021d5b1a001ea8f104769d942ebf5e7f4a488ebf36",
+                                "uncompressed-sha256": "6240812b4c5929dafb210fd117cf5e73960b540a7f6c925c73ff6c6bc337713a"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0b30c2df012d49808"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0dc4218d5c3e85cd7"
                         },
                         "ap-east-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-05747b06141fb8d21"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-024602ad7c9a4be62"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0a218a991a1d694dc"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-09ff7831b71e49cb9"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0f08fcbc43ea681d4"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-07cff52187e49adab"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-083141b2e42f44882"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0399a710a4d545eb3"
                         },
                         "ap-south-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0e2ee812cf0a8bad7"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0efab128e78954950"
                         },
                         "ap-south-2": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0b838f33a18adbf11"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-051e862799863bdb8"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0d2edecc650cd30c0"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-02703bf2a9611eaab"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0312986fcb192f380"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-02a2d5d2c6228e517"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0c2a70329cedf464c"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0a2d2443782021453"
                         },
                         "ca-central-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0fca7e57266127d17"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-04e73ffca0003c151"
                         },
                         "eu-central-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-001e48360d4d408f1"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0cdb0597990ecaa2a"
                         },
                         "eu-central-2": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-01685214e3e5c51b3"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-073b75ac546e803eb"
                         },
                         "eu-north-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-014c9634de9f9dd51"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-09493e2a0248dada1"
                         },
                         "eu-south-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-051c21d33881db603"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0d97e638ab9016148"
                         },
                         "eu-south-2": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0936ecf583f268236"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0596fd5fb22632d1b"
                         },
                         "eu-west-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0086b2aba5d8ea2d0"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-05fdf23af6acaea9e"
                         },
                         "eu-west-2": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-035ca7c954d58f3f6"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0af50987df8d1a1b0"
                         },
                         "eu-west-3": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-094f4089829255c3d"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-03df1c6072867bfe5"
                         },
                         "me-central-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-0ad5c86b3a17d305b"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-01a91600869cde8e4"
                         },
                         "me-south-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-03ddbac6009359b07"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0d33deac63dfef313"
                         },
                         "sa-east-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-01a33f4da07a7805a"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0b61c9f907efeac20"
                         },
                         "us-east-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-024044166849cbef4"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0d474e3bfc936f338"
                         },
                         "us-east-2": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-080076578edd81422"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-0fea5e691f5edfc82"
                         },
                         "us-west-1": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-02186c15db7772141"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-01432a82c7d925472"
                         },
                         "us-west-2": {
-                            "release": "37.20230107.2.0",
-                            "image": "ami-02215a6cfae50fed5"
+                            "release": "37.20230110.2.0",
+                            "image": "ami-050d145ee5a259f7a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230107.2.0",
+                    "release": "37.20230110.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-37-20230107-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230110-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-01-10T15:34:47Z"
+    "last-modified": "2023-01-12T05:15:17Z"
   },
   "releases": [
     {
@@ -73,6 +73,16 @@
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "37.20230110.1.0",
+      "metadata": {
+        "rollout": {
+          "duration_minutes": 2160,
+          "start_epoch": 1673532000,
+          "start_percentage": 0.0
         }
       }
     }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-01-10T15:34:46Z"
+    "last-modified": "2023-01-12T05:15:17Z"
   },
   "releases": [
     {
@@ -89,6 +89,16 @@
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "37.20230110.2.0",
+      "metadata": {
+        "rollout": {
+          "duration_minutes": 2160,
+          "start_epoch": 1673532000,
+          "start_percentage": 0.0
         }
       }
     }


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).