### PR TITLE
updates/next: don't rollout f38

### DIFF
--- a/updates/next.json
+++ b/updates/next.json
@@ -75,16 +75,6 @@
           "start_percentage": 1.0
         }
       }
-    },
-    {
-      "version": "38.20230310.1.0",
-      "metadata": {
-        "rollout": {
-          "duration_minutes": 2160,
-          "start_epoch": 1678953600,
-          "start_percentage": 0.0
-        }
-      }
     }
   ]
 }


### PR DESCRIPTION
We found a last-minute issue on updating aarch64 nodes: https://github.com/coreos/fedora-coreos-tracker/issues/1441

Let's cancel the rollout while we figure out how to address this.