### PR TITLE
Roll out stable 37.20230205.3.0, testing 37.20230218.2.0, next 37.20230218.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-02-07T21:03:10Z",
-        "generator": "fedora-coreos-stream-generator v0.2.10"
+        "last-modified": "2023-02-21T16:04:55Z",
+        "generator": "fedora-coreos-stream-generator v0.2.11"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "d7064622b2abea457241a064203f016c4fafcf1397867d6e4f78460169925e96",
-                                "uncompressed-sha256": "94eb8dc61e1a338044937300d1a965e1b345dc7e0400c8279eab362f5a423979"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "9ad201136109cedec67cfe089b4166282567d7b24c2bd798f580b7e3c9196511",
+                                "uncompressed-sha256": "9557e84644ed3ebe3b1c48397face1a0559a4a43932f5aafdc0b90d30d97ed5c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "cc42f67b6b2a129c22813a4bf762ab94c3e6e9b35403afa3f9ecf87dbae4d73d",
-                                "uncompressed-sha256": "3b5b1a2f910b4c3281a61b34daafcda08c483c3f74133e1df53b4dd5ddde07e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "0eeb64f070fd8a04d3f92263708c6a0eec7b5c4899d22f9f172ff45ec0a0ddf0",
+                                "uncompressed-sha256": "554476323eeb388a99a246ab7e84f1b3a95f21829e1de1479e49ddda2a27865e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "5a20fcf0c0a0e6decdfbe5228bc7c694ffa3d2f7fd53b56e31c84a255287f023",
-                                "uncompressed-sha256": "913c8e14b71789db008fc20861f9548929c3fc8ff8174ed47c45d52e779bf708"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "ab064f470cc2ebc7f11eb9cae4319c9a0f0051870868801b7ba285c92a2096bf",
+                                "uncompressed-sha256": "6ee19acef4341693dceb08d580b01c057b5d471bee08cd28e8c3a796fe2996d7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-live.aarch64.iso.sig",
-                                "sha256": "95e0aea37f8ea96e14749c3db2ac388ff90e50d7107cd7ae3d7dd5e6781b5588"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-live.aarch64.iso.sig",
+                                "sha256": "52a2debc696fc904fb2f7a5b37a248c796b9705cd8ac1aa72ac8ad413902efbe"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-live-kernel-aarch64.sig",
-                                "sha256": "0730a6ce19f36e22a33197a6df829cbe0feda95e1dcbd328391d0cf004259b03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-live-kernel-aarch64.sig",
+                                "sha256": "9428fce81f0197f03efb05f98e2daaf6d198483ffc23d019bb21655c5c88074b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "7c87dacf3e35db36e5be10ac7564d71a2a37eff4f95ef1e31f2518169e6514dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "eae31f6213420155e69598a5fafc4d67a31b33c9b935e2624192ae1e1b81b05c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "c4bfcba841f7ad5fcf79d81717c6e6bcdc28dac009e811dd09c69da502f2baf0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "5c4508e5d3b8b9bc55ff0dd11d7dbf02068deb54b4ffafd83dcd36506c624c59"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "408e78969c179e74808a9be9369fd7b0dcd3115ba2fc271b6f82d95ea4ed81de",
-                                "uncompressed-sha256": "9eb2c06a633cd4c123156f55da8ac3b6c9feeb6182152e0b4549b797534cc25a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "33a35b038f5d1f1c49daf1ba827c5eb0e433e0975315187f44a1dab0ac2680c4",
+                                "uncompressed-sha256": "d1b40de07a7643c6fa983a5f7598c917788c700a22c425e1caaf00a9fd5c0715"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "dd77c62002154b56b0c8b613e33632e79fff35723f18016bf56b9f07c4ec07a8",
-                                "uncompressed-sha256": "65e2be5dfa2bf2ef5a270e4d91c3b96653508112c3de8d312b572a303ff9223b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "718d4b4ba89d42abd53587f9e88010e47097166fb8a2a43a20afaea4e1738cb3",
+                                "uncompressed-sha256": "5e8105753ec1fa55138b935850e8b5c99f67bfcade673234aa3054db4238d35f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/aarch64/fedora-coreos-37.20230205.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "8508461a0aef1e12c4b10a7cbc54d71465981fc448583f8eb4e928ad4145a56f",
-                                "uncompressed-sha256": "6736cba38500c2679c7de1e6bab5764b7da4a9755e2fd43b59b887e12f689dd7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "bec37cf1ea8f11574a15b8c5506e4ab45076fad4d205936f24d963d7f0c98a5d",
+                                "uncompressed-sha256": "52c1f8434a3a0e9088526aadf6634538039a08201789fedd096ebe78deaf9028"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-08b566e0b28a18a7b"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-05e1c3bcd8a38122c"
                         },
                         "ap-east-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-02332dbd28e4e7a40"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0149c5883ebda0c71"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-084cde0f9afe75206"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0048d71bf8fc11087"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0c9a24163e609cde5"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0f605928b3c93d7f8"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0447b4d2f088a71e3"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0d1208f34d331c856"
                         },
                         "ap-south-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-021c944e7731d5e83"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0ca3aea830d4b05ca"
                         },
                         "ap-south-2": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0cb128800aa35673b"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-010e096ee1422c653"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-05d28d02b34914496"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-03a22c168369b0be9"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-06bf8508c4ef90b08"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0d4feef3a7a1201db"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-06e20e69de4476a12"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0d727bab8f6b4538b"
                         },
                         "ca-central-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0eef9894a634bf5c3"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-027e0834a9890a799"
                         },
                         "eu-central-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-02f97dd2d0c5ef48c"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0a6493d7d1a63a493"
                         },
                         "eu-central-2": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0454b47724f3b73ff"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-09a1a16d70d11b132"
                         },
                         "eu-north-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-07b67753148474277"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0561c1eaf691b5a4c"
                         },
                         "eu-south-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0b4a7ca3c633716bc"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0eb8dc92e8a38b44e"
                         },
                         "eu-south-2": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-09c073e5111f990e7"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0f8e02e6d026d0e51"
                         },
                         "eu-west-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0f83fd68fedc87144"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0f22fba56ed88fbce"
                         },
                         "eu-west-2": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0dd75507f915a4a76"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0785193073848716d"
                         },
                         "eu-west-3": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0b060e421dedb8be8"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-06a0fc8ca5a19f5ce"
                         },
                         "me-central-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0331d7dca8ef4167f"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-00810b125b57551fa"
                         },
                         "me-south-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0b26516289071effb"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-074a471147ef628a5"
                         },
                         "sa-east-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-072702db23c845f96"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-097a6339b0b616e57"
                         },
                         "us-east-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0c9bc174991b9c03b"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0fe934b16b17aacdb"
                         },
                         "us-east-2": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-020fc642a555b90ba"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0baa82c004539615e"
                         },
                         "us-west-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0a43bef04ea9cd4e1"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0d2b8cc8676556e90"
                         },
                         "us-west-2": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0355ac84ae4a9de90"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0a6da216883ab2a1f"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "680d23493930d9c64f1f16e82c22d6735c904a3c0da72451c2b607dfa94cd7e9",
-                                "uncompressed-sha256": "8a7ac5f3ff11eaf32f291d0149813d079cb9ad1c9789c5a22183ac83608198d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "3b110b17eb3c4a5f5dfd4486f5ea74334b180045a551b730bbb24b4d32deda82",
+                                "uncompressed-sha256": "8ddf124440c893bc6e933cd90f3f7e95b03b0d92cb60cde8a12c3399e8f87e6c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "4d45818be520a22b59ae884a9ed48cd5d9c5ae305e29d91c0f45807bbb6e85c3",
-                                "uncompressed-sha256": "beef73d16c2214b0e8777addc2f83bee301857c826512f5c4ac8a85df4db21f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "9e5b1e730242f704179286facf87fbb10b66b94cff347478266d979352eb7f4a",
+                                "uncompressed-sha256": "f6b13bff11c8738d582f1760b0a8c55424e7b63ba7d55c7d248bec3ea67e754e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-live.s390x.iso.sig",
-                                "sha256": "23ad185f671d758bce7c811c241d68905632457d825c703e9a91f6233e3c83ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-live.s390x.iso.sig",
+                                "sha256": "45381ec2d957142fe6e4d9344b0ec54d3182004f6bdb1e895cf5bdcdcc0f9fe7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-live-kernel-s390x.sig",
-                                "sha256": "8a9c8e3a4101f67d57f0d5b2cc136d10b976d27f129aa7b9947215749e4185bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-live-kernel-s390x.sig",
+                                "sha256": "040b3279e9bde970438f8ae099d2b6aeaa2f2a3ae841142bb5b327a75c30d16d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "37bb53de0e9493a768702e6154808e84f95d73e07607374365d7701317b8719b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "fc37177fc776038224573c74dfe865cf05e62acea517a60c48da1525ea13f4ea"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "6f9644c31f33766c6f1e8ad9310e643def6aec28c0a686c78b6ecf9e8a888501"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "cf6b16671d949d57edd4bcfc991709bbe86f6d4f4582b387149785847168e5a1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "119784a5ee2f4dc9553ceb427098da28cea75b9e32e0341013c6223738bce352",
-                                "uncompressed-sha256": "a8b10c57a83426ae901fad77837661854174e957f5229b8b8d374cf4dd0e831f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "f9983b14a3f5be276fd2143cb3e11e1fb6368218a3ccebe46869315b8a187872",
+                                "uncompressed-sha256": "70d5a1005031f61da59807d5c9bcb883f4998cf903dea8fd489176a3c39262db"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "145e9e274b1e9b674854754c18b06220443ac92dc64714ceca649e54213656ef",
-                                "uncompressed-sha256": "55b1566ac3558c30c4babcdfd6399bca38ef391e3dbd80db6908671c21014753"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "0d576e159cecfee8e64044536b240c101ac553c8b4c57384cb60bb7cf2d95e2b",
+                                "uncompressed-sha256": "79769fb8db8c058b5549494bf4671a23881666768c819b82babbe792b22c3782"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/s390x/fedora-coreos-37.20230205.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "a2bec17934ffc225533bc401c158d5d4e3273698b038919e7397bf5f0a4d9a2d",
-                                "uncompressed-sha256": "7e04b7e3efef56963a82f017ee709c372d4332763b822ce981fb1604f2802a2a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "bca7b678c6e107518e88c7ad99e0197d37327b34269a2a8b99bb6b7e95df4380",
+                                "uncompressed-sha256": "622cb32f546bea51d96ff7fea69e916bf963ec8102f9be3e40471f7cee508e49"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "72423e710bd57a2160fd438a2aa6b7c24c05646c3a6473208e78917178438afb",
-                                "uncompressed-sha256": "f8555a215b5b65e51932292931aa395b2e199562b6be0952ece9bb4e539d04b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "96f5c59869de83f13b1994585c3fc4b298c2568e4e6f39de081ed487a60ab3c7",
+                                "uncompressed-sha256": "19ce29fdf1c607e7fce1e7419d04bb9f265fc53f6dcf777808ad9ad211537129"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "68a8a41dc306d04477efaf4c438e1f6f18f2fa59d886c28e70c2638418e52f7b",
-                                "uncompressed-sha256": "71a62bbceee696b698fdf5486cc4629a0475fa1476a601922b716d3c0ebb15a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "4a3f622c2808d5edcb786164f43bf0864b929080669d3ef886da1d3c0c477d29",
+                                "uncompressed-sha256": "3e5bfb1c7efd29e6299ff6113e4bd0675e11a49d87c8772384b68ddb8444db75"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "01bfbd181ce223abc66a76f552cf6d3833a59b45de5a35bf5954dd49170abb11",
-                                "uncompressed-sha256": "fef7ba472a909c40996793d74352deddd4684873b191deb680352e351b3e0cec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "1857e02fc2fc13bd792e9ca0abbb0bf2acf4faef6db7124f7942942e13ee0aee",
+                                "uncompressed-sha256": "b3dea115d25b187f2787fa63463e8c346f88dda8ce85f121bb4c8a0b83f33dcc"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "3869a7051ea74d6d4c36903a67da76140429bcff393586883128e969b7aea2dd",
-                                "uncompressed-sha256": "095778fef7ff57d6f4ab5fb3c7ea1687b40585a8c37f1feab96121fb1da47153"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "4752244cb941928121fd2bc3fb848258dd3c2350707a528909b23ccc6786e660",
+                                "uncompressed-sha256": "d52f271e9499964feabee6ebb62bcc726c489117afd4037d10f14c00821ee9bc"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "7a9c7d5b4b0da9b91afc44574c1d3a8fe18a3d2cf417201cbe1561e216a576ce",
-                                "uncompressed-sha256": "bc2b68e150ef947a9291b97060a99f386ca9414dac6bf99d6ea2eff26308fbcf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "e8ea2cddf79a4d3e89af73fb00d85e0452eef5328519019ec5d67046977fc035",
+                                "uncompressed-sha256": "60ac1350fcbbd26effa7e41cdfb680c6471ed39b3089f474d7b7cc4ed5135cf6"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a445bc1568660c0ef6b74e7c2234f42c485c7bedb7171297a95cfaa514345417",
-                                "uncompressed-sha256": "9bcc882dbb9a0139beb76f99a4f83c0533fbfcc2ac06bdd29ae4b15ccbfd2b04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "9c688a6364a3d8b55775fddf53caec30813acdad851730a84fe4f23a6ce74120",
+                                "uncompressed-sha256": "22c39d019d3003495122dd7ce1ef8b745319f34fff10508507b9a2a682e33344"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "2ec98a8e0d3a154a4d77faa8ded61c41dbc5dc7df4f06def7814647b55cc600f",
-                                "uncompressed-sha256": "3bb7f1fb05ccb6b45923435e64e7467ddefeec15982e5370934fc16a0210afed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "ce3740ff096b5062c8b0eb1bf64d2fc87cbf88f144434731433dae57ed5cecdc",
+                                "uncompressed-sha256": "8b15995b4e28b5835dbe2d12c5f684a7c76fce7beff3867ce4da649f570b07f1"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "b97b726ae15a42bd811dd82f8eecd93077d10e6c7da8988d2dc2606e3d668f8c",
-                                "uncompressed-sha256": "776c5dc00b4473c719acb7d416415b93c7a729cc9e88ad7b4a5d963ffba0cb83"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "2e758eddc1132e7fae2f831dfe0612953d1e0388f589531d0647a453e4f6ac7f",
+                                "uncompressed-sha256": "0535dc3159e6ca46926ff29a20b3162104c4c382edbecafb5233b26c2c66b89c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "0ee35a828b791eaeb1391eab87467def46bd4762fe2eed63954e1f0a33f9c251",
-                                "uncompressed-sha256": "6c8d9008772e08c25cf0e4d3ba4311dfe033f1b9f79862b7bcd92ef4982008b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "bda088ef003267ec1003cfff9860a7aa6b713037a4826a2f6b0ee19884032d23",
+                                "uncompressed-sha256": "3b3d0c35965178f11af5661dcae4b30466893a9f9b4835b0431abee255a2fdb0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-live.x86_64.iso.sig",
-                                "sha256": "5de204ee32f0ae7eb768a1eaa355b69fbf751824827571df7207aaf63146c220"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-live.x86_64.iso.sig",
+                                "sha256": "837cfd69ef6bbff3f8d8fa7b9611fc069266a1026d60be9cc165661f1b363681"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-live-kernel-x86_64.sig",
-                                "sha256": "26442d4c1ad591008d38fd40648db3bf5f566e86aa8c408907680451c69190e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-live-kernel-x86_64.sig",
+                                "sha256": "ed8e05b50402c8d57c6f6d250009f56cefc4c993e16aa22e5d70eb67c4597a40"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "c07f1da4a1d6716f4e47de9553a80538ee7f9e22fd5c67d1ff69e6395f0daac5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "d5dc7e7bae15fc2230aa6dc8683b745f938ac6fd25bb009f4a249eea6c449752"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "2de918e8cf53d0975821639261799fca96185b6741c148399b548880a6b0a429"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "08a78d0dec0d02db687baa06c9283616cf8362bf3fd54c9b9a55642266c9318b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "b3cb62fefc794b3938e92323a87f9dee2b8a918053f86347b485f3d13c3a676d",
-                                "uncompressed-sha256": "724d3993b795e1e7cc40ee40f254173648734b7b1d0d6569ee98480974afb92c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "7e48ddeddfd283264360baed3a84c33b800dee6fd218ba72d5ef7f0ac2928450",
+                                "uncompressed-sha256": "95836856c4133999f39fda149fd97c410d9a8ab582a2573a35cf9e71696314b1"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "b271b6847aec614ce81be3631d1b9f3e0844eb315263812596880fa145fbaf7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "ce096ba1ed6d12cb1f43e687558acc914af1a6123b89a3f37bb52e6765dac58c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "2d92d73987ea0028000069f4ba0122dc823af77a0fbd5f2f02e7b5943b4de224",
-                                "uncompressed-sha256": "85202d53e95ea3aebcdcf3d675548c063700d0bbc5c08f54fbccddfad959810e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "b66951a633de73681b68d11030b634997d86c0f5e3fde37a4f92a7dd80adb50a",
+                                "uncompressed-sha256": "c59cfa8834a6ffa5748a08506951492c72c7c0d83b3f0c9d8dd89abb26322e50"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "423c4dc81ebde903300f105b7f760d06b96fd0514bc0886d3f471b02efc49087",
-                                "uncompressed-sha256": "6b1ea2d712d061453a48675fdf0adefe212a76009a77ec1626f401346a17bc89"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "3f6db487082d6748bfd8d1a67322ef89006996f6b7ad60f698d7ea8ad6255f32",
+                                "uncompressed-sha256": "cba058be134d0b1abcd917b2ba1fa0f774dc66a72d3b8244e61777b9bf1f1e21"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "2cf1875da457acf617249815645e24a03fb36a6cfacfe57bf567092df27387f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "7eda44a19df617e5c973437afe6a465d22826d0af6349843c1cfc6d875b69ea8"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "dd9ef30b48b6c5f784109584f0ab662233f81d90f3e272ed4497b9f3427cf8c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "52267906db172d9d8baad835ebedeaede85a921dc5c7272e156ba4bc5ae72930"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230205.1.0/x86_64/fedora-coreos-37.20230205.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "5669ab8da79e54ee00766fb21d9de2c6bf434c3cad52042adf5a719a82bef9af",
-                                "uncompressed-sha256": "c67e3950b2f93a9ad0af1751baa51e24ad455614f91f61f93f37b8a89c4ffbcd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "c9bf328d0ad416f3b49cd8b8671c536a8bed4db328e5b2c69733ec85c164bc2e",
+                                "uncompressed-sha256": "9dd2e12efc8f9d050ed410b2a103d42caaa6ab0d7a82c8d57e0a7a12596a80d9"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0b12e4b9067805794"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0b5a01790192f5605"
                         },
                         "ap-east-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-093f2e642d36a63ea"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0a520aafebefba284"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-00f2df43acb8959d6"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0c551de085db0cd5b"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0326ce9275cdcfe32"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-03b476f2dc4c06edf"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-050f81e41888c5605"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0e96874528106aa1a"
                         },
                         "ap-south-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-01c2578680ca063b5"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0d28aad5398370514"
                         },
                         "ap-south-2": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0bbebe07908184589"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0d103a737e8602b5a"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-05bdc788a3113bf34"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-04aee5acc54f7f792"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-067b670cd5ce1056a"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-06bacb783922def6b"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0cd00a49fc6f97c16"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0e4061ac63912a444"
                         },
                         "ca-central-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-090d365bec06dadbf"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-07c474ab812ef1d53"
                         },
                         "eu-central-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-04f90aa4936d86b74"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0704b2b47cef2bea7"
                         },
                         "eu-central-2": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-03490b1888e661e0e"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-017b917f80437564d"
                         },
                         "eu-north-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0ca51353c7edc4615"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-069c1c63b09d8014d"
                         },
                         "eu-south-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-090b1cc721ae8c3d8"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-001f99ca2cca0ece6"
                         },
                         "eu-south-2": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-088bbe63641fafa8e"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-04f34dd74789955d0"
                         },
                         "eu-west-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0430cd76cc62f04e3"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-00eba51b29eda773b"
                         },
                         "eu-west-2": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-07d275869dce6f482"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-02b168e448e2555c8"
                         },
                         "eu-west-3": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-04d8b83286495d836"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0e0d7fc06906e5b34"
                         },
                         "me-central-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0dbda463123ee837d"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0a41280bdb90f4182"
                         },
                         "me-south-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-0de788dc809ad4907"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-00b1bee62cee41003"
                         },
                         "sa-east-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-00a067ec7ef70960e"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0dacf7773c4896f5a"
                         },
                         "us-east-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-064193a3e780b217f"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-044407ad5ec1a2134"
                         },
                         "us-east-2": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-07572271f14d4d8c4"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-04773eb5ed357e4d2"
                         },
                         "us-west-1": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-01dc2eec6477eb48e"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0ccdba3405af5ca71"
                         },
                         "us-west-2": {
-                            "release": "37.20230205.1.0",
-                            "image": "ami-04cda126f45ec27b8"
+                            "release": "37.20230218.1.0",
+                            "image": "ami-0a093f413b771d219"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230205.1.0",
+                    "release": "37.20230218.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-37-20230205-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230218-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,105 +1,105 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-02-07T21:03:08Z",
-        "generator": "fedora-coreos-stream-generator v0.2.10"
+        "last-modified": "2023-02-21T16:04:51Z",
+        "generator": "fedora-coreos-stream-generator v0.2.11"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "dc266c8509111e35e87937f4dbf2b12c49d8f512e9ca5338f7064d646fa0f994",
-                                "uncompressed-sha256": "97efc70e1649fedaae3f0aab62efb74dba4a60a7e373835a15de5d50ba570654"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "b9f5da798436aae303091014e36382dcf6eefacc7463476066c1a91ca53fef51",
+                                "uncompressed-sha256": "421f388aef0ec3c4fca96a812ee3bec52ae817b264a88cf0270bcda2d934b71b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "e6676dfb89d494941f600b8d5abbdbf7d41c5af749e01bef92c7dd39aa8e76d9",
-                                "uncompressed-sha256": "273c553de158fef9f5dd2af9c82ad7a0815ef3776c3101de7aba4fb099c5ace0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "c4730aebd066dcbae90d72a313d01dfd37c45c6c8e1ae0b93e900c80f5647ef5",
+                                "uncompressed-sha256": "0aea35a9dd93c4ce6fd9317b458713398d876cd67dc4033164e1795cff1003fb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "d0e642a832774e9b61d57b59dc9163b7df3f038d20d02d3a8a761445a9988542",
-                                "uncompressed-sha256": "cae2ef591aaf95948daf1a7cde073776f36886513b73e81abb172688a681d719"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "522c6e0ce5c4252459b1fc360b600db9d28d932a048cc7928ca7ba654f68aa31",
+                                "uncompressed-sha256": "617f3385316ba935fa668a432f8d1e67ad90f5694be0b81aeced193bef2caa60"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-live.aarch64.iso.sig",
-                                "sha256": "906b389609fafffc2bd50fdd8bdc218a12ff0a095ff656ec87b4f01fec01e016"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-live.aarch64.iso.sig",
+                                "sha256": "3a128e55fc1ae277292cc44286ef3b1eb0014acc842b0ac70f682bd93110d755"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-live-kernel-aarch64.sig",
-                                "sha256": "418b756ca5d9439386086efffbc299607a53d618739e0e1df76ef4d0f959d045"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-live-kernel-aarch64.sig",
+                                "sha256": "0730a6ce19f36e22a33197a6df829cbe0feda95e1dcbd328391d0cf004259b03"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "7c4308fe399ac3caeb0188a91c19e5fdbeb04d411d6b79c1ee3ae170b22a5750"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "1674c9a33588b8442e251f0c38f2a60137cc6cc7acb9d56bf609521734291470"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "f17225259d4d82e41c24e7dd8c17a02799c6760eb055c6841ad6fff8f35341be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "dade6427e6954b8bdc91ce707ca5165777cbae27953d6480b82bcf6e581229ed"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "27e14da56596180e0c50b345c463f4b0a6247fb1e837473913e796e5c9f04d96",
-                                "uncompressed-sha256": "202f7e3cb3cf179844dbd8d6bc30307d5eac45aaf7eaf78d1a8ba9967752df40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "3d1233329888476e74f9fc746f17c8b4e5d8a217967d201e210459f1e07302d3",
+                                "uncompressed-sha256": "a4ae03006ccd631cecfcc4c04c88bd607876b57165387de75124e5e0fbe39278"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "76fc228396636a307652b930830832b97d99e3fcd2897a2aa444dec06c2cc07e",
-                                "uncompressed-sha256": "61268d21ea510287d54a2673d8de24f5f56e0460b9f45ce24c596122df0de24e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "3fb816477f7e0d175968fd11858ca0ceaca6cce872ce52eabb248a2a6e00c393",
+                                "uncompressed-sha256": "aac5a4c0fc2be711563320cc1a368586c5cc8ab4702db984b22fe721c5000734"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/aarch64/fedora-coreos-37.20230122.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "c697d694b135502b6819a437ff622184e911a4ea06a10077b06cc8137886f01d",
-                                "uncompressed-sha256": "c9f11d7958a700286100f3e8bdb0cdb6a441eb5915ad242dbef7a26fdfed355d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "90e9f5d093019c3edccdae0c2c528865d9608dcc76494b891a0759f858789201",
+                                "uncompressed-sha256": "a4e6e98a3ffbbea6f7bae03154a258b2440e9108457ffcacc5353fffd341b98f"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0310eb419a3944255"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-05ebb0a6b46adfa90"
                         },
                         "ap-east-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-04da545b18f959a2c"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0aab29a3eebdd9411"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-03f45ebb1d6831b3e"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0f8993236d0d733f7"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-09b1372c545567036"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0224ed01167ac83db"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-05a1cc9341e9ba5a8"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0a5a3c87031ecdd2e"
                         },
                         "ap-south-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-051cfaadf3c9d1f8e"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-01b479a2357cb2a3d"
                         },
                         "ap-south-2": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0c5000dc77536ba52"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0ea0e1a37e32b6969"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0c1ebf24e0389882c"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-03e08720978407495"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0c1a26592e831944b"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-021203339ade26f85"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0873222ba3af232da"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0de7d503bdb5de7cd"
                         },
                         "ca-central-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0f7f64a2e312f9964"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-033bcc13fff7ce3eb"
                         },
                         "eu-central-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-05ef713b6eb9bd4c9"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-065b7a13a68cc7546"
                         },
                         "eu-central-2": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0106e57d1b4bf51ca"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0cdb86225c867763b"
                         },
                         "eu-north-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-044f85aaa1fe008aa"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0e5632749d360cad2"
                         },
                         "eu-south-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-029f3bd5e4f87e3d0"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-02fe8bffb0065ed72"
                         },
                         "eu-south-2": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-04eda3daa0f05a6fe"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-018a1439d90f75d03"
                         },
                         "eu-west-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-09815a27ae6b6f069"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0335464875e816816"
                         },
                         "eu-west-2": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-01317d5620b6b2bed"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-066e8ab8109e6aa68"
                         },
                         "eu-west-3": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0f34cd831d8f657a6"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-052a0b586493e4049"
                         },
                         "me-central-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-05fe133d249126213"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-02e21d2436ba62318"
                         },
                         "me-south-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-06f47fe6ed2568089"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-034b5f98e97edf544"
                         },
                         "sa-east-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-08194a51d2b3c26f4"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-07ea08bba61ad719a"
                         },
                         "us-east-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0fd4462bf11868d31"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-088f55ee028de421a"
                         },
                         "us-east-2": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-085680c5618a3c6f8"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-03d8bf6cc88937ea2"
                         },
                         "us-west-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0d350659c5c7622fc"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0279bbf15c662ba3c"
                         },
                         "us-west-2": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0ae6ea17b3e995314"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-07147778b24f55018"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "cdf5c298f1c30b9f8f00bef2cba60d4fb70d7cb097c45dc31b972f47f76fdf5b",
-                                "uncompressed-sha256": "ce3ea2a1fbd51607dab0356c84b6a8fb0f92c32e2bcdc556d50a2c0876597ec3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "02985f12ee8f3d5306291183cd00fd75a1de51b8130156c734a4b8e6ef9cd8bd",
+                                "uncompressed-sha256": "8f298accde4c1e7a1fb8b59bf1dc37b68346f3cd6112110306166c7362dfb2ce"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "fbe41f9b476b70274f6b8eb90d057cfee2c9de5123330c3641fe1c134bc50dd4",
-                                "uncompressed-sha256": "f04e7efc1a7a301fe264d4870cbd64995a8f565d2aaad080ffd1f59458bd9a74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "25d7df9e7b88eab8d4f1935e01f4a9933234c8c8fe3d3e5ceec7acdac3d65625",
+                                "uncompressed-sha256": "82ac5888b3feda4f9a494eb21eb8f30a6a9ae2f31649f89239e6999c8c324de7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-live.s390x.iso.sig",
-                                "sha256": "2cde51fa835536cb7ba042e0715c1980cfef7a171e6a74165a810fa402737cfc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-live.s390x.iso.sig",
+                                "sha256": "725f3282be837b84baf26f4b048762022fb14cebc3d194a8f6f8b9e4f5009c8b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-live-kernel-s390x.sig",
-                                "sha256": "948ef8cd83f563fe92a9e73ff5c389b3898a980540c222d8a62d57366ecc0585"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-live-kernel-s390x.sig",
+                                "sha256": "8a9c8e3a4101f67d57f0d5b2cc136d10b976d27f129aa7b9947215749e4185bf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "260307778ae5a499f241e2b119cc600c5ebd8deb2e66b334810944b0f8526033"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "190ef6cf50cd25e703d02f49fad226da5f839b440cd58551eb0603c6b1fc4fc2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "3ff081adbfecf2036e55ae9751afdc79d50227fe9bfd1d8010a9e822431f409a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "e7156a77bb35d4c5cf620eb9c24248d2ef04f9cdd4d53666f9b1da4749cc5269"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "6360b9966dd16d6c397286d09255cab67881f5b7aed0a56b4e7377f2ee6a824b",
-                                "uncompressed-sha256": "2624634b11cad679265638c5dddc99f35fe03f59c7b8e8aa06794a668ccfef32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "7add676212b63e24ea926404d3f57ff362b909035b1877b233b2158b55fa9efe",
+                                "uncompressed-sha256": "8934929dc4a0aade8236c9895a3c97bfc0eb36dd19555c5b362409842106b092"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "d5963b18b442a65e7c0e933c7a3ede36ed7307fc291dfebcf2d9ce2031ce392c",
-                                "uncompressed-sha256": "8a521cc14584c799dccaf3d544ab0c3a2328163d4bd2c6ef72b268e12e0a7a46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "1f0dcb47b1bfebaf15381e8df512e3bf3c86b63875f973d46341d90317621e58",
+                                "uncompressed-sha256": "7f1d77b0ecf67cb9c09482b09a96adfcf50a19d44e88a96b1f717f1fe2b4a03f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/s390x/fedora-coreos-37.20230122.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "f7e649cadfd988dbba79d196440ad2635f98ef35c797d9751a6ea6e4046645f9",
-                                "uncompressed-sha256": "528fb9c2ff000430aeba77cd3ba2306330058314a12ad438a43115e067060f99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "55e003e3a8456be620bf35567de388c9b0b7dcd47149bc1f8a93f1a8e09b780b",
+                                "uncompressed-sha256": "278bccc975d6f6d864eca6738f36c61613045f548c5b2ededa04673f58f3580e"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "5a248b83619b8bbf4a91156faca4138f6e96089693b6d0dd580f80d28db296c1",
-                                "uncompressed-sha256": "6b31b08714c22b0cb406167e8884109c27800b97046d1cc3a9ea9c657377a9cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "39db101fc982c0363931a25bc8726e9b7030ce0f2537c47e9ca222c16a67d547",
+                                "uncompressed-sha256": "c15b00bcbf9036faf4bb24b904be2def9de9eba6dcfa786d5f4044ddbb489a20"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "f066db9f133e7c57a4eadf7f0bbaef0c845ff3a0587c0f279bbf20bf540314f1",
-                                "uncompressed-sha256": "b91374decd200b603d009c27d199c51794ed68a2dc2ab98211cb08778b299f1b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "bb34e1ed123ea8f3274b9835af05a7bfc844eb3f7bc0516a605fefcb564c1884",
+                                "uncompressed-sha256": "342c7a6226f9eb398986cbdf5536f4a8ae700799194995a728e272810d7d6b09"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "0b82cf6beccf9f8cc75c1d04e732a713f770d08a65b6b2120b646cbac99189ea",
-                                "uncompressed-sha256": "89414c266277c6c764797ca08d8f6279fa5dfd26aa440ce90fe74acbf21384c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "1779640662f33f9ed900ee4a371d4b105e0a9a6e4eda1e3a6cf80b831537c916",
+                                "uncompressed-sha256": "d15a316f0c1a91e95e4b488dd48b6183eaf5e0d828c060caf18d88b1ba69ffc8"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "40641169f9a022d8fb57db049ec190da9e2f33ab7a0b776f0b75e0d0107a4765",
-                                "uncompressed-sha256": "c2d1fa59b2a887317e2b7c8be7434607818b1824b85bc5679efc5b025b9e2e78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "cf725415c56268e52f96a2dcb5705cd1c0cda7d5932dd99e012061c5a35e5c2c",
+                                "uncompressed-sha256": "b157853815c21f7eff2b3ca6f0d08bd9503689ab24b42265f96e80b9e77e6c2a"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "73d59f58727e3625439a7923a00a6dfe06cf85a2f49d1bb9a1cd9b521ce206c1",
-                                "uncompressed-sha256": "4100250e9cc0340511b7ee6b4ea31c326ff5c57edd262a3313496b11266f872e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "92f6860eb30e108a4c6ecbc3ac09cec4413e7573aa22826a3b6ad3209dc26164",
+                                "uncompressed-sha256": "cd6020867295293b56008381be7fa192f6d41eee4ae1020cd5ae1b6fc4785e96"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "c22da17d90af2058dd4f0486480fa794975292e9f9c20554f58696c37b809c12",
-                                "uncompressed-sha256": "bdb91e8df55d34e752ba9076fac9ac2f36a530dbad8f9fb47cb329377f5b1614"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "046a1eab294a5da100e19760409f27e2aa0cedce4fd7cb4909906a65943c4a54",
+                                "uncompressed-sha256": "a9d63d72356b88aaf99eb688b7f992fb7269e8da2bfa9b616afed6c23baa9c62"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "73129c4aa6b856a8921623a4047ef7230dceeaf91d743d141e8010836f54f4a8",
-                                "uncompressed-sha256": "1bcdc78a19ade115ef97823280e33e88c809d02ea5c715f8a03b5d44edd06967"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "916dabcd8529a31b5baffbb40aab181f0707f6ed8de783d3d3d1dba19f5f899c",
+                                "uncompressed-sha256": "f549c54f3a6cc4d9f65ce2feed7564e12ba841539a315d7f3b4aba9335aec996"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "210185102caecb5942904f13ac634786d37bd22af76f945dd7e269379b279549",
-                                "uncompressed-sha256": "a8cc8f12856fcc3966c85245bb714f800c27c4676567808572f6c7bf6d9c305f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "7b4fc57028d8b3a18d8edb26fc07782ca021808f7c6ab3c8c8e46a13dfe72dd2",
+                                "uncompressed-sha256": "76f7d73467d9b55f3148df9c63c6ff122d3f4b7fc5277ceb73abb7cb7028dcba"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "8e886368ae6246f0f2d737a0bdad4b5913b02e78d296313b64d4661752d1ac3f",
-                                "uncompressed-sha256": "4127cc6f178a70177ed7e03739d4081fa2f7cd35772e8472a09a873c45764f01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "df6c173a036024c5db268c00cb8daacb5a744bb793fe19db136dacd899bc4eff",
+                                "uncompressed-sha256": "e8db6e0cc50fff1b5f98277952c778420481d05678ade6545aff747af64cfa65"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-live.x86_64.iso.sig",
-                                "sha256": "48ad6f408766c348de38baf5b504689a3646fc2ef35f3ecfbbfd2b3f8cd76ff7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-live.x86_64.iso.sig",
+                                "sha256": "02953cd2ec289d35448a364dfc16a8a56a65e138960df2762b39b41058b403b6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-live-kernel-x86_64.sig",
-                                "sha256": "61a156435dbcf37b02314416584cbdc1c91594bb98764ca9e2e8db51f7f40607"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-live-kernel-x86_64.sig",
+                                "sha256": "26442d4c1ad591008d38fd40648db3bf5f566e86aa8c408907680451c69190e7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "41b143e491ad004fb1ece9e7bc31ad37c9991b1f41ecfeea22408446b50ab693"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "58a718ea448ba7a77863bbfad9b8e3742fc07b1a901300ab5646990245b71445"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "e491b0680699a3b6c015489925f7f3f347e2ab726879636b9cff8c55dac562d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "fd4bfaef2d747d3f447badd2cbd8e8fc6c9f6c2cfc64672e4bfc0dcac42c22eb"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "76aa6a4bbd0a301b5a670efcca7e4a3e8d0e70b4ae72fefc64bcea7e6f5e3758",
-                                "uncompressed-sha256": "b4c16e46d560934ee3c2e7d6431f76e4f244284d39812e73b229c3db033add90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "72c1e95c47708cbce55e73c064bc69d2f374e249588edf1a56b1622407c0ef00",
+                                "uncompressed-sha256": "7772ce7701a5fb31831649105b3a841fa5f4544e470300301f36dc112e9be883"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "63c77f10659ef59632c5f0dad24cb86e2ff66ecea29aa34eff663c81e6fe4ecc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "0731c5be8d923610201f176c4681f30aeb3fd38d3f70f1ba57fb0cb7b8a90001"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "77231ec5231427d2b6b9e2906b1db9e1daabdbcd502c11ee2f6cc10b5882b93a",
-                                "uncompressed-sha256": "f0711618008985b0aa95d854847b3fb4795eac4b128da2ea3d713a8b3b6272c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "c4da59dcc6f78d7be6f0b94966abee4373d3060302d477964d870058852ba93a",
+                                "uncompressed-sha256": "b18d68cf181fb89f2803e057d42434ea259a0523f127e83bbef54ab447041ce8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "32947172dd44b924d1879447d2212c8baa063ecfd31376fb6ae3848e25d6b0f9",
-                                "uncompressed-sha256": "c9210b199b12e5c83cefdaed3c2fd272067edebde8047a1ce179d150f837b7f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "a6ca82cde089233a51bb672763db08d887b4e1c5ab19be89fe3f8bc841339cee",
+                                "uncompressed-sha256": "581b9ccb39b16e7805476489a9d5207f10b6cf1c519be2e2d0132195208a7ea6"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "492e1e3b4548f69661d46e4727f93816c05ced5cf17ba121e105eac2c31a5bed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "dac27cddfd263a89490538e4ab26b7ce2f0e5c55e69ae9604543488d7bc0326f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "422a80f69cb8b6b1e9919da42b81941a68ca16452868df54365b1631a3d5434b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "62877537fe487a81cc0054081444daaed466d82783eac6b41f216ad120de2e3c"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230122.3.0/x86_64/fedora-coreos-37.20230122.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "db9ae52e96138b34335d2e97c976a8410a8b434b56769fbd4dc8731515805f5c",
-                                "uncompressed-sha256": "20ec347eb24f57e484f26ff7935a5a3b2f45e705d4bfd70e8ba84b426a380c2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "8c8ba127d7fe03b2a3d0fbc95fa51ec942409166d4e8be14754021f6cb809c6d",
+                                "uncompressed-sha256": "0172022309c3b8e2afe81b4a086286d53b9e705b97063d04ce29a6c6f167e661"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-008e07652e4bfa2f3"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0c10024a9cb49941b"
                         },
                         "ap-east-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0af0d619b9853a8e7"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-03b30db8c0915813f"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-042e3baf835f66897"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0f1a7d9d0dbced6ac"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0bd66195b12c34ff7"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-00b5f405548182f5c"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0302d4d35f7fb4b8c"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-064e616d1f8b53c02"
                         },
                         "ap-south-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-05811ba97643b3931"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0541d84fdf6bffec7"
                         },
                         "ap-south-2": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0d3b30373f025b5a4"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0457f89cd5ebe4d96"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0f66f871473b9635c"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-039ec37ae06d815f5"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0510c968b0890af75"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-06fe1b3de29c15434"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0c176f24627f2235c"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-09a0141c59be238af"
                         },
                         "ca-central-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-04b374d7dd97d2da4"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0c8e570ae2be00945"
                         },
                         "eu-central-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0716739f9b48d73d9"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-09cf3225593391bdf"
                         },
                         "eu-central-2": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-06768f1dec08ecac6"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-09f1cd8dae04922ad"
                         },
                         "eu-north-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0640be686e7b9218a"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-046a4cdd138a59e58"
                         },
                         "eu-south-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-053525b07562f143d"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-083b0c231134f3bde"
                         },
                         "eu-south-2": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0eef3745aea785963"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-003d15e7d8cb3fd0d"
                         },
                         "eu-west-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0a15099019711ba5b"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-093450ad45960ca6e"
                         },
                         "eu-west-2": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-01707bb098f84669c"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0c4b97b699044194c"
                         },
                         "eu-west-3": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0209bd2341d51c61e"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0794dfc38c408f663"
                         },
                         "me-central-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0c017ccb68f61fa5e"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0ad41aa2c0fe8ca84"
                         },
                         "me-south-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-02453d5b08287dde6"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0b5910251eaaeb736"
                         },
                         "sa-east-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-0cdc931efc5659e3e"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0279f12ba3461dfa7"
                         },
                         "us-east-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-00625af34d22904b9"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-082df3a48fbabe6c0"
                         },
                         "us-east-2": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-02a811d6fd3020af4"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-05441ca97071a011d"
                         },
                         "us-west-1": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-02a1adc99b232cef9"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-0b49faaedb7f92e7b"
                         },
                         "us-west-2": {
-                            "release": "37.20230122.3.0",
-                            "image": "ami-048be8c49e4684abc"
+                            "release": "37.20230205.3.0",
+                            "image": "ami-07c4374f51226937b"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230122.3.0",
+                    "release": "37.20230205.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-37-20230122-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230205-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-02-07T21:03:09Z",
-        "generator": "fedora-coreos-stream-generator v0.2.10"
+        "last-modified": "2023-02-21T16:04:53Z",
+        "generator": "fedora-coreos-stream-generator v0.2.11"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "dd6018ab46b5606857e962ff886b6bfe6200d1488e22355cd95957b95712cad3",
-                                "uncompressed-sha256": "3076198ad9e47634214d261ad3750b057ad0611ff8fa7cbf8e09e9e1f23a9902"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "fda3e2aa7f00119b90ed33d901e80e732b0012e28fae10aa49263f8ff963ddf1",
+                                "uncompressed-sha256": "c87e7fd19887adec16616cb06ebb2385f547f2954fe1bba62a9e003aec1a0f66"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "4c46407f427076ffbbe37416db1aef635c185af046c2a6bcf3892e66682a2c38",
-                                "uncompressed-sha256": "108b14f3a0f38f05a7f15ddd0e86cab0a5bdde9cf32fbe52b301ce1978d3038f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "664340e12ac55d54314c861162768b761fd8b896c4fd2262f50985475cfc90de",
+                                "uncompressed-sha256": "74d76292ab8814bbc3e4e136c6b1f1c57b17c4a65e777dee35757e55c371122e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "d1bfa26e7c897dd67f117511990cf8431e567e745bede388e4cd7ffc8fb9d811",
-                                "uncompressed-sha256": "3a2360d3d3668c4be87121605610eb1f0b5729ea7a349b25f46cb5a4eb441602"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "3638f2848e2d7321fbc9604ba08eb1d749c936c18cb3cf090294e96899755218",
+                                "uncompressed-sha256": "9475ebfc9de312e8b0c2da9965eb6e17d310ef2f3ae824691edfbd190c3c026b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-live.aarch64.iso.sig",
-                                "sha256": "579642a40cc5cb7e9de8e4cb7a37b5af2b006ff76ea444fffbaaa4d202fcbbc6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-live.aarch64.iso.sig",
+                                "sha256": "c7cbe43ded5f1a8ca9805fbe5b9385944e77247a3d9bfdf38be04b85ebc66994"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-live-kernel-aarch64.sig",
-                                "sha256": "0730a6ce19f36e22a33197a6df829cbe0feda95e1dcbd328391d0cf004259b03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-live-kernel-aarch64.sig",
+                                "sha256": "9428fce81f0197f03efb05f98e2daaf6d198483ffc23d019bb21655c5c88074b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "b806660a0a14273bbd024479de81bf292c4295f6a86ef9b68b9fde6154285ab4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "6a21c44a8a1e3b8bd428c2d684d5d5a772e41ecf127f1442e3d1de000e1d7eeb"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "6200d888621a14960527a6b2698e22c44c54a20a3e389799fb6a52b523f93805"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "d366d61da39a7636fdccf225d75d4f7e264e588526e802f07cfa55e6b152732c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "e57588297b18b78f07e1fb9db11a5be0a0121ea015880384a33e281f265a659b",
-                                "uncompressed-sha256": "b5e0175f16a530795a08d8c01f247c3f3f0d298b6b1e993c18597006ed21a6b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "fca44ea25f18a268b75934d85c4fef1305f6e67d54ec536aff3234de8378668c",
+                                "uncompressed-sha256": "e4cd35b2f18be9e3504611218f76f5c5bfe3855c8be5c813cd93da08bd6fe530"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "0c97d17ce72f813900a285fe58c33dbb5415b4c359b909fe0d911969bf03d0e3",
-                                "uncompressed-sha256": "aecae76f4553bcd09422354c4f7158d51104e3979f006a25ff97fcb2cadd4d3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c6af6327c0345bab9c208f22a5884f6a2a118b3cbf41c8d54479f570e25914f2",
+                                "uncompressed-sha256": "a12d49f832c4ed08e19e8834fd7065802e49666161ccb0f2b41d8f322255d9b6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/aarch64/fedora-coreos-37.20230205.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "1ed8bffd86d3783c4797b8fe058fbd717926469d48801cf20929342e6a4e5a9b",
-                                "uncompressed-sha256": "e5309a90657b5b381d5a83446ca658d06239c79e36969914819961fb502ac6e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "acf3f4507d9387c25b2eb8871c6f7bbcb70572aedd336837034aa171c441b81d",
+                                "uncompressed-sha256": "79421b2c77ad9e2c57813bc4ab3c9db19d23d97f104ef2fcc20ae717e9f3cca7"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-0c31ca95cd0edc245"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-093ce0d5ed86e6bea"
                         },
                         "ap-east-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-028afc711a6bf3620"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-06bf33fa30f5a24ca"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-0c21045ca666a4e00"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0fa305f1ab9206661"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-05c6fcb8b58499206"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-01b3d8e4de13dace7"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-0af9e43f28af66ede"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0b273f120407e5256"
                         },
                         "ap-south-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-04b331a57a49bb0c1"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-09df923a841e9a020"
                         },
                         "ap-south-2": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-042865585d4727c7f"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0be8bb85572977148"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-009bfa57d6b94bee5"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0fa47bd5e821e751a"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-0b312cf0de0b8ead7"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-09b66dda0187cc581"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-066d8491b1d1602a2"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0600222580981a874"
                         },
                         "ca-central-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-038f86f1d1cdd0a69"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0c984c86d518069f9"
                         },
                         "eu-central-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-00b2e10e1575360d5"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0373da699019dd207"
                         },
                         "eu-central-2": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-0ba225ff331a06ee2"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-06f04337eeb1b2f41"
                         },
                         "eu-north-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-01ef2306f25400427"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-06c4060d42ef275bd"
                         },
                         "eu-south-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-0d739b62d9fe2b946"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-00457c73d6a60c7c3"
                         },
                         "eu-south-2": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-037e9052eba197955"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-05226689d4456bb33"
                         },
                         "eu-west-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-059b452ab974db5ad"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-09651c6679aa64a0a"
                         },
                         "eu-west-2": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-0c1b0b9b745e9a96d"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0522324c2d0fb98ab"
                         },
                         "eu-west-3": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-04e645734447d21ec"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0eb7e18a30f2133be"
                         },
                         "me-central-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-00cdb1ed634db4eef"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0590b60a0a3af4416"
                         },
                         "me-south-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-04a8622611c622cee"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-01b4449779bd1a91b"
                         },
                         "sa-east-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-070610f169718a645"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0b59e3542f4c05b37"
                         },
                         "us-east-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-021893cb29f26dea5"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0f8365a6516fc6691"
                         },
                         "us-east-2": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-019a3a1e63fb0de67"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-04c8e3ec65563db15"
                         },
                         "us-west-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-06ab5785288f0109d"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-07af503044e028335"
                         },
                         "us-west-2": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-07930db21c9309f20"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-039ae6423fa6db70c"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "7c76fa712b4cadd178b0442c69ca0dfe6a60bea9a4abc8353dc7e6e071c2c1f4",
-                                "uncompressed-sha256": "e8afd2891683b36844c6d2ba63dc897efbdc01e686263faad4378b4a23bcc3e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "e384d381d1698aa7fd397f8f2f319bf9cebf2432251f1679e1c35cc50ca73f72",
+                                "uncompressed-sha256": "494926b1567ce83ad289fc08ffedb73fbf1c1223f43269e239721bf62a93f6d9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "c813e8971cc66c5c95f7ba8b5323dca08183d314cfe3ba6bb71a04f945016795",
-                                "uncompressed-sha256": "04894972055da9cafe043ff86b8583300ad0bda0b0a410d8b36079e8fb68c442"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "06ed0c2bba3308b7ed10522aeb31b963de56c9456b275c2f903367bb150a6e95",
+                                "uncompressed-sha256": "b00fe764519ae7376870885efbf7ce84f13e560f97a19940a79ffb64d72ef623"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-live.s390x.iso.sig",
-                                "sha256": "86e35f54efd97746f8beda6c74f3a2390257684de1ed30a5f6e2d6b4984b3e79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-live.s390x.iso.sig",
+                                "sha256": "cd645c96dc6963fee437a439d44b6ccf536a2ed048ecf7e955445f4d550894b7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-live-kernel-s390x.sig",
-                                "sha256": "8a9c8e3a4101f67d57f0d5b2cc136d10b976d27f129aa7b9947215749e4185bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-live-kernel-s390x.sig",
+                                "sha256": "040b3279e9bde970438f8ae099d2b6aeaa2f2a3ae841142bb5b327a75c30d16d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "05ed1d7d183f9439803b86aa2be6c645204887fe0b6674b8cde7591eea4cd4e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "ede1bbbed439000da2c9a6c4d012aaa3e2037b59ee25139d6d7466c8f63e1e37"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "0cdfa96553eece461bc452b13ff8cf6b117f8907f09e60e63f15fd837eb2ae44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "4a42e6634bc5593b1e96650f506bb81303eaea2fd1a39142db7b14d099878f9c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "8c55aff422c23602d15c777cb463aa8c9790c0e1461923d804a0f4886720a199",
-                                "uncompressed-sha256": "34e0cd2693bd2651e6fd9e027c4420e0181e84bfa996bc0e14cfd52693c8c7f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "a622da961df700fffdef9f3a17df9c6051d2f0481a1a98e20918e4143b4bffaa",
+                                "uncompressed-sha256": "a141e48b9617179dc8830c0b9764d59a946346cbe0557b0b6d20bbe697d13798"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "a2b2cf41ad838b65b1bedd64f785bad16f9dc77eb14f700e55e2550cf7100bdb",
-                                "uncompressed-sha256": "930104354c15241508a18b2e908fdcc53680ad57f450550a28313efba4ca678c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "94303f2c750487508e9d3f53c31b6c2ea28dfaaccbcdd9db6c44b18ec6453d2f",
+                                "uncompressed-sha256": "e38c3e6d0f194911f69185ba8f79cc4967c8b72bb92052c7fd9306b6d21ed071"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/s390x/fedora-coreos-37.20230205.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "f87300423b75ee0b7e63b321f117d9f3cb3bd7972fa8d390374d210733c3cf3e",
-                                "uncompressed-sha256": "d608dbca93628c69d322df52f0ac997576dd9740502146473d7a269ce0dee7cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "da37b914e5d6dcafc3886bab7a4209d92fdcaa764eaea7210d3a434475cd013e",
+                                "uncompressed-sha256": "7f41c9e8c680f16fb2af1ce154f225aa191ba800231748da25e1e2aa79cc827d"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "ca9f39ea6136fd737ac4a28428af130d222b98b8a26c80c37b9f945d0ce79d81",
-                                "uncompressed-sha256": "7dbd3a1febf5fcc898976fa00e1f9f1b092e320c53ca7550ec620b8be375b93d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "ab54502c67c95bfc8afad7902481959a005c42e0c7deb8aaa9b6826281364578",
+                                "uncompressed-sha256": "de01ed758291a56b6c5f285d618c95be6062efc41f519010d62f65ef73dc5ce6"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "40d349e963abec30dda79b7a18850d95af075936a1ee596ddf5750ef16ac3412",
-                                "uncompressed-sha256": "ff23cd22800d7afe655a698c95cf5db4df1bdc0f9622cdac83969ba6dd2ddee4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "1d44d31f8f97f7bdc4d5204ea6855e6a3d036c76a2011248f66680243d928457",
+                                "uncompressed-sha256": "7b165fe7af4f779353379f3e2c79958888cb728b5bf15adc518ae3313a2a3ca7"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "6da7b231e26def095b125d9aa8d54df808ee22b8b5814ba5b7813dcf04f24a1c",
-                                "uncompressed-sha256": "b688e1d627f8d987e44671e9919ef669d19edfd95e7bd3850bca53946d897ecf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "0fc20ad53036ebc2910a0cbceddf68eca9f8a3648363ff0b7c5fff3946d643e9",
+                                "uncompressed-sha256": "6f64ad5c2652e4a21aa036d27227ccf270bfd743fb671021380a767a2d010435"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "e49aaf51b8e2bfb67834459a08f473d4f49c87ccaf6a3284535bff4b45a8b18c",
-                                "uncompressed-sha256": "28c3e8f3250313e231af2aac49e7df1fb82f532fa607f274c47b7a3d9bdf74ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "b43e58224997f39ab0275ba0fc8f90493cbd45515ef3a3eaf8b2adb32ed7ec7c",
+                                "uncompressed-sha256": "d39c44f64bb1fe701d341402574c3cbfa13cf64e77c47b06d2de65220ca91d44"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "cb0dd7d6e4e9b37b46c7c19c355cb6d02748e20725ea727046f1d13a2d295de6",
-                                "uncompressed-sha256": "a7e77c2002dcb9aae3f0bcb3bc536d0e6ac50f081799eaa3bb3b5070980f4843"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "fc92769434bcb414d86ce638d5d3dcf49c73f002d88dcaa5687d7baba406daf1",
+                                "uncompressed-sha256": "5b3a2608fa3a069a79818064abfd2334855f2e1a1febc519360b8c4fc0ff566a"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "9720237afe300d91f91776cc16aa82b91307ee503038a3d8945340d99dec1e92",
-                                "uncompressed-sha256": "a5de480f98fa03becce809f44b5c5fcbf642432a9a6396aeb3904c8f434a1009"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "28f766b4c03349692e1d7d79a575142896bbafaaf19103b49328274c264d32da",
+                                "uncompressed-sha256": "d40601fb16d8badd3fb4a6a054795270aa163c0714c4573b74ab361f9a51b60a"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "58956d83b79cb1e58f381dc7c74e11c0bfd36133f3a98706284f3204df344208",
-                                "uncompressed-sha256": "35879aa6937a875b9f8cfc6edb456c7cb694ae6c9662468d738b26dd611c9020"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "cdbfd2f63a64442677d9b580f6cf75a7ac56f6dfa1c87e20ba8ec965647b36f1",
+                                "uncompressed-sha256": "bf876eb67056ee33193fcf760cb51024f28696b60d18127ded36af91e176aad3"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "7907e25f08d5c1e170e79eaa85eb13655e89beb52f94913f0d4ae7a952931eda",
-                                "uncompressed-sha256": "58cebc6904c7a3ccf0803a535cad640d5f84775c9069f6d53f604339b938642c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "a1c88291e0cbc273e06d62c01896e5076bde06bc72f5a1d294bc035caf1e9fa9",
+                                "uncompressed-sha256": "65fec707781357b35021498db5b74bd232b75df7871d8d1266f3a3e3ff26e8dc"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "2754fd52fab633af8013ea6c9a8cd8af7774d1493ad43e4661bd5e8f2bbf7dac",
-                                "uncompressed-sha256": "95fb089bc90108e1d866862f5d0345c837ea80f3ab5ab45722d515862ab69229"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "cae683f3bc7af2f61c34e9005c5ad9a46b193b28fe42f82607e15af8703e85ed",
+                                "uncompressed-sha256": "a47e1bfa2747c2cfedb552cb394b84e739b33c8c79479e8b6d57aaf42d809b56"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-live.x86_64.iso.sig",
-                                "sha256": "176403daf98758f9b322ee8b513cde5de2df84a9a05f369543608842ec023e38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-live.x86_64.iso.sig",
+                                "sha256": "743388598cb7a772990578a6637a81fa52430a45924e2878d24cea552d61bcf0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-live-kernel-x86_64.sig",
-                                "sha256": "26442d4c1ad591008d38fd40648db3bf5f566e86aa8c408907680451c69190e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-live-kernel-x86_64.sig",
+                                "sha256": "ed8e05b50402c8d57c6f6d250009f56cefc4c993e16aa22e5d70eb67c4597a40"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "edbdb604509550e99593ea34eeec1ee5e04dfa1e2158068af666ed55e73eb146"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "532974ea37a857d16a7ff1cf68ba6eb845c65dbecc0feefec6f4407d462acb3d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "f9b1a93f3bd28d429e037839ae29c6fe1f922870a3b4608aa83811dfa04e3cc6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "4b50b512a6db5dfa7b89fbf215bbba3966ce8f1b06f69ddd19c8b3e6623801bc"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "c315887918304914400de225521cd8be75ebeeb04a988a8bbe0926f9b78ad3a1",
-                                "uncompressed-sha256": "4ebc4253ee56926e09b84ea14baec28f872de517306ea04ed6e3144a3936514e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "6a265674d1719328cd6e81241d36185c0d011b1a7952abbb5c997913abc6ec54",
+                                "uncompressed-sha256": "11ddafd9f08f6ea571eee6ba30d22c6e99c7f1530f5646a3a0c70d46d6ff1bd1"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "4849a106b8073c42626074fcd37420b28b74b548b609688561c5192bc2491780"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "0c838eb91431bf11496a798eab441a9a62c7c98d3e0790c1474b1d235dbd2e70"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "08d87767fadbb2cbef4bb18fa1439b294f7725b03b0176d27f4dc94b5f78792b",
-                                "uncompressed-sha256": "4712d525e24ab73d6c24cbe15d5d2635d7128d1c61b0242536beb4c1ab7f98d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "61ca52e80cca3f6e73324a4e223db0f8cb6e7bf5f6db37493f91cbd4082061b1",
+                                "uncompressed-sha256": "ea0233e415dbb353a87b8c034bd032e003392c240c0bfca8752bb4bbcccbe5fb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "f13fe827d4ff248c623e3468bb9d538c342872b86dfa6c36018aa64e3b5116f8",
-                                "uncompressed-sha256": "ce8cf0922733d7bbf6fde66c68483851bec37c5555bb2d04dbce4c96db1fa583"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "98c1c1f671d3fb6511c69147001b721e787026bb2d8022fa6fe591b514bf39f4",
+                                "uncompressed-sha256": "fbca7af088f088038f3c0d0e3a396bce52916e58913fcd3368cc2b7678e0902f"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "c39f32b1a33e2d4589ebcda1ddc752ca4ab7c9032824e73154868ea6016b2e00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "a483db547dd1c6451f615288151c3baf78aa1296d50fe774aaf34542afedca45"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "b632bfb7aeb41484f09db12db7ff8217ea579a1eef7678729cdc1b0ba683f09b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "8f51e7fb83abeb5eeeddce49a769f26db94c8040ceb786886df58ddfbaa13d84"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230205.2.0/x86_64/fedora-coreos-37.20230205.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "5fb9ca0bb04441a886a819e608e121ba89b01fe3bff8e6e15b33cdda8febb977",
-                                "uncompressed-sha256": "eea9e1f1bc5af6040c3d6a66460ad1ea4fc1fa77c09ea7abd8c96d657efeadc2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "51eef6fcf47a0118269ede8f7b6a9541ccce99cfe1b431aaa1f579ed2f0e8bc9",
+                                "uncompressed-sha256": "c11cbb6940f6fe46e17aee759937babef4adadb21f456f062ee2e5a6a3e03852"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-0ad14e18d1fc57e09"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0d7170e43dc52bc11"
                         },
                         "ap-east-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-04bce71d2a613aec3"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-045ea48036361e288"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-0a7078ccf995cc41b"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-008f246ac645c87cf"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-09cb70454ea10b060"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-097744623fd491639"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-0ffc312eaf33d5811"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0290a4fcdf4454d55"
                         },
                         "ap-south-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-0a4e2a402dd2cceb6"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-006c36e13d3715b47"
                         },
                         "ap-south-2": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-07963af81aa337fa6"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-09adb619a8b10a3dd"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-0085accac8ed8c59f"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0bcbfe79db43cd6fe"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-0d0f2fa43085eb418"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-07684b3f03f1fd4a1"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-00b50dc0e088ec0fb"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-017f7262124e10c24"
                         },
                         "ca-central-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-050c078e93a49aac6"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-05de1fa717b441466"
                         },
                         "eu-central-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-050269c8177777a63"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0d78a855246c15d0d"
                         },
                         "eu-central-2": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-0edd74eba0459a7af"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-03e3966ed457b8777"
                         },
                         "eu-north-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-059a01086f81e66af"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0d9fce4d3486540e8"
                         },
                         "eu-south-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-0a03d22166921d9e4"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0b6a10e8cee65d03c"
                         },
                         "eu-south-2": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-0c3999e71ddabd4d4"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0259fa47d7925bd27"
                         },
                         "eu-west-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-0b52f306db40ca00d"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-047e9012e54b56ec1"
                         },
                         "eu-west-2": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-0079b117d298ef679"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0d85b6ffa51937524"
                         },
                         "eu-west-3": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-036dab1d3154bfa66"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0e049d38a4dd804f6"
                         },
                         "me-central-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-0989dae1b015db12a"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0978f179fd3828ecb"
                         },
                         "me-south-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-099ac32f503cd783a"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-02f866c32335e38e7"
                         },
                         "sa-east-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-02c52928e562d4c84"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0f5dcd692232e908a"
                         },
                         "us-east-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-08ab2c39e5cdda385"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-07337da7c28e54a36"
                         },
                         "us-east-2": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-0bd85e77613fad313"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0f951d4e7b8577dd7"
                         },
                         "us-west-1": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-09fb130c6942aa71a"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-0310f1a5d2854c18d"
                         },
                         "us-west-2": {
-                            "release": "37.20230205.2.0",
-                            "image": "ami-07439a55f6aaead16"
+                            "release": "37.20230218.2.0",
+                            "image": "ami-094da2c0103a00b85"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230205.2.0",
+                    "release": "37.20230218.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-37-20230205-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230218-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-02-07T21:03:10Z"
+    "last-modified": "2023-02-21T16:04:56Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "37.20230122.1.1",
+      "version": "37.20230205.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "37.20230205.1.0",
+      "version": "37.20230218.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1675864800,
+          "start_epoch": 1677006000,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-02-07T21:03:09Z"
+    "last-modified": "2023-02-21T16:04:52Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "37.20230110.3.1",
+      "version": "37.20230122.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "37.20230122.3.0",
+      "version": "37.20230205.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1675864800,
+          "start_epoch": 1677006000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-02-07T21:03:09Z"
+    "last-modified": "2023-02-21T16:04:54Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "37.20230122.2.0",
+      "version": "37.20230205.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "37.20230205.2.0",
+      "version": "37.20230218.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1675864800,
+          "start_epoch": 1677006000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).