### PR TITLE
release-notes: updates for 20230111 releases

### DIFF
--- a/release-notes/next.yml
+++ b/release-notes/next.yml
@@ -1,4 +1,8 @@
 releases:
+  37.20230110.1.0:
+    issues:
+      - text: "Linux v6.0.16 breaks CIFS mounts" 
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1379"
   37.20230107.1.0:
     issues:
       - text: "Add back in criu-libs package"

--- a/release-notes/testing.yml
+++ b/release-notes/testing.yml
@@ -1,4 +1,8 @@
 releases:
+  37.20230110.2.0:
+    issues:
+      - text: "Linux v6.0.16 breaks CIFS mounts"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1379"
   37.20230107.2.0:
     issues:
       - text: "Add back in criu-libs package"


### PR DESCRIPTION
release-notes: updates for 20230111 releases
See: https://github.com/coreos/fedora-coreos-tracker/issues/1379