### PR TITLE
updates: make 37.20230303.1.1 a barrier release

### DIFF
--- a/updates/next.json
+++ b/updates/next.json
@@ -87,6 +87,9 @@
     {
       "version": "37.20230303.1.1",
       "metadata": {
+        "barrier": {
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1441"
+        },
         "rollout": {
           "duration_minutes": 1440,
           "start_epoch": 1679412600,


### PR DESCRIPTION
We need upgrading nodes to flow through 37.20230303.1.1 so they'll run the bootupctl update systemd service to update the bootloader to ensure they can boot the 6.2 kernels on aarch64.