### PR TITLE
next: deadend 38.20230310.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-03-14T14:53:02Z",
+        "last-modified": "2023-03-17T15:20:35Z",
         "generator": "fedora-coreos-stream-generator v0.2.11"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/aarch64/fedora-coreos-38.20230310.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/aarch64/fedora-coreos-38.20230310.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "ac669873127efcadbaec65605000a0927b21ad96d3ef4b823b731a2da91a39d4",
-                                "uncompressed-sha256": "65fd6e357d1a0b56e88e71c50a1675b7ca768a57f86e6d9c3499fc7345928ec0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "29023678ecfb3a606eb7082bd8208756e80aaa31352d910996ed19531c2efe86",
+                                "uncompressed-sha256": "59fce428a5823e6e699100f89c39df717a1335687534681569df070750f7ad4f"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/aarch64/fedora-coreos-38.20230310.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/aarch64/fedora-coreos-38.20230310.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "2aa58089a15510eb02957f79ecb631362d31bb63ae303b26dadc538c91d287f6",
-                                "uncompressed-sha256": "babd1fade9dcc0609f804efc240b56ed48fbf31a59d9956df32d0e92777701cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "484a54e07b1602a96443115d40ecf73894b9617c5d7afb5b0136e9668ce4aa39",
+                                "uncompressed-sha256": "64e24098ac6950380543fe8783bdd33038666610ef7392da946f94fcff23bf01"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/aarch64/fedora-coreos-38.20230310.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/aarch64/fedora-coreos-38.20230310.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "eb2c2cdd5e139256a24361f39844bcd117ab5ed9fe3dc0c0c175dcf6c6a02928",
-                                "uncompressed-sha256": "da908ad2fb410c595a8e955c7cfce42bf6d7e0a38a075b7e3c08b6f9c668ec4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "6f90977733f17df11e6af708d64d361ce9ce31c027b7e513efc69d6e0700f1fe",
+                                "uncompressed-sha256": "81574d660f50e351fc7acc4abac3e473a6b61d4b77447f801f3f70c0f38e93f8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/aarch64/fedora-coreos-38.20230310.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/aarch64/fedora-coreos-38.20230310.1.0-live.aarch64.iso.sig",
-                                "sha256": "476f22d976b570e0b6f117a0a83b3d2fd2278bac3b257fe8fae765fceb13331e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-live.aarch64.iso.sig",
+                                "sha256": "23b23fae020f6b3f9752a9b221180d900f26be3357a990fec7211081de799039"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/aarch64/fedora-coreos-38.20230310.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/aarch64/fedora-coreos-38.20230310.1.0-live-kernel-aarch64.sig",
-                                "sha256": "c813b9a8ef83b4ec5b43a78992239d1876e283f13facc3a02b3aad71bf5a931b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-live-kernel-aarch64.sig",
+                                "sha256": "c5f240c9e7d6299de97568c2829add78adbf97a7ed8b46183d432e51da3e3e53"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/aarch64/fedora-coreos-38.20230310.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/aarch64/fedora-coreos-38.20230310.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "2d5b234e68234bcd82ac0b52435b852ef4bbfeb2703170eb37b65bd0245cf7e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "332ee1f35e6a52fa1fd5363fefbfe6da1ce0599aae93af7ece08ddc078524bf6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/aarch64/fedora-coreos-38.20230310.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/aarch64/fedora-coreos-38.20230310.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "a31270c62be8ec38e45c7b047651e270c39af1813d4391b1e8b9272f74fd3bc1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "27462bf382a75597be1aa991e9ebbe645d97ead4a9ccb42eb1e35a8494ce9778"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/aarch64/fedora-coreos-38.20230310.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/aarch64/fedora-coreos-38.20230310.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "3d7bf9e429ea38447edb8fd3202f150ef4872139a954cb7e2646e95dd60e598e",
-                                "uncompressed-sha256": "3a820ea9f81550f2d9694b6448cd04acc701bf45070a42a038de78802a670453"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "87427b89deb72511b7eaa50407cfc6a8c8598c90062a5398fa94b3cc24f886e9",
+                                "uncompressed-sha256": "bf0f4b2162ad651258a7a90943031ddc88c3481f2d1667b925280951eee5689f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/aarch64/fedora-coreos-38.20230310.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/aarch64/fedora-coreos-38.20230310.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "efbc2f2db7ec13ace32b1a5106bd3ff57726efdac3873d8337bd4b678c2b39d0",
-                                "uncompressed-sha256": "73a7d44ff5ef4c19c1542cc47fcc75684523bdd31493fc965457f60851064dc6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "84c4785f5cab10123ef037a8e0648680a29c4a92b7577dbaafec1b4ba650af84",
+                                "uncompressed-sha256": "ea73b98da0484d1871d45ae6e4a5023f0e8fd53b20ca1a3b45cfe0f3d2629c53"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/aarch64/fedora-coreos-38.20230310.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/aarch64/fedora-coreos-38.20230310.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "72077c9d9398f1bb4daf5a61bd0cfa6c5fc42dc868b8abfd621cb2d779382768",
-                                "uncompressed-sha256": "5ae2979abfb5cf72f0a2e66865653aa3edab3fb8d19911f050055b876f2df361"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/aarch64/fedora-coreos-37.20230303.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "3cc90457d7b5fd761c261987f20e604a989c90799b149663bfa1c0566d4bb272",
+                                "uncompressed-sha256": "61751741589bea5e4051eca154b217b38ecfa887a231f5586cb10d203a5cf63a"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-00324a479ee419aad"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0e0f0cae2a012fd6e"
                         },
                         "ap-east-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0111b142d9c21ffa5"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0333dd8b42d5a79c0"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-03cd68d3e08e2262d"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0df2c2d733b883301"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-012ae2c9e8266d047"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0691cfb03fb16b395"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0955901410a39452a"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0958fa457a78f1740"
                         },
                         "ap-south-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-02e768fac58b990de"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0fc3b98c764d13d06"
                         },
                         "ap-south-2": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0404454602663405a"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-04d8b07c484585039"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0230c4ce4b9dbb7ce"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-06efd6143d33c5b1b"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0569461ead08a78e9"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-01cd74dca17062c69"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0e272dc856f82ec8b"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-04a3bc5231da787da"
                         },
                         "ca-central-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0b57132714fd1cb6d"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0ddcd976b029fc322"
                         },
                         "eu-central-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-007e978c2a7fe092e"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0ebb5e2f23e945371"
                         },
                         "eu-central-2": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0d097790d5ace049a"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-02f746b47bed8ac4c"
                         },
                         "eu-north-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-093b75fe9f72e4187"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0d8ee5d07c225257d"
                         },
                         "eu-south-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-04f8d7757ba15636a"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0c2d7000ebc0859e4"
                         },
                         "eu-south-2": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0a5bef1158954777c"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-08f19a117cbbd56d8"
                         },
                         "eu-west-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-019313746da4a3ca7"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0a4727707bc0202bf"
                         },
                         "eu-west-2": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0faaed7a4098217e7"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-03bde43c141565655"
                         },
                         "eu-west-3": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-086f5e45ad6096a26"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0493c7bd9a6d50d1f"
                         },
                         "me-central-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0a5603620c6f53bb1"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0a66173b36e8d7b02"
                         },
                         "me-south-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-017b3f7c42d82496c"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0b0dee6c394f91f8b"
                         },
                         "sa-east-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0cf6c3c9733ad3544"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-031695d508013f360"
                         },
                         "us-east-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0d2b3ab1556ade3fa"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0b957e7afbbf8d795"
                         },
                         "us-east-2": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-04432678fcc911946"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0fd2bf8ae7a73f83c"
                         },
                         "us-west-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-002c43c7d4605b8d2"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-07d1f163f0da4ebc0"
                         },
                         "us-west-2": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-001df0fce67b93ed2"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0d00b24c5d5c493e1"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/s390x/fedora-coreos-38.20230310.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/s390x/fedora-coreos-38.20230310.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "e2c3358b8eb08b82a92c4afa18206b812ea421066d3375329889cdd8518d2cf8",
-                                "uncompressed-sha256": "5245d2c9c74c9940cb45c0e462c0e7ffa85749367f7aeb0e46e521d48c28b775"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "fabe5efe94362d5b6d19a86667372c8075ebb3ebecd6f5f39f0c7b601612bd7f",
+                                "uncompressed-sha256": "fa23bcd157bd9deffc82ba27113add44fda3ce853e2153bcb97d8aedc91d2dbd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/s390x/fedora-coreos-38.20230310.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/s390x/fedora-coreos-38.20230310.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "49621805c18a9b064862fb7e5db3a127fd7e763bd2934a11c29ca48f86b44e10",
-                                "uncompressed-sha256": "f87294d0609c1204320f109d49d8b8ad2f03afcc8532bc2ebdbb5b14f998617e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "9bc996e48a7241371e8de4e6681a39a5e25478f07a6e921116cc58f358e96eaa",
+                                "uncompressed-sha256": "bbc9f78e431be6d0ba77045e8ae9d467510ee244fe42ccc0639c4b4fb1168453"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/s390x/fedora-coreos-38.20230310.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/s390x/fedora-coreos-38.20230310.1.0-live.s390x.iso.sig",
-                                "sha256": "64b8ff0282e011e705a525144fb4e1095115a8c495563ce0e7e90baf7ffc424e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-live.s390x.iso.sig",
+                                "sha256": "b6ee122c5129a9d72fcf8298565c95e4d64f6153a651477a5b8690e9b5b5d9c1"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/s390x/fedora-coreos-38.20230310.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/s390x/fedora-coreos-38.20230310.1.0-live-kernel-s390x.sig",
-                                "sha256": "de3156ff949ce0ecae51dda39897e4fec5846ed4b910a75b89fd32c67a73addc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-live-kernel-s390x.sig",
+                                "sha256": "c4efcc3b3ee50d31221a98b349fb6a723f1db725156d95adcfa45877c31948d7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/s390x/fedora-coreos-38.20230310.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/s390x/fedora-coreos-38.20230310.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "2d5cd2be030cec7457af07dc074278242279e18e5d73ae5d3164026c8bb4b8c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "d190aaeb3e25974338f39b1a0d8995ad7dffec7e55b447e71cce1915a9cec330"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/s390x/fedora-coreos-38.20230310.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/s390x/fedora-coreos-38.20230310.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "126d762ba49299f581426e265cdc771d0603fd0945c783c10ec35df65b3539eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "d76c36812b7ae8226da9aa1bec0650e79207ef03a7b492890d08c7fa52cc4636"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/s390x/fedora-coreos-38.20230310.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/s390x/fedora-coreos-38.20230310.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "0b9eae55c038352012d7c3c90f381f59bb54c473190ca541285fd7adcc601ece",
-                                "uncompressed-sha256": "58d0ce41290f013803027c12968f7842f8084134201cc998593f7bef6240df50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "93aa78c198d6203ff3be8e22c64d7d5e72c5045b39b158527e47569df9215c93",
+                                "uncompressed-sha256": "0dcd553f29316746977d2e119655cbfd377238e09788cf78db99dd6850e4296b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/s390x/fedora-coreos-38.20230310.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/s390x/fedora-coreos-38.20230310.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "2ba40f0cd47108775c459e3850f2e6984cdfc4f25e0bfb46b04ba74cb2501ea5",
-                                "uncompressed-sha256": "232ed4355193fc128c4c09e0985b3311026ab1952dc096a1029ae59f77f27c8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "e82735e4e18edd54b93af581aa286ec7ff052d8e40247e112fc0ff94f36dc8d1",
+                                "uncompressed-sha256": "372e653e4b60db349730c90f15cefed9dab4fef674f9ea9bf375f635ad3ccdca"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/s390x/fedora-coreos-38.20230310.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/s390x/fedora-coreos-38.20230310.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "47f048921e396fceaef2013d8579100082a0192b166b87537562103ea4f57594",
-                                "uncompressed-sha256": "13f195e8b2094c199c7e870f94543db198d3c2f560c1cf9410c6d5ad6d0bc329"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/s390x/fedora-coreos-37.20230303.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "37e78518db956008dd5f5b306535f1d6c313543c42c5dbefd430f2ff340d7c67",
+                                "uncompressed-sha256": "7c1e121673a5d69fbbdb05d39ae1614aebe69ec313ea8862642bc7c12f860b42"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "972e1e4f26d1e29aafffd1504cbba5bebcfa5c7d78421ee1ccc9b4d950266d22",
-                                "uncompressed-sha256": "372efbde0d0aa9058921c5b7c99e5643b9a13de6d49b8aba241eeae87d2df4de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "59ab7889f3b788d9fbaddae32fc1c207611b2d0e71c66386a779d90d2b2b8c88",
+                                "uncompressed-sha256": "c35df877673c08d0bbb346a4767a3b1cf19471d7ce1b5e7ed61306c33dca6dd9"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "8b0e61a8199ad511893262cf4997ce41754306635e903e223461ad2c903f4b85",
-                                "uncompressed-sha256": "e0068992d6c179d0f465eb73ae719e9ae1a4cd5ecbea5ae36639973a4e97f531"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "a4f164c3af0cb04fbab644a957fb2e60a70970fac015fad14ec10f7fcf13e165",
+                                "uncompressed-sha256": "3e3aca8176c6782b38baca00677b990bc362c328e1c9cb88937de4f7e27fcfda"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "48a402ab1d689e5bdd5c1ceb8eb37e8f5cd7fd202c8ee709a3f920077a19f9d7",
-                                "uncompressed-sha256": "d8f15e584c7a2b3058140c87b1a90414e508daa17ee2dbbce47bcaba3f666301"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "2314168c5361b2d134ce1c2822f2cf777522df84a135bb4ee5ed838b2d0c413e",
+                                "uncompressed-sha256": "c97f49c3423b72c9000b9fe8286d72f8ec2608b883f63bf45300d374362d5c7a"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "d172ea58d45346166158aa1dfd2d4fd0a90858b9e26b899b2026b5a88f4456a8",
-                                "uncompressed-sha256": "01a31c083cca4522218f3bbc1b3edd6a25b26aa192e49e03151a92ff3ddd97de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "3e7d36d9351feda4859897cca15e7c6c618d2921bf6caa514e6f939d3ebfee4e",
+                                "uncompressed-sha256": "178e27f29e8a8c6664f6e69f64191358828ff9d8e2cdfed8034bfb30125b6e31"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "19ff9f230671c27f0408d5d1f5545c96988b11f694cd18b3dd869914530d3c36",
-                                "uncompressed-sha256": "29887ef0ea3e737dbd0193765cc067203faf5ba83612dffa934e3008a29cfff6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "6bcdcb2b7b7046975a8b71a21e7ce8e445c60a09099e2019c4685b1e8afcd961",
+                                "uncompressed-sha256": "2a03b5252197e51cefa39992f852dc04cb9499335bbbf3c1cdf8ce65112f3321"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "cd95b93a4f24c0e086cd224cbba334a87c6f750f4065d9fb45d1f3b7f739bc23",
-                                "uncompressed-sha256": "5328d520da7d58c5c0c088ddfd5672481ea1a6b15cf01d6b74e4ba2f9c19896b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "f5968b88a1e0635ab077aeeaf75f855e87f27d0100edb0202efbf3536eebe447",
+                                "uncompressed-sha256": "1db9a97efe2edfe83c8f051136ed30e827770f82dd549893d280a28c5a246089"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "92b127360249243d29d5bab03fa1528db93253cdfafe83798626f47b098b024d",
-                                "uncompressed-sha256": "4ced549e74dbb79435a9263ebb794b6d6118306b0bc69da1bb436a9d7c50abdb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f56a33d16885a2e3eb0c3168dd3f0ebbc2e17f326cc0fb8c45e53786fde44c22",
+                                "uncompressed-sha256": "1069bd848c8988e36febb7636f4558757cfa972baf29e4ae329220ea4f9aeb48"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "228a85285c4e1e057a41985cf7302a137e952a0df001810fca1bb2c59e73f83a",
-                                "uncompressed-sha256": "327a112827891ad208f092b716c6266af93f6e71cf43ebfdcdfa287b55ae4151"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "1b28b9cd8d7a6e2ec1a82e9205da149a8958404ad86978a48112d2f8da397ec3",
+                                "uncompressed-sha256": "6de339bb7617cd62f92a92c573654fc758010d26fcb059943ad55a4a4a4afc96"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "cc493a46baded08a3c9941ceeb53ea5d55d932eb3488de54231dbbf4e0877b63",
-                                "uncompressed-sha256": "ae849d2075f99f4ef7683c2221b39034e00ca5f470d6e71913c3b3915663f997"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "8718ad68f2fb9ead511430f81b002ffa234e7a2deb7f9bcd5a742247c58cbad6",
+                                "uncompressed-sha256": "4784d6de689a84c64811d97cdfe2fe097e055059b852d16fc583c857b550ec1d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-live.x86_64.iso.sig",
-                                "sha256": "8e37715a1557018b4360e696f3e8a498874a260e67e80594e40d1a1940e3b7a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-live.x86_64.iso.sig",
+                                "sha256": "a495da10957039498c8ffbb61c773de7b19ac3fca6d8a4c668af0ea57fc06634"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-live-kernel-x86_64.sig",
-                                "sha256": "d863584fe5f83306659958d58dac755be59fc45c09e630e583c895201e76940e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-live-kernel-x86_64.sig",
+                                "sha256": "862d7ccbcbb26f36e53772a7022bbc3921d5db8edb47fe6df94065d20cf73830"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "b51a45a5403af9c7f92031aa06e50dc035a204c2fc2eadad7b67f6fa6362c807"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "0aff8c468bf67f923fa3dafe62a25e87846ae2115337d4c2175e00017bc222ad"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "16ea9144961ae522c21f2684aa2f9bd76f2b568b2ad7439d958d2174a45c7156"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "31961dffba88b8b698e027f43a21f579a3641cff30244d681714086b125b9f3d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "49e34108444838da99d45a1b070cf0f70f11705dc6475644e4119da8f005cfec",
-                                "uncompressed-sha256": "ae8df5dee7b5361d9ee27fa37dc60d3f1ff24c822e20b4f2166bce7c759a8918"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "5c1bd9fdc680a6acec9503695d5a2209b6025bb4554497c4f1c5ec2169b7e525",
+                                "uncompressed-sha256": "ab37d85ef54c5c76716425430801b10a32714455e8477b236c00232762d8495b"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "5b001a9f28b801bb5650d672ed8c444f023e7dee9c61d0c5039eba300697c4e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "f5140ead3c380084fab0c38d44f5c21d1b162095ed2de4924029ddd1f522befb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "83be940c93f15fbe55923eec459cbb0fe6a5607ef315b2f2a1658ae4d674b2d8",
-                                "uncompressed-sha256": "70e3d3542c090252620a63aba1695541b6b8c4d68e49591df319ed1e37468ad5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "0be55cf95de126f33e8ea993d2c90b9d5f2053a761f5e3fc837c049f391306cf",
+                                "uncompressed-sha256": "c7eb05ad52662aadb4c0441b58bf6d18dad971324dde8c8bf28cba478e7bc41b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "4d2eabdbd0433c9df3d1f337f92141a71e915ffcf0e9636f64b447108242d838",
-                                "uncompressed-sha256": "05179f9ed35acb73d0774594ffee53009921d7d4cf06a2a21ad4a9487d5f7169"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "c5c2dab2c0d2d4067851c894c12ba4c4a6ccbd0e95448f8ded107c22e9d99392",
+                                "uncompressed-sha256": "6f9272af0762dd74146dc33c68f6b4f5c5f96875191e93dcc15a66ac1097d082"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "b630c6a5a2eb50d1303a6aec55678f497b46afa180ab6a15a1b3777805352dce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "c9b56db659f69da7a7c340b443978bbf121e72c3c9ebf2ef5bfb7a4b85b1b91f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "d78e3c613e67611fadd54beeec131566103b82af9ff97c0e1d69ae99c32115b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "9b7df167ce60e47f7a3bc533fb9637d323a67982132408bdaca0fd9aff0cd8f9"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230310.1.0/x86_64/fedora-coreos-38.20230310.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "a6cf46def0aab5316a324463b2460b161847edad8eabf36ed85da2de5a18d076",
-                                "uncompressed-sha256": "8b153ae824a781d832fd442f121fa66ad581c7e8636a907f2b66b4b1347bd16e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/37.20230303.1.0/x86_64/fedora-coreos-37.20230303.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "3d041fc39e11a6aceb2530c6b747a6a84f00c112dec34f4d314d4b138a067a50",
+                                "uncompressed-sha256": "50e449989f6a2b8edfa46593232d9f2d188abc634665e1942fb62a00c5b32682"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0933993fffd518f74"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-050545b8f846cf46c"
                         },
                         "ap-east-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0ff9860e42a538d40"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0ba5018367e4725d7"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-04910dd4eff1c0edd"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0861a9b75c8f3de79"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0f0f2592f582aa1c2"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0416458539bce7a97"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0a4bcc8c9f2e95922"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-07a908ce4b66f7d35"
                         },
                         "ap-south-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-018545fd76adc5396"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-02fabc84e4ad0cbb1"
                         },
                         "ap-south-2": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-00f2874f5ce2d4361"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0d9e796ea79750fa2"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0dd4c9379609bf693"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-09c4817fed612b3d5"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-07b5e5cd90d2f77b1"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-01654890a6e0ab5ea"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0e60fabe7adbcc0aa"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0b70ae48e384069c4"
                         },
                         "ca-central-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-044341d13240962f6"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-094f58c6b3a0a4e7b"
                         },
                         "eu-central-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-028ea5cc7a8289f31"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-07414e221421d4eb7"
                         },
                         "eu-central-2": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-00cbfdeebe6c14304"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0a627ac79e938f877"
                         },
                         "eu-north-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0b9641a9cc964921b"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-04c0621c5f70fd1da"
                         },
                         "eu-south-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0e61e878ddd8e99a4"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-071716a3364a5e0df"
                         },
                         "eu-south-2": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0eebe18d96d63b72c"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0497240072b42d5e1"
                         },
                         "eu-west-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-057475effb07c7835"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-05298dc9819d01fb4"
                         },
                         "eu-west-2": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0f85102b8469f2818"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-086a0aceada4cc159"
                         },
                         "eu-west-3": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0627945512d487a3f"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0014b58ae02b604e6"
                         },
                         "me-central-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-05fe4cd163111d399"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-054bc26e7d6076508"
                         },
                         "me-south-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-09b4328a9efd5400f"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-0a07eea869d944e6b"
                         },
                         "sa-east-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-03f12fe52e8c64f82"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-050597fb60cf84334"
                         },
                         "us-east-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-08cbf82307d443c70"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-01a6e6bc371dffff0"
                         },
                         "us-east-2": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-020d2245cc4cbd103"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-04bbe7d8e848cb08a"
                         },
                         "us-west-1": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0d954e091a53f7fa4"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-05329d3c86167a809"
                         },
                         "us-west-2": {
-                            "release": "38.20230310.1.0",
-                            "image": "ami-0c3e4540779bc342b"
+                            "release": "37.20230303.1.0",
+                            "image": "ami-068373f3897205516"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230310.1.0",
+                    "release": "37.20230303.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-38-20230310-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230303-1-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-03-14T14:53:04Z"
+    "last-modified": "2023-03-17T15:20:35Z"
   },
   "releases": [
     {
@@ -73,6 +73,14 @@
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "38.20230310.1.0",
+      "metadata": {
+        "deadend": {
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1441"
         }
       }
     }


### PR DESCRIPTION
To work around https://github.com/coreos/fedora-coreos-tracker/issues/1441, we'll need to ship an F37-based barrier release that updates the bootloader before updating to F38.  Newly-deployed nodes on 38.20230310.1.0 don't need to go through that barrier release, but our Cincinnati graph builder would force it to do so anyway, causing a downgrade from F38 to F37, and that isn't necessarily safe.  38.20230310.1.0 was never rolled out and was only published for three days, so just deadend it, and roll back stream metadata.

This effectively reverts b28f0f3ce419ce318b527735f57c3e5d670ca43f.