### PR TITLE
Roll out stable 37.20230122.3.0, testing 37.20230205.2.0, next 37.20230205.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-01-25T14:05:28Z",
-        "generator": "fedora-coreos-stream-generator v0.2.8"
+        "last-modified": "2023-02-07T21:03:10Z",
+        "generator": "fedora-coreos-stream-generator v0.2.10"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "9ee4b27de1af4c943508a5d12cc8242b15a1da47d497782d7f5a07a7f70dfbbd",
-                                "uncompressed-sha256": "ab4cbc122fb2cd96d99c3678d70d97f30d96b678f13097fe73a0218c51440a8d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "d7064622b2abea457241a064203f016c4fafcf1397867d6e4f78460169925e96",
+                                "uncompressed-sha256": "94eb8dc61e1a338044937300d1a965e1b345dc7e0400c8279eab362f5a423979"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "7b6dbbffec8ab3ab41002f37addfcfdf30bb4dd614c9decde86474c3ca5fcf66",
-                                "uncompressed-sha256": "01d5dc077f9cd95e4e8f76bf1e17cc20b2cef940f7cfdc9ddacda1912fbdf387"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "cc42f67b6b2a129c22813a4bf762ab94c3e6e9b35403afa3f9ecf87dbae4d73d",
+                                "uncompressed-sha256": "3b5b1a2f910b4c3281a61b34daafcda08c483c3f74133e1df53b4dd5ddde07e1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "6c6cf82a12d59001d10e806185cb33271a7700e55fef4f2d2555be16d1c8cf8b",
-                                "uncompressed-sha256": "697b781a5c3bfa49a609700e7503f898a1fadebea92905fcb110087fb3d29f30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "5a20fcf0c0a0e6decdfbe5228bc7c694ffa3d2f7fd53b56e31c84a255287f023",
+                                "uncompressed-sha256": "913c8e14b71789db008fc20861f9548929c3fc8ff8174ed47c45d52e779bf708"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-live.aarch64.iso.sig",
-                                "sha256": "4cd6006676ccba34ef27f819b2ed7686fa35e16094dd59717fe5c24714eb5ea3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-live.aarch64.iso.sig",
+                                "sha256": "95e0aea37f8ea96e14749c3db2ac388ff90e50d7107cd7ae3d7dd5e6781b5588"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-live-kernel-aarch64.sig",
-                                "sha256": "418b756ca5d9439386086efffbc299607a53d618739e0e1df76ef4d0f959d045"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-live-kernel-aarch64.sig",
+                                "sha256": "0730a6ce19f36e22a33197a6df829cbe0feda95e1dcbd328391d0cf004259b03"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "f5039aa7b9e240af74a0a8ce0a569c25ccb381e1ca9744e184aac41a97911c45"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "7c87dacf3e35db36e5be10ac7564d71a2a37eff4f95ef1e31f2518169e6514dd"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "0bc897e546d5253f05e0c336bb96790abae66a1b9a37455a414afd983ed87c4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "c4bfcba841f7ad5fcf79d81717c6e6bcdc28dac009e811dd09c69da502f2baf0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "4913e62671b1176aa6d590819cafd62465a7154c961f76e452a15f0c7b2e65ed",
-                                "uncompressed-sha256": "8e4d084fa77498c2f19a7f29f7cf13ba6dd9223bcd90126df51e29becbe44c92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "408e78969c179e74808a9be9369fd7b0dcd3115ba2fc271b6f82d95ea4ed81de",
+                                "uncompressed-sha256": "9eb2c06a633cd4c123156f55da8ac3b6c9feeb6182152e0b4549b797534cc25a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "5b783b955e546f5b13a39bf918238ceeb7239a501d080adaeb73a63dd0931012",
-                                "uncompressed-sha256": "29d19e67bb216c27678dadd7248671543f2f73bdadf4d18de243d0826b40bdab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "dd77c62002154b56b0c8b613e33632e79fff35723f18016bf56b9f07c4ec07a8",
+                                "uncompressed-sha256": "65e2be5dfa2bf2ef5a270e4d91c3b96653508112c3de8d312b572a303ff9223b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/aarch64/fedora-coreos-37.20230122.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "7641c4c22089e45379ee4161f4dd65122a50fd68d31fd09b5487b9abda2628bf",
-                                "uncompressed-sha256": "a652d3f9455d35176d2e2cb8baea4852e029d33a5fafc33f840c43a57273449b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "8508461a0aef1e12c4b10a7cbc54d71465981fc448583f8eb4e928ad4145a56f",
+                                "uncompressed-sha256": "6736cba38500c2679c7de1e6bab5764b7da4a9755e2fd43b59b887e12f689dd7"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0ed9f61b3a71c5268"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-08b566e0b28a18a7b"
                         },
                         "ap-east-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0ebc76d35b2a04e81"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-02332dbd28e4e7a40"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-03d600b85df70cf3a"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-084cde0f9afe75206"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-03d432716149471ab"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0c9a24163e609cde5"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0bdbe4d1f04028419"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0447b4d2f088a71e3"
                         },
                         "ap-south-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-06169c1b2129bd4a8"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-021c944e7731d5e83"
                         },
                         "ap-south-2": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-06233e3db809d7f75"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0cb128800aa35673b"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-066a786a6a3c1180a"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-05d28d02b34914496"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-04683ef7b83d53179"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-06bf8508c4ef90b08"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0534d87a45e6f2df2"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-06e20e69de4476a12"
                         },
                         "ca-central-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0ae6ebe88ede96631"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0eef9894a634bf5c3"
                         },
                         "eu-central-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-04981869d70f0e749"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-02f97dd2d0c5ef48c"
                         },
                         "eu-central-2": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-072cbc7aa25d4ec3f"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0454b47724f3b73ff"
                         },
                         "eu-north-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0d2ea3adc0c3af2fb"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-07b67753148474277"
                         },
                         "eu-south-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-01551250bbe34c3c5"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0b4a7ca3c633716bc"
                         },
                         "eu-south-2": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0f8362db65e122ec3"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-09c073e5111f990e7"
                         },
                         "eu-west-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-008fe89e42fbe312b"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0f83fd68fedc87144"
                         },
                         "eu-west-2": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-08dc83dbdf7b412e1"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0dd75507f915a4a76"
                         },
                         "eu-west-3": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0437ae730d57ef82f"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0b060e421dedb8be8"
                         },
                         "me-central-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-085eeeb749242f203"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0331d7dca8ef4167f"
                         },
                         "me-south-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-01e3a6cc9068a41ae"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0b26516289071effb"
                         },
                         "sa-east-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0e8c68eeb51f49702"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-072702db23c845f96"
                         },
                         "us-east-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-02efb12e25c7c0715"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0c9bc174991b9c03b"
                         },
                         "us-east-2": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0b75228e0fb6a05da"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-020fc642a555b90ba"
                         },
                         "us-west-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0385b1cf3dc298b4f"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0a43bef04ea9cd4e1"
                         },
                         "us-west-2": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0c7875d032c72f7f0"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0355ac84ae4a9de90"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "7fd9c47b8468787d6fb318e4e61e3643bd35a235fc889662aea10296818e2a41",
-                                "uncompressed-sha256": "8767a10ca656793c599a48f828f93e408d12a6221257df32afa4bc8c5ab9335c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "680d23493930d9c64f1f16e82c22d6735c904a3c0da72451c2b607dfa94cd7e9",
+                                "uncompressed-sha256": "8a7ac5f3ff11eaf32f291d0149813d079cb9ad1c9789c5a22183ac83608198d1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "ad5ba319321ce4ffd834286a0bec7ddf08925504b893206a83e5f2cbf72b8231",
-                                "uncompressed-sha256": "0c2dd5703b7c6efd2a39fe84bd6ac00858bfb66b5959a90ee71ca1c62c9efd77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "4d45818be520a22b59ae884a9ed48cd5d9c5ae305e29d91c0f45807bbb6e85c3",
+                                "uncompressed-sha256": "beef73d16c2214b0e8777addc2f83bee301857c826512f5c4ac8a85df4db21f6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-live.s390x.iso.sig",
-                                "sha256": "3311553eb2f08db3423e8fe62c7e629e979697ac487682ca829db7eef397c582"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-live.s390x.iso.sig",
+                                "sha256": "23ad185f671d758bce7c811c241d68905632457d825c703e9a91f6233e3c83ae"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-live-kernel-s390x.sig",
-                                "sha256": "948ef8cd83f563fe92a9e73ff5c389b3898a980540c222d8a62d57366ecc0585"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-live-kernel-s390x.sig",
+                                "sha256": "8a9c8e3a4101f67d57f0d5b2cc136d10b976d27f129aa7b9947215749e4185bf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "146b07077e3df2b105caa5c807aeae6f53f32ccf0ef1ee433b4290b57d536c34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "37bb53de0e9493a768702e6154808e84f95d73e07607374365d7701317b8719b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "55de53064fbff3af1f0b55a96507ebb7417b5e413c19d619666fb4920341d3d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "6f9644c31f33766c6f1e8ad9310e643def6aec28c0a686c78b6ecf9e8a888501"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "11aec39a342a7f5e5e55de2bb51c20617d296e94f4ee582fa939a7fe2b95a930",
-                                "uncompressed-sha256": "2ee8b7d3bae5b743f45ea8108216b99e159d768ba57991b8df7e71bbfc195b25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "119784a5ee2f4dc9553ceb427098da28cea75b9e32e0341013c6223738bce352",
+                                "uncompressed-sha256": "a8b10c57a83426ae901fad77837661854174e957f5229b8b8d374cf4dd0e831f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "d03fa7b1c968b215b9fa232503f8d8937e791fb0ed610168661cbcdc9b6c8c0b",
-                                "uncompressed-sha256": "d3d4b30623e056f0a8b60833a6aba913be8044bba42a309a6c853089e5ed75e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "145e9e274b1e9b674854754c18b06220443ac92dc64714ceca649e54213656ef",
+                                "uncompressed-sha256": "55b1566ac3558c30c4babcdfd6399bca38ef391e3dbd80db6908671c21014753"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/s390x/fedora-coreos-37.20230122.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "0d1c081c71ada98481bf0f906daff08987cf7ae01a40ce20a683499746a9688f",
-                                "uncompressed-sha256": "330e12cc8b72ebc0ba6775d2d5557b5a8ef605e9f89378106a370af9540dd64e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "a2bec17934ffc225533bc401c158d5d4e3273698b038919e7397bf5f0a4d9a2d",
+                                "uncompressed-sha256": "7e04b7e3efef56963a82f017ee709c372d4332763b822ce981fb1604f2802a2a"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "cec705a42166fbf598dc10de9f7498d03006cccff9383fbb783b67cbf9c456e1",
-                                "uncompressed-sha256": "299d0ac896a25deba8528107806c589baec1e20a2984b802ead416d02414f603"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "72423e710bd57a2160fd438a2aa6b7c24c05646c3a6473208e78917178438afb",
+                                "uncompressed-sha256": "f8555a215b5b65e51932292931aa395b2e199562b6be0952ece9bb4e539d04b3"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "bd3540a2925995b19d13efa22c7f5c7993d0e79d22e5277b8aebadc38404467a",
-                                "uncompressed-sha256": "722684da66a041afc8710ae5c5129f496036921a0e5065145dc293d9069f59df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "68a8a41dc306d04477efaf4c438e1f6f18f2fa59d886c28e70c2638418e52f7b",
+                                "uncompressed-sha256": "71a62bbceee696b698fdf5486cc4629a0475fa1476a601922b716d3c0ebb15a4"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "8e8bce9843c7b269758c75ee4393de63de4722dc12bd580355cf7f3f9d364485",
-                                "uncompressed-sha256": "96d8533905ef3dd9004ab8c855d6510843658c8f6bc4fc39c848b7dba41cd1e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "01bfbd181ce223abc66a76f552cf6d3833a59b45de5a35bf5954dd49170abb11",
+                                "uncompressed-sha256": "fef7ba472a909c40996793d74352deddd4684873b191deb680352e351b3e0cec"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "cfa0e2be6550e0d489c92e7e3ed6c2e2816afc5a1d97fce071af3165ded78d8c",
-                                "uncompressed-sha256": "8c718565ec6bc4c502e79f397a4eece3394280c96087837a6b9c1a79b07bdfa7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "3869a7051ea74d6d4c36903a67da76140429bcff393586883128e969b7aea2dd",
+                                "uncompressed-sha256": "095778fef7ff57d6f4ab5fb3c7ea1687b40585a8c37f1feab96121fb1da47153"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "1fd393c2b620317794f42863a2fea259715a738c030f46fabcdaf52c39d3403d",
-                                "uncompressed-sha256": "3e14ec5208f2a8678632a297acd2f2fe3bfe80cd6fcee01e39ddd4a0857922ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "7a9c7d5b4b0da9b91afc44574c1d3a8fe18a3d2cf417201cbe1561e216a576ce",
+                                "uncompressed-sha256": "bc2b68e150ef947a9291b97060a99f386ca9414dac6bf99d6ea2eff26308fbcf"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "6664f30bf12b38dfced4cf225391175ca115467afb4cc9e557438c4919db8d90",
-                                "uncompressed-sha256": "546db4df907a58c3a789e0185e53f5c010a21227fb154ac9cea44ff81ae2c311"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "a445bc1568660c0ef6b74e7c2234f42c485c7bedb7171297a95cfaa514345417",
+                                "uncompressed-sha256": "9bcc882dbb9a0139beb76f99a4f83c0533fbfcc2ac06bdd29ae4b15ccbfd2b04"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "9adb7df316f062b03f275468dc20e7b135df951815f96a535ec8a37be4b4efa4",
-                                "uncompressed-sha256": "1b9e5390e3e4fdb3be72c95017be2b83bdb2cd5498be1633414e17f2704a1d25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "2ec98a8e0d3a154a4d77faa8ded61c41dbc5dc7df4f06def7814647b55cc600f",
+                                "uncompressed-sha256": "3bb7f1fb05ccb6b45923435e64e7467ddefeec15982e5370934fc16a0210afed"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "c96d4f7ef17f62010250a4719d0a5e3f3aa20765aad52492ddb432add1d3d008",
-                                "uncompressed-sha256": "ed1de7e64be9aab9ce9e6bb9506e0d9e0247686ae9d06343e030313b2c2c9a7f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "b97b726ae15a42bd811dd82f8eecd93077d10e6c7da8988d2dc2606e3d668f8c",
+                                "uncompressed-sha256": "776c5dc00b4473c719acb7d416415b93c7a729cc9e88ad7b4a5d963ffba0cb83"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "73a88f0e465a41770d290123783e28dc49ba570f7070fb8e3c894acb1a4a3844",
-                                "uncompressed-sha256": "1dc95315b60f79e17ed8055fb67dddfef400c75ea135820dd55087d77dc22fd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "0ee35a828b791eaeb1391eab87467def46bd4762fe2eed63954e1f0a33f9c251",
+                                "uncompressed-sha256": "6c8d9008772e08c25cf0e4d3ba4311dfe033f1b9f79862b7bcd92ef4982008b8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-live.x86_64.iso.sig",
-                                "sha256": "36cba43e53da268bd936818ef9448b253941aaae780d3265f5ddb849f62266c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-live.x86_64.iso.sig",
+                                "sha256": "5de204ee32f0ae7eb768a1eaa355b69fbf751824827571df7207aaf63146c220"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-live-kernel-x86_64.sig",
-                                "sha256": "61a156435dbcf37b02314416584cbdc1c91594bb98764ca9e2e8db51f7f40607"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-live-kernel-x86_64.sig",
+                                "sha256": "26442d4c1ad591008d38fd40648db3bf5f566e86aa8c408907680451c69190e7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "d4fe92dc617015da8f688e8f4413756c260319b20d8b7ffcfa74f6264eb51531"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "c07f1da4a1d6716f4e47de9553a80538ee7f9e22fd5c67d1ff69e6395f0daac5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "b5fddabcf2a178da73ff14f6d75f2fb295beca5cd0a1695b56f3bda1e5e803a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "2de918e8cf53d0975821639261799fca96185b6741c148399b548880a6b0a429"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "d69e74864ee8ae4588cf3d592bb80722341c15287b724e94e9ea6532c14d8680",
-                                "uncompressed-sha256": "7111e6e798c39c0d7895186523dec7cd7bafdf74a7f99ce517dee15071ee5c74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "b3cb62fefc794b3938e92323a87f9dee2b8a918053f86347b485f3d13c3a676d",
+                                "uncompressed-sha256": "724d3993b795e1e7cc40ee40f254173648734b7b1d0d6569ee98480974afb92c"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "e3111d2779497fdff02e6f07b2fa8bde6edfcf4c8afb79b1a1da75261103e6f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "b271b6847aec614ce81be3631d1b9f3e0844eb315263812596880fa145fbaf7a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "930f7c17c3e160a88714e75219184562a8449245e729ac2532c72d3f9f80850a",
-                                "uncompressed-sha256": "37da3a9fe0d7b2267849c211a8b93c3a86669ecd3d0f1abe38e0165fdfe1eb47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "2d92d73987ea0028000069f4ba0122dc823af77a0fbd5f2f02e7b5943b4de224",
+                                "uncompressed-sha256": "85202d53e95ea3aebcdcf3d675548c063700d0bbc5c08f54fbccddfad959810e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "c855f7637755bc7a60436da6bc140f473a6b7c6873bf5a498a44e7e671708c91",
-                                "uncompressed-sha256": "c9fa98078db5670237baa1eb96f2eac7971fa4ebb21764454149a93557020d56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "423c4dc81ebde903300f105b7f760d06b96fd0514bc0886d3f471b02efc49087",
+                                "uncompressed-sha256": "6b1ea2d712d061453a48675fdf0adefe212a76009a77ec1626f401346a17bc89"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "52853f16e9421872f5b522edcb000e1cfe15be2d5c91a1d73cc8ceb624b4649e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "2cf1875da457acf617249815645e24a03fb36a6cfacfe57bf567092df27387f1"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "0d16bed44ac028ed779bac21d0ea590bf0980c474d50cf1aca7122e18d1add91"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "dd9ef30b48b6c5f784109584f0ab662233f81d90f3e272ed4497b9f3427cf8c2"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230122.1.1/x86_64/fedora-coreos-37.20230122.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "99425d1bd86e9d6dc90b8332cafd230b69940f29a3781d8bc5ded4b079dcbde8",
-                                "uncompressed-sha256": "0dd996cedd0000e55bcab426c459363f30c241a50caf331cdb013211b0ab8e5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "5669ab8da79e54ee00766fb21d9de2c6bf434c3cad52042adf5a719a82bef9af",
+                                "uncompressed-sha256": "c67e3950b2f93a9ad0af1751baa51e24ad455614f91f61f93f37b8a89c4ffbcd"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0ad3bf9ea8e0bdd86"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0b12e4b9067805794"
                         },
                         "ap-east-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0485ef908eb2bc88b"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-093f2e642d36a63ea"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0276a5fdc4ded38cc"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-00f2df43acb8959d6"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-09ce3045c1d667d33"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0326ce9275cdcfe32"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-06b1eaf61bcc2d6f1"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-050f81e41888c5605"
                         },
                         "ap-south-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-07e48e4b2836e0d53"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-01c2578680ca063b5"
                         },
                         "ap-south-2": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-015a25e05e0ee3a96"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0bbebe07908184589"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-01bf57b6f9c241af4"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-05bdc788a3113bf34"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0de841a39687bd778"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-067b670cd5ce1056a"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-065564d45042262ca"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0cd00a49fc6f97c16"
                         },
                         "ca-central-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0f5fbcbea5e5470c6"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-090d365bec06dadbf"
                         },
                         "eu-central-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-03a8e6e591929dfa1"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-04f90aa4936d86b74"
                         },
                         "eu-central-2": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0c447c6e9b6a15e6d"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-03490b1888e661e0e"
                         },
                         "eu-north-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0f24649a3f25cf9fe"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0ca51353c7edc4615"
                         },
                         "eu-south-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0ba57964a24b4ffa9"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-090b1cc721ae8c3d8"
                         },
                         "eu-south-2": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0fc61ff5d9bd866d2"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-088bbe63641fafa8e"
                         },
                         "eu-west-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-05287e61f18e34097"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0430cd76cc62f04e3"
                         },
                         "eu-west-2": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-09969e2681eec247c"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-07d275869dce6f482"
                         },
                         "eu-west-3": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-05e7d5737fcdb12b0"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-04d8b83286495d836"
                         },
                         "me-central-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0e9c755a148c7e955"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0dbda463123ee837d"
                         },
                         "me-south-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0ddfcbd6e43ee542b"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-0de788dc809ad4907"
                         },
                         "sa-east-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-09e2beb129716f85c"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-00a067ec7ef70960e"
                         },
                         "us-east-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-024fca6df6d29c717"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-064193a3e780b217f"
                         },
                         "us-east-2": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-04b5f473be55029e9"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-07572271f14d4d8c4"
                         },
                         "us-west-1": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-03d5b4f1e901df740"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-01dc2eec6477eb48e"
                         },
                         "us-west-2": {
-                            "release": "37.20230122.1.1",
-                            "image": "ami-0084256cbe1d43c1b"
+                            "release": "37.20230205.1.0",
+                            "image": "ami-04cda126f45ec27b8"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230122.1.1",
+                    "release": "37.20230205.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-37-20230122-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230205-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,105 +1,105 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-01-25T14:05:26Z",
-        "generator": "fedora-coreos-stream-generator v0.2.8"
+        "last-modified": "2023-02-07T21:03:08Z",
+        "generator": "fedora-coreos-stream-generator v0.2.10"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "86fac0d091623cafd12dc83f93b19ddcdcd0875f98fa984d57773d5d2911cf29",
-                                "uncompressed-sha256": "e61b197f5d46a0bbed7e580a29be77e1089bc6321897f5b8f84590087a70a801"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "dc266c8509111e35e87937f4dbf2b12c49d8f512e9ca5338f7064d646fa0f994",
+                                "uncompressed-sha256": "97efc70e1649fedaae3f0aab62efb74dba4a60a7e373835a15de5d50ba570654"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "37447ae354bdf2d68592a9e80a9309f2dfce3e80359e8a9b9cdd44313a081c23",
-                                "uncompressed-sha256": "5ad6d3e9761f50066adc6afc61ea8022d0beb250501b201db154c9ebeb069c46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "e6676dfb89d494941f600b8d5abbdbf7d41c5af749e01bef92c7dd39aa8e76d9",
+                                "uncompressed-sha256": "273c553de158fef9f5dd2af9c82ad7a0815ef3776c3101de7aba4fb099c5ace0"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "fae3f3694dee23f259ab24dcffbb3dd29dfa2dcb9f0d857c8092b1451a0b0926",
-                                "uncompressed-sha256": "c2f584f3c5460ac2d622a69f82bbb28bbbb28f786efd123dc4bd67b3674d8c3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "d0e642a832774e9b61d57b59dc9163b7df3f038d20d02d3a8a761445a9988542",
+                                "uncompressed-sha256": "cae2ef591aaf95948daf1a7cde073776f36886513b73e81abb172688a681d719"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-live.aarch64.iso.sig",
-                                "sha256": "386be7b5405d6e062c633bd56e4377e8d3d942b8a3945ef41fa44d2295062328"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-live.aarch64.iso.sig",
+                                "sha256": "906b389609fafffc2bd50fdd8bdc218a12ff0a095ff656ec87b4f01fec01e016"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-live-kernel-aarch64.sig",
-                                "sha256": "a2ef50a7dac3de0f10a256f32a4a03cbaa89b985cf0dc350d8028146daa57d6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-live-kernel-aarch64.sig",
+                                "sha256": "418b756ca5d9439386086efffbc299607a53d618739e0e1df76ef4d0f959d045"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "ada8acd9c753a677e00efa135d2ee4455fb9409c8c0a1d9973cb60cfa1450ce8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "7c4308fe399ac3caeb0188a91c19e5fdbeb04d411d6b79c1ee3ae170b22a5750"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "4513955875ef9e793e11630f140e8d74fdf91c9bf57e22ff8d4fee419d370212"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "f17225259d4d82e41c24e7dd8c17a02799c6760eb055c6841ad6fff8f35341be"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "0c70a4447eef0635bc00b2d3ecd0f7b4aa40b5eef30bd32ef578328addc08699",
-                                "uncompressed-sha256": "8af1e6a2e6dfd5aa5aec0c66aa4244e04067cee4f4585391a7ecec450389f4eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "27e14da56596180e0c50b345c463f4b0a6247fb1e837473913e796e5c9f04d96",
+                                "uncompressed-sha256": "202f7e3cb3cf179844dbd8d6bc30307d5eac45aaf7eaf78d1a8ba9967752df40"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "f99c20981c16a00f4163f98f2a786dae089d18b5cb40367091ad0b7a3ff24803",
-                                "uncompressed-sha256": "cf7c13f9a52613a7ae937f0cffea722c46a14b9f4dd958061c5418755a9c36eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "76fc228396636a307652b930830832b97d99e3fcd2897a2aa444dec06c2cc07e",
+                                "uncompressed-sha256": "61268d21ea510287d54a2673d8de24f5f56e0460b9f45ce24c596122df0de24e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/aarch64/fedora-coreos-37.20230110.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "665a7d130fb801b34341b4489fda108febeb5e58c1388468095f213fa4dacb7e",
-                                "uncompressed-sha256": "d129db9361184c57559626182604a3268e7bc73426c764c421356c99ccb92534"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "c697d694b135502b6819a437ff622184e911a4ea06a10077b06cc8137886f01d",
+                                "uncompressed-sha256": "c9f11d7958a700286100f3e8bdb0cdb6a441eb5915ad242dbef7a26fdfed355d"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0fcb5d4b0124acac9"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0310eb419a3944255"
                         },
                         "ap-east-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-09a29a21e3a5a9177"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-04da545b18f959a2c"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0cf40902b6145c561"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-03f45ebb1d6831b3e"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-06453dcf75b0324dc"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-09b1372c545567036"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-011c345f0b56cdde6"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-05a1cc9341e9ba5a8"
                         },
                         "ap-south-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-025e6450e02b7f79e"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-051cfaadf3c9d1f8e"
                         },
                         "ap-south-2": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-057d7a89ab3fb6daa"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0c5000dc77536ba52"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-07ccc56dd186ab634"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0c1ebf24e0389882c"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-03d57b9d375d12012"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0c1a26592e831944b"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0a98db5cf170c25a8"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0873222ba3af232da"
                         },
                         "ca-central-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0d5c79f464f1b10d6"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0f7f64a2e312f9964"
                         },
                         "eu-central-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-026d388cdda04574c"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-05ef713b6eb9bd4c9"
                         },
                         "eu-central-2": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-06e2d6cfd5fd0c877"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0106e57d1b4bf51ca"
                         },
                         "eu-north-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0616cdd4e7c960761"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-044f85aaa1fe008aa"
                         },
                         "eu-south-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0496bdbaa6002c4f3"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-029f3bd5e4f87e3d0"
                         },
                         "eu-south-2": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0177be3f3b274e3bd"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-04eda3daa0f05a6fe"
                         },
                         "eu-west-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-07d0b087ee511ec79"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-09815a27ae6b6f069"
                         },
                         "eu-west-2": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-09961def81406d78b"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-01317d5620b6b2bed"
                         },
                         "eu-west-3": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0858c1eb316563ee9"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0f34cd831d8f657a6"
                         },
                         "me-central-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0c4dd3c2eb48a562d"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-05fe133d249126213"
                         },
                         "me-south-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-01f19391139cecd89"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-06f47fe6ed2568089"
                         },
                         "sa-east-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0ee52b8176a0503b1"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-08194a51d2b3c26f4"
                         },
                         "us-east-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0367f0b56905de4e7"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0fd4462bf11868d31"
                         },
                         "us-east-2": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0ba6cecc6b99e5e01"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-085680c5618a3c6f8"
                         },
                         "us-west-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-001423f27dde982bb"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0d350659c5c7622fc"
                         },
                         "us-west-2": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-054b45ad3486691ec"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0ae6ea17b3e995314"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "919291bb4a6f3e150c8e08d07f09b13acc6dc940ddd8efad3dc592317a019e68",
-                                "uncompressed-sha256": "f1d1bbdd5bd972d9e03fc49179fe5b3fbab82ad9546b7a7ee6c7c1003c545fc3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "cdf5c298f1c30b9f8f00bef2cba60d4fb70d7cb097c45dc31b972f47f76fdf5b",
+                                "uncompressed-sha256": "ce3ea2a1fbd51607dab0356c84b6a8fb0f92c32e2bcdc556d50a2c0876597ec3"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "752f0b529f171d48f340ccffc05a6cd87d6b63cea62de8e72d934ac3273171e3",
-                                "uncompressed-sha256": "0d7d578259a59ff4a32d3c4e62150e45ba23a1301846ed6637b648d522395419"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "fbe41f9b476b70274f6b8eb90d057cfee2c9de5123330c3641fe1c134bc50dd4",
+                                "uncompressed-sha256": "f04e7efc1a7a301fe264d4870cbd64995a8f565d2aaad080ffd1f59458bd9a74"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-live.s390x.iso.sig",
-                                "sha256": "eb6b3c54215ef6e05e31ee5b4f8faf05d5c279150f2c7671db3b2e6ec78d57f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-live.s390x.iso.sig",
+                                "sha256": "2cde51fa835536cb7ba042e0715c1980cfef7a171e6a74165a810fa402737cfc"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-live-kernel-s390x.sig",
-                                "sha256": "495f557b4b78e633c1830eaebe75ef93f6d2f6f30ef9a4423b3646fd9f0a5383"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-live-kernel-s390x.sig",
+                                "sha256": "948ef8cd83f563fe92a9e73ff5c389b3898a980540c222d8a62d57366ecc0585"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "a52e324fc02e0fac16315ea5291e11e6ba02108d9b0346ef068af7e46e79f1a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "260307778ae5a499f241e2b119cc600c5ebd8deb2e66b334810944b0f8526033"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "74938aa291282cd4366308fc9a7da324ce7374f3f9db6558d8ac49df31f6c896"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "3ff081adbfecf2036e55ae9751afdc79d50227fe9bfd1d8010a9e822431f409a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "298d1f151774db9bbb1b2e8224693284fc700a2ba4e9717eafb476e54d832d99",
-                                "uncompressed-sha256": "0901d91c1a894e58bedf33d13514ebeaec2f9cc15a5b7afc891f1e5f51c6809f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "6360b9966dd16d6c397286d09255cab67881f5b7aed0a56b4e7377f2ee6a824b",
+                                "uncompressed-sha256": "2624634b11cad679265638c5dddc99f35fe03f59c7b8e8aa06794a668ccfef32"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "b117d6b8a1cb0e0cfa281ddb1ddff04684357ab34e15b40b44cb6873afc12a48",
-                                "uncompressed-sha256": "27697eb22d29088a17fc2c643a761bc3d630a78341399a25d0056c446f5e5cbc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "d5963b18b442a65e7c0e933c7a3ede36ed7307fc291dfebcf2d9ce2031ce392c",
+                                "uncompressed-sha256": "8a521cc14584c799dccaf3d544ab0c3a2328163d4bd2c6ef72b268e12e0a7a46"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/s390x/fedora-coreos-37.20230110.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "f71d6d50af62f56e710fca007c4dea07557ef09599986bae7f9b791882ba6774",
-                                "uncompressed-sha256": "698f00d711ec363ab87aae6a1c0515c967dba921c9a67219187156454e05e7ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "f7e649cadfd988dbba79d196440ad2635f98ef35c797d9751a6ea6e4046645f9",
+                                "uncompressed-sha256": "528fb9c2ff000430aeba77cd3ba2306330058314a12ad438a43115e067060f99"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "6d99b637a71d347284d975f2e463d8ea1af15cb669d4f83691a7dcbff85e5c79",
-                                "uncompressed-sha256": "6a7a88a6eb3aa9d73721750f42c7b22e023ec30a1d5844530fd6a2ca52dcf081"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "5a248b83619b8bbf4a91156faca4138f6e96089693b6d0dd580f80d28db296c1",
+                                "uncompressed-sha256": "6b31b08714c22b0cb406167e8884109c27800b97046d1cc3a9ea9c657377a9cb"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "a2209cdb1002396d385ef1b949a2fe8c8c78c9fd15614372419fb85a559c4490",
-                                "uncompressed-sha256": "d34ba1c0791cf97681635c5e072672c2652ff6257ab56ce1b44109b98f515385"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "f066db9f133e7c57a4eadf7f0bbaef0c845ff3a0587c0f279bbf20bf540314f1",
+                                "uncompressed-sha256": "b91374decd200b603d009c27d199c51794ed68a2dc2ab98211cb08778b299f1b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "0e7b45b8c6f7e5ea3f72d57dd780c19ff41b3d217babe620900cd8c41172a422",
-                                "uncompressed-sha256": "adcd40956ebe6699390977d95a0329bba217709f03388f3fbfc1b67dd4c8a9a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "0b82cf6beccf9f8cc75c1d04e732a713f770d08a65b6b2120b646cbac99189ea",
+                                "uncompressed-sha256": "89414c266277c6c764797ca08d8f6279fa5dfd26aa440ce90fe74acbf21384c8"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "14b6c1c6d999cd8e55b140147f88a2bfc3e24e60267ef7a6e326321fcdec7101",
-                                "uncompressed-sha256": "b68b346ec20645f6df6230d5bf63ecb2fb77e541849403916882dfd217bfa427"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "40641169f9a022d8fb57db049ec190da9e2f33ab7a0b776f0b75e0d0107a4765",
+                                "uncompressed-sha256": "c2d1fa59b2a887317e2b7c8be7434607818b1824b85bc5679efc5b025b9e2e78"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c36014940b31995c5ccada7786b461ad9aedac49680555b4e6eb1ac1f33fd23c",
-                                "uncompressed-sha256": "1bf8bfc895b731090d7e0eb6d8b44d7a1201b5e9e2324ed76ef4272a581786f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "73d59f58727e3625439a7923a00a6dfe06cf85a2f49d1bb9a1cd9b521ce206c1",
+                                "uncompressed-sha256": "4100250e9cc0340511b7ee6b4ea31c326ff5c57edd262a3313496b11266f872e"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "4ae8862d42cec6bbdbe759b336f9048afad8b6b3f0bf2bcaa4788abdf33ebd9e",
-                                "uncompressed-sha256": "a8dc3ad8dd7327e17266ff3e1dbbf4dee35cd90b96e05a9bf6c8e1822e54e32b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "c22da17d90af2058dd4f0486480fa794975292e9f9c20554f58696c37b809c12",
+                                "uncompressed-sha256": "bdb91e8df55d34e752ba9076fac9ac2f36a530dbad8f9fb47cb329377f5b1614"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "70ec89af3313257bc0090f4911919ca54fae1acd8466dfbd8b1664d02a853edb",
-                                "uncompressed-sha256": "b9c3b803d1b94387ad66eddf963c85e2095cc086890969137f7a52161f59e8c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "73129c4aa6b856a8921623a4047ef7230dceeaf91d743d141e8010836f54f4a8",
+                                "uncompressed-sha256": "1bcdc78a19ade115ef97823280e33e88c809d02ea5c715f8a03b5d44edd06967"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "e8e4161feb8326d5f7dc5683c33f65945a3f1a088f94d664e255794b216e81e5",
-                                "uncompressed-sha256": "00a11186856d997df28099dbae0c0d4e95cb18b583b7a20c635c009c38a7c064"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "210185102caecb5942904f13ac634786d37bd22af76f945dd7e269379b279549",
+                                "uncompressed-sha256": "a8cc8f12856fcc3966c85245bb714f800c27c4676567808572f6c7bf6d9c305f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "7bc906c22e51b98ca7563354c5b7ec74841ea16823166a034a0381fe0ff59bc8",
-                                "uncompressed-sha256": "c206e33c54645030e88ef8a900e2d674bc56c11af75cfe36f097ac436cbbfd54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "8e886368ae6246f0f2d737a0bdad4b5913b02e78d296313b64d4661752d1ac3f",
+                                "uncompressed-sha256": "4127cc6f178a70177ed7e03739d4081fa2f7cd35772e8472a09a873c45764f01"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-live.x86_64.iso.sig",
-                                "sha256": "d2180f2bc902c2807c847957f07cbccfd6118ffda9ad1881845565a1d149393e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-live.x86_64.iso.sig",
+                                "sha256": "48ad6f408766c348de38baf5b504689a3646fc2ef35f3ecfbbfd2b3f8cd76ff7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-live-kernel-x86_64.sig",
-                                "sha256": "d76b102cc1b5fc711adfea30dae7d07948179d8837ee470797064de14017e15f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-live-kernel-x86_64.sig",
+                                "sha256": "61a156435dbcf37b02314416584cbdc1c91594bb98764ca9e2e8db51f7f40607"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "0aea9537392c78131ffadc519a7c2a0fcbfb224838d63f0ef6a4a6f875cb2756"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "41b143e491ad004fb1ece9e7bc31ad37c9991b1f41ecfeea22408446b50ab693"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "0ae167d335a7a2a26bf93375dfdf06d02bb2912e211899a4b5f3a0df55c1fff0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "e491b0680699a3b6c015489925f7f3f347e2ab726879636b9cff8c55dac562d7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "05e024e43fcf6258ab292e9b110bd453715943852ec6cd1e354688a21983140c",
-                                "uncompressed-sha256": "a8bff0084fa81da42bc692e933b5047bd97375f69f1ec9994e65fc9a9d2687b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "76aa6a4bbd0a301b5a670efcca7e4a3e8d0e70b4ae72fefc64bcea7e6f5e3758",
+                                "uncompressed-sha256": "b4c16e46d560934ee3c2e7d6431f76e4f244284d39812e73b229c3db033add90"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "e5a42c23095f3a39b9aae53dbacb96ce3d596e2392700c02f796da1e85f08b4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "63c77f10659ef59632c5f0dad24cb86e2ff66ecea29aa34eff663c81e6fe4ecc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "be3ed9796b339ad5c4b178713205676c6845a45b0c64e388f81154ada2941a73",
-                                "uncompressed-sha256": "3e8e53c590c41a3232a81d20e9296582ab80f39652950aaf770b34e052b44a10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "77231ec5231427d2b6b9e2906b1db9e1daabdbcd502c11ee2f6cc10b5882b93a",
+                                "uncompressed-sha256": "f0711618008985b0aa95d854847b3fb4795eac4b128da2ea3d713a8b3b6272c2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "02147d6e00a5c26c55cec0610b75bc839b7743201b65b46ea262693d397281e4",
-                                "uncompressed-sha256": "064f4fdf7475de0d8fbb9968f58a2c9b78ae25a126cc0f1fdf7dee89ba360ccd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "32947172dd44b924d1879447d2212c8baa063ecfd31376fb6ae3848e25d6b0f9",
+                                "uncompressed-sha256": "c9210b199b12e5c83cefdaed3c2fd272067edebde8047a1ce179d150f837b7f6"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "cdde6d1877f544cca63997b286eaa5f7e075aacc2c1795abf1e0a361275c5144"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "492e1e3b4548f69661d46e4727f93816c05ced5cf17ba121e105eac2c31a5bed"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "a6b768329b8145b26edd5917b5f27ada6de18954719bcf9f6125e49064146f68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "422a80f69cb8b6b1e9919da42b81941a68ca16452868df54365b1631a3d5434b"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230110.3.1/x86_64/fedora-coreos-37.20230110.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "4245a581daccb506beea7f161cc8483f7e5a40e24ad8b15439ff85b880df98c6",
-                                "uncompressed-sha256": "b16af78e659d4b15e3ff23f1dd880c23dbc4617447abd1cfb10f8b3423f6467f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "db9ae52e96138b34335d2e97c976a8410a8b434b56769fbd4dc8731515805f5c",
+                                "uncompressed-sha256": "20ec347eb24f57e484f26ff7935a5a3b2f45e705d4bfd70e8ba84b426a380c2d"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-00b59583ce73fd2f5"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-008e07652e4bfa2f3"
                         },
                         "ap-east-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0cd674b418cc03afb"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0af0d619b9853a8e7"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-003544e66a785b084"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-042e3baf835f66897"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0d7f428e0cb3e0b11"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0bd66195b12c34ff7"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0a030c10a47bb2513"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0302d4d35f7fb4b8c"
                         },
                         "ap-south-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-066e9c65a3c9d7248"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-05811ba97643b3931"
                         },
                         "ap-south-2": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-07390df5d02479106"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0d3b30373f025b5a4"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0361005e35feecf1f"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0f66f871473b9635c"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-057fe4d7ef8a036ed"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0510c968b0890af75"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0173a78c7ea24e5a4"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0c176f24627f2235c"
                         },
                         "ca-central-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0fb35fad13643d096"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-04b374d7dd97d2da4"
                         },
                         "eu-central-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-00f8e408bb2e9b06e"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0716739f9b48d73d9"
                         },
                         "eu-central-2": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0c3daa48e57457f7e"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-06768f1dec08ecac6"
                         },
                         "eu-north-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-05aacc0e8ef0155ef"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0640be686e7b9218a"
                         },
                         "eu-south-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0daf9f6e02112eb70"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-053525b07562f143d"
                         },
                         "eu-south-2": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0425f5dad817e69aa"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0eef3745aea785963"
                         },
                         "eu-west-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0ba465efb4d725a63"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0a15099019711ba5b"
                         },
                         "eu-west-2": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-045027e0b0d682e17"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-01707bb098f84669c"
                         },
                         "eu-west-3": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0a2072ececf83f369"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0209bd2341d51c61e"
                         },
                         "me-central-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0ec02a1f4a84092db"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0c017ccb68f61fa5e"
                         },
                         "me-south-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0a53afd1a27556d82"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-02453d5b08287dde6"
                         },
                         "sa-east-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0dbc125545ef2bf63"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-0cdc931efc5659e3e"
                         },
                         "us-east-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-073e0c8bbade4a737"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-00625af34d22904b9"
                         },
                         "us-east-2": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-096a7382f79795588"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-02a811d6fd3020af4"
                         },
                         "us-west-1": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-07e8ad7748e107eed"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-02a1adc99b232cef9"
                         },
                         "us-west-2": {
-                            "release": "37.20230110.3.1",
-                            "image": "ami-0a46b1a879d8aab46"
+                            "release": "37.20230122.3.0",
+                            "image": "ami-048be8c49e4684abc"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230110.3.1",
+                    "release": "37.20230122.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-37-20230110-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230122-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-01-25T14:05:27Z",
-        "generator": "fedora-coreos-stream-generator v0.2.8"
+        "last-modified": "2023-02-07T21:03:09Z",
+        "generator": "fedora-coreos-stream-generator v0.2.10"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "347fff93b6ca651a9d7c6641067c9c88eeae75e6bee2035538f56963e72956a8",
-                                "uncompressed-sha256": "a4a67c3f9a6067e0a1972fa04adf2d577d8d47eda68353261fb27ddfe0198a47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "dd6018ab46b5606857e962ff886b6bfe6200d1488e22355cd95957b95712cad3",
+                                "uncompressed-sha256": "3076198ad9e47634214d261ad3750b057ad0611ff8fa7cbf8e09e9e1f23a9902"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "abf485b2c044ae77d83b9e624bbfdea8a76428631161d56fce87f71f2ba0e952",
-                                "uncompressed-sha256": "2086ea5b694bdd9fe9f42b751bc382d4023273d5dea3a13532ef6eae02ceaf86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "4c46407f427076ffbbe37416db1aef635c185af046c2a6bcf3892e66682a2c38",
+                                "uncompressed-sha256": "108b14f3a0f38f05a7f15ddd0e86cab0a5bdde9cf32fbe52b301ce1978d3038f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "c1b8c990521b0a57a896a3160105fdca7456deb5b8fadb5b05ceb84ef8aed1e8",
-                                "uncompressed-sha256": "69d56317db43ee232e2de229735808b5d58c2c55b6fc99d7566e2a3dc9d82491"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "d1bfa26e7c897dd67f117511990cf8431e567e745bede388e4cd7ffc8fb9d811",
+                                "uncompressed-sha256": "3a2360d3d3668c4be87121605610eb1f0b5729ea7a349b25f46cb5a4eb441602"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-live.aarch64.iso.sig",
-                                "sha256": "aa778d8e56e6dd5516c561e7eb2e74f1444785e69251d4c3129465229064a06b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-live.aarch64.iso.sig",
+                                "sha256": "579642a40cc5cb7e9de8e4cb7a37b5af2b006ff76ea444fffbaaa4d202fcbbc6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-live-kernel-aarch64.sig",
-                                "sha256": "418b756ca5d9439386086efffbc299607a53d618739e0e1df76ef4d0f959d045"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-live-kernel-aarch64.sig",
+                                "sha256": "0730a6ce19f36e22a33197a6df829cbe0feda95e1dcbd328391d0cf004259b03"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "45e34c580ee36bbaaa180482153280a7366f851830dcfb7003d65d5e2538e608"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "b806660a0a14273bbd024479de81bf292c4295f6a86ef9b68b9fde6154285ab4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "c47003c8ded908d182c3f184d910765b5d48d71695c9b4cee67a03746bbc47d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "6200d888621a14960527a6b2698e22c44c54a20a3e389799fb6a52b523f93805"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "60255254cbcacc1ac38b54f5f27304a80c86ae1e56a7bafcfdb016ba56493c6b",
-                                "uncompressed-sha256": "e6974825651cbf2036832dcc8b14fa6bf302ba0533c6e40ab2f12d64b68a72e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "e57588297b18b78f07e1fb9db11a5be0a0121ea015880384a33e281f265a659b",
+                                "uncompressed-sha256": "b5e0175f16a530795a08d8c01f247c3f3f0d298b6b1e993c18597006ed21a6b1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "c62fa90315752c18ba8f4c84825c994636077bb2bf1efe630108849bb5a13307",
-                                "uncompressed-sha256": "e9d68acbba147779b16f2fbe91424677e04d695070eb3b6b3c5122a343c925aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "0c97d17ce72f813900a285fe58c33dbb5415b4c359b909fe0d911969bf03d0e3",
+                                "uncompressed-sha256": "aecae76f4553bcd09422354c4f7158d51104e3979f006a25ff97fcb2cadd4d3f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/aarch64/fedora-coreos-37.20230122.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "dcc847cb2353ff81f5ec7d9b0295dda8b5f8ae39aa2a896c7b9a9b2c631eda60",
-                                "uncompressed-sha256": "e8067113efbc2d79ef56c49c02a2436cfc98801a72c31579cce09cadbb023f72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "1ed8bffd86d3783c4797b8fe058fbd717926469d48801cf20929342e6a4e5a9b",
+                                "uncompressed-sha256": "e5309a90657b5b381d5a83446ca658d06239c79e36969914819961fb502ac6e2"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-03b4db64a923115c9"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-0c31ca95cd0edc245"
                         },
                         "ap-east-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0b284fa186f7851aa"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-028afc711a6bf3620"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-081ba15e25fdfb10a"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-0c21045ca666a4e00"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0ab7ef72de2267217"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-05c6fcb8b58499206"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-06da6b529a52d77a4"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-0af9e43f28af66ede"
                         },
                         "ap-south-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0cc5e053f2b8b0729"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-04b331a57a49bb0c1"
                         },
                         "ap-south-2": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-051b49bd1ac6e8e2d"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-042865585d4727c7f"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-05e21386a4992e786"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-009bfa57d6b94bee5"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-058376136ae63c1b8"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-0b312cf0de0b8ead7"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-05887fcd79e972c5f"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-066d8491b1d1602a2"
                         },
                         "ca-central-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-08d2dd5cd19e83c82"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-038f86f1d1cdd0a69"
                         },
                         "eu-central-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-05ab2ba89a9aa6580"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-00b2e10e1575360d5"
                         },
                         "eu-central-2": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0973209d293cb31fd"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-0ba225ff331a06ee2"
                         },
                         "eu-north-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0ab92ca2cee9080b1"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-01ef2306f25400427"
                         },
                         "eu-south-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-086943525b6fe1682"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-0d739b62d9fe2b946"
                         },
                         "eu-south-2": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0b3a85d882d8cc4b0"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-037e9052eba197955"
                         },
                         "eu-west-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0b2844f49f9081aae"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-059b452ab974db5ad"
                         },
                         "eu-west-2": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-008ccb8ca6ae7a238"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-0c1b0b9b745e9a96d"
                         },
                         "eu-west-3": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-008e85f45147f0326"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-04e645734447d21ec"
                         },
                         "me-central-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-086c966c8426858f7"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-00cdb1ed634db4eef"
                         },
                         "me-south-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-059b3e4dd3ca07568"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-04a8622611c622cee"
                         },
                         "sa-east-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-066d4a4fe352c22c1"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-070610f169718a645"
                         },
                         "us-east-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-00c3c54b4de6df3ba"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-021893cb29f26dea5"
                         },
                         "us-east-2": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0ca4dee198ad7d12c"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-019a3a1e63fb0de67"
                         },
                         "us-west-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0842371daba6e0185"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-06ab5785288f0109d"
                         },
                         "us-west-2": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0d5bcf3d97cf65055"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-07930db21c9309f20"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "ad16cb39d308dea39b2b57e5661b9a469193f5198720afb8ebac5f8bd9777d17",
-                                "uncompressed-sha256": "aa61e1429a4accab4b0c72bcd1993cb2afa45a85179c0ee7066c7fd75c991c45"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "7c76fa712b4cadd178b0442c69ca0dfe6a60bea9a4abc8353dc7e6e071c2c1f4",
+                                "uncompressed-sha256": "e8afd2891683b36844c6d2ba63dc897efbdc01e686263faad4378b4a23bcc3e0"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "1a0a87ebd3bc493361ee8c3770eaa772b23f506602cf659aea823db28cdae301",
-                                "uncompressed-sha256": "05095dd51d961dba761f7116cce3afa4b6f2ba60aacb11afc67c9b8083b49405"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "c813e8971cc66c5c95f7ba8b5323dca08183d314cfe3ba6bb71a04f945016795",
+                                "uncompressed-sha256": "04894972055da9cafe043ff86b8583300ad0bda0b0a410d8b36079e8fb68c442"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-live.s390x.iso.sig",
-                                "sha256": "07331198e2d4a41f867a2395909158f4c2c9716eba48334d232910a5142101c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-live.s390x.iso.sig",
+                                "sha256": "86e35f54efd97746f8beda6c74f3a2390257684de1ed30a5f6e2d6b4984b3e79"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-live-kernel-s390x.sig",
-                                "sha256": "948ef8cd83f563fe92a9e73ff5c389b3898a980540c222d8a62d57366ecc0585"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-live-kernel-s390x.sig",
+                                "sha256": "8a9c8e3a4101f67d57f0d5b2cc136d10b976d27f129aa7b9947215749e4185bf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "f6a3e3f7d5364dbb97079b1d2c43485031c521ce4f9ec14d7c29978e99b63d3e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "05ed1d7d183f9439803b86aa2be6c645204887fe0b6674b8cde7591eea4cd4e0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "331e66928d573ef51002c0b71fbd6b3b8cb49601ba4109c86db8b57b3cb89f28"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "0cdfa96553eece461bc452b13ff8cf6b117f8907f09e60e63f15fd837eb2ae44"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "c8a1478874e977008c150206c69eda9ee233302607d1e7f4ab24497a69c7ec1c",
-                                "uncompressed-sha256": "1cbac1f18a98875915df6196c3c48b458b26a53f846e7e8631860690b9e318b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "8c55aff422c23602d15c777cb463aa8c9790c0e1461923d804a0f4886720a199",
+                                "uncompressed-sha256": "34e0cd2693bd2651e6fd9e027c4420e0181e84bfa996bc0e14cfd52693c8c7f0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "e3109faf7cd86f578f1fb66adeb60f1ce4d28107ed02d13c8be9b185267115d6",
-                                "uncompressed-sha256": "a2d23088aeb8de0bef135738644167bbae415d4452779f37652f5006d6cd1001"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "a2b2cf41ad838b65b1bedd64f785bad16f9dc77eb14f700e55e2550cf7100bdb",
+                                "uncompressed-sha256": "930104354c15241508a18b2e908fdcc53680ad57f450550a28313efba4ca678c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/s390x/fedora-coreos-37.20230122.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "28a81a218c1df0a1567f9ce78ee39ca2e49f7a7ec6caaf2243d2234a267c420f",
-                                "uncompressed-sha256": "d9c513c4e09f9f00d3bcc7a74139e38e8067ebfffb806003c5456c46ca22c418"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "f87300423b75ee0b7e63b321f117d9f3cb3bd7972fa8d390374d210733c3cf3e",
+                                "uncompressed-sha256": "d608dbca93628c69d322df52f0ac997576dd9740502146473d7a269ce0dee7cd"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "2d357b4caf0c565ca3392fdbebc95ddbb0dd2a56ba074a0d8f96d61bbaaa3441",
-                                "uncompressed-sha256": "e39e3b49c164c14803ba165a862978e7ba0740cfc7af79b9aa2a875d9f62aa39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "ca9f39ea6136fd737ac4a28428af130d222b98b8a26c80c37b9f945d0ce79d81",
+                                "uncompressed-sha256": "7dbd3a1febf5fcc898976fa00e1f9f1b092e320c53ca7550ec620b8be375b93d"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "b303cde3c48e050412edd700f8f2c694987603130cc26ce87f6f046a2f1fc9b2",
-                                "uncompressed-sha256": "37cb40f63fd429b38e320cb39b1235f1467c9ffedbfa5d0780a397c1e859ce66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "40d349e963abec30dda79b7a18850d95af075936a1ee596ddf5750ef16ac3412",
+                                "uncompressed-sha256": "ff23cd22800d7afe655a698c95cf5db4df1bdc0f9622cdac83969ba6dd2ddee4"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "0f5a75b257a975c19f1c550bd060704e4d0e71565a47b1b32880dbfbc107f31a",
-                                "uncompressed-sha256": "6a6f3ab9cab74602e30ecec02898017ec90eddc075bdeea0f31be9eb5cbd7e4e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "6da7b231e26def095b125d9aa8d54df808ee22b8b5814ba5b7813dcf04f24a1c",
+                                "uncompressed-sha256": "b688e1d627f8d987e44671e9919ef669d19edfd95e7bd3850bca53946d897ecf"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "fa3f42fc598b2714381a280cc1242663ac0d8aaf650953e4224d06110eae59c4",
-                                "uncompressed-sha256": "5bdabc5f5de70df68a4a1ec55a9efe6108c26dc8878fae050a0503d789299626"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "e49aaf51b8e2bfb67834459a08f473d4f49c87ccaf6a3284535bff4b45a8b18c",
+                                "uncompressed-sha256": "28c3e8f3250313e231af2aac49e7df1fb82f532fa607f274c47b7a3d9bdf74ef"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "3913eda0639182b7bf4d0b92ed9a59709b16395756cd86e980de208bc34c0ddb",
-                                "uncompressed-sha256": "63e0610b1d395c56d58494f6b4188fc747fc1c84c8f569ad77673a0ec2759522"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "cb0dd7d6e4e9b37b46c7c19c355cb6d02748e20725ea727046f1d13a2d295de6",
+                                "uncompressed-sha256": "a7e77c2002dcb9aae3f0bcb3bc536d0e6ac50f081799eaa3bb3b5070980f4843"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "841c073cf6f50118aca7a9e212ea897693dda5e3889581895c762475a1ddb4f2",
-                                "uncompressed-sha256": "d36ef13db8581a8e3ac4ce4f01b71039ed4db1f1c22c0a7057eadf9595df097f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "9720237afe300d91f91776cc16aa82b91307ee503038a3d8945340d99dec1e92",
+                                "uncompressed-sha256": "a5de480f98fa03becce809f44b5c5fcbf642432a9a6396aeb3904c8f434a1009"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "257ee2df1193c964de1e7c2c4842ed5c017c5788558300d3878767f6074d1313",
-                                "uncompressed-sha256": "6a3a33a1e1c2e90a6921a685bf644006ee5d918c7aa7efd9763e19c400fcce36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "58956d83b79cb1e58f381dc7c74e11c0bfd36133f3a98706284f3204df344208",
+                                "uncompressed-sha256": "35879aa6937a875b9f8cfc6edb456c7cb694ae6c9662468d738b26dd611c9020"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "3ee019b5603b3d08fa349433ba87bdc1af7f86e0be0113fc7aea1008678885dc",
-                                "uncompressed-sha256": "81cc5790510c8600eb48a3883462f5d3f7fc13be6f2f0447be8d9e606606f2cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "7907e25f08d5c1e170e79eaa85eb13655e89beb52f94913f0d4ae7a952931eda",
+                                "uncompressed-sha256": "58cebc6904c7a3ccf0803a535cad640d5f84775c9069f6d53f604339b938642c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "280dca510e6cea3f00265b6fee32c6dd47e00dfe5ba2a61dcd8b8a08e608b07b",
-                                "uncompressed-sha256": "d463f4cec817424d2690a9fb87f118a4a42a1e43a2ca342f49b15492dbdb6763"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "2754fd52fab633af8013ea6c9a8cd8af7774d1493ad43e4661bd5e8f2bbf7dac",
+                                "uncompressed-sha256": "95fb089bc90108e1d866862f5d0345c837ea80f3ab5ab45722d515862ab69229"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-live.x86_64.iso.sig",
-                                "sha256": "013da69039c830baa2f0c33bd05ae4df343ba63e0e30488c9aeb9a32bed1fc69"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-live.x86_64.iso.sig",
+                                "sha256": "176403daf98758f9b322ee8b513cde5de2df84a9a05f369543608842ec023e38"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-live-kernel-x86_64.sig",
-                                "sha256": "61a156435dbcf37b02314416584cbdc1c91594bb98764ca9e2e8db51f7f40607"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-live-kernel-x86_64.sig",
+                                "sha256": "26442d4c1ad591008d38fd40648db3bf5f566e86aa8c408907680451c69190e7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "1698cef195cc52d75a2e0f34c421780a319f9a8ddd10c5b4cbdbf95423c7e690"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "edbdb604509550e99593ea34eeec1ee5e04dfa1e2158068af666ed55e73eb146"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "d66bbed7eefc163732f2e056bbb1425acd2c55724205e1206b8a5ffe4ff9cb6a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "f9b1a93f3bd28d429e037839ae29c6fe1f922870a3b4608aa83811dfa04e3cc6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "7bfbcd00d7b82721f9e0b256b012aec63a28755e2f00b24dd274b81899b7cf0f",
-                                "uncompressed-sha256": "f3e330ba61075c4a80e3f1f326ef6bb061ab1b9c96f444ed1d48e01e1aa1c787"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "c315887918304914400de225521cd8be75ebeeb04a988a8bbe0926f9b78ad3a1",
+                                "uncompressed-sha256": "4ebc4253ee56926e09b84ea14baec28f872de517306ea04ed6e3144a3936514e"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "29befbc46fa2a07c38d148292133e01c653b7e4e8cc8666e4a235ccf3d76078e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "4849a106b8073c42626074fcd37420b28b74b548b609688561c5192bc2491780"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "5458dd5021ff62842506abcda7926a075a74fe92464d1b52b0d52fb0fe45a34b",
-                                "uncompressed-sha256": "b093e27201f507b93b15931b7e9a8d2eb3c57913dac4509ed4768dabcf9207a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "08d87767fadbb2cbef4bb18fa1439b294f7725b03b0176d27f4dc94b5f78792b",
+                                "uncompressed-sha256": "4712d525e24ab73d6c24cbe15d5d2635d7128d1c61b0242536beb4c1ab7f98d1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "6c272bd95a760696a0132e26e59fa610e644ab8afb9de1fb2c28033840aff198",
-                                "uncompressed-sha256": "649312fcb6ec6844654cdb531f6905b91ae5f838c0200f1e06d9f28083c931cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "f13fe827d4ff248c623e3468bb9d538c342872b86dfa6c36018aa64e3b5116f8",
+                                "uncompressed-sha256": "ce8cf0922733d7bbf6fde66c68483851bec37c5555bb2d04dbce4c96db1fa583"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "2ad518e9d03671aeadad4e223d1d84114786aefc01c8a0151a4853fef5f88ee0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "c39f32b1a33e2d4589ebcda1ddc752ca4ab7c9032824e73154868ea6016b2e00"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "879a81c3ad7a7510112cdda5d96d0f70c958749f8d49c2cba42009639fce1002"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "b632bfb7aeb41484f09db12db7ff8217ea579a1eef7678729cdc1b0ba683f09b"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230122.2.0/x86_64/fedora-coreos-37.20230122.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "0465941804c939b123af87833675cf66ae4daff1a626d4bcdea5d41747252883",
-                                "uncompressed-sha256": "0f4cf226955b373d892cb0ac4f9c047ca465a612a9428a9b4f24f54d86e54eb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "5fb9ca0bb04441a886a819e608e121ba89b01fe3bff8e6e15b33cdda8febb977",
+                                "uncompressed-sha256": "eea9e1f1bc5af6040c3d6a66460ad1ea4fc1fa77c09ea7abd8c96d657efeadc2"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-087f5f05f49af9904"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-0ad14e18d1fc57e09"
                         },
                         "ap-east-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0b31b2c3d905b15e2"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-04bce71d2a613aec3"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-006e09d942126a891"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-0a7078ccf995cc41b"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0117b8d132388f713"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-09cb70454ea10b060"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-047aac0ee3af22efc"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-0ffc312eaf33d5811"
                         },
                         "ap-south-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0b4addf91f5dca8c7"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-0a4e2a402dd2cceb6"
                         },
                         "ap-south-2": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0b9bab922b50a6e6c"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-07963af81aa337fa6"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-04d8a4336b7328596"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-0085accac8ed8c59f"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-01c9ab9217c76540e"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-0d0f2fa43085eb418"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-039f4ca89705eb6ae"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-00b50dc0e088ec0fb"
                         },
                         "ca-central-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0f3ca0ad8020da163"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-050c078e93a49aac6"
                         },
                         "eu-central-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-066b99f6475e2986f"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-050269c8177777a63"
                         },
                         "eu-central-2": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0e6821de3d82e6e39"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-0edd74eba0459a7af"
                         },
                         "eu-north-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-06d6b4cb1c60de558"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-059a01086f81e66af"
                         },
                         "eu-south-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0f0592310bd809137"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-0a03d22166921d9e4"
                         },
                         "eu-south-2": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0d0861169fa7305ef"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-0c3999e71ddabd4d4"
                         },
                         "eu-west-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-032dfdac1d50c2dc8"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-0b52f306db40ca00d"
                         },
                         "eu-west-2": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0b51ffeca929b6792"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-0079b117d298ef679"
                         },
                         "eu-west-3": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-00faf728036ab8e22"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-036dab1d3154bfa66"
                         },
                         "me-central-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-09aa5fd1297b42cfe"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-0989dae1b015db12a"
                         },
                         "me-south-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0241fa16613f6b260"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-099ac32f503cd783a"
                         },
                         "sa-east-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0b54a4d6764529442"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-02c52928e562d4c84"
                         },
                         "us-east-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-016069fc4cb84c296"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-08ab2c39e5cdda385"
                         },
                         "us-east-2": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0afd3f358d777da56"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-0bd85e77613fad313"
                         },
                         "us-west-1": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-07aa40f486151aefd"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-09fb130c6942aa71a"
                         },
                         "us-west-2": {
-                            "release": "37.20230122.2.0",
-                            "image": "ami-0a4fa778fd4c9cf50"
+                            "release": "37.20230205.2.0",
+                            "image": "ami-07439a55f6aaead16"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230122.2.0",
+                    "release": "37.20230205.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-37-20230122-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230205-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-01-25T14:05:29Z"
+    "last-modified": "2023-02-07T21:03:10Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "37.20230110.1.0",
+      "version": "37.20230122.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "37.20230122.1.1",
+      "version": "37.20230205.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1674658800,
+          "start_epoch": 1675864800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-01-25T14:05:26Z"
+    "last-modified": "2023-02-07T21:03:09Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "37.20221225.3.0",
+      "version": "37.20230110.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "37.20230110.3.1",
+      "version": "37.20230122.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1674658800,
+          "start_epoch": 1675864800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-01-25T14:05:27Z"
+    "last-modified": "2023-02-07T21:03:09Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "37.20230110.2.0",
+      "version": "37.20230122.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "37.20230122.2.0",
+      "version": "37.20230205.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1674658800,
+          "start_epoch": 1675864800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).