### PR TITLE
Roll out stable 37.20230218.3.0, testing 37.20230303.2.0, next 37.20230303.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-02-21T16:04:55Z",
+        "last-modified": "2023-03-07T13:05:07Z",
         "generator": "fedora-coreos-stream-generator v0.2.11"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "9ad201136109cedec67cfe089b4166282567d7b24c2bd798f580b7e3c9196511",
-                                "uncompressed-sha256": "9557e84644ed3ebe3b1c48397face1a0559a4a43932f5aafdc0b90d30d97ed5c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "29023678ecfb3a606eb7082bd8208756e80aaa31352d910996ed19531c2efe86",
+                                "uncompressed-sha256": "59fce428a5823e6e699100f89c39df717a1335687534681569df070750f7ad4f"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "0eeb64f070fd8a04d3f92263708c6a0eec7b5c4899d22f9f172ff45ec0a0ddf0",
-                                "uncompressed-sha256": "554476323eeb388a99a246ab7e84f1b3a95f21829e1de1479e49ddda2a27865e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "484a54e07b1602a96443115d40ecf73894b9617c5d7afb5b0136e9668ce4aa39",
+                                "uncompressed-sha256": "64e24098ac6950380543fe8783bdd33038666610ef7392da946f94fcff23bf01"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "ab064f470cc2ebc7f11eb9cae4319c9a0f0051870868801b7ba285c92a2096bf",
-                                "uncompressed-sha256": "6ee19acef4341693dceb08d580b01c057b5d471bee08cd28e8c3a796fe2996d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "6f90977733f17df11e6af708d64d361ce9ce31c027b7e513efc69d6e0700f1fe",
+                                "uncompressed-sha256": "81574d660f50e351fc7acc4abac3e473a6b61d4b77447f801f3f70c0f38e93f8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-live.aarch64.iso.sig",
-                                "sha256": "52a2debc696fc904fb2f7a5b37a248c796b9705cd8ac1aa72ac8ad413902efbe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-live.aarch64.iso.sig",
+                                "sha256": "23b23fae020f6b3f9752a9b221180d900f26be3357a990fec7211081de799039"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-live-kernel-aarch64.sig",
-                                "sha256": "9428fce81f0197f03efb05f98e2daaf6d198483ffc23d019bb21655c5c88074b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-live-kernel-aarch64.sig",
+                                "sha256": "c5f240c9e7d6299de97568c2829add78adbf97a7ed8b46183d432e51da3e3e53"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "eae31f6213420155e69598a5fafc4d67a31b33c9b935e2624192ae1e1b81b05c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "332ee1f35e6a52fa1fd5363fefbfe6da1ce0599aae93af7ece08ddc078524bf6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "5c4508e5d3b8b9bc55ff0dd11d7dbf02068deb54b4ffafd83dcd36506c624c59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "27462bf382a75597be1aa991e9ebbe645d97ead4a9ccb42eb1e35a8494ce9778"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "33a35b038f5d1f1c49daf1ba827c5eb0e433e0975315187f44a1dab0ac2680c4",
-                                "uncompressed-sha256": "d1b40de07a7643c6fa983a5f7598c917788c700a22c425e1caaf00a9fd5c0715"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "87427b89deb72511b7eaa50407cfc6a8c8598c90062a5398fa94b3cc24f886e9",
+                                "uncompressed-sha256": "bf0f4b2162ad651258a7a90943031ddc88c3481f2d1667b925280951eee5689f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "718d4b4ba89d42abd53587f9e88010e47097166fb8a2a43a20afaea4e1738cb3",
-                                "uncompressed-sha256": "5e8105753ec1fa55138b935850e8b5c99f67bfcade673234aa3054db4238d35f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "84c4785f5cab10123ef037a8e0648680a29c4a92b7577dbaafec1b4ba650af84",
+                                "uncompressed-sha256": "ea73b98da0484d1871d45ae6e4a5023f0e8fd53b20ca1a3b45cfe0f3d2629c53"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/aarch64/fedora-coreos-37.20230218.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "bec37cf1ea8f11574a15b8c5506e4ab45076fad4d205936f24d963d7f0c98a5d",
-                                "uncompressed-sha256": "52c1f8434a3a0e9088526aadf6634538039a08201789fedd096ebe78deaf9028"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "3cc90457d7b5fd761c261987f20e604a989c90799b149663bfa1c0566d4bb272",
+                                "uncompressed-sha256": "61751741589bea5e4051eca154b217b38ecfa887a231f5586cb10d203a5cf63a"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-05e1c3bcd8a38122c"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0e0f0cae2a012fd6e"
                         },
                         "ap-east-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0149c5883ebda0c71"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0333dd8b42d5a79c0"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0048d71bf8fc11087"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0df2c2d733b883301"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0f605928b3c93d7f8"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0691cfb03fb16b395"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0d1208f34d331c856"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0958fa457a78f1740"
                         },
                         "ap-south-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0ca3aea830d4b05ca"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0fc3b98c764d13d06"
                         },
                         "ap-south-2": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-010e096ee1422c653"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-04d8b07c484585039"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-03a22c168369b0be9"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-06efd6143d33c5b1b"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0d4feef3a7a1201db"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-01cd74dca17062c69"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0d727bab8f6b4538b"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-04a3bc5231da787da"
                         },
                         "ca-central-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-027e0834a9890a799"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0ddcd976b029fc322"
                         },
                         "eu-central-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0a6493d7d1a63a493"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0ebb5e2f23e945371"
                         },
                         "eu-central-2": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-09a1a16d70d11b132"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-02f746b47bed8ac4c"
                         },
                         "eu-north-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0561c1eaf691b5a4c"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0d8ee5d07c225257d"
                         },
                         "eu-south-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0eb8dc92e8a38b44e"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0c2d7000ebc0859e4"
                         },
                         "eu-south-2": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0f8e02e6d026d0e51"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-08f19a117cbbd56d8"
                         },
                         "eu-west-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0f22fba56ed88fbce"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0a4727707bc0202bf"
                         },
                         "eu-west-2": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0785193073848716d"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-03bde43c141565655"
                         },
                         "eu-west-3": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-06a0fc8ca5a19f5ce"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0493c7bd9a6d50d1f"
                         },
                         "me-central-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-00810b125b57551fa"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0a66173b36e8d7b02"
                         },
                         "me-south-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-074a471147ef628a5"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0b0dee6c394f91f8b"
                         },
                         "sa-east-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-097a6339b0b616e57"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-031695d508013f360"
                         },
                         "us-east-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0fe934b16b17aacdb"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0b957e7afbbf8d795"
                         },
                         "us-east-2": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0baa82c004539615e"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0fd2bf8ae7a73f83c"
                         },
                         "us-west-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0d2b8cc8676556e90"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-07d1f163f0da4ebc0"
                         },
                         "us-west-2": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0a6da216883ab2a1f"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0d00b24c5d5c493e1"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "3b110b17eb3c4a5f5dfd4486f5ea74334b180045a551b730bbb24b4d32deda82",
-                                "uncompressed-sha256": "8ddf124440c893bc6e933cd90f3f7e95b03b0d92cb60cde8a12c3399e8f87e6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "fabe5efe94362d5b6d19a86667372c8075ebb3ebecd6f5f39f0c7b601612bd7f",
+                                "uncompressed-sha256": "fa23bcd157bd9deffc82ba27113add44fda3ce853e2153bcb97d8aedc91d2dbd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "9e5b1e730242f704179286facf87fbb10b66b94cff347478266d979352eb7f4a",
-                                "uncompressed-sha256": "f6b13bff11c8738d582f1760b0a8c55424e7b63ba7d55c7d248bec3ea67e754e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "9bc996e48a7241371e8de4e6681a39a5e25478f07a6e921116cc58f358e96eaa",
+                                "uncompressed-sha256": "bbc9f78e431be6d0ba77045e8ae9d467510ee244fe42ccc0639c4b4fb1168453"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-live.s390x.iso.sig",
-                                "sha256": "45381ec2d957142fe6e4d9344b0ec54d3182004f6bdb1e895cf5bdcdcc0f9fe7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-live.s390x.iso.sig",
+                                "sha256": "b6ee122c5129a9d72fcf8298565c95e4d64f6153a651477a5b8690e9b5b5d9c1"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-live-kernel-s390x.sig",
-                                "sha256": "040b3279e9bde970438f8ae099d2b6aeaa2f2a3ae841142bb5b327a75c30d16d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-live-kernel-s390x.sig",
+                                "sha256": "c4efcc3b3ee50d31221a98b349fb6a723f1db725156d95adcfa45877c31948d7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "fc37177fc776038224573c74dfe865cf05e62acea517a60c48da1525ea13f4ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "d190aaeb3e25974338f39b1a0d8995ad7dffec7e55b447e71cce1915a9cec330"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "cf6b16671d949d57edd4bcfc991709bbe86f6d4f4582b387149785847168e5a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "d76c36812b7ae8226da9aa1bec0650e79207ef03a7b492890d08c7fa52cc4636"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "f9983b14a3f5be276fd2143cb3e11e1fb6368218a3ccebe46869315b8a187872",
-                                "uncompressed-sha256": "70d5a1005031f61da59807d5c9bcb883f4998cf903dea8fd489176a3c39262db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "93aa78c198d6203ff3be8e22c64d7d5e72c5045b39b158527e47569df9215c93",
+                                "uncompressed-sha256": "0dcd553f29316746977d2e119655cbfd377238e09788cf78db99dd6850e4296b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "0d576e159cecfee8e64044536b240c101ac553c8b4c57384cb60bb7cf2d95e2b",
-                                "uncompressed-sha256": "79769fb8db8c058b5549494bf4671a23881666768c819b82babbe792b22c3782"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "e82735e4e18edd54b93af581aa286ec7ff052d8e40247e112fc0ff94f36dc8d1",
+                                "uncompressed-sha256": "372e653e4b60db349730c90f15cefed9dab4fef674f9ea9bf375f635ad3ccdca"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/s390x/fedora-coreos-37.20230218.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "bca7b678c6e107518e88c7ad99e0197d37327b34269a2a8b99bb6b7e95df4380",
-                                "uncompressed-sha256": "622cb32f546bea51d96ff7fea69e916bf963ec8102f9be3e40471f7cee508e49"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "37e78518db956008dd5f5b306535f1d6c313543c42c5dbefd430f2ff340d7c67",
+                                "uncompressed-sha256": "7c1e121673a5d69fbbdb05d39ae1614aebe69ec313ea8862642bc7c12f860b42"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "96f5c59869de83f13b1994585c3fc4b298c2568e4e6f39de081ed487a60ab3c7",
-                                "uncompressed-sha256": "19ce29fdf1c607e7fce1e7419d04bb9f265fc53f6dcf777808ad9ad211537129"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "59ab7889f3b788d9fbaddae32fc1c207611b2d0e71c66386a779d90d2b2b8c88",
+                                "uncompressed-sha256": "c35df877673c08d0bbb346a4767a3b1cf19471d7ce1b5e7ed61306c33dca6dd9"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "4a3f622c2808d5edcb786164f43bf0864b929080669d3ef886da1d3c0c477d29",
-                                "uncompressed-sha256": "3e5bfb1c7efd29e6299ff6113e4bd0675e11a49d87c8772384b68ddb8444db75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "a4f164c3af0cb04fbab644a957fb2e60a70970fac015fad14ec10f7fcf13e165",
+                                "uncompressed-sha256": "3e3aca8176c6782b38baca00677b990bc362c328e1c9cb88937de4f7e27fcfda"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "1857e02fc2fc13bd792e9ca0abbb0bf2acf4faef6db7124f7942942e13ee0aee",
-                                "uncompressed-sha256": "b3dea115d25b187f2787fa63463e8c346f88dda8ce85f121bb4c8a0b83f33dcc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "2314168c5361b2d134ce1c2822f2cf777522df84a135bb4ee5ed838b2d0c413e",
+                                "uncompressed-sha256": "c97f49c3423b72c9000b9fe8286d72f8ec2608b883f63bf45300d374362d5c7a"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "4752244cb941928121fd2bc3fb848258dd3c2350707a528909b23ccc6786e660",
-                                "uncompressed-sha256": "d52f271e9499964feabee6ebb62bcc726c489117afd4037d10f14c00821ee9bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "3e7d36d9351feda4859897cca15e7c6c618d2921bf6caa514e6f939d3ebfee4e",
+                                "uncompressed-sha256": "178e27f29e8a8c6664f6e69f64191358828ff9d8e2cdfed8034bfb30125b6e31"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "e8ea2cddf79a4d3e89af73fb00d85e0452eef5328519019ec5d67046977fc035",
-                                "uncompressed-sha256": "60ac1350fcbbd26effa7e41cdfb680c6471ed39b3089f474d7b7cc4ed5135cf6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "6bcdcb2b7b7046975a8b71a21e7ce8e445c60a09099e2019c4685b1e8afcd961",
+                                "uncompressed-sha256": "2a03b5252197e51cefa39992f852dc04cb9499335bbbf3c1cdf8ce65112f3321"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "9c688a6364a3d8b55775fddf53caec30813acdad851730a84fe4f23a6ce74120",
-                                "uncompressed-sha256": "22c39d019d3003495122dd7ce1ef8b745319f34fff10508507b9a2a682e33344"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "f5968b88a1e0635ab077aeeaf75f855e87f27d0100edb0202efbf3536eebe447",
+                                "uncompressed-sha256": "1db9a97efe2edfe83c8f051136ed30e827770f82dd549893d280a28c5a246089"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "ce3740ff096b5062c8b0eb1bf64d2fc87cbf88f144434731433dae57ed5cecdc",
-                                "uncompressed-sha256": "8b15995b4e28b5835dbe2d12c5f684a7c76fce7beff3867ce4da649f570b07f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f56a33d16885a2e3eb0c3168dd3f0ebbc2e17f326cc0fb8c45e53786fde44c22",
+                                "uncompressed-sha256": "1069bd848c8988e36febb7636f4558757cfa972baf29e4ae329220ea4f9aeb48"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "2e758eddc1132e7fae2f831dfe0612953d1e0388f589531d0647a453e4f6ac7f",
-                                "uncompressed-sha256": "0535dc3159e6ca46926ff29a20b3162104c4c382edbecafb5233b26c2c66b89c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "1b28b9cd8d7a6e2ec1a82e9205da149a8958404ad86978a48112d2f8da397ec3",
+                                "uncompressed-sha256": "6de339bb7617cd62f92a92c573654fc758010d26fcb059943ad55a4a4a4afc96"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "bda088ef003267ec1003cfff9860a7aa6b713037a4826a2f6b0ee19884032d23",
-                                "uncompressed-sha256": "3b3d0c35965178f11af5661dcae4b30466893a9f9b4835b0431abee255a2fdb0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "8718ad68f2fb9ead511430f81b002ffa234e7a2deb7f9bcd5a742247c58cbad6",
+                                "uncompressed-sha256": "4784d6de689a84c64811d97cdfe2fe097e055059b852d16fc583c857b550ec1d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-live.x86_64.iso.sig",
-                                "sha256": "837cfd69ef6bbff3f8d8fa7b9611fc069266a1026d60be9cc165661f1b363681"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-live.x86_64.iso.sig",
+                                "sha256": "a495da10957039498c8ffbb61c773de7b19ac3fca6d8a4c668af0ea57fc06634"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-live-kernel-x86_64.sig",
-                                "sha256": "ed8e05b50402c8d57c6f6d250009f56cefc4c993e16aa22e5d70eb67c4597a40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-live-kernel-x86_64.sig",
+                                "sha256": "862d7ccbcbb26f36e53772a7022bbc3921d5db8edb47fe6df94065d20cf73830"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "d5dc7e7bae15fc2230aa6dc8683b745f938ac6fd25bb009f4a249eea6c449752"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "0aff8c468bf67f923fa3dafe62a25e87846ae2115337d4c2175e00017bc222ad"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "08a78d0dec0d02db687baa06c9283616cf8362bf3fd54c9b9a55642266c9318b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "31961dffba88b8b698e027f43a21f579a3641cff30244d681714086b125b9f3d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "7e48ddeddfd283264360baed3a84c33b800dee6fd218ba72d5ef7f0ac2928450",
-                                "uncompressed-sha256": "95836856c4133999f39fda149fd97c410d9a8ab582a2573a35cf9e71696314b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "5c1bd9fdc680a6acec9503695d5a2209b6025bb4554497c4f1c5ec2169b7e525",
+                                "uncompressed-sha256": "ab37d85ef54c5c76716425430801b10a32714455e8477b236c00232762d8495b"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "ce096ba1ed6d12cb1f43e687558acc914af1a6123b89a3f37bb52e6765dac58c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "f5140ead3c380084fab0c38d44f5c21d1b162095ed2de4924029ddd1f522befb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "b66951a633de73681b68d11030b634997d86c0f5e3fde37a4f92a7dd80adb50a",
-                                "uncompressed-sha256": "c59cfa8834a6ffa5748a08506951492c72c7c0d83b3f0c9d8dd89abb26322e50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "0be55cf95de126f33e8ea993d2c90b9d5f2053a761f5e3fc837c049f391306cf",
+                                "uncompressed-sha256": "c7eb05ad52662aadb4c0441b58bf6d18dad971324dde8c8bf28cba478e7bc41b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "3f6db487082d6748bfd8d1a67322ef89006996f6b7ad60f698d7ea8ad6255f32",
-                                "uncompressed-sha256": "cba058be134d0b1abcd917b2ba1fa0f774dc66a72d3b8244e61777b9bf1f1e21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "c5c2dab2c0d2d4067851c894c12ba4c4a6ccbd0e95448f8ded107c22e9d99392",
+                                "uncompressed-sha256": "6f9272af0762dd74146dc33c68f6b4f5c5f96875191e93dcc15a66ac1097d082"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "7eda44a19df617e5c973437afe6a465d22826d0af6349843c1cfc6d875b69ea8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "c9b56db659f69da7a7c340b443978bbf121e72c3c9ebf2ef5bfb7a4b85b1b91f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "52267906db172d9d8baad835ebedeaede85a921dc5c7272e156ba4bc5ae72930"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "9b7df167ce60e47f7a3bc533fb9637d323a67982132408bdaca0fd9aff0cd8f9"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230218.1.0/x86_64/fedora-coreos-37.20230218.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "c9bf328d0ad416f3b49cd8b8671c536a8bed4db328e5b2c69733ec85c164bc2e",
-                                "uncompressed-sha256": "9dd2e12efc8f9d050ed410b2a103d42caaa6ab0d7a82c8d57e0a7a12596a80d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "3d041fc39e11a6aceb2530c6b747a6a84f00c112dec34f4d314d4b138a067a50",
+                                "uncompressed-sha256": "50e449989f6a2b8edfa46593232d9f2d188abc634665e1942fb62a00c5b32682"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0b5a01790192f5605"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-050545b8f846cf46c"
                         },
                         "ap-east-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0a520aafebefba284"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0ba5018367e4725d7"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0c551de085db0cd5b"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0861a9b75c8f3de79"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-03b476f2dc4c06edf"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0416458539bce7a97"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0e96874528106aa1a"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-07a908ce4b66f7d35"
                         },
                         "ap-south-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0d28aad5398370514"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-02fabc84e4ad0cbb1"
                         },
                         "ap-south-2": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0d103a737e8602b5a"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0d9e796ea79750fa2"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-04aee5acc54f7f792"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-09c4817fed612b3d5"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-06bacb783922def6b"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-01654890a6e0ab5ea"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0e4061ac63912a444"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0b70ae48e384069c4"
                         },
                         "ca-central-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-07c474ab812ef1d53"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-094f58c6b3a0a4e7b"
                         },
                         "eu-central-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0704b2b47cef2bea7"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-07414e221421d4eb7"
                         },
                         "eu-central-2": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-017b917f80437564d"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0a627ac79e938f877"
                         },
                         "eu-north-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-069c1c63b09d8014d"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-04c0621c5f70fd1da"
                         },
                         "eu-south-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-001f99ca2cca0ece6"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-071716a3364a5e0df"
                         },
                         "eu-south-2": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-04f34dd74789955d0"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0497240072b42d5e1"
                         },
                         "eu-west-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-00eba51b29eda773b"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-05298dc9819d01fb4"
                         },
                         "eu-west-2": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-02b168e448e2555c8"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-086a0aceada4cc159"
                         },
                         "eu-west-3": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0e0d7fc06906e5b34"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0014b58ae02b604e6"
                         },
                         "me-central-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0a41280bdb90f4182"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-054bc26e7d6076508"
                         },
                         "me-south-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-00b1bee62cee41003"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0a07eea869d944e6b"
                         },
                         "sa-east-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0dacf7773c4896f5a"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-050597fb60cf84334"
                         },
                         "us-east-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-044407ad5ec1a2134"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-01a6e6bc371dffff0"
                         },
                         "us-east-2": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-04773eb5ed357e4d2"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-04bbe7d8e848cb08a"
                         },
                         "us-west-1": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0ccdba3405af5ca71"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-05329d3c86167a809"
                         },
                         "us-west-2": {
-                            "release": "37.20230218.1.0",
-                            "image": "ami-0a093f413b771d219"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-068373f3897205516"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230218.1.0",
+                    "release": "37.20230303.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-37-20230218-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230303-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,105 +1,105 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-02-21T16:04:51Z",
+        "last-modified": "2023-03-07T13:05:05Z",
         "generator": "fedora-coreos-stream-generator v0.2.11"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "b9f5da798436aae303091014e36382dcf6eefacc7463476066c1a91ca53fef51",
-                                "uncompressed-sha256": "421f388aef0ec3c4fca96a812ee3bec52ae817b264a88cf0270bcda2d934b71b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "c3a546d07bbc28b064e502a10b2a7e7c0ddc4b0c7b7391b8adccb27f99c9d81e",
+                                "uncompressed-sha256": "04a6381358c8793b225027cab79f507a7fe72915ecbf7d7483520a4d68d4be37"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "c4730aebd066dcbae90d72a313d01dfd37c45c6c8e1ae0b93e900c80f5647ef5",
-                                "uncompressed-sha256": "0aea35a9dd93c4ce6fd9317b458713398d876cd67dc4033164e1795cff1003fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "05bc49d333e6f0dabdfec7a9c258ec726ee311b1057da6409aed2327f78c1564",
+                                "uncompressed-sha256": "5eb245df7c3e3176b7ce8e563deb9d66da1b15627ac41bb8917314a497c80c38"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "522c6e0ce5c4252459b1fc360b600db9d28d932a048cc7928ca7ba654f68aa31",
-                                "uncompressed-sha256": "617f3385316ba935fa668a432f8d1e67ad90f5694be0b81aeced193bef2caa60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "64cc5b50e373532799c1c1b83a9f9f8e62d867ebe81cefb46805046bffadc4ea",
+                                "uncompressed-sha256": "6c160984ff248835d2c9cc679fdbcbfa794f441ae9a41dc969f848abedcbc5a9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-live.aarch64.iso.sig",
-                                "sha256": "3a128e55fc1ae277292cc44286ef3b1eb0014acc842b0ac70f682bd93110d755"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-live.aarch64.iso.sig",
+                                "sha256": "817916a58b56d1d51f9152d867ef46e2b1e708047abeb786b875c2424bca1a87"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-live-kernel-aarch64.sig",
-                                "sha256": "0730a6ce19f36e22a33197a6df829cbe0feda95e1dcbd328391d0cf004259b03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-live-kernel-aarch64.sig",
+                                "sha256": "9428fce81f0197f03efb05f98e2daaf6d198483ffc23d019bb21655c5c88074b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "1674c9a33588b8442e251f0c38f2a60137cc6cc7acb9d56bf609521734291470"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "667f07f7eddf25027924bed96c8c5cb362f72a22e96dd978bda47512adcb9fe5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "dade6427e6954b8bdc91ce707ca5165777cbae27953d6480b82bcf6e581229ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "cec85357ba2b61a7e234a59fdd35b06d0856f06457636aa43cc8e283344bdf06"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "3d1233329888476e74f9fc746f17c8b4e5d8a217967d201e210459f1e07302d3",
-                                "uncompressed-sha256": "a4ae03006ccd631cecfcc4c04c88bd607876b57165387de75124e5e0fbe39278"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "db8d3b40d07a07c986c0b1256afc0f93d45e5698ee919e6e6f87093cfc237237",
+                                "uncompressed-sha256": "cd42602feaf19f88a2ecefe2af1b84a21b95e731c7fbd6f04590f3b24ff1ef0e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "3fb816477f7e0d175968fd11858ca0ceaca6cce872ce52eabb248a2a6e00c393",
-                                "uncompressed-sha256": "aac5a4c0fc2be711563320cc1a368586c5cc8ab4702db984b22fe721c5000734"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "44b22fc6574a197e77c811488b82b5946454e4c15f0f34cdfdd354c834b17587",
+                                "uncompressed-sha256": "df6e5cb7036ba173542195b116c66b5da54df8cca91e73747caa94f1066b47a6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/aarch64/fedora-coreos-37.20230205.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "90e9f5d093019c3edccdae0c2c528865d9608dcc76494b891a0759f858789201",
-                                "uncompressed-sha256": "a4e6e98a3ffbbea6f7bae03154a258b2440e9108457ffcacc5353fffd341b98f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "564bfd80edacf7ab9c4c53aa1434b622c0c31753951df308b3708c4f8d5c91e5",
+                                "uncompressed-sha256": "19a56c471d2cb82a17f489a09d11d8869c367618d79e3f1770de4b077625b0ae"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-05ebb0a6b46adfa90"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-03503c6a3b53ea484"
                         },
                         "ap-east-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0aab29a3eebdd9411"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0f89b77ca833cd014"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0f8993236d0d733f7"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-02c0f1673cbdce087"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0224ed01167ac83db"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0cdc4382e6b711c63"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0a5a3c87031ecdd2e"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-065f58b31c588be84"
                         },
                         "ap-south-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-01b479a2357cb2a3d"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-05c57e049bc1d3f13"
                         },
                         "ap-south-2": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0ea0e1a37e32b6969"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0d4c60a5305208c11"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-03e08720978407495"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0eae3a808e6eb1f8a"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-021203339ade26f85"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-04af56b1505a57dfc"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0de7d503bdb5de7cd"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0d333cd70bc64b6f9"
                         },
                         "ca-central-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-033bcc13fff7ce3eb"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0dcfb88577b128ccd"
                         },
                         "eu-central-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-065b7a13a68cc7546"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-06f3f5f5e6b035136"
                         },
                         "eu-central-2": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0cdb86225c867763b"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0719c5f965f96d478"
                         },
                         "eu-north-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0e5632749d360cad2"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0ccffb04b1582b6ca"
                         },
                         "eu-south-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-02fe8bffb0065ed72"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0176185ba17449fb2"
                         },
                         "eu-south-2": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-018a1439d90f75d03"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0942079a9c845115e"
                         },
                         "eu-west-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0335464875e816816"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0d299ff1ad9ed6dc3"
                         },
                         "eu-west-2": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-066e8ab8109e6aa68"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-069fea085217f341a"
                         },
                         "eu-west-3": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-052a0b586493e4049"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0aa6548d5fac4f6ee"
                         },
                         "me-central-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-02e21d2436ba62318"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0a78d2d3aa6121f9e"
                         },
                         "me-south-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-034b5f98e97edf544"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-054b9c2dd5f24f979"
                         },
                         "sa-east-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-07ea08bba61ad719a"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-02b1c713643b570d6"
                         },
                         "us-east-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-088f55ee028de421a"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-04697edf0f2fefc15"
                         },
                         "us-east-2": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-03d8bf6cc88937ea2"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0f4b1af824d736104"
                         },
                         "us-west-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0279bbf15c662ba3c"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-07bc4235692ef9c32"
                         },
                         "us-west-2": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-07147778b24f55018"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0af9fe3ba19a82066"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "02985f12ee8f3d5306291183cd00fd75a1de51b8130156c734a4b8e6ef9cd8bd",
-                                "uncompressed-sha256": "8f298accde4c1e7a1fb8b59bf1dc37b68346f3cd6112110306166c7362dfb2ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "9fa202b6ee1effabd378269303daf6fef3e38379f2ba5a7bd0538e5bbb37db5c",
+                                "uncompressed-sha256": "c705aa100934903b2531b2da5b498dd36a10f64ef0c4f1a5febb33105e3868f7"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "25d7df9e7b88eab8d4f1935e01f4a9933234c8c8fe3d3e5ceec7acdac3d65625",
-                                "uncompressed-sha256": "82ac5888b3feda4f9a494eb21eb8f30a6a9ae2f31649f89239e6999c8c324de7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "0f4e9935469dab6fcef8f6e3459f745ea0445690e322b93a23d3bf12e61c79ce",
+                                "uncompressed-sha256": "d7965ad2636708ce37a786e2690f52d93ae70d585793400840e012fbdafebd52"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-live.s390x.iso.sig",
-                                "sha256": "725f3282be837b84baf26f4b048762022fb14cebc3d194a8f6f8b9e4f5009c8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-live.s390x.iso.sig",
+                                "sha256": "f0e68761b0b68ec92e96098c4c3bac91daa0aae59d466d9bbe75e994bfdad0fd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-live-kernel-s390x.sig",
-                                "sha256": "8a9c8e3a4101f67d57f0d5b2cc136d10b976d27f129aa7b9947215749e4185bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-live-kernel-s390x.sig",
+                                "sha256": "040b3279e9bde970438f8ae099d2b6aeaa2f2a3ae841142bb5b327a75c30d16d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "190ef6cf50cd25e703d02f49fad226da5f839b440cd58551eb0603c6b1fc4fc2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "6ec0c45bc58c7749ab066c4e3dd9ac5d4b3adf6762ea7a6c8ac60bfefc7f9c25"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "e7156a77bb35d4c5cf620eb9c24248d2ef04f9cdd4d53666f9b1da4749cc5269"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "d79094ee981800b6488d4964af6c0bb08387e6aaed7f1d231f02e6c6113f7852"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "7add676212b63e24ea926404d3f57ff362b909035b1877b233b2158b55fa9efe",
-                                "uncompressed-sha256": "8934929dc4a0aade8236c9895a3c97bfc0eb36dd19555c5b362409842106b092"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "cd50f55a0dc97cb74b3fad3d592282b5289a71564d8f11b5480153cb550b0944",
+                                "uncompressed-sha256": "f3f1ec86a935c5285d95f65229abe7e714fb2b126734cb0c538c1983ecc5f898"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "1f0dcb47b1bfebaf15381e8df512e3bf3c86b63875f973d46341d90317621e58",
-                                "uncompressed-sha256": "7f1d77b0ecf67cb9c09482b09a96adfcf50a19d44e88a96b1f717f1fe2b4a03f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "c428af675fbb041e428b5e95aa0b426651d1ce27b9a35487410bf2250c4cdb50",
+                                "uncompressed-sha256": "c815c505e85543be998c0b60d3522158233922fb3b46e1f9c399368721a1f08b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/s390x/fedora-coreos-37.20230205.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "55e003e3a8456be620bf35567de388c9b0b7dcd47149bc1f8a93f1a8e09b780b",
-                                "uncompressed-sha256": "278bccc975d6f6d864eca6738f36c61613045f548c5b2ededa04673f58f3580e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "63b462e58f5c0c294b3f60febc8c6e49ca5175be12c99797603789bbc079f93c",
+                                "uncompressed-sha256": "6aa55c23a59f86e1d815f5e31319694e82290665bba90e4a0083acfa2e0411e8"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "39db101fc982c0363931a25bc8726e9b7030ce0f2537c47e9ca222c16a67d547",
-                                "uncompressed-sha256": "c15b00bcbf9036faf4bb24b904be2def9de9eba6dcfa786d5f4044ddbb489a20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "21a6bd8833e88bab10d7235ba79663f764b2970b85b02c53cd232d9cd73ebf17",
+                                "uncompressed-sha256": "b14b4c9fea8fc3caf4fb7a6b4209dabc324ce579fbc6990f9a2ae547e5696cd1"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "bb34e1ed123ea8f3274b9835af05a7bfc844eb3f7bc0516a605fefcb564c1884",
-                                "uncompressed-sha256": "342c7a6226f9eb398986cbdf5536f4a8ae700799194995a728e272810d7d6b09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "8b63eb6cccc84369ee209bcf7aba0b99f46dc1e3d8eb3caea1465a138fb2416c",
+                                "uncompressed-sha256": "70ced11107afeffb6f999f0d708f54dff94e1175bdc724448395a9039db34ebc"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "1779640662f33f9ed900ee4a371d4b105e0a9a6e4eda1e3a6cf80b831537c916",
-                                "uncompressed-sha256": "d15a316f0c1a91e95e4b488dd48b6183eaf5e0d828c060caf18d88b1ba69ffc8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "4b9bc654a969502f3a22ea4dfd332ee416d72956a4526b19f4b2b9fb688dce57",
+                                "uncompressed-sha256": "1bb27f6772f1a56f476be957bb07caabb2c1f5d4bca9cb9f2838a0deecf4c5ad"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "cf725415c56268e52f96a2dcb5705cd1c0cda7d5932dd99e012061c5a35e5c2c",
-                                "uncompressed-sha256": "b157853815c21f7eff2b3ca6f0d08bd9503689ab24b42265f96e80b9e77e6c2a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "1be377bc80ed2a8abbe26be74dce5e8ba40e55f0d74f91efc7c6865a4c6d67e3",
+                                "uncompressed-sha256": "02d4b1b073cd08e3797a64be453766cb2e3823a69762aab29d2d152aaac1e95d"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "92f6860eb30e108a4c6ecbc3ac09cec4413e7573aa22826a3b6ad3209dc26164",
-                                "uncompressed-sha256": "cd6020867295293b56008381be7fa192f6d41eee4ae1020cd5ae1b6fc4785e96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "853aa872ddc56550f20a0f0648cf64e059bf7bac79ca88d67264fd46f140310b",
+                                "uncompressed-sha256": "71670d941bdf358bf7cafd44d8b9f09153fa026680d234a08f581591efe0e4d5"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "046a1eab294a5da100e19760409f27e2aa0cedce4fd7cb4909906a65943c4a54",
-                                "uncompressed-sha256": "a9d63d72356b88aaf99eb688b7f992fb7269e8da2bfa9b616afed6c23baa9c62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "6593825c44404924f2eb930c51faaee1af99290d34faa4d6dd151ad825a347e1",
+                                "uncompressed-sha256": "bc8d05ffe80625b16e3242d1317c4c29edc0206e87fc280c17ad9bc3241c625c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "916dabcd8529a31b5baffbb40aab181f0707f6ed8de783d3d3d1dba19f5f899c",
-                                "uncompressed-sha256": "f549c54f3a6cc4d9f65ce2feed7564e12ba841539a315d7f3b4aba9335aec996"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "64379db6257cc9b25a0d95b7b6cd0f37c5fa666a30ce14b03318813426b73351",
+                                "uncompressed-sha256": "e5aeac306bde3d1bd57bb630904fbb1fd491b0fcbf7b2aa5ce4e630ab1633c2f"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "7b4fc57028d8b3a18d8edb26fc07782ca021808f7c6ab3c8c8e46a13dfe72dd2",
-                                "uncompressed-sha256": "76f7d73467d9b55f3148df9c63c6ff122d3f4b7fc5277ceb73abb7cb7028dcba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4313e4b4d2c791369ff309c66c2d6b0cb66ad0de7b31455e654c27d2de1f1739",
+                                "uncompressed-sha256": "e8a7beec89c030701640780245efd82d602a7b8b3ddbf8c2efe133e4a5de7d09"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "df6c173a036024c5db268c00cb8daacb5a744bb793fe19db136dacd899bc4eff",
-                                "uncompressed-sha256": "e8db6e0cc50fff1b5f98277952c778420481d05678ade6545aff747af64cfa65"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "454f986279bfc098a31be04e3618a7ab8f05b58629b25d4fcf18b3fa61e0e1a2",
+                                "uncompressed-sha256": "8f96ff0a0ef708dab746c8490161fe3632fc078acff39e10d65c010863c1fad0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-live.x86_64.iso.sig",
-                                "sha256": "02953cd2ec289d35448a364dfc16a8a56a65e138960df2762b39b41058b403b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-live.x86_64.iso.sig",
+                                "sha256": "217368ecc251924e0d59fbfc3d51a1df0f3e5efe79d6890e785edae0bc1825ea"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-live-kernel-x86_64.sig",
-                                "sha256": "26442d4c1ad591008d38fd40648db3bf5f566e86aa8c408907680451c69190e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-live-kernel-x86_64.sig",
+                                "sha256": "ed8e05b50402c8d57c6f6d250009f56cefc4c993e16aa22e5d70eb67c4597a40"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "58a718ea448ba7a77863bbfad9b8e3742fc07b1a901300ab5646990245b71445"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "b7c8f9c1d7703fd043ea1eb6e24368f136644e2701f11f2a9be4f0ca7eb51502"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "fd4bfaef2d747d3f447badd2cbd8e8fc6c9f6c2cfc64672e4bfc0dcac42c22eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "92a32352fa69b714eb2f185187574e4b90ee9e54717eee1141cc04e89d1817bb"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "72c1e95c47708cbce55e73c064bc69d2f374e249588edf1a56b1622407c0ef00",
-                                "uncompressed-sha256": "7772ce7701a5fb31831649105b3a841fa5f4544e470300301f36dc112e9be883"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "980228e15969d5a62fc3e8d6768d99bd1af252d7d8c68da7a2b83b85fa09e7b7",
+                                "uncompressed-sha256": "79c6196b0f7cf8bdbdc736e9b05c9f8a3c3e114c6477523793dc0a19ccd996af"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "0731c5be8d923610201f176c4681f30aeb3fd38d3f70f1ba57fb0cb7b8a90001"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "a2e0329c0f45b3463ec2545d4d878d5ec22ca9b363b278bbe2b708632586c07f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "c4da59dcc6f78d7be6f0b94966abee4373d3060302d477964d870058852ba93a",
-                                "uncompressed-sha256": "b18d68cf181fb89f2803e057d42434ea259a0523f127e83bbef54ab447041ce8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "e7df5c39b058b1c9d11e2620ae1dd6fff1b1dd76cf83bd41e76296af729bcc49",
+                                "uncompressed-sha256": "912a932bd92dc2e1170bf723cd54fdfeb3c203af9dd8c0799a674308ff6278a6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "a6ca82cde089233a51bb672763db08d887b4e1c5ab19be89fe3f8bc841339cee",
-                                "uncompressed-sha256": "581b9ccb39b16e7805476489a9d5207f10b6cf1c519be2e2d0132195208a7ea6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "4557c582f846706426ecbe8ef64f5c3b1bb84cf4cc4c53fbf40c88ce2ed4d6ab",
+                                "uncompressed-sha256": "2c0cc39cb5fb24b8491a753d63c1ca22317a9b95234dfd892239426a6fad6818"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "dac27cddfd263a89490538e4ab26b7ce2f0e5c55e69ae9604543488d7bc0326f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "bc68f7ea6dd036176e4297553e04f8d9012f5eef5baf4b2a1c1b3b7a0b03602c"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "62877537fe487a81cc0054081444daaed466d82783eac6b41f216ad120de2e3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "7fcd0dc5b3857a7b52eec1ec00a9e2ebceb5582f65832042ba11bddd97a4fc63"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230205.3.0/x86_64/fedora-coreos-37.20230205.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "8c8ba127d7fe03b2a3d0fbc95fa51ec942409166d4e8be14754021f6cb809c6d",
-                                "uncompressed-sha256": "0172022309c3b8e2afe81b4a086286d53b9e705b97063d04ce29a6c6f167e661"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "60a4e7c3ea1d3721d5e6aa23c51ac2f8de42dc96ecee4df609136f09d5bdf8dc",
+                                "uncompressed-sha256": "2f1d09c28e38c7ce694f0311bfc84c83f293449eb88269415a267e0cfb53ca38"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0c10024a9cb49941b"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0b48e62701922e1f4"
                         },
                         "ap-east-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-03b30db8c0915813f"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0ecf7270efbf95f32"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0f1a7d9d0dbced6ac"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0ea31040dc0dbf412"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-00b5f405548182f5c"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0463d98bb3ce9dbf8"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-064e616d1f8b53c02"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0d0d24209416667bd"
                         },
                         "ap-south-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0541d84fdf6bffec7"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-00fd06d3b81d974ef"
                         },
                         "ap-south-2": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0457f89cd5ebe4d96"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-09b9923a26dc32e56"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-039ec37ae06d815f5"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-02068126fe1c6d4fe"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-06fe1b3de29c15434"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-07ba40ca37c239646"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-09a0141c59be238af"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0c51a857ae646aa28"
                         },
                         "ca-central-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0c8e570ae2be00945"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-07829a3d297b73b71"
                         },
                         "eu-central-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-09cf3225593391bdf"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0f127ed0961761d43"
                         },
                         "eu-central-2": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-09f1cd8dae04922ad"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-06e005390c45bd991"
                         },
                         "eu-north-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-046a4cdd138a59e58"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0edc4efe0bb6e5d0e"
                         },
                         "eu-south-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-083b0c231134f3bde"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-07712ef1a02482360"
                         },
                         "eu-south-2": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-003d15e7d8cb3fd0d"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0a908cb0ce6a45bba"
                         },
                         "eu-west-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-093450ad45960ca6e"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0be0736ccdb484858"
                         },
                         "eu-west-2": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0c4b97b699044194c"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-06d1b457e81b15ddd"
                         },
                         "eu-west-3": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0794dfc38c408f663"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0664bd8d7f1abfc1d"
                         },
                         "me-central-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0ad41aa2c0fe8ca84"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-056bb9d61b43d6591"
                         },
                         "me-south-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0b5910251eaaeb736"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0f2ff300d68e3a170"
                         },
                         "sa-east-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0279f12ba3461dfa7"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-09110e7c0ea6a7f7e"
                         },
                         "us-east-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-082df3a48fbabe6c0"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0238c550d424194d2"
                         },
                         "us-east-2": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-05441ca97071a011d"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-01e4c69e3fd1fbfd0"
                         },
                         "us-west-1": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-0b49faaedb7f92e7b"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-05ebe5fc7b5463afa"
                         },
                         "us-west-2": {
-                            "release": "37.20230205.3.0",
-                            "image": "ami-07c4374f51226937b"
+                            "release": "37.20230218.3.0",
+                            "image": "ami-0da35dae4eaceeb9f"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230205.3.0",
+                    "release": "37.20230218.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-37-20230205-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230218-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-02-21T16:04:53Z",
+        "last-modified": "2023-03-07T13:05:06Z",
         "generator": "fedora-coreos-stream-generator v0.2.11"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "fda3e2aa7f00119b90ed33d901e80e732b0012e28fae10aa49263f8ff963ddf1",
-                                "uncompressed-sha256": "c87e7fd19887adec16616cb06ebb2385f547f2954fe1bba62a9e003aec1a0f66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "a14049a7e3b6cc829396556256f1501a490b549fd4cb276991becc31cc6175a4",
+                                "uncompressed-sha256": "b06d35fb7364910885f23f7948242800d7449e005b73afd9cd1c783e29d6ead6"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "664340e12ac55d54314c861162768b761fd8b896c4fd2262f50985475cfc90de",
-                                "uncompressed-sha256": "74d76292ab8814bbc3e4e136c6b1f1c57b17c4a65e777dee35757e55c371122e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "8acb2c8bb352340455aeda25f91c41252d705f16843b0146b62d621e87dd1bda",
+                                "uncompressed-sha256": "666b77de33541b0efabf776e88775c6aafd6bc514d02c8ee28e482b19f5a4b44"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "3638f2848e2d7321fbc9604ba08eb1d749c936c18cb3cf090294e96899755218",
-                                "uncompressed-sha256": "9475ebfc9de312e8b0c2da9965eb6e17d310ef2f3ae824691edfbd190c3c026b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "420ee29f2ebd20271e081750d98b2d10eff54ed7834058d079ffb7fe15888c67",
+                                "uncompressed-sha256": "f72d0a65353c28ac04c9606a1de963ef4c19b18fe0ed09f8e74e774d2028bec6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-live.aarch64.iso.sig",
-                                "sha256": "c7cbe43ded5f1a8ca9805fbe5b9385944e77247a3d9bfdf38be04b85ebc66994"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-live.aarch64.iso.sig",
+                                "sha256": "1f7855cbad37d011351e619db5f3cb89ee89faa60633c658c4657ccc46f18878"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-live-kernel-aarch64.sig",
-                                "sha256": "9428fce81f0197f03efb05f98e2daaf6d198483ffc23d019bb21655c5c88074b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-live-kernel-aarch64.sig",
+                                "sha256": "c5f240c9e7d6299de97568c2829add78adbf97a7ed8b46183d432e51da3e3e53"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "6a21c44a8a1e3b8bd428c2d684d5d5a772e41ecf127f1442e3d1de000e1d7eeb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "a8dc994775e21727be630552c7483836d6ffc475d5e50abac6182d9753ce05cc"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "d366d61da39a7636fdccf225d75d4f7e264e588526e802f07cfa55e6b152732c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "7875672c89cf86a26f9cffee948a17287b7fe85b245ae350ff84290658fb20ad"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "fca44ea25f18a268b75934d85c4fef1305f6e67d54ec536aff3234de8378668c",
-                                "uncompressed-sha256": "e4cd35b2f18be9e3504611218f76f5c5bfe3855c8be5c813cd93da08bd6fe530"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "5a2babcd47ebc50523c0e35e8ad3a5b9357c571b8a3cac8c7cdc3deb41196770",
+                                "uncompressed-sha256": "121f88710e7ad1c14d6508b7f2ae499db1a42757e6f3ff5911f757c19f4033aa"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "c6af6327c0345bab9c208f22a5884f6a2a118b3cbf41c8d54479f570e25914f2",
-                                "uncompressed-sha256": "a12d49f832c4ed08e19e8834fd7065802e49666161ccb0f2b41d8f322255d9b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "76cce7ff08384671c97ffc2ff472eb784916d542d905f84b702d9a42f186db42",
+                                "uncompressed-sha256": "5a80aab9ee921eb39ca689ed7320e165c07a5ffcc2dfabf1cd45a200f8f0555a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/aarch64/fedora-coreos-37.20230218.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "acf3f4507d9387c25b2eb8871c6f7bbcb70572aedd336837034aa171c441b81d",
-                                "uncompressed-sha256": "79421b2c77ad9e2c57813bc4ab3c9db19d23d97f104ef2fcc20ae717e9f3cca7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "137462d9b58cd2b0db107a7802529ac1d3537975a8bef0123b077f12db08b3b2",
+                                "uncompressed-sha256": "752e22770414dddc137845826bd4834fab246bbbc79f73809f19910d306caa45"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-093ce0d5ed86e6bea"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-034d1745a49dd8c16"
                         },
                         "ap-east-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-06bf33fa30f5a24ca"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-050b9a02582bfaa63"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0fa305f1ab9206661"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0e3792646a08dfb72"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-01b3d8e4de13dace7"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0f21df897deb22017"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0b273f120407e5256"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-07041059d1bc71e9c"
                         },
                         "ap-south-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-09df923a841e9a020"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0b30aca1072e6dd18"
                         },
                         "ap-south-2": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0be8bb85572977148"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-06fb2d447203e346c"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0fa47bd5e821e751a"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0e952a437561b9baf"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-09b66dda0187cc581"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0cbe02dde271f781f"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0600222580981a874"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0c37af1237fc2f86e"
                         },
                         "ca-central-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0c984c86d518069f9"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-002fd64bceba90405"
                         },
                         "eu-central-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0373da699019dd207"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0746d8204f6f3548d"
                         },
                         "eu-central-2": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-06f04337eeb1b2f41"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-071d28c365ef48cb7"
                         },
                         "eu-north-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-06c4060d42ef275bd"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-02d7ba4c8af7ca316"
                         },
                         "eu-south-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-00457c73d6a60c7c3"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0bbc1b7222e161b72"
                         },
                         "eu-south-2": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-05226689d4456bb33"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-04be4acaea71470e5"
                         },
                         "eu-west-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-09651c6679aa64a0a"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0df07a0cb2516c773"
                         },
                         "eu-west-2": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0522324c2d0fb98ab"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-035737d7777dfda1e"
                         },
                         "eu-west-3": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0eb7e18a30f2133be"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-064fcc9e22f07487b"
                         },
                         "me-central-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0590b60a0a3af4416"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0b9b2ed3dd25ac47b"
                         },
                         "me-south-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-01b4449779bd1a91b"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-04bb42b28e11a6275"
                         },
                         "sa-east-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0b59e3542f4c05b37"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0a497e5796d8c4b83"
                         },
                         "us-east-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0f8365a6516fc6691"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0db150e00bc8a0673"
                         },
                         "us-east-2": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-04c8e3ec65563db15"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0b19ffae4ffdb6c7c"
                         },
                         "us-west-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-07af503044e028335"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0b296626693917dc5"
                         },
                         "us-west-2": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-039ae6423fa6db70c"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-00e7ade0057dcf4de"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "e384d381d1698aa7fd397f8f2f319bf9cebf2432251f1679e1c35cc50ca73f72",
-                                "uncompressed-sha256": "494926b1567ce83ad289fc08ffedb73fbf1c1223f43269e239721bf62a93f6d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "d551f3a0c7d5247d526a136e90a6189510c71a34ef25b1607496dcc4edf9ef8f",
+                                "uncompressed-sha256": "02dfd345ecb8252ac1dfe82be6cf7aa8b689f657d51976066a29ecc52bffdb2f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "06ed0c2bba3308b7ed10522aeb31b963de56c9456b275c2f903367bb150a6e95",
-                                "uncompressed-sha256": "b00fe764519ae7376870885efbf7ce84f13e560f97a19940a79ffb64d72ef623"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "6d8fc60344a381d923d73c22d463b550e257eabf953b3cceacd7370146d68e31",
+                                "uncompressed-sha256": "51334704900f0fa07edf07f1699cce44823fb6bf00a33036790b5086e007b25a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-live.s390x.iso.sig",
-                                "sha256": "cd645c96dc6963fee437a439d44b6ccf536a2ed048ecf7e955445f4d550894b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-live.s390x.iso.sig",
+                                "sha256": "c830533bef4eba20b03f7258963c1368113f7a5db4d19a82f867e5bdd747e087"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-live-kernel-s390x.sig",
-                                "sha256": "040b3279e9bde970438f8ae099d2b6aeaa2f2a3ae841142bb5b327a75c30d16d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-live-kernel-s390x.sig",
+                                "sha256": "c4efcc3b3ee50d31221a98b349fb6a723f1db725156d95adcfa45877c31948d7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "ede1bbbed439000da2c9a6c4d012aaa3e2037b59ee25139d6d7466c8f63e1e37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "265881b3dff4edc1a8dfbf78f39ab3f0986e5f5f5beffcfd47c75213ec8ae04e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "4a42e6634bc5593b1e96650f506bb81303eaea2fd1a39142db7b14d099878f9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "1b3198c2834fa232f5e6486d8e34e481f843651b58c5f69fbbf1474b71b2ac83"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "a622da961df700fffdef9f3a17df9c6051d2f0481a1a98e20918e4143b4bffaa",
-                                "uncompressed-sha256": "a141e48b9617179dc8830c0b9764d59a946346cbe0557b0b6d20bbe697d13798"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "0d5a268617066b96de34c7155086f4902595628daf39f67660f1ae3682c915bc",
+                                "uncompressed-sha256": "393a673ed2c4f806250d11c591ba5235e456d295b6465baa0ffe7165f63955d4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "94303f2c750487508e9d3f53c31b6c2ea28dfaaccbcdd9db6c44b18ec6453d2f",
-                                "uncompressed-sha256": "e38c3e6d0f194911f69185ba8f79cc4967c8b72bb92052c7fd9306b6d21ed071"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "a99704414da3a1f55471529b7dcc4adfa578bb7bc77d1a8f0db38cf86e1254a4",
+                                "uncompressed-sha256": "10964863292cae7952f45cb00133eb6968fe188573ba84ad2c9458087bd69dce"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/s390x/fedora-coreos-37.20230218.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "da37b914e5d6dcafc3886bab7a4209d92fdcaa764eaea7210d3a434475cd013e",
-                                "uncompressed-sha256": "7f41c9e8c680f16fb2af1ce154f225aa191ba800231748da25e1e2aa79cc827d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "c7fc7e273c83dfbdd49e3279796129c54b5592ca9813b14aa2a34c119bcbe51c",
+                                "uncompressed-sha256": "ebac87cbdd577ba151089de443a09062f6d871e3de7e8442d9f3e11f07293dd0"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "ab54502c67c95bfc8afad7902481959a005c42e0c7deb8aaa9b6826281364578",
-                                "uncompressed-sha256": "de01ed758291a56b6c5f285d618c95be6062efc41f519010d62f65ef73dc5ce6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "3864da30d55f87e1bbe9c760d5bb4fb88aca10283544347fcb41f6865e4a3c65",
+                                "uncompressed-sha256": "2c35a672fb837e5dd45fcc771bb0f2b311c905e9f9727aed7d90da837ccf5238"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "1d44d31f8f97f7bdc4d5204ea6855e6a3d036c76a2011248f66680243d928457",
-                                "uncompressed-sha256": "7b165fe7af4f779353379f3e2c79958888cb728b5bf15adc518ae3313a2a3ca7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "45c65240d3d7490c7676dcc8dbc15643fa3ef42d59a183907366232c7ec42366",
+                                "uncompressed-sha256": "93fb9ad5b5989328ab41bbc563438a1d2c141e5b50deb82e7dbbc50271477068"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "0fc20ad53036ebc2910a0cbceddf68eca9f8a3648363ff0b7c5fff3946d643e9",
-                                "uncompressed-sha256": "6f64ad5c2652e4a21aa036d27227ccf270bfd743fb671021380a767a2d010435"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "1a0c51492694cdd682c49a97a14f1ba39d4666f65112258aeaa60fc9d40dc30e",
+                                "uncompressed-sha256": "811de4673d9e058fbc8e96fa56f302a6fefe9eeba9a0eb42f5dd3b7e4f81d952"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "b43e58224997f39ab0275ba0fc8f90493cbd45515ef3a3eaf8b2adb32ed7ec7c",
-                                "uncompressed-sha256": "d39c44f64bb1fe701d341402574c3cbfa13cf64e77c47b06d2de65220ca91d44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "c8f40c6a43dcfdd15e34af10935433a2379bde743960cbd2cbb1f84ec5628bff",
+                                "uncompressed-sha256": "a97bbded8995359081ace027c8cb7a7c5477c8bdcce2af8922bf094a25b22997"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "fc92769434bcb414d86ce638d5d3dcf49c73f002d88dcaa5687d7baba406daf1",
-                                "uncompressed-sha256": "5b3a2608fa3a069a79818064abfd2334855f2e1a1febc519360b8c4fc0ff566a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "aeacc38ac75940f97d4d0dde438ad089ba4eca7d97cf7d3e91283a7d6c192b19",
+                                "uncompressed-sha256": "7fa18dc26de956fc74fb29aa59a255c636c9dbfc1b963946a507957421bba5f2"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "28f766b4c03349692e1d7d79a575142896bbafaaf19103b49328274c264d32da",
-                                "uncompressed-sha256": "d40601fb16d8badd3fb4a6a054795270aa163c0714c4573b74ab361f9a51b60a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "f91ccda218830ce95fa078a64e61bf0a0c7d949b34d2ef15160166001837d995",
+                                "uncompressed-sha256": "550d9062e2ba47f6e3eb397f88af98d89971baff0ea7010870690d1d511f7c13"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "cdbfd2f63a64442677d9b580f6cf75a7ac56f6dfa1c87e20ba8ec965647b36f1",
-                                "uncompressed-sha256": "bf876eb67056ee33193fcf760cb51024f28696b60d18127ded36af91e176aad3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "df9c807960ba869fa65ebf7e961b0db0de12191f627d63f7c994240a0de3dc89",
+                                "uncompressed-sha256": "4e17cb5dd539604882e6481382c2a9b18f70eee3c94b2c679ee523a2bf82d7cf"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a1c88291e0cbc273e06d62c01896e5076bde06bc72f5a1d294bc035caf1e9fa9",
-                                "uncompressed-sha256": "65fec707781357b35021498db5b74bd232b75df7871d8d1266f3a3e3ff26e8dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "43c0f55fcbaea5821c3157892454ada333fa8ca21fe0cce4b68ffdcd663a48f7",
+                                "uncompressed-sha256": "eebda37dc7309fe1960a459076ad8b26955cc6f03b3296ef0300d19c52aeff2c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "cae683f3bc7af2f61c34e9005c5ad9a46b193b28fe42f82607e15af8703e85ed",
-                                "uncompressed-sha256": "a47e1bfa2747c2cfedb552cb394b84e739b33c8c79479e8b6d57aaf42d809b56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "f2cd36fddf31f26e6a6f71b044db2b5ddff8b1a3c07e1c88c35b70c37cb16f2e",
+                                "uncompressed-sha256": "3b40a2aa4c6b5d126571aafcb6b4beba30fb3afd75e4ae58d38711fd01f34739"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-live.x86_64.iso.sig",
-                                "sha256": "743388598cb7a772990578a6637a81fa52430a45924e2878d24cea552d61bcf0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-live.x86_64.iso.sig",
+                                "sha256": "274fa212bbb5f59998227797e9ae7ba7176b3d6c1ef0f71d1984bc3c3d3e4858"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-live-kernel-x86_64.sig",
-                                "sha256": "ed8e05b50402c8d57c6f6d250009f56cefc4c993e16aa22e5d70eb67c4597a40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-live-kernel-x86_64.sig",
+                                "sha256": "862d7ccbcbb26f36e53772a7022bbc3921d5db8edb47fe6df94065d20cf73830"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "532974ea37a857d16a7ff1cf68ba6eb845c65dbecc0feefec6f4407d462acb3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "e7f88613439bd3b66107d829be6fd24d3abfc0a7d6107ede3c0735e4c4bbc651"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "4b50b512a6db5dfa7b89fbf215bbba3966ce8f1b06f69ddd19c8b3e6623801bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "e80f1b6bcf66a0643f038c98874cb92ad33e9bd0f90cd8f01e91a4773b06ff02"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "6a265674d1719328cd6e81241d36185c0d011b1a7952abbb5c997913abc6ec54",
-                                "uncompressed-sha256": "11ddafd9f08f6ea571eee6ba30d22c6e99c7f1530f5646a3a0c70d46d6ff1bd1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "b2faaf27426f0ccad3234a3cf5284f1c4e9cfd5817b7919e6c7151fd9458c3ab",
+                                "uncompressed-sha256": "923a22395b7632a73199358f215eda7660fc88299ad862b3a53eee3895e12544"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "0c838eb91431bf11496a798eab441a9a62c7c98d3e0790c1474b1d235dbd2e70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "da41e9c1f202a890e347bfe082f18fbb5754e90533c5fff23aa1e8fffb584d88"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "61ca52e80cca3f6e73324a4e223db0f8cb6e7bf5f6db37493f91cbd4082061b1",
-                                "uncompressed-sha256": "ea0233e415dbb353a87b8c034bd032e003392c240c0bfca8752bb4bbcccbe5fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "377ff5eb2112ca5f2eee7a438e8bba1bb92a236bb0fd69f92b5c7f986cbfb0ae",
+                                "uncompressed-sha256": "0215fa466e4f2bd03a3584a70788d1a83a5e182171ebf817c1aceefbd33a7705"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "98c1c1f671d3fb6511c69147001b721e787026bb2d8022fa6fe591b514bf39f4",
-                                "uncompressed-sha256": "fbca7af088f088038f3c0d0e3a396bce52916e58913fcd3368cc2b7678e0902f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "6b9ec6b593ce80a76c22e8b7f4876c07430b498207ea0d85a80d820144344cbd",
+                                "uncompressed-sha256": "41b251d18e5894a0f51ae0a472968c9de349c6ee903cfe1803aa4ff8e06c2356"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "a483db547dd1c6451f615288151c3baf78aa1296d50fe774aaf34542afedca45"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "17929673d3d66dd926bb0582d3b523687bf596546df0c768296ad228d9cfd97f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "8f51e7fb83abeb5eeeddce49a769f26db94c8040ceb786886df58ddfbaa13d84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "219785e31ff0ba2a356e62ace083fe4fe5501407f039fe3d561f59a27e4176eb"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230218.2.0/x86_64/fedora-coreos-37.20230218.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "51eef6fcf47a0118269ede8f7b6a9541ccce99cfe1b431aaa1f579ed2f0e8bc9",
-                                "uncompressed-sha256": "c11cbb6940f6fe46e17aee759937babef4adadb21f456f062ee2e5a6a3e03852"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "57cda460fa1b3aac81b41853a0e90be499186c7fed9c1cde08bb99b6ef6a2ef8",
+                                "uncompressed-sha256": "7810699e3a459a4ea3d4901c7b4c99e7e55e7f27e21c6d3091307fd15018f7b2"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0d7170e43dc52bc11"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-02097d16a61fbeffd"
                         },
                         "ap-east-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-045ea48036361e288"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0639b2472d8fd416e"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-008f246ac645c87cf"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-07fcfa81d770af659"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-097744623fd491639"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-09fd255c4e33b8240"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0290a4fcdf4454d55"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-09893c739d20336f4"
                         },
                         "ap-south-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-006c36e13d3715b47"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0b7696f241e502318"
                         },
                         "ap-south-2": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-09adb619a8b10a3dd"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-06cb0e42b206ebf8e"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0bcbfe79db43cd6fe"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-03d0935a3673c21d9"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-07684b3f03f1fd4a1"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-09f2f107fa0bd4490"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-017f7262124e10c24"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-04ae08eab4361dc33"
                         },
                         "ca-central-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-05de1fa717b441466"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-03116bb56b91710a3"
                         },
                         "eu-central-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0d78a855246c15d0d"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0734acb45b4ae8788"
                         },
                         "eu-central-2": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-03e3966ed457b8777"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-050dee80ff06daa87"
                         },
                         "eu-north-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0d9fce4d3486540e8"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0cf5828fccd755d35"
                         },
                         "eu-south-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0b6a10e8cee65d03c"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0ce70695a772eadb1"
                         },
                         "eu-south-2": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0259fa47d7925bd27"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0e00c41bdb926165c"
                         },
                         "eu-west-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-047e9012e54b56ec1"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-02e93c3b61c083d0d"
                         },
                         "eu-west-2": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0d85b6ffa51937524"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-023be26fd05995f64"
                         },
                         "eu-west-3": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0e049d38a4dd804f6"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0b0a3a73c0bb25955"
                         },
                         "me-central-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0978f179fd3828ecb"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0b67035b631c75179"
                         },
                         "me-south-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-02f866c32335e38e7"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0c18e254efdb3b7db"
                         },
                         "sa-east-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0f5dcd692232e908a"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-052225389012a9fc7"
                         },
                         "us-east-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-07337da7c28e54a36"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-06f72317d3b7692e6"
                         },
                         "us-east-2": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0f951d4e7b8577dd7"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-05b90f01ad27ca23b"
                         },
                         "us-west-1": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-0310f1a5d2854c18d"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0fe1ac0e44989a2e0"
                         },
                         "us-west-2": {
-                            "release": "37.20230218.2.0",
-                            "image": "ami-094da2c0103a00b85"
+                            "release": "37.20230303.2.0",
+                            "image": "ami-0acbbaecc2650f8c4"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230218.2.0",
+                    "release": "37.20230303.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-37-20230218-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230303-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-02-21T16:04:56Z"
+    "last-modified": "2023-03-07T13:05:08Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "37.20230205.1.0",
+      "version": "37.20230218.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "37.20230218.1.0",
+      "version": "37.20230303.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1677006000,
+          "start_epoch": 1678204800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-02-21T16:04:52Z"
+    "last-modified": "2023-03-07T13:05:06Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "37.20230122.3.0",
+      "version": "37.20230205.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "37.20230205.3.0",
+      "version": "37.20230218.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1677006000,
+          "start_epoch": 1678204800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-02-21T16:04:54Z"
+    "last-modified": "2023-03-07T13:05:07Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "37.20230205.2.0",
+      "version": "37.20230218.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "37.20230218.2.0",
+      "version": "37.20230303.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1677006000,
+          "start_epoch": 1678204800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @cverna via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).