### PR TITLE
Roll out stable 37.20230110.3.1, testing 37.20230122.2.0, next 37.20230122.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-01-12T05:15:17Z",
+        "last-modified": "2023-01-25T10:23:32Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "2051a66e33b18b9330d24f27c100992d0832d53efd81f385e34114fd29cb6e48",
-                                "uncompressed-sha256": "dccd2744ae561dde0431fb2a21779a5ca1d34f22d52530e11531b2bcd5f72f17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "9ee4b27de1af4c943508a5d12cc8242b15a1da47d497782d7f5a07a7f70dfbbd",
+                                "uncompressed-sha256": "ab4cbc122fb2cd96d99c3678d70d97f30d96b678f13097fe73a0218c51440a8d"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "b0b8830530b5a9bd1a056c70c4249dea7ae52b8b9446a2495bb3ff998747572e",
-                                "uncompressed-sha256": "3cf82b24547a2bd4be09c2e058f505b05171ab33a41277af628121ee870d1d8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "7b6dbbffec8ab3ab41002f37addfcfdf30bb4dd614c9decde86474c3ca5fcf66",
+                                "uncompressed-sha256": "01d5dc077f9cd95e4e8f76bf1e17cc20b2cef940f7cfdc9ddacda1912fbdf387"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "ebfb67026d9d687ff270d6f645be70bbe80a55d420c9b5846c83186371df4202",
-                                "uncompressed-sha256": "93d62392f51097ba9aacf3dceb7925e26f4f8d986640b779f7b73d8db6fb5a8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "6c6cf82a12d59001d10e806185cb33271a7700e55fef4f2d2555be16d1c8cf8b",
+                                "uncompressed-sha256": "697b781a5c3bfa49a609700e7503f898a1fadebea92905fcb110087fb3d29f30"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-live.aarch64.iso.sig",
-                                "sha256": "83c239bda7f6b4f93fb87b99d44fe081f46c97dbc53d1283284c7408d4aca722"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-live.aarch64.iso.sig",
+                                "sha256": "4cd6006676ccba34ef27f819b2ed7686fa35e16094dd59717fe5c24714eb5ea3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-live-kernel-aarch64.sig",
-                                "sha256": "a2ef50a7dac3de0f10a256f32a4a03cbaa89b985cf0dc350d8028146daa57d6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-live-kernel-aarch64.sig",
+                                "sha256": "418b756ca5d9439386086efffbc299607a53d618739e0e1df76ef4d0f959d045"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "37dffd210262c500c606d8ae6aee77da3612d2ca860a5ea83ea1dff659afc3a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "f5039aa7b9e240af74a0a8ce0a569c25ccb381e1ca9744e184aac41a97911c45"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "da0368d3c88efa5ee67a4ee7f5761387d228869bccb1239e82d953dc93dd7bfd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "0bc897e546d5253f05e0c336bb96790abae66a1b9a37455a414afd983ed87c4f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "a2a968de8896070aa69baa3f330002b1a988b75ce19ab97a9a700371a45a10ec",
-                                "uncompressed-sha256": "a6660d617c9a9029d05575bac283e0abd6078cd93f23d43fec2a2e1f9ebfd306"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "4913e62671b1176aa6d590819cafd62465a7154c961f76e452a15f0c7b2e65ed",
+                                "uncompressed-sha256": "8e4d084fa77498c2f19a7f29f7cf13ba6dd9223bcd90126df51e29becbe44c92"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "c5aa2728063c8f2e837ab9b54e32a5452a80fa0be8d5b85b5eb7d30db7aa473a",
-                                "uncompressed-sha256": "0e8e5cceeb3217fde2cf1d86c7348782fd2b51e726141e71e96c667f6651ab33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "5b783b955e546f5b13a39bf918238ceeb7239a501d080adaeb73a63dd0931012",
+                                "uncompressed-sha256": "29d19e67bb216c27678dadd7248671543f2f73bdadf4d18de243d0826b40bdab"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/aarch64/fedora-coreos-37.20230110.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "06e3a515a769514a0f807308238d86270db6ec3bd7b1e5635e56dfde64b71bad",
-                                "uncompressed-sha256": "bbcdcc2758959761563d4361f84b86aa26e5d927dd9cc168de70e4fc736970a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "7641c4c22089e45379ee4161f4dd65122a50fd68d31fd09b5487b9abda2628bf",
+                                "uncompressed-sha256": "a652d3f9455d35176d2e2cb8baea4852e029d33a5fafc33f840c43a57273449b"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-095fe626f72365dae"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0ed9f61b3a71c5268"
                         },
                         "ap-east-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0fc1b43f52c2f23a3"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0ebc76d35b2a04e81"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0d6ef9e2dd37c4565"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-03d600b85df70cf3a"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-05e4222b3d84461e1"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-03d432716149471ab"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0e70709fe1d53249b"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0bdbe4d1f04028419"
                         },
                         "ap-south-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-03fd7d2c2c4211864"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-06169c1b2129bd4a8"
                         },
                         "ap-south-2": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0a76bcfc665042a97"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-06233e3db809d7f75"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-067d409aab2cd908d"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-066a786a6a3c1180a"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0b9589a2c0b680969"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-04683ef7b83d53179"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-07d67e6b26bf74003"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0534d87a45e6f2df2"
                         },
                         "ca-central-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0b9f832e9c7e42c90"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0ae6ebe88ede96631"
                         },
                         "eu-central-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-094044767dd7052a5"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-04981869d70f0e749"
                         },
                         "eu-central-2": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-02c1d232f7c94cedb"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-072cbc7aa25d4ec3f"
                         },
                         "eu-north-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0eb4e8d1ac1299db8"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0d2ea3adc0c3af2fb"
                         },
                         "eu-south-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-09a518edf00960006"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-01551250bbe34c3c5"
                         },
                         "eu-south-2": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-03c06e933e6af5b7e"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0f8362db65e122ec3"
                         },
                         "eu-west-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0ce70de66007c4514"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-008fe89e42fbe312b"
                         },
                         "eu-west-2": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-098b7a7302c4c908d"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-08dc83dbdf7b412e1"
                         },
                         "eu-west-3": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-05e23601195443a8d"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0437ae730d57ef82f"
                         },
                         "me-central-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0bfaec78b366bfc83"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-085eeeb749242f203"
                         },
                         "me-south-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-02b6e82c123cf4a68"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-01e3a6cc9068a41ae"
                         },
                         "sa-east-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-036a7a30c1d5f6076"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0e8c68eeb51f49702"
                         },
                         "us-east-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0254f671bafb0df7f"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-02efb12e25c7c0715"
                         },
                         "us-east-2": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-04f07a1323f5ea598"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0b75228e0fb6a05da"
                         },
                         "us-west-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-02021af6ef82291d4"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0385b1cf3dc298b4f"
                         },
                         "us-west-2": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0bde92d55487d7cae"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0c7875d032c72f7f0"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "56518e6b9e9b9d537828fc343b8270c0a2f1de8d00f52daed343991f8d9ae78e",
-                                "uncompressed-sha256": "42b51d16650c2a1fa83735f360b599420883aa7d9c263417aacda357260f7508"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "7fd9c47b8468787d6fb318e4e61e3643bd35a235fc889662aea10296818e2a41",
+                                "uncompressed-sha256": "8767a10ca656793c599a48f828f93e408d12a6221257df32afa4bc8c5ab9335c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "e3d82efa859714922259e16901f13d973730a0b641861bed24fe19b15f18ebfb",
-                                "uncompressed-sha256": "f32e875b73c30415810e5e6300bff130ab90b001f5b4ec4de41fe726b581e2e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "ad5ba319321ce4ffd834286a0bec7ddf08925504b893206a83e5f2cbf72b8231",
+                                "uncompressed-sha256": "0c2dd5703b7c6efd2a39fe84bd6ac00858bfb66b5959a90ee71ca1c62c9efd77"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-live.s390x.iso.sig",
-                                "sha256": "28bc5cbe4a05d4f1cdb977388cce7091457a3cfd3ff17cc1382c10e6d71b6494"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-live.s390x.iso.sig",
+                                "sha256": "3311553eb2f08db3423e8fe62c7e629e979697ac487682ca829db7eef397c582"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-live-kernel-s390x.sig",
-                                "sha256": "495f557b4b78e633c1830eaebe75ef93f6d2f6f30ef9a4423b3646fd9f0a5383"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-live-kernel-s390x.sig",
+                                "sha256": "948ef8cd83f563fe92a9e73ff5c389b3898a980540c222d8a62d57366ecc0585"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "6e954d359d3bbfdc18a662ccccdd00b5a11acfafaf10a374378d5590426e96c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "146b07077e3df2b105caa5c807aeae6f53f32ccf0ef1ee433b4290b57d536c34"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "ca08862cbfe4d9ba9cf60d69665a68974bdaf4513bda78d333e08b585b0f17e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "55de53064fbff3af1f0b55a96507ebb7417b5e413c19d619666fb4920341d3d3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "c20e565451eec98de3780a27af0c575c0b17e450b01d956f1e1b8e04bdca1cde",
-                                "uncompressed-sha256": "e55931b9ff134844c40688f5fb8f473866cef8805af51900f17d50c148cbbf7e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "11aec39a342a7f5e5e55de2bb51c20617d296e94f4ee582fa939a7fe2b95a930",
+                                "uncompressed-sha256": "2ee8b7d3bae5b743f45ea8108216b99e159d768ba57991b8df7e71bbfc195b25"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "73a22d3b7d2ad112f8f8c83d0c86e49a331435bbb2a9f60a6acfb6a209d9903e",
-                                "uncompressed-sha256": "6172ffbf24b5f1596a21a262044827d0ef13e8693b3a18de56530deb10d49525"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "d03fa7b1c968b215b9fa232503f8d8937e791fb0ed610168661cbcdc9b6c8c0b",
+                                "uncompressed-sha256": "d3d4b30623e056f0a8b60833a6aba913be8044bba42a309a6c853089e5ed75e9"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/s390x/fedora-coreos-37.20230110.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "9c6c86951bcd8c7927e51836cde04089047f89c811a8fcd84a058de097079102",
-                                "uncompressed-sha256": "8186bc3393ed95005794a709ef0d338eb0ce2679d909238cf9d9891d74721a73"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "0d1c081c71ada98481bf0f906daff08987cf7ae01a40ce20a683499746a9688f",
+                                "uncompressed-sha256": "330e12cc8b72ebc0ba6775d2d5557b5a8ef605e9f89378106a370af9540dd64e"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "e5c810c0da4e9e3f4e680086ee2f75699b378f897f15f1e7b5b01998ad521b94",
-                                "uncompressed-sha256": "6d411eb6ee9f1d8d27020062d42ca28b71224cdcebbf081be9a2c9336ceac160"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "cec705a42166fbf598dc10de9f7498d03006cccff9383fbb783b67cbf9c456e1",
+                                "uncompressed-sha256": "299d0ac896a25deba8528107806c589baec1e20a2984b802ead416d02414f603"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "87156ab342b0714cc24fe5e56ae4998d6e3625f79dc3d661f30c0cd2fbddbaf9",
-                                "uncompressed-sha256": "7522aa170210243b5bbd8452d684e591bd19ca6b8d5c0483d1a1436d10438972"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "bd3540a2925995b19d13efa22c7f5c7993d0e79d22e5277b8aebadc38404467a",
+                                "uncompressed-sha256": "722684da66a041afc8710ae5c5129f496036921a0e5065145dc293d9069f59df"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "8e9d23fc9175a5cff0da5ec09f81ddf77cf914a1ba66b94ad0d4a3699f77dd0a",
-                                "uncompressed-sha256": "b2c729c4c54db4f82c2b5d258411eb2de86ef05a4b3ef47cc10588bb7a4aa071"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "8e8bce9843c7b269758c75ee4393de63de4722dc12bd580355cf7f3f9d364485",
+                                "uncompressed-sha256": "96d8533905ef3dd9004ab8c855d6510843658c8f6bc4fc39c848b7dba41cd1e1"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "0a3bb54035f982baaa28e7c62762fbdd4840c9265fc6b8187251161ebebee5a7",
-                                "uncompressed-sha256": "6a9aeeaaa51d5c1e94297f7b792c16dfce83a163795c77747c347d72ba06c156"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "cfa0e2be6550e0d489c92e7e3ed6c2e2816afc5a1d97fce071af3165ded78d8c",
+                                "uncompressed-sha256": "8c718565ec6bc4c502e79f397a4eece3394280c96087837a6b9c1a79b07bdfa7"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "b05bd786099ba9439c474b4a7733598bacda0d4146060dae828b5d26456ff0c6",
-                                "uncompressed-sha256": "1dfd86f50984e2449ae8b5f80fbf05be45e36ac079a5726185deb3a1c0c93974"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "1fd393c2b620317794f42863a2fea259715a738c030f46fabcdaf52c39d3403d",
+                                "uncompressed-sha256": "3e14ec5208f2a8678632a297acd2f2fe3bfe80cd6fcee01e39ddd4a0857922ee"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "6106ac5d0a548d5319d787edb8a083e4cd002e5ece503ae698b1dbc12addceef",
-                                "uncompressed-sha256": "94323c963c882c0ace24aaae5650fd6ba499d1e33bcf271cbc300f12142212e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "6664f30bf12b38dfced4cf225391175ca115467afb4cc9e557438c4919db8d90",
+                                "uncompressed-sha256": "546db4df907a58c3a789e0185e53f5c010a21227fb154ac9cea44ff81ae2c311"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "3e5b468577f42745a7fb8c295da64d22e5cda35a81bd62f3dc56f7e9a3c1a0f2",
-                                "uncompressed-sha256": "1e02b8754d66e16b49c457e1f4f25be787457a83ab838adb9af63cbf8860cd7e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "9adb7df316f062b03f275468dc20e7b135df951815f96a535ec8a37be4b4efa4",
+                                "uncompressed-sha256": "1b9e5390e3e4fdb3be72c95017be2b83bdb2cd5498be1633414e17f2704a1d25"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "f71badb35543f647d217139bb13beb1082dfd166689f0dde152617d9af5ca8c0",
-                                "uncompressed-sha256": "3856379fbd6a3a463c3083f3711bd6f3e4c4f5f3e2638834e53066eb44df5872"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "c96d4f7ef17f62010250a4719d0a5e3f3aa20765aad52492ddb432add1d3d008",
+                                "uncompressed-sha256": "ed1de7e64be9aab9ce9e6bb9506e0d9e0247686ae9d06343e030313b2c2c9a7f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "f5c903429b3b785faff9cf7ff2a6c67b1f780478856ddc03c6f65f376209b9f0",
-                                "uncompressed-sha256": "11864ee80ea5c4a8e2c7407e06165a9b846265ec992ff18b3fafb82a9af0ad47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "73a88f0e465a41770d290123783e28dc49ba570f7070fb8e3c894acb1a4a3844",
+                                "uncompressed-sha256": "1dc95315b60f79e17ed8055fb67dddfef400c75ea135820dd55087d77dc22fd0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-live.x86_64.iso.sig",
-                                "sha256": "97f4ac88856aaef253df68a41529fd8f3ee3baf401837907c3a376f3087c6e9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-live.x86_64.iso.sig",
+                                "sha256": "36cba43e53da268bd936818ef9448b253941aaae780d3265f5ddb849f62266c3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-live-kernel-x86_64.sig",
-                                "sha256": "d76b102cc1b5fc711adfea30dae7d07948179d8837ee470797064de14017e15f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-live-kernel-x86_64.sig",
+                                "sha256": "61a156435dbcf37b02314416584cbdc1c91594bb98764ca9e2e8db51f7f40607"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "13eeec1a465c967d79f90b3cddf6d08ae453edda644b9649f68fac5ce6f711db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "d4fe92dc617015da8f688e8f4413756c260319b20d8b7ffcfa74f6264eb51531"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "55edac2cc74e7354e44c7ca34d6399789a6fe39475fbbcb51828d58f42f9121c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "b5fddabcf2a178da73ff14f6d75f2fb295beca5cd0a1695b56f3bda1e5e803a7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f8a13cb62aa42d11419c2f66454bd3ca7203ef91f5580e13f6d76a9d9c68de58",
-                                "uncompressed-sha256": "32d3101a67c59d480a13f504432a19091600704a0360f24e9157b8ff719a5721"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "d69e74864ee8ae4588cf3d592bb80722341c15287b724e94e9ea6532c14d8680",
+                                "uncompressed-sha256": "7111e6e798c39c0d7895186523dec7cd7bafdf74a7f99ce517dee15071ee5c74"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "699157915db97f8c3bdc1f27ad3460054284a99cfde67085403e758f61cd459a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "e3111d2779497fdff02e6f07b2fa8bde6edfcf4c8afb79b1a1da75261103e6f7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e770b416c03aa058575e42c9c8f0338469023e6a33ca71ab77051dcb57d581c5",
-                                "uncompressed-sha256": "dbc4cbc96395e51e386adb4e424f5c611c9b441473365664b1bfbe6b3b6adbce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "930f7c17c3e160a88714e75219184562a8449245e729ac2532c72d3f9f80850a",
+                                "uncompressed-sha256": "37da3a9fe0d7b2267849c211a8b93c3a86669ecd3d0f1abe38e0165fdfe1eb47"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "7f2d3e6d0134cc0c43e0087cee00d21a3629cf137efe7a8fa12ecb1eff8d5c07",
-                                "uncompressed-sha256": "7a842dd2a8a905ee75a2656d26e1a9f5574613bf4d9aba9ba32aeffbff18172b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "c855f7637755bc7a60436da6bc140f473a6b7c6873bf5a498a44e7e671708c91",
+                                "uncompressed-sha256": "c9fa98078db5670237baa1eb96f2eac7971fa4ebb21764454149a93557020d56"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "e64e88b1804bc3081771542cb9efc4bf665497eae7c46e87dec23543c6c5d664"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "52853f16e9421872f5b522edcb000e1cfe15be2d5c91a1d73cc8ceb624b4649e"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "dd14da3e63e3e0a7a9bb6cf86d50075f6fa691deb001d354fcf05be721a7afa8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "0d16bed44ac028ed779bac21d0ea590bf0980c474d50cf1aca7122e18d1add91"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230110.1.0/x86_64/fedora-coreos-37.20230110.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "adbe5454999ae8582c3d6b91a36f16984ef42d032e639c5fd6a47aff9e8a6e60",
-                                "uncompressed-sha256": "971dec4c1819c0b7912033f8a098460b1ac42c623cab395a46bf4159856152af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "99425d1bd86e9d6dc90b8332cafd230b69940f29a3781d8bc5ded4b079dcbde8",
+                                "uncompressed-sha256": "0dd996cedd0000e55bcab426c459363f30c241a50caf331cdb013211b0ab8e5b"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0e57b47ea594474fe"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0ad3bf9ea8e0bdd86"
                         },
                         "ap-east-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-08a562e0bc13d47cd"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0485ef908eb2bc88b"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-07cb1da511e817ac2"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0276a5fdc4ded38cc"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-02e83b8ccf74b5a3a"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-09ce3045c1d667d33"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-03907ae5ffc10f9e5"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-06b1eaf61bcc2d6f1"
                         },
                         "ap-south-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0bbffa0b6a4182f21"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-07e48e4b2836e0d53"
                         },
                         "ap-south-2": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0bbcde3faf558630a"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-015a25e05e0ee3a96"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-05fc2b20a89684357"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-01bf57b6f9c241af4"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-06dd96a18123af9b8"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0de841a39687bd778"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0b7c888375b620cef"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-065564d45042262ca"
                         },
                         "ca-central-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-03e510230371c134f"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0f5fbcbea5e5470c6"
                         },
                         "eu-central-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-03ad598b815ade5b3"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-03a8e6e591929dfa1"
                         },
                         "eu-central-2": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0ef50629d68bdeb08"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0c447c6e9b6a15e6d"
                         },
                         "eu-north-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-020dd9fb02f9dab37"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0f24649a3f25cf9fe"
                         },
                         "eu-south-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-078bb1c98ddfc83ec"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0ba57964a24b4ffa9"
                         },
                         "eu-south-2": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-023b9e6c285e30cfd"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0fc61ff5d9bd866d2"
                         },
                         "eu-west-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0ea1b80890576bf2b"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-05287e61f18e34097"
                         },
                         "eu-west-2": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0d8c53259d5762892"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-09969e2681eec247c"
                         },
                         "eu-west-3": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0e102dda4366fff0b"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-05e7d5737fcdb12b0"
                         },
                         "me-central-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-04e2f29306394df0f"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0e9c755a148c7e955"
                         },
                         "me-south-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0c4882222359c08b6"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0ddfcbd6e43ee542b"
                         },
                         "sa-east-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-069ae89b080c06eae"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-09e2beb129716f85c"
                         },
                         "us-east-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0ae2c6206508f3b0e"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-024fca6df6d29c717"
                         },
                         "us-east-2": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-08a62aa175ca3074a"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-04b5f473be55029e9"
                         },
                         "us-west-1": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0f02bbce67965c16e"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-03d5b4f1e901df740"
                         },
                         "us-west-2": {
-                            "release": "37.20230110.1.0",
-                            "image": "ami-0c0620e4b43f4e325"
+                            "release": "37.20230122.1.1",
+                            "image": "ami-0084256cbe1d43c1b"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230110.1.0",
+                    "release": "37.20230122.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-37-20230110-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230122-1-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,105 +1,105 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-01-10T15:34:45Z",
+        "last-modified": "2023-01-25T10:23:27Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "c5357b69e1fda577804e5cbaa35dfd3003f9589a186b3119007e73e170d8fa86",
-                                "uncompressed-sha256": "8d934f369ec3c5341c5864b3982bbd8d0a64b488fba7074c365f931cbba3564f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "86fac0d091623cafd12dc83f93b19ddcdcd0875f98fa984d57773d5d2911cf29",
+                                "uncompressed-sha256": "e61b197f5d46a0bbed7e580a29be77e1089bc6321897f5b8f84590087a70a801"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "d3aca8d6edc9f2a4a2645bf5e0268063a83d5e595716e1f4ab848319cd166573",
-                                "uncompressed-sha256": "e08def9d914ff7e32165d7937da18fbc3130f431a9bc2556593ce7547e1a1fd8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "37447ae354bdf2d68592a9e80a9309f2dfce3e80359e8a9b9cdd44313a081c23",
+                                "uncompressed-sha256": "5ad6d3e9761f50066adc6afc61ea8022d0beb250501b201db154c9ebeb069c46"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "bf608b2d4b2c5b49db43d02df0f513f4dc6b3c334240e7e078093e36508ed028",
-                                "uncompressed-sha256": "effa0ed1efddd8611ed779cae1f2a6884c877df6385bf11cd45132cad7b6ffb9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "fae3f3694dee23f259ab24dcffbb3dd29dfa2dcb9f0d857c8092b1451a0b0926",
+                                "uncompressed-sha256": "c2f584f3c5460ac2d622a69f82bbb28bbbb28f786efd123dc4bd67b3674d8c3c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-live.aarch64.iso.sig",
-                                "sha256": "2b115c2b999fd6b428b5c1f6fe48c4ca9e809e51d972ef5477554abaa32adc5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-live.aarch64.iso.sig",
+                                "sha256": "386be7b5405d6e062c633bd56e4377e8d3d942b8a3945ef41fa44d2295062328"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-live-kernel-aarch64.sig",
-                                "sha256": "6c87ccd2811cf5754df2756cc755f358180fb63bf981aa9b7754599b6f379339"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-live-kernel-aarch64.sig",
+                                "sha256": "a2ef50a7dac3de0f10a256f32a4a03cbaa89b985cf0dc350d8028146daa57d6e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "3add203626aac4765595a108ac1358ee12bf79d336ef25c4dc0e48e7fdc8ddad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "ada8acd9c753a677e00efa135d2ee4455fb9409c8c0a1d9973cb60cfa1450ce8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "ce70bc40fa306291f5f28d84ab274f1f0fdba23141b3364d8f2a30b94934ec6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "4513955875ef9e793e11630f140e8d74fdf91c9bf57e22ff8d4fee419d370212"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "c525191d960e0ce2b4ff64dc15fc166b937449e505cc11d4fa283f7ea938828c",
-                                "uncompressed-sha256": "9ffd05e5cf57ab5a59934633655eefb79006cea6cf6169bdb230d3b57443097d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "0c70a4447eef0635bc00b2d3ecd0f7b4aa40b5eef30bd32ef578328addc08699",
+                                "uncompressed-sha256": "8af1e6a2e6dfd5aa5aec0c66aa4244e04067cee4f4585391a7ecec450389f4eb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "fa9e7a4512055b7b3047d535a399e9b0d5c524f6fc15694a4f652d6d5110dca8",
-                                "uncompressed-sha256": "93cb3c078ffb6f78b637734f8c1c07730fdbcfba63cb29e0e8bf39db520db942"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "f99c20981c16a00f4163f98f2a786dae089d18b5cb40367091ad0b7a3ff24803",
+                                "uncompressed-sha256": "cf7c13f9a52613a7ae937f0cffea722c46a14b9f4dd958061c5418755a9c36eb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/aarch64/fedora-coreos-37.20221225.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "8e45fa8997c611400b66ebebf8a50ae6df04024636207d3664ac868b159691fe",
-                                "uncompressed-sha256": "e495beefdd63b8ab6029406250a9a728cd72dd890a7ed0268f5cada3c250278a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "665a7d130fb801b34341b4489fda108febeb5e58c1388468095f213fa4dacb7e",
+                                "uncompressed-sha256": "d129db9361184c57559626182604a3268e7bc73426c764c421356c99ccb92534"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-06d26d2f08d7b9062"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0fcb5d4b0124acac9"
                         },
                         "ap-east-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-060b6078e64de3e73"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-09a29a21e3a5a9177"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-001ac427fe7d89eeb"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0cf40902b6145c561"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-04dcf95e62d51c84f"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-06453dcf75b0324dc"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-023945e28656cbb1a"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-011c345f0b56cdde6"
                         },
                         "ap-south-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-01add1e599b13c0cc"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-025e6450e02b7f79e"
                         },
                         "ap-south-2": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-03aced59e4f04fa49"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-057d7a89ab3fb6daa"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0c32fe3b7bf381af4"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-07ccc56dd186ab634"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0c091f8157811fc19"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-03d57b9d375d12012"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0ed4da84e9cefe8ea"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0a98db5cf170c25a8"
                         },
                         "ca-central-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0cde7a2b15ac01a69"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0d5c79f464f1b10d6"
                         },
                         "eu-central-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-033c41c6f9430716a"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-026d388cdda04574c"
                         },
                         "eu-central-2": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-073df58253f36a98b"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-06e2d6cfd5fd0c877"
                         },
                         "eu-north-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0ef19b714025349a6"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0616cdd4e7c960761"
                         },
                         "eu-south-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-007236bf9f80ca505"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0496bdbaa6002c4f3"
                         },
                         "eu-south-2": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0ac1b59af953f2f25"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0177be3f3b274e3bd"
                         },
                         "eu-west-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-039ed07dc04136b0f"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-07d0b087ee511ec79"
                         },
                         "eu-west-2": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-018d1cfe267918469"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-09961def81406d78b"
                         },
                         "eu-west-3": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-04480a3648d5dca71"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0858c1eb316563ee9"
                         },
                         "me-central-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-04781b16cf3af7765"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0c4dd3c2eb48a562d"
                         },
                         "me-south-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-036cb48cbb39c5cc4"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-01f19391139cecd89"
                         },
                         "sa-east-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-004ec4afcc34c7e4b"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0ee52b8176a0503b1"
                         },
                         "us-east-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-03be86ff62fe082ad"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0367f0b56905de4e7"
                         },
                         "us-east-2": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-04d3ef399dbfcfd53"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0ba6cecc6b99e5e01"
                         },
                         "us-west-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-05abddf43d55a6e70"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-001423f27dde982bb"
                         },
                         "us-west-2": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0f60f80218c57cb91"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-054b45ad3486691ec"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "0c9080b2fcaece3beea1306a37d3396475f72af0653a0416f5d3b997b563b564",
-                                "uncompressed-sha256": "b091f833aef129c187fdce48d7008453f3e9331a843d8fc96f01568863456965"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "919291bb4a6f3e150c8e08d07f09b13acc6dc940ddd8efad3dc592317a019e68",
+                                "uncompressed-sha256": "f1d1bbdd5bd972d9e03fc49179fe5b3fbab82ad9546b7a7ee6c7c1003c545fc3"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "d3ed2090b69fb2a0b701d344aced64e6bf8ae1c348838fcdbe5164cb54e6c48f",
-                                "uncompressed-sha256": "9a6d1305b81cfa49ea75a1bd2164e3eeb811b3f5933c0cb5ba2ef5526ffdef48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "752f0b529f171d48f340ccffc05a6cd87d6b63cea62de8e72d934ac3273171e3",
+                                "uncompressed-sha256": "0d7d578259a59ff4a32d3c4e62150e45ba23a1301846ed6637b648d522395419"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-live.s390x.iso.sig",
-                                "sha256": "02e9e5fb5987893298c05a17068caccf18fd48500073dfbe7af51248c82e3fa6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-live.s390x.iso.sig",
+                                "sha256": "eb6b3c54215ef6e05e31ee5b4f8faf05d5c279150f2c7671db3b2e6ec78d57f7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-live-kernel-s390x.sig",
-                                "sha256": "647edd9b580f1628ca8b68159accc5c41484c8b94572fdce7fc895c98f3d7168"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-live-kernel-s390x.sig",
+                                "sha256": "495f557b4b78e633c1830eaebe75ef93f6d2f6f30ef9a4423b3646fd9f0a5383"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "67d167c8269a0fc4de453777726c19cb4567332bffea899e4126daa378d6fe49"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "a52e324fc02e0fac16315ea5291e11e6ba02108d9b0346ef068af7e46e79f1a8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "ba8e85bef7ce86bf1be72f48a50d57c7a8de039f34472a5133301bf4d712aada"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "74938aa291282cd4366308fc9a7da324ce7374f3f9db6558d8ac49df31f6c896"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "bcb637e382947c7e6dc7c8a4417eec4b112a5d9890b4dcd94411045f70934265",
-                                "uncompressed-sha256": "cecca0c48698ba3699033b9c0e2b89897bab36f613ef9c0cb21d02118cfffc72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "298d1f151774db9bbb1b2e8224693284fc700a2ba4e9717eafb476e54d832d99",
+                                "uncompressed-sha256": "0901d91c1a894e58bedf33d13514ebeaec2f9cc15a5b7afc891f1e5f51c6809f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "973a50d1181f68003a3dc35779342f3348fa622e5ceefd5af7fb18bdb4994077",
-                                "uncompressed-sha256": "f5392c5ca64630677ac94c38da80d88686f2319ec0d5b291f2f1656462ca2c62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "b117d6b8a1cb0e0cfa281ddb1ddff04684357ab34e15b40b44cb6873afc12a48",
+                                "uncompressed-sha256": "27697eb22d29088a17fc2c643a761bc3d630a78341399a25d0056c446f5e5cbc"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/s390x/fedora-coreos-37.20221225.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "bb61e903d78ef804fe5ba4af484f530f52f32ba30ba3ca8b96bdc582bf21e1e3",
-                                "uncompressed-sha256": "9fef2f0e4eaf56966b338744dc91d5d3fcdac3bdff657c57a2ef64632c997278"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "f71d6d50af62f56e710fca007c4dea07557ef09599986bae7f9b791882ba6774",
+                                "uncompressed-sha256": "698f00d711ec363ab87aae6a1c0515c967dba921c9a67219187156454e05e7ef"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "db8c65aa46de008394ae9ac2e4cd2843db01800e92d9f44e4bbe4bd886426110",
-                                "uncompressed-sha256": "b6d8d6ee677370e5db0c626ca49840a84fe815a97186545aa6bfaeb6e186371a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "6d99b637a71d347284d975f2e463d8ea1af15cb669d4f83691a7dcbff85e5c79",
+                                "uncompressed-sha256": "6a7a88a6eb3aa9d73721750f42c7b22e023ec30a1d5844530fd6a2ca52dcf081"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "c341e0a2ff198eb1020f4bb714be7bc459db45009577442f01485130b01bd8f4",
-                                "uncompressed-sha256": "40cb32cf1ed575f19942fdd8e1b4df9f7f9d32a135e5a06c4af3d5ec55312417"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "a2209cdb1002396d385ef1b949a2fe8c8c78c9fd15614372419fb85a559c4490",
+                                "uncompressed-sha256": "d34ba1c0791cf97681635c5e072672c2652ff6257ab56ce1b44109b98f515385"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "c51b20b7db8111132c60570fe3d8692a4a3e9137a3481f141534bcda12842396",
-                                "uncompressed-sha256": "54e3acd8c4c4ffd2ef8950d508c70b42f2a7711c816286e91fa28e1b2fde1097"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "0e7b45b8c6f7e5ea3f72d57dd780c19ff41b3d217babe620900cd8c41172a422",
+                                "uncompressed-sha256": "adcd40956ebe6699390977d95a0329bba217709f03388f3fbfc1b67dd4c8a9a8"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "5c02b9b9d90a978a149e35cfff0ca0ca471ca5a01a7d923f729e672e56994297",
-                                "uncompressed-sha256": "9bf54797024fcb701a483e763d689721c2756a1d3aa58eeedb76787469fbfd25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "14b6c1c6d999cd8e55b140147f88a2bfc3e24e60267ef7a6e326321fcdec7101",
+                                "uncompressed-sha256": "b68b346ec20645f6df6230d5bf63ecb2fb77e541849403916882dfd217bfa427"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "28b3c432b1bf5959230ae83b929a0a68cf247a245ad22940c4a0df9ed8cbf01d",
-                                "uncompressed-sha256": "a9b21a15a59a7a976cc41081b9f89d5d1c2faabd08d74e9b2eec2145494b15d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "c36014940b31995c5ccada7786b461ad9aedac49680555b4e6eb1ac1f33fd23c",
+                                "uncompressed-sha256": "1bf8bfc895b731090d7e0eb6d8b44d7a1201b5e9e2324ed76ef4272a581786f1"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "2087f2f79e088ddd6fbeff110f38b862e3a9dc95a789d855ff9dd6142f841eb3",
-                                "uncompressed-sha256": "d15c867eff7741ab135aa9a2cbe65b52c5e9d3cbbbf95238c7d46ba8745216bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "4ae8862d42cec6bbdbe759b336f9048afad8b6b3f0bf2bcaa4788abdf33ebd9e",
+                                "uncompressed-sha256": "a8dc3ad8dd7327e17266ff3e1dbbf4dee35cd90b96e05a9bf6c8e1822e54e32b"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "dc2e98e09b24bc2d7d10f69141c3d6a2c12572cfbdd8b9b76d2051296cb474c0",
-                                "uncompressed-sha256": "79a54ea1ad1708e85a959e5d7e3b662f69a068329941b179f42ab0fc3f2e6a1f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "70ec89af3313257bc0090f4911919ca54fae1acd8466dfbd8b1664d02a853edb",
+                                "uncompressed-sha256": "b9c3b803d1b94387ad66eddf963c85e2095cc086890969137f7a52161f59e8c9"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "0167dc052da1643d6abeb9cf8807ccec54c4d525a5a14bc2a69357c0c8dd5aad",
-                                "uncompressed-sha256": "d6f7de74dd6f1ee000bc1f50b2eef66bccd3f241527569562148677dc31c3924"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "e8e4161feb8326d5f7dc5683c33f65945a3f1a088f94d664e255794b216e81e5",
+                                "uncompressed-sha256": "00a11186856d997df28099dbae0c0d4e95cb18b583b7a20c635c009c38a7c064"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "d2b838ba58a2f18648d153c83e7a5a08a9ef933f075ee360acd0811c42fc95ad",
-                                "uncompressed-sha256": "34bc7b380d86e2dbf0d0bd6b8bd59c21d5b2b092776dc77fc947a8c270e61fe7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "7bc906c22e51b98ca7563354c5b7ec74841ea16823166a034a0381fe0ff59bc8",
+                                "uncompressed-sha256": "c206e33c54645030e88ef8a900e2d674bc56c11af75cfe36f097ac436cbbfd54"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-live.x86_64.iso.sig",
-                                "sha256": "c6bd43780d601910b1ea222d9b8a2bffe360095a0e32cc4254d05a1727a59ab5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-live.x86_64.iso.sig",
+                                "sha256": "d2180f2bc902c2807c847957f07cbccfd6118ffda9ad1881845565a1d149393e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-live-kernel-x86_64.sig",
-                                "sha256": "9db5d790857d1d9e60d60e76c770e606a2cfd993a5a2c09ca30c4e54a4c23ef6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-live-kernel-x86_64.sig",
+                                "sha256": "d76b102cc1b5fc711adfea30dae7d07948179d8837ee470797064de14017e15f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "810439bc50e6ca986770d206dc1562930f4ddb0b23d83cef6158a4f2ff29aa1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "0aea9537392c78131ffadc519a7c2a0fcbfb224838d63f0ef6a4a6f875cb2756"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "342fea07af6f9853ae7db1a0c8961641cb381ca134c9ad31fdf0ca52aa05ebfd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "0ae167d335a7a2a26bf93375dfdf06d02bb2912e211899a4b5f3a0df55c1fff0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f7e3df1f2b835b594164fc698f1736f911142e746fc6e2f9cf8cc776bd9b1944",
-                                "uncompressed-sha256": "22106f90ecfd717d5cbab1a8a52af444fffd3e5593538141d4cfbd33fd84277e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "05e024e43fcf6258ab292e9b110bd453715943852ec6cd1e354688a21983140c",
+                                "uncompressed-sha256": "a8bff0084fa81da42bc692e933b5047bd97375f69f1ec9994e65fc9a9d2687b2"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "5916c09d9917816b8a1222aeda54fb87a511bec58ab8b7631f04c8cc59a58012"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "e5a42c23095f3a39b9aae53dbacb96ce3d596e2392700c02f796da1e85f08b4f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "0a4ac2e8d0503f736d65ecb0489cb5034211c081dbb941671740ef547f634220",
-                                "uncompressed-sha256": "e00bf7d3c5686bebcc83bcc9936c08a9de77a9406a404c42f6293da4e3efdf3e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "be3ed9796b339ad5c4b178713205676c6845a45b0c64e388f81154ada2941a73",
+                                "uncompressed-sha256": "3e8e53c590c41a3232a81d20e9296582ab80f39652950aaf770b34e052b44a10"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "8bdf7ab04fe147680a18e7b28187f535cc05e41fe2e4b233f99cf1dcddf39c41",
-                                "uncompressed-sha256": "42cc6152fb4c84ebd0859bfc474452226649d3d65358f3ada707c9ec48ec78ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "02147d6e00a5c26c55cec0610b75bc839b7743201b65b46ea262693d397281e4",
+                                "uncompressed-sha256": "064f4fdf7475de0d8fbb9968f58a2c9b78ae25a126cc0f1fdf7dee89ba360ccd"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "b2543665e0fc2316a6e50bc1de82e5ae6e75b68dd7d7b471586dd1df5a90f888"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "cdde6d1877f544cca63997b286eaa5f7e075aacc2c1795abf1e0a361275c5144"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "60a10066c38b73a45ea6c0daf6a678a90ad381858a30eda533e169f7d8beb3d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "a6b768329b8145b26edd5917b5f27ada6de18954719bcf9f6125e49064146f68"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "bc532ddee639959e95029ccb9ad8a35753488873e75aea382e709797727dbf2e",
-                                "uncompressed-sha256": "fc44fda308921efceeebcfbf1602f0a55f1356bdeeaad8587e40a0bb867ab67f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "4245a581daccb506beea7f161cc8483f7e5a40e24ad8b15439ff85b880df98c6",
+                                "uncompressed-sha256": "b16af78e659d4b15e3ff23f1dd880c23dbc4617447abd1cfb10f8b3423f6467f"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0c6dd632c5ae88ae6"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-00b59583ce73fd2f5"
                         },
                         "ap-east-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0562cc1ff70fd6ebf"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0cd674b418cc03afb"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0f56fb6fbf94c491a"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-003544e66a785b084"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-079b35a9ea188726e"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0d7f428e0cb3e0b11"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-03dfecc812169c6ca"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0a030c10a47bb2513"
                         },
                         "ap-south-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-00a027d6ec9b5699d"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-066e9c65a3c9d7248"
                         },
                         "ap-south-2": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-00714523e52d36d13"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-07390df5d02479106"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0e29fe54b08c44ef0"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0361005e35feecf1f"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-06b0a136ac9046081"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-057fe4d7ef8a036ed"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0cf19fddc0e08896d"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0173a78c7ea24e5a4"
                         },
                         "ca-central-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0d592428317839f86"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0fb35fad13643d096"
                         },
                         "eu-central-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0a30595d0b835938d"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-00f8e408bb2e9b06e"
                         },
                         "eu-central-2": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-04022ee1b2ad11264"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0c3daa48e57457f7e"
                         },
                         "eu-north-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0638138db7e47bf44"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-05aacc0e8ef0155ef"
                         },
                         "eu-south-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-083fd24555c0b7468"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0daf9f6e02112eb70"
                         },
                         "eu-south-2": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-03ace2588f245c49a"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0425f5dad817e69aa"
                         },
                         "eu-west-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0a515364f37cc3718"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0ba465efb4d725a63"
                         },
                         "eu-west-2": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-031a782a2dd2a3434"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-045027e0b0d682e17"
                         },
                         "eu-west-3": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0526431bcc8f76de1"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0a2072ececf83f369"
                         },
                         "me-central-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-05877175bad9f86f4"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0ec02a1f4a84092db"
                         },
                         "me-south-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0977375da1606d0cf"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0a53afd1a27556d82"
                         },
                         "sa-east-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0a93326b2a7af3d9d"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0dbc125545ef2bf63"
                         },
                         "us-east-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0ce26a467370cadf3"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-073e0c8bbade4a737"
                         },
                         "us-east-2": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-02dfb61b98736d52e"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-096a7382f79795588"
                         },
                         "us-west-1": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0cad4e17ef908f6bf"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-07e8ad7748e107eed"
                         },
                         "us-west-2": {
-                            "release": "37.20221225.3.0",
-                            "image": "ami-0c7b5a429d32199e1"
+                            "release": "37.20230110.3.1",
+                            "image": "ami-0a46b1a879d8aab46"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20221225.3.0",
+                    "release": "37.20230110.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-37-20221225-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230110-3-1-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-01-12T05:15:16Z",
+        "last-modified": "2023-01-25T10:23:30Z",
         "generator": "fedora-coreos-stream-generator v0.2.8"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "d1c9d37fafca2f388b59f5b6e8d92ca4f85d49eaa115706089597e9934a98c38",
-                                "uncompressed-sha256": "8944c374114a62f5ba94fab1dc3d606ec411b6d037fdb16cc3cafc389cdfa4db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "347fff93b6ca651a9d7c6641067c9c88eeae75e6bee2035538f56963e72956a8",
+                                "uncompressed-sha256": "a4a67c3f9a6067e0a1972fa04adf2d577d8d47eda68353261fb27ddfe0198a47"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "96e5ab3eb9b3ee47d6f3fb98ef05c88acca96efeedbeae9ce909614773e1e636",
-                                "uncompressed-sha256": "838636623e4d1f89a25015bf7baf00315318d762af3c787a12bfb91435872f23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "abf485b2c044ae77d83b9e624bbfdea8a76428631161d56fce87f71f2ba0e952",
+                                "uncompressed-sha256": "2086ea5b694bdd9fe9f42b751bc382d4023273d5dea3a13532ef6eae02ceaf86"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "99b89768bef6dd1240c690d66f2bccefb5b07473fa353cad94d9a56666f34ece",
-                                "uncompressed-sha256": "bee5758159137c81a08778cff92b0c2f5affaec6b68681efd6209e29f1aac7c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "c1b8c990521b0a57a896a3160105fdca7456deb5b8fadb5b05ceb84ef8aed1e8",
+                                "uncompressed-sha256": "69d56317db43ee232e2de229735808b5d58c2c55b6fc99d7566e2a3dc9d82491"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-live.aarch64.iso.sig",
-                                "sha256": "2745ffbea8f77c7db26ad53b73a80b4bb6acbc0afd85f6a018ae62c8bec850dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-live.aarch64.iso.sig",
+                                "sha256": "aa778d8e56e6dd5516c561e7eb2e74f1444785e69251d4c3129465229064a06b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-live-kernel-aarch64.sig",
-                                "sha256": "a2ef50a7dac3de0f10a256f32a4a03cbaa89b985cf0dc350d8028146daa57d6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-live-kernel-aarch64.sig",
+                                "sha256": "418b756ca5d9439386086efffbc299607a53d618739e0e1df76ef4d0f959d045"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "afff55a72f9aa1a9736557c0206d28b9e43373a82ca02876f528683775dad5db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "45e34c580ee36bbaaa180482153280a7366f851830dcfb7003d65d5e2538e608"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "694974163ce4f1c6f001cab87b8e7ae2502d01a5658c1af6e4f31ee78a8df5c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "c47003c8ded908d182c3f184d910765b5d48d71695c9b4cee67a03746bbc47d3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "9a60bec313dc6104d5333186975651d996167335c079bca7549a7c4635f98df7",
-                                "uncompressed-sha256": "9f1a9a3c1c74207fadb9ac2001c6ac2b13ec6652a9ec65d505a95a5b1028f319"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "60255254cbcacc1ac38b54f5f27304a80c86ae1e56a7bafcfdb016ba56493c6b",
+                                "uncompressed-sha256": "e6974825651cbf2036832dcc8b14fa6bf302ba0533c6e40ab2f12d64b68a72e3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "004d159f781e024690fd377af77102f43ac145858235c323329c88bcf2702f1a",
-                                "uncompressed-sha256": "2a7f614f22953f35dbe7c71166cca90d1c27a83292b8eb661cbb3ee6b685a3b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c62fa90315752c18ba8f4c84825c994636077bb2bf1efe630108849bb5a13307",
+                                "uncompressed-sha256": "e9d68acbba147779b16f2fbe91424677e04d695070eb3b6b3c5122a343c925aa"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/aarch64/fedora-coreos-37.20230110.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "5a09a75091ea24bc656e3d6d41c32af72d73bcf32ffc29fa7d06bf1d0d287039",
-                                "uncompressed-sha256": "a31ece55a78cb1fc2a4b3b3c2fa9c6269151fb9127b9c97c8c93b3ccfc6d9b22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "dcc847cb2353ff81f5ec7d9b0295dda8b5f8ae39aa2a896c7b9a9b2c631eda60",
+                                "uncompressed-sha256": "e8067113efbc2d79ef56c49c02a2436cfc98801a72c31579cce09cadbb023f72"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-009c05ead6fa732d7"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-03b4db64a923115c9"
                         },
                         "ap-east-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0e6e277487a1d68cd"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0b284fa186f7851aa"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0be998e42d8e9cad5"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-081ba15e25fdfb10a"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0940b847996723fea"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0ab7ef72de2267217"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0616a86428bfefc6a"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-06da6b529a52d77a4"
                         },
                         "ap-south-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-034836539386412ca"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0cc5e053f2b8b0729"
                         },
                         "ap-south-2": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0f67e3a4dce747fcf"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-051b49bd1ac6e8e2d"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-055bc40cd628cc3f7"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-05e21386a4992e786"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-09ac6e6294a4569f1"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-058376136ae63c1b8"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0173f5e6b6b3e9477"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-05887fcd79e972c5f"
                         },
                         "ca-central-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-09e8a8eb0907a444b"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-08d2dd5cd19e83c82"
                         },
                         "eu-central-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-08ed726e001eb8291"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-05ab2ba89a9aa6580"
                         },
                         "eu-central-2": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0000b9598de36696b"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0973209d293cb31fd"
                         },
                         "eu-north-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-001ac96c41d87479c"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0ab92ca2cee9080b1"
                         },
                         "eu-south-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0408ffb2102172775"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-086943525b6fe1682"
                         },
                         "eu-south-2": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0137e46c937d68b34"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0b3a85d882d8cc4b0"
                         },
                         "eu-west-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-03c6da4fb80437ab9"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0b2844f49f9081aae"
                         },
                         "eu-west-2": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0ae44818e4ef4352c"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-008ccb8ca6ae7a238"
                         },
                         "eu-west-3": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0ac447fd22ad35a88"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-008e85f45147f0326"
                         },
                         "me-central-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-007b4f36fddac9ebc"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-086c966c8426858f7"
                         },
                         "me-south-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-03ec80f2fb5734052"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-059b3e4dd3ca07568"
                         },
                         "sa-east-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0f5bb1ac31d8ffd9d"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-066d4a4fe352c22c1"
                         },
                         "us-east-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0f876c8337d89cc6f"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-00c3c54b4de6df3ba"
                         },
                         "us-east-2": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-06754f411091c0487"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0ca4dee198ad7d12c"
                         },
                         "us-west-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-00bc1fb74eceac0b7"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0842371daba6e0185"
                         },
                         "us-west-2": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0edf3af6072f6843e"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0d5bcf3d97cf65055"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "225002322510dddcd9279477e2644971f2dbd990eb7ec83325ecdb8e84773c4f",
-                                "uncompressed-sha256": "58873607cf5273fc70f33f208fa09f75e22eac8472ff99a555f81a2f07b96782"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "ad16cb39d308dea39b2b57e5661b9a469193f5198720afb8ebac5f8bd9777d17",
+                                "uncompressed-sha256": "aa61e1429a4accab4b0c72bcd1993cb2afa45a85179c0ee7066c7fd75c991c45"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "369d9cddde94c2baa0de1063f4b6cc028c858a0de240e1cf58666c1dfc875275",
-                                "uncompressed-sha256": "720ffe6330dc04b12fc82bb6e13876720c649fd369188f062bb60602b1b92ac1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "1a0a87ebd3bc493361ee8c3770eaa772b23f506602cf659aea823db28cdae301",
+                                "uncompressed-sha256": "05095dd51d961dba761f7116cce3afa4b6f2ba60aacb11afc67c9b8083b49405"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-live.s390x.iso.sig",
-                                "sha256": "598a8e3f4253e676fd6116c90168e576b43b66055ecbdc166f266b8f833b5db8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-live.s390x.iso.sig",
+                                "sha256": "07331198e2d4a41f867a2395909158f4c2c9716eba48334d232910a5142101c2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-live-kernel-s390x.sig",
-                                "sha256": "495f557b4b78e633c1830eaebe75ef93f6d2f6f30ef9a4423b3646fd9f0a5383"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-live-kernel-s390x.sig",
+                                "sha256": "948ef8cd83f563fe92a9e73ff5c389b3898a980540c222d8a62d57366ecc0585"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "1508ce066cf79e4ee5eaeb787bd1e70e04d79f2d14aa3dd6636ff54cb9b14c87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "f6a3e3f7d5364dbb97079b1d2c43485031c521ce4f9ec14d7c29978e99b63d3e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "06f478ec8c8306e2ac1e219baaaea0312aaf2736b81e4264321c349918749f08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "331e66928d573ef51002c0b71fbd6b3b8cb49601ba4109c86db8b57b3cb89f28"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "83cbc44d5b26db66bc71677a85de3032c967eb8fdcc8acde2689e430247961f1",
-                                "uncompressed-sha256": "f7662088e8017856615d2d9330ff70ff73797f990f171dcc3bab7ec5a6b84844"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "c8a1478874e977008c150206c69eda9ee233302607d1e7f4ab24497a69c7ec1c",
+                                "uncompressed-sha256": "1cbac1f18a98875915df6196c3c48b458b26a53f846e7e8631860690b9e318b7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "3edac2624589c198060b5add23f58e407735214d1d9ad79ae05bdd9c28fb02c6",
-                                "uncompressed-sha256": "bbe84a90e8c3304b2f8299b69d2d99ca160490de26b322cdacb659efb52d5310"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "e3109faf7cd86f578f1fb66adeb60f1ce4d28107ed02d13c8be9b185267115d6",
+                                "uncompressed-sha256": "a2d23088aeb8de0bef135738644167bbae415d4452779f37652f5006d6cd1001"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/s390x/fedora-coreos-37.20230110.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "f38962d365d0c44a43ef3a32c1afa887a71d8ea69dd254d5465371dae1a973d0",
-                                "uncompressed-sha256": "85480e9bc54f4a99d5e132553891963731d7a5d8d0582f496b2671548b41a72d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "28a81a218c1df0a1567f9ce78ee39ca2e49f7a7ec6caaf2243d2234a267c420f",
+                                "uncompressed-sha256": "d9c513c4e09f9f00d3bcc7a74139e38e8067ebfffb806003c5456c46ca22c418"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "2a9d404e0c6faf29829547ba33126fba414a974e9a0f2a2cf6214316cbaba0dd",
-                                "uncompressed-sha256": "f6df0dce1ac83e85ae16e13fb66a018cc75481ca76902eefc2458858e13571f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "2d357b4caf0c565ca3392fdbebc95ddbb0dd2a56ba074a0d8f96d61bbaaa3441",
+                                "uncompressed-sha256": "e39e3b49c164c14803ba165a862978e7ba0740cfc7af79b9aa2a875d9f62aa39"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "13699e5c5ec9dbfab85da658d4e69cfeea8362f6d8cc0eb7d25dfb47ac5a9cad",
-                                "uncompressed-sha256": "c4704a2a1acc1ffd094d2f7d9af0b3ac7dfaebb6a1b2a3f46fc21b71b20e8df7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "b303cde3c48e050412edd700f8f2c694987603130cc26ce87f6f046a2f1fc9b2",
+                                "uncompressed-sha256": "37cb40f63fd429b38e320cb39b1235f1467c9ffedbfa5d0780a397c1e859ce66"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "da122eb914ee303ea3744ff48c4841ae1dc00659a748623956e01e9f75661eb2",
-                                "uncompressed-sha256": "f33cd8e12178b4bb56faf11ab0b07ecd4218e067094795e8ccf56443dcecf774"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "0f5a75b257a975c19f1c550bd060704e4d0e71565a47b1b32880dbfbc107f31a",
+                                "uncompressed-sha256": "6a6f3ab9cab74602e30ecec02898017ec90eddc075bdeea0f31be9eb5cbd7e4e"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "b7bbeaef0b58dcf7903c5d69028c649cb299583f7f71ceca631486806f777a3d",
-                                "uncompressed-sha256": "7f284ec090124cd9d123e7b7435b176b37852061d02c740995ba72582a234252"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "fa3f42fc598b2714381a280cc1242663ac0d8aaf650953e4224d06110eae59c4",
+                                "uncompressed-sha256": "5bdabc5f5de70df68a4a1ec55a9efe6108c26dc8878fae050a0503d789299626"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "775ebaf861dd0150e42f85e996a8bf56e33c1e630cba38fcd6d8244c5d6a1c57",
-                                "uncompressed-sha256": "9f72ae5f768c0bbc7257ef80f8aaf8fca7310cf39db58b5ba69e199d0f899869"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "3913eda0639182b7bf4d0b92ed9a59709b16395756cd86e980de208bc34c0ddb",
+                                "uncompressed-sha256": "63e0610b1d395c56d58494f6b4188fc747fc1c84c8f569ad77673a0ec2759522"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "6d62210d1997320b74d1e15eac0a12986a745b67900ce0432bb0df4e6d9b2445",
-                                "uncompressed-sha256": "5d7a97fb0871f480453f3c63ad529d961fbc356a936149d05a5e05e12725bdfb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "841c073cf6f50118aca7a9e212ea897693dda5e3889581895c762475a1ddb4f2",
+                                "uncompressed-sha256": "d36ef13db8581a8e3ac4ce4f01b71039ed4db1f1c22c0a7057eadf9595df097f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "503c42022ecfc1ce23f35ad32bcb2ccf84d7a66363c56d341c3ea10181f8c958",
-                                "uncompressed-sha256": "b457552fb66b78dcdfbb190bd13b31c0d5f65aa2fe33fe89036dedd122d68d2b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "257ee2df1193c964de1e7c2c4842ed5c017c5788558300d3878767f6074d1313",
+                                "uncompressed-sha256": "6a3a33a1e1c2e90a6921a685bf644006ee5d918c7aa7efd9763e19c400fcce36"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "185fd81b5d6222888201c8f0837644916ee95a9ee42bcd3c4f280956df33d167",
-                                "uncompressed-sha256": "59724677c259a30459cd8667cca2d128bebbe2b06188dc77e143ecef974afbc3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "3ee019b5603b3d08fa349433ba87bdc1af7f86e0be0113fc7aea1008678885dc",
+                                "uncompressed-sha256": "81cc5790510c8600eb48a3883462f5d3f7fc13be6f2f0447be8d9e606606f2cd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "0b5a0af36680bbbfa5edfb16d45aadfd2a29e242336873638505f8ed5c8b4821",
-                                "uncompressed-sha256": "315371c738c3ecb9422922ff5fed96376243b7729757a1c3e21e1c3ab282e27d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "280dca510e6cea3f00265b6fee32c6dd47e00dfe5ba2a61dcd8b8a08e608b07b",
+                                "uncompressed-sha256": "d463f4cec817424d2690a9fb87f118a4a42a1e43a2ca342f49b15492dbdb6763"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-live.x86_64.iso.sig",
-                                "sha256": "08422c5998f7bfb10788b2a49b4b45421a205db0d3be8ab2a681e38962aead59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-live.x86_64.iso.sig",
+                                "sha256": "013da69039c830baa2f0c33bd05ae4df343ba63e0e30488c9aeb9a32bed1fc69"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-live-kernel-x86_64.sig",
-                                "sha256": "d76b102cc1b5fc711adfea30dae7d07948179d8837ee470797064de14017e15f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-live-kernel-x86_64.sig",
+                                "sha256": "61a156435dbcf37b02314416584cbdc1c91594bb98764ca9e2e8db51f7f40607"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "70e40dae9cbfdf930fd370ba57c76bf31fb6cd7854cbc4622f363067a51a6f3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "1698cef195cc52d75a2e0f34c421780a319f9a8ddd10c5b4cbdbf95423c7e690"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "1b8f37046c12341f1690abcd4004fcd72c22080b88ca8ffd0800a8c6f3d10dd3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "d66bbed7eefc163732f2e056bbb1425acd2c55724205e1206b8a5ffe4ff9cb6a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "29451cb7287c71c4eb65df58eeb4d00bf53a28df511e50d7d867523314d3f142",
-                                "uncompressed-sha256": "b7a8de2cf6a41ab5cbd937f179f6ea6202f8fa7ba88389f9ad2664b99cf5cf7e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "7bfbcd00d7b82721f9e0b256b012aec63a28755e2f00b24dd274b81899b7cf0f",
+                                "uncompressed-sha256": "f3e330ba61075c4a80e3f1f326ef6bb061ab1b9c96f444ed1d48e01e1aa1c787"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "2865ad3702811fa782de4fa03060615aff5f4e297fa5f8f9d2a89c0299e75ca4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "29befbc46fa2a07c38d148292133e01c653b7e4e8cc8666e4a235ccf3d76078e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "36ac1d902459604f13b61f97ad47bd82a31f755ab4dff2b2deaab9aa22c05eba",
-                                "uncompressed-sha256": "a1d0833bb8465a142788007fdb16e3644c5bbe558296c5ccf36edf67cbfbfa7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "5458dd5021ff62842506abcda7926a075a74fe92464d1b52b0d52fb0fe45a34b",
+                                "uncompressed-sha256": "b093e27201f507b93b15931b7e9a8d2eb3c57913dac4509ed4768dabcf9207a2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "05997cfaba9f80e9d17ccf44085a0a9b66c20a20d6b8e7e3a2917e7cd46a6c94",
-                                "uncompressed-sha256": "8f46e0a0b459b86ed3d2dcb452d43e229c7612c5794c7527a4d66da7c8fd07a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "6c272bd95a760696a0132e26e59fa610e644ab8afb9de1fb2c28033840aff198",
+                                "uncompressed-sha256": "649312fcb6ec6844654cdb531f6905b91ae5f838c0200f1e06d9f28083c931cf"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "c78c7a700d87e060d4fe8fdae74d9f5073cbb43441dc161585a76c5904adde43"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "2ad518e9d03671aeadad4e223d1d84114786aefc01c8a0151a4853fef5f88ee0"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "9ad63de0be5fa0da75993e5ce3439e78bb4ff406f2e4fbea35ff1d3e2e503536"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "879a81c3ad7a7510112cdda5d96d0f70c958749f8d49c2cba42009639fce1002"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230110.2.0/x86_64/fedora-coreos-37.20230110.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "df8e77a427c457c6733931021d5b1a001ea8f104769d942ebf5e7f4a488ebf36",
-                                "uncompressed-sha256": "6240812b4c5929dafb210fd117cf5e73960b540a7f6c925c73ff6c6bc337713a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "0465941804c939b123af87833675cf66ae4daff1a626d4bcdea5d41747252883",
+                                "uncompressed-sha256": "0f4cf226955b373d892cb0ac4f9c047ca465a612a9428a9b4f24f54d86e54eb4"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0dc4218d5c3e85cd7"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-087f5f05f49af9904"
                         },
                         "ap-east-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-024602ad7c9a4be62"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0b31b2c3d905b15e2"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-09ff7831b71e49cb9"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-006e09d942126a891"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-07cff52187e49adab"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0117b8d132388f713"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0399a710a4d545eb3"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-047aac0ee3af22efc"
                         },
                         "ap-south-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0efab128e78954950"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0b4addf91f5dca8c7"
                         },
                         "ap-south-2": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-051e862799863bdb8"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0b9bab922b50a6e6c"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-02703bf2a9611eaab"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-04d8a4336b7328596"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-02a2d5d2c6228e517"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-01c9ab9217c76540e"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0a2d2443782021453"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-039f4ca89705eb6ae"
                         },
                         "ca-central-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-04e73ffca0003c151"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0f3ca0ad8020da163"
                         },
                         "eu-central-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0cdb0597990ecaa2a"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-066b99f6475e2986f"
                         },
                         "eu-central-2": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-073b75ac546e803eb"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0e6821de3d82e6e39"
                         },
                         "eu-north-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-09493e2a0248dada1"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-06d6b4cb1c60de558"
                         },
                         "eu-south-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0d97e638ab9016148"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0f0592310bd809137"
                         },
                         "eu-south-2": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0596fd5fb22632d1b"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0d0861169fa7305ef"
                         },
                         "eu-west-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-05fdf23af6acaea9e"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-032dfdac1d50c2dc8"
                         },
                         "eu-west-2": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0af50987df8d1a1b0"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0b51ffeca929b6792"
                         },
                         "eu-west-3": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-03df1c6072867bfe5"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-00faf728036ab8e22"
                         },
                         "me-central-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-01a91600869cde8e4"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-09aa5fd1297b42cfe"
                         },
                         "me-south-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0d33deac63dfef313"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0241fa16613f6b260"
                         },
                         "sa-east-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0b61c9f907efeac20"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0b54a4d6764529442"
                         },
                         "us-east-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0d474e3bfc936f338"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-016069fc4cb84c296"
                         },
                         "us-east-2": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-0fea5e691f5edfc82"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0afd3f358d777da56"
                         },
                         "us-west-1": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-01432a82c7d925472"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-07aa40f486151aefd"
                         },
                         "us-west-2": {
-                            "release": "37.20230110.2.0",
-                            "image": "ami-050d145ee5a259f7a"
+                            "release": "37.20230122.2.0",
+                            "image": "ami-0a4fa778fd4c9cf50"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230110.2.0",
+                    "release": "37.20230122.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-37-20230110-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230122-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-01-12T05:15:17Z"
+    "last-modified": "2023-01-25T10:23:33Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "37.20221225.1.2",
+      "version": "37.20230110.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "37.20230110.1.0",
+      "version": "37.20230122.1.1",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2160,
-          "start_epoch": 1673532000,
+          "duration_minutes": 2880,
+          "start_epoch": 1674651600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-01-10T15:34:45Z"
+    "last-modified": "2023-01-25T10:23:29Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "37.20221211.3.0",
+      "version": "37.20221225.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "37.20221225.3.0",
+      "version": "37.20230110.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1673373600,
+          "start_epoch": 1674651600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-01-12T05:15:17Z"
+    "last-modified": "2023-01-25T10:23:31Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "37.20221225.2.2",
+      "version": "37.20230110.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "37.20230110.2.0",
+      "version": "37.20230122.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2160,
-          "start_epoch": 1673532000,
+          "duration_minutes": 2880,
+          "start_epoch": 1674651600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @cverna via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).