### PR TITLE
Roll out stable 37.20230303.3.0, testing 37.20230322.2.0

### DIFF
--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,105 +1,105 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-03-07T13:05:05Z",
+        "last-modified": "2023-03-23T02:20:28Z",
         "generator": "fedora-coreos-stream-generator v0.2.11"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "c3a546d07bbc28b064e502a10b2a7e7c0ddc4b0c7b7391b8adccb27f99c9d81e",
-                                "uncompressed-sha256": "04a6381358c8793b225027cab79f507a7fe72915ecbf7d7483520a4d68d4be37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "e6620ebadf40bde110e528a52593288c52bcc49bdc0e10150d6823034c73d2ce",
+                                "uncompressed-sha256": "d72bc9c6eacab2605f388b1263947c9bb0a50b9de7b31b0e668ed2bb3671ccaa"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "05bc49d333e6f0dabdfec7a9c258ec726ee311b1057da6409aed2327f78c1564",
-                                "uncompressed-sha256": "5eb245df7c3e3176b7ce8e563deb9d66da1b15627ac41bb8917314a497c80c38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "51c89157fabd91fbe6055e4eb86c0452d3cfe3fc086d199dde8d3d2a62707217",
+                                "uncompressed-sha256": "201080ec10b85a638e1916218535d4d2df9757c04daf0469c1e5b79063e19199"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "64cc5b50e373532799c1c1b83a9f9f8e62d867ebe81cefb46805046bffadc4ea",
-                                "uncompressed-sha256": "6c160984ff248835d2c9cc679fdbcbfa794f441ae9a41dc969f848abedcbc5a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "c20d95cbf54cc57125ffc2959608ae147dc5495cc31b0816f3c300284e420d28",
+                                "uncompressed-sha256": "ba23068f809164401fa3d86b440477ed60757a938102ac6b61ea594556af46ba"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-live.aarch64.iso.sig",
-                                "sha256": "817916a58b56d1d51f9152d867ef46e2b1e708047abeb786b875c2424bca1a87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-live.aarch64.iso.sig",
+                                "sha256": "bee9ce2dd8434b7ccfce7886700f12cd6cc37802406c9684b174af2cc47d34ef"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-live-kernel-aarch64.sig",
-                                "sha256": "9428fce81f0197f03efb05f98e2daaf6d198483ffc23d019bb21655c5c88074b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-live-kernel-aarch64.sig",
+                                "sha256": "c5f240c9e7d6299de97568c2829add78adbf97a7ed8b46183d432e51da3e3e53"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "667f07f7eddf25027924bed96c8c5cb362f72a22e96dd978bda47512adcb9fe5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "d41706f87b0cdd3921c09c685ca9ee89ab1280284f0a1762beaf32ce4bb4d8fd"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "cec85357ba2b61a7e234a59fdd35b06d0856f06457636aa43cc8e283344bdf06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "2c618b439528d952c940cdf4ad9477fbab7bdd27ee8d0ecddcc4613a66d113a3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "db8d3b40d07a07c986c0b1256afc0f93d45e5698ee919e6e6f87093cfc237237",
-                                "uncompressed-sha256": "cd42602feaf19f88a2ecefe2af1b84a21b95e731c7fbd6f04590f3b24ff1ef0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "25208e0c06176a10ca52d33c1795f516e996e53a2c0202740a3765db863e53e1",
+                                "uncompressed-sha256": "9ed8d99dd547fc87807d3197ca509b8e1f46bbbc46a67a480bb41a723697dbdb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "44b22fc6574a197e77c811488b82b5946454e4c15f0f34cdfdd354c834b17587",
-                                "uncompressed-sha256": "df6e5cb7036ba173542195b116c66b5da54df8cca91e73747caa94f1066b47a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "ceb9fe6b1b82c56f1e7495e954360b1772dc19676b251fe671380ec86d8c1a07",
+                                "uncompressed-sha256": "1836a0565d5d14738cbd9faf6a13a5337ea5673c243339ce6680b37afc67868b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/aarch64/fedora-coreos-37.20230218.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "564bfd80edacf7ab9c4c53aa1434b622c0c31753951df308b3708c4f8d5c91e5",
-                                "uncompressed-sha256": "19a56c471d2cb82a17f489a09d11d8869c367618d79e3f1770de4b077625b0ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "602c1a2f1915f1646048855ec8c49721ac3de72b25eb0ded2290b7e3ddc07ec7",
+                                "uncompressed-sha256": "7e45dc3bc990ef51240fcc57d042459155438ae9ad6bf177cb118b7466deb8ac"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-03503c6a3b53ea484"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-023d601f5e5444b75"
                         },
                         "ap-east-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0f89b77ca833cd014"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0aee54ae4f48db3d5"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-02c0f1673cbdce087"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0ba7ac76cd5da531b"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0cdc4382e6b711c63"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0bc671b6866be6b08"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-065f58b31c588be84"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-00b79e636aff16d65"
                         },
                         "ap-south-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-05c57e049bc1d3f13"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0009ff92079059c6b"
                         },
                         "ap-south-2": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0d4c60a5305208c11"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0c882e3e9bb31f74b"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0eae3a808e6eb1f8a"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0c926247963527349"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-04af56b1505a57dfc"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0ffe548b0fffa3e8c"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0d333cd70bc64b6f9"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0df57e33549da196b"
                         },
                         "ca-central-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0dcfb88577b128ccd"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0d3b83afad1736cfb"
                         },
                         "eu-central-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-06f3f5f5e6b035136"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-020e13e32a997ab8d"
                         },
                         "eu-central-2": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0719c5f965f96d478"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0ea9cbd32dc36f975"
                         },
                         "eu-north-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0ccffb04b1582b6ca"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-096a6fc85d362e7c5"
                         },
                         "eu-south-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0176185ba17449fb2"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-02a229e56ee04289d"
                         },
                         "eu-south-2": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0942079a9c845115e"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-02d50780473aa11fc"
                         },
                         "eu-west-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0d299ff1ad9ed6dc3"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-087fcfc57b54c7216"
                         },
                         "eu-west-2": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-069fea085217f341a"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0e7648a0d321101de"
                         },
                         "eu-west-3": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0aa6548d5fac4f6ee"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0597c8a637e26a015"
                         },
                         "me-central-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0a78d2d3aa6121f9e"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0f7e1c4790e8b71fa"
                         },
                         "me-south-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-054b9c2dd5f24f979"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0ae47caaf54968d8a"
                         },
                         "sa-east-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-02b1c713643b570d6"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-061b9d4cc5e713670"
                         },
                         "us-east-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-04697edf0f2fefc15"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0a75935f93bd371af"
                         },
                         "us-east-2": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0f4b1af824d736104"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0128f699a4448ab4e"
                         },
                         "us-west-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-07bc4235692ef9c32"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-086db802b89b47bb1"
                         },
                         "us-west-2": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0af9fe3ba19a82066"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-069ce7754d7f30062"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "9fa202b6ee1effabd378269303daf6fef3e38379f2ba5a7bd0538e5bbb37db5c",
-                                "uncompressed-sha256": "c705aa100934903b2531b2da5b498dd36a10f64ef0c4f1a5febb33105e3868f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "ba94ea54be9cb7181e9813741e545d40744c04d91c9222929a05ce92805618f3",
+                                "uncompressed-sha256": "8949e781bd1fdfd7d810fd803f02aeb216d0ed8d964e173731d0a6cc41fcca76"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "0f4e9935469dab6fcef8f6e3459f745ea0445690e322b93a23d3bf12e61c79ce",
-                                "uncompressed-sha256": "d7965ad2636708ce37a786e2690f52d93ae70d585793400840e012fbdafebd52"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "798c5234a607765ca9d402fb3664ef2801549b103a184c17a903fbdaf681f49b",
+                                "uncompressed-sha256": "451470111e2a0327b9ca21f2b046895de11051eabeb3a77044c9a69c183ff8a5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-live.s390x.iso.sig",
-                                "sha256": "f0e68761b0b68ec92e96098c4c3bac91daa0aae59d466d9bbe75e994bfdad0fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-live.s390x.iso.sig",
+                                "sha256": "63b55fc4e99f63ad02abf5fe7f42812c68e97ee3848a1efdcffeb7417a93149c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-live-kernel-s390x.sig",
-                                "sha256": "040b3279e9bde970438f8ae099d2b6aeaa2f2a3ae841142bb5b327a75c30d16d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-live-kernel-s390x.sig",
+                                "sha256": "c4efcc3b3ee50d31221a98b349fb6a723f1db725156d95adcfa45877c31948d7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "6ec0c45bc58c7749ab066c4e3dd9ac5d4b3adf6762ea7a6c8ac60bfefc7f9c25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "ac021fc606092481643fd782566374e07fadb376c8e214ec284e29223493a1a1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "d79094ee981800b6488d4964af6c0bb08387e6aaed7f1d231f02e6c6113f7852"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "c9b0f34724b65e768f987f0b6ddd82ffc3b9b16930682b74c8d1a2daa5589d65"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "cd50f55a0dc97cb74b3fad3d592282b5289a71564d8f11b5480153cb550b0944",
-                                "uncompressed-sha256": "f3f1ec86a935c5285d95f65229abe7e714fb2b126734cb0c538c1983ecc5f898"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "d335714fed753b32ee037d92cdcbce63bb5a7e8e7490ea871c501582402823d4",
+                                "uncompressed-sha256": "f9c93fcf916546b625fecde34748d9c5e1dabb479fb7636f8958b818a03e067e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "c428af675fbb041e428b5e95aa0b426651d1ce27b9a35487410bf2250c4cdb50",
-                                "uncompressed-sha256": "c815c505e85543be998c0b60d3522158233922fb3b46e1f9c399368721a1f08b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "c4c2c92f809368250b8cb829f5532d7319f65ebba409e18d9391b43fb5c0e5e2",
+                                "uncompressed-sha256": "d4c3d2468c565f0cdcddc98ff8ed61f98293f57100d5621147f6ac8cd3c0136e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/s390x/fedora-coreos-37.20230218.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "63b462e58f5c0c294b3f60febc8c6e49ca5175be12c99797603789bbc079f93c",
-                                "uncompressed-sha256": "6aa55c23a59f86e1d815f5e31319694e82290665bba90e4a0083acfa2e0411e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "46f5f38563c13b347de1b061c7039443e063f746fd02df4a2847b8809de7d8d1",
+                                "uncompressed-sha256": "99070de0a9b53bbf1ab6100a995d522f58880a0d5e2273dc3582c3d45af56834"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "21a6bd8833e88bab10d7235ba79663f764b2970b85b02c53cd232d9cd73ebf17",
-                                "uncompressed-sha256": "b14b4c9fea8fc3caf4fb7a6b4209dabc324ce579fbc6990f9a2ae547e5696cd1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "3c028debfcddac1c960f253cab408441e0943ecac29e1f8037684816484649ca",
+                                "uncompressed-sha256": "5202c3b93e24ae664c06d8a05659a2be26dcc2755b9f0937fc97586a05bda5be"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "8b63eb6cccc84369ee209bcf7aba0b99f46dc1e3d8eb3caea1465a138fb2416c",
-                                "uncompressed-sha256": "70ced11107afeffb6f999f0d708f54dff94e1175bdc724448395a9039db34ebc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "2759c3a86a7e952313c8736b1b3aa1e809ecbc39398f7608e7e1fbfd5308379e",
+                                "uncompressed-sha256": "f85e356ec91e395f8c22e5b56ee1cb603a778931bf91a5e01cd89fdd03e21dd1"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "4b9bc654a969502f3a22ea4dfd332ee416d72956a4526b19f4b2b9fb688dce57",
-                                "uncompressed-sha256": "1bb27f6772f1a56f476be957bb07caabb2c1f5d4bca9cb9f2838a0deecf4c5ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e5ee6f627b0e92d9d6167e0f586fc7ed5739efc0beebec7b78e8875b89d56911",
+                                "uncompressed-sha256": "5627abee7a80886cc03cfe53d6f96f54427aa4b5108058096549fcad734c3adb"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "1be377bc80ed2a8abbe26be74dce5e8ba40e55f0d74f91efc7c6865a4c6d67e3",
-                                "uncompressed-sha256": "02d4b1b073cd08e3797a64be453766cb2e3823a69762aab29d2d152aaac1e95d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "04593723eca9d158f1ed65d1ecf520c4d3dc00feb5a862117d4b6c687474367e",
+                                "uncompressed-sha256": "1546ee48d145bee895ed1c316661e2dbafa6f2aae4403ffea07492005a42314d"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "853aa872ddc56550f20a0f0648cf64e059bf7bac79ca88d67264fd46f140310b",
-                                "uncompressed-sha256": "71670d941bdf358bf7cafd44d8b9f09153fa026680d234a08f581591efe0e4d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "aa6ecc8d5bed353dd7c915794558b6838e64d6abd788f138417b0688e03231fe",
+                                "uncompressed-sha256": "ab5886f5418db2bae33ad418607969124d93236103dc70eab8cb951378e56c14"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "6593825c44404924f2eb930c51faaee1af99290d34faa4d6dd151ad825a347e1",
-                                "uncompressed-sha256": "bc8d05ffe80625b16e3242d1317c4c29edc0206e87fc280c17ad9bc3241c625c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "ed8c20129ef97c6cd627c24cbe7288856704f50ce823f455f65048c82bc0f328",
+                                "uncompressed-sha256": "147cbe547315ddda19145d9d449f44a97a651225b35400c3c00809d05a7fb104"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "64379db6257cc9b25a0d95b7b6cd0f37c5fa666a30ce14b03318813426b73351",
-                                "uncompressed-sha256": "e5aeac306bde3d1bd57bb630904fbb1fd491b0fcbf7b2aa5ce4e630ab1633c2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "41c78c085081debca22e794dc9c2623a2e5f371d2c7e7182ddab51d6de747735",
+                                "uncompressed-sha256": "b23b3d2ce72fb2c8571ab5372c672878e1aa27c23a24e1303b87fccab62e8781"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "4313e4b4d2c791369ff309c66c2d6b0cb66ad0de7b31455e654c27d2de1f1739",
-                                "uncompressed-sha256": "e8a7beec89c030701640780245efd82d602a7b8b3ddbf8c2efe133e4a5de7d09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "7f9bf72928ada04884e4c09e14c958e0c1657d6c07837afbcb060646ca3b72d5",
+                                "uncompressed-sha256": "285d1323f036847f214f5797ee7a6e1138e1e477719ccc90e48ca6ebf8146b3b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "454f986279bfc098a31be04e3618a7ab8f05b58629b25d4fcf18b3fa61e0e1a2",
-                                "uncompressed-sha256": "8f96ff0a0ef708dab746c8490161fe3632fc078acff39e10d65c010863c1fad0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "aee85c3ab6e0ca100e727d07384cb4775cbfadb1333c46518564ee65ca320446",
+                                "uncompressed-sha256": "835054b71529f144f18f7605673c10aa5d1ed1734e96839fdea4c7239aa0d290"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-live.x86_64.iso.sig",
-                                "sha256": "217368ecc251924e0d59fbfc3d51a1df0f3e5efe79d6890e785edae0bc1825ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-live.x86_64.iso.sig",
+                                "sha256": "955f20f4287a910bc9f9eaaf87d75f7595a41ca7a42487701c38298097587200"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-live-kernel-x86_64.sig",
-                                "sha256": "ed8e05b50402c8d57c6f6d250009f56cefc4c993e16aa22e5d70eb67c4597a40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-live-kernel-x86_64.sig",
+                                "sha256": "862d7ccbcbb26f36e53772a7022bbc3921d5db8edb47fe6df94065d20cf73830"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "b7c8f9c1d7703fd043ea1eb6e24368f136644e2701f11f2a9be4f0ca7eb51502"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "4c1e74e78bf87aac43aca5016012bc1a11fe6518d6b63ac844bf1a0d59ea4a75"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "92a32352fa69b714eb2f185187574e4b90ee9e54717eee1141cc04e89d1817bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "ee5e9d4f7fd4c16f479144cf98a7ffce25b257f05e3871d031fa4f6e4c55a892"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "980228e15969d5a62fc3e8d6768d99bd1af252d7d8c68da7a2b83b85fa09e7b7",
-                                "uncompressed-sha256": "79c6196b0f7cf8bdbdc736e9b05c9f8a3c3e114c6477523793dc0a19ccd996af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "30bd2a734663b04b0b8ce2ceb0a5fe81fb8ad801dc75e661345184ba19b2e15a",
+                                "uncompressed-sha256": "94bc39f7797830d5867223b186aed7ccda77c8371dfef380b674c6fec8a5c85f"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "a2e0329c0f45b3463ec2545d4d878d5ec22ca9b363b278bbe2b708632586c07f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "d8b75c22fd31fe4f57202dd2a4264d50abd3cee13c3264a6b6db775172f2c757"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e7df5c39b058b1c9d11e2620ae1dd6fff1b1dd76cf83bd41e76296af729bcc49",
-                                "uncompressed-sha256": "912a932bd92dc2e1170bf723cd54fdfeb3c203af9dd8c0799a674308ff6278a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "e1d79baff5e4e45a50e05011ff3d8ab745b96466416f37c1105f9a480cd7b269",
+                                "uncompressed-sha256": "461aec429f5fbe07c7efdbdde4fdb1d417ffb81f5868af08926baea97edb556d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "4557c582f846706426ecbe8ef64f5c3b1bb84cf4cc4c53fbf40c88ce2ed4d6ab",
-                                "uncompressed-sha256": "2c0cc39cb5fb24b8491a753d63c1ca22317a9b95234dfd892239426a6fad6818"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "98bf7b4707439ac8a0cc35ced01f5fab450ccbe5be56d8ae1a7b630d1c3ab0ae",
+                                "uncompressed-sha256": "e27090d4465c0e33e656cb35c251b508fc079c4a86fa74e631a64762eef90cbd"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "bc68f7ea6dd036176e4297553e04f8d9012f5eef5baf4b2a1c1b3b7a0b03602c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "fc7786e40245a8802f9dcb5f7c8f2b597ca513cb890407b8b360999843ea4805"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "7fcd0dc5b3857a7b52eec1ec00a9e2ebceb5582f65832042ba11bddd97a4fc63"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "04308d63170ecc33dc4a76d20056eb7f2fe33f8e27e92650302b541e73a68cbb"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230218.3.0/x86_64/fedora-coreos-37.20230218.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "60a4e7c3ea1d3721d5e6aa23c51ac2f8de42dc96ecee4df609136f09d5bdf8dc",
-                                "uncompressed-sha256": "2f1d09c28e38c7ce694f0311bfc84c83f293449eb88269415a267e0cfb53ca38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "768235f02024a32d84b2f6f3c170696520e41c4b198dbf1b97e3b5cea8fc52b0",
+                                "uncompressed-sha256": "d1b24cb37a4a5f8a3e3eaf6287e44f318187300747c17f77b218654436204c94"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0b48e62701922e1f4"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-02e2635158daadee8"
                         },
                         "ap-east-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0ecf7270efbf95f32"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-00b4c955ac5c85314"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0ea31040dc0dbf412"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0deb1576298bba708"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0463d98bb3ce9dbf8"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0f2d70db33108cdd5"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0d0d24209416667bd"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-05725adfe7bd9878b"
                         },
                         "ap-south-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-00fd06d3b81d974ef"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0cbb65419bd2739f2"
                         },
                         "ap-south-2": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-09b9923a26dc32e56"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-027aed14203ed15d4"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-02068126fe1c6d4fe"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-07b3cd735e05dc2c9"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-07ba40ca37c239646"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0b1c1736f1241c5ab"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0c51a857ae646aa28"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0db744020bec7ac88"
                         },
                         "ca-central-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-07829a3d297b73b71"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-084aafc893a27acc5"
                         },
                         "eu-central-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0f127ed0961761d43"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-05426870cdf857352"
                         },
                         "eu-central-2": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-06e005390c45bd991"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-045d8869c56080fa1"
                         },
                         "eu-north-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0edc4efe0bb6e5d0e"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0166a82ade2f560f2"
                         },
                         "eu-south-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-07712ef1a02482360"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-09e3fd56e9b3e691f"
                         },
                         "eu-south-2": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0a908cb0ce6a45bba"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0fb840bb50c533945"
                         },
                         "eu-west-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0be0736ccdb484858"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-079508508f25b4921"
                         },
                         "eu-west-2": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-06d1b457e81b15ddd"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0940afd01dda29df6"
                         },
                         "eu-west-3": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0664bd8d7f1abfc1d"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-01edfbfe6d458399b"
                         },
                         "me-central-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-056bb9d61b43d6591"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-044976b27f21d87aa"
                         },
                         "me-south-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0f2ff300d68e3a170"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-07f8d7f8ad72dec35"
                         },
                         "sa-east-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-09110e7c0ea6a7f7e"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-037eb53919858639c"
                         },
                         "us-east-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0238c550d424194d2"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0c0bc857a43b6d158"
                         },
                         "us-east-2": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-01e4c69e3fd1fbfd0"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0ed17ac79c5602c98"
                         },
                         "us-west-1": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-05ebe5fc7b5463afa"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0a89df44e67c12c29"
                         },
                         "us-west-2": {
-                            "release": "37.20230218.3.0",
-                            "image": "ami-0da35dae4eaceeb9f"
+                            "release": "37.20230303.3.0",
+                            "image": "ami-0b9f8b8320dc825d6"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230218.3.0",
+                    "release": "37.20230303.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-37-20230218-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230303-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-03-07T13:05:06Z",
+        "last-modified": "2023-03-23T02:20:29Z",
         "generator": "fedora-coreos-stream-generator v0.2.11"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "a14049a7e3b6cc829396556256f1501a490b549fd4cb276991becc31cc6175a4",
-                                "uncompressed-sha256": "b06d35fb7364910885f23f7948242800d7449e005b73afd9cd1c783e29d6ead6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "05035eee0cea2c3b2f67d95db15aa6a5158a684fe3f7362781a0606e830b2b7b",
+                                "uncompressed-sha256": "ec98472ead34daea8bf2e4542081734d099c7995f82b63911b561d3faa729750"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "8acb2c8bb352340455aeda25f91c41252d705f16843b0146b62d621e87dd1bda",
-                                "uncompressed-sha256": "666b77de33541b0efabf776e88775c6aafd6bc514d02c8ee28e482b19f5a4b44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "7f081a4aa8d8c45e0b657f317bf672641aeac867a6cc697844a9a66011f4a6ff",
+                                "uncompressed-sha256": "19dd7a56381b2b308809ec9e43f861aa3fc1d7e6e102ee97627248b4cfc9773b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "420ee29f2ebd20271e081750d98b2d10eff54ed7834058d079ffb7fe15888c67",
-                                "uncompressed-sha256": "f72d0a65353c28ac04c9606a1de963ef4c19b18fe0ed09f8e74e774d2028bec6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "0f16e15bdd2518da0f39953337fe7177dc531ba196b78f64c3b0fe2e78870921",
+                                "uncompressed-sha256": "2691a22a00605612659c9ae38dcd1d4f619680f8a06f53316493ff01a849bd0e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-live.aarch64.iso.sig",
-                                "sha256": "1f7855cbad37d011351e619db5f3cb89ee89faa60633c658c4657ccc46f18878"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-live.aarch64.iso.sig",
+                                "sha256": "7046960daf7012ba2cc075f47e4cfc05567e77cb678e11fd09de64f0780ac963"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-live-kernel-aarch64.sig",
-                                "sha256": "c5f240c9e7d6299de97568c2829add78adbf97a7ed8b46183d432e51da3e3e53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-live-kernel-aarch64.sig",
+                                "sha256": "a99228f65715b0bfe75ef83db32739ba54ec4b6d0103760de915c2b0f4928fa9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "a8dc994775e21727be630552c7483836d6ffc475d5e50abac6182d9753ce05cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "7dea8edd437e47dec84658a8e6c04da8c915f7e41278a7ee45d8f184f070c506"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "7875672c89cf86a26f9cffee948a17287b7fe85b245ae350ff84290658fb20ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "a0f77734ccc15fad7e10178906e4cc9086d00b88129da2c227ed63b8acfd65d4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "5a2babcd47ebc50523c0e35e8ad3a5b9357c571b8a3cac8c7cdc3deb41196770",
-                                "uncompressed-sha256": "121f88710e7ad1c14d6508b7f2ae499db1a42757e6f3ff5911f757c19f4033aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "a2f896d928f2a13f0709a0eea7a7ad32da3c8c9c3a35e27b66d998b338704d48",
+                                "uncompressed-sha256": "6672665860d568de1536339aa3624e63d0411b6453cfab6d2a0f6319327c85e9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "76cce7ff08384671c97ffc2ff472eb784916d542d905f84b702d9a42f186db42",
-                                "uncompressed-sha256": "5a80aab9ee921eb39ca689ed7320e165c07a5ffcc2dfabf1cd45a200f8f0555a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "d2c557cc5a1189dbf6ac3fe7d5144923c5b7d4528b4b227f8c2904dfedd53ea4",
+                                "uncompressed-sha256": "4cb1a1991fc4f43ecfd1e906484989526acccfffa0f409df3ae329aff71be850"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/aarch64/fedora-coreos-37.20230303.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "137462d9b58cd2b0db107a7802529ac1d3537975a8bef0123b077f12db08b3b2",
-                                "uncompressed-sha256": "752e22770414dddc137845826bd4834fab246bbbc79f73809f19910d306caa45"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "a1885681b3125db0a7aff36bfeb01b65a8a42268fe096080d69af21c43d0d363",
+                                "uncompressed-sha256": "a037a7fd8668d008af1c9152cd759e60c7e79dcde01bf5b9367aa09ef3f7253a"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-034d1745a49dd8c16"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-098abb681d88fec82"
                         },
                         "ap-east-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-050b9a02582bfaa63"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-03881796e67997f1b"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0e3792646a08dfb72"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-038dd52d074a98734"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0f21df897deb22017"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-082d1372fbb540604"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-07041059d1bc71e9c"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-098bbdce9596f3d81"
                         },
                         "ap-south-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0b30aca1072e6dd18"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0a8c8370efb8e714d"
                         },
                         "ap-south-2": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-06fb2d447203e346c"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0b3f31cd747766a06"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0e952a437561b9baf"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-060ee00af96b6fe27"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0cbe02dde271f781f"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0b9dc4e2e5130b680"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0c37af1237fc2f86e"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0cd18f22c607eaa89"
                         },
                         "ca-central-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-002fd64bceba90405"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0761e90970d4b052e"
                         },
                         "eu-central-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0746d8204f6f3548d"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0e7b9ae29e9f1cdaf"
                         },
                         "eu-central-2": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-071d28c365ef48cb7"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-08f428c8a20668959"
                         },
                         "eu-north-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-02d7ba4c8af7ca316"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-03fbd0adbcea414f4"
                         },
                         "eu-south-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0bbc1b7222e161b72"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-036f9913b2c094953"
                         },
                         "eu-south-2": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-04be4acaea71470e5"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0fc84af08a42de8ce"
                         },
                         "eu-west-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0df07a0cb2516c773"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0f7caceced3df152f"
                         },
                         "eu-west-2": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-035737d7777dfda1e"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-09fc7fb27797dcec5"
                         },
                         "eu-west-3": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-064fcc9e22f07487b"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0c0aaf59c6cf53d87"
                         },
                         "me-central-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0b9b2ed3dd25ac47b"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0c49e3d663d9cfa3e"
                         },
                         "me-south-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-04bb42b28e11a6275"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-02bd500b6ce507470"
                         },
                         "sa-east-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0a497e5796d8c4b83"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-017a8529eb012d2d8"
                         },
                         "us-east-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0db150e00bc8a0673"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-097d6e0dc7c80b45b"
                         },
                         "us-east-2": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0b19ffae4ffdb6c7c"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0cc6945769585aa55"
                         },
                         "us-west-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0b296626693917dc5"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0064b63fb25645d4f"
                         },
                         "us-west-2": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-00e7ade0057dcf4de"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0db5fcd611330582f"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "d551f3a0c7d5247d526a136e90a6189510c71a34ef25b1607496dcc4edf9ef8f",
-                                "uncompressed-sha256": "02dfd345ecb8252ac1dfe82be6cf7aa8b689f657d51976066a29ecc52bffdb2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "b785a669f0daf7c1aa32a980d5013c18d74101673a83ae7215e184ecaf3b2781",
+                                "uncompressed-sha256": "ecd107c275809c52d31a5938a528bc659f9e7ddfb9c9a66ba13dbea8f1d438c0"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "6d8fc60344a381d923d73c22d463b550e257eabf953b3cceacd7370146d68e31",
-                                "uncompressed-sha256": "51334704900f0fa07edf07f1699cce44823fb6bf00a33036790b5086e007b25a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "993c6160b008bc67afd1db93d42c2fd4f091ba171488681490bbb61e537237d3",
+                                "uncompressed-sha256": "246bc1bac009b4abf2e0ac33b246687c86c9f04bb54ac463eeeeee951ac4079d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-live.s390x.iso.sig",
-                                "sha256": "c830533bef4eba20b03f7258963c1368113f7a5db4d19a82f867e5bdd747e087"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-live.s390x.iso.sig",
+                                "sha256": "1a846058bfc76f377a36caa5b6affa33ff413d3658ed109ea1475388928b8676"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-live-kernel-s390x.sig",
-                                "sha256": "c4efcc3b3ee50d31221a98b349fb6a723f1db725156d95adcfa45877c31948d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-live-kernel-s390x.sig",
+                                "sha256": "47dcd65d330d40d0cd6e7e9f95c64088e2c3a8f394a77b13cfb109198b93e4f4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "265881b3dff4edc1a8dfbf78f39ab3f0986e5f5f5beffcfd47c75213ec8ae04e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "002b9447ae9c0f2077f0d677173fee437528f207f637df5b9ee36292a2d45324"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "1b3198c2834fa232f5e6486d8e34e481f843651b58c5f69fbbf1474b71b2ac83"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "5058f7a96ee91d255fc45c50041753fbbbd1fad122a54982a41087c5de8caf50"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "0d5a268617066b96de34c7155086f4902595628daf39f67660f1ae3682c915bc",
-                                "uncompressed-sha256": "393a673ed2c4f806250d11c591ba5235e456d295b6465baa0ffe7165f63955d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "bbc061669dc61f5596cf15890f9dea5ad30b0340cec286be7ebf892a6d3dacb4",
+                                "uncompressed-sha256": "e844a504476768655c7b21deff568041d3d0e982deae82b955d8b7100ef789c7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "a99704414da3a1f55471529b7dcc4adfa578bb7bc77d1a8f0db38cf86e1254a4",
-                                "uncompressed-sha256": "10964863292cae7952f45cb00133eb6968fe188573ba84ad2c9458087bd69dce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "fa96a18644de322d6f28d5ef2c22a9a4a2ebe223c0758012928cb0702bbe9127",
+                                "uncompressed-sha256": "268e7b02944b6cfba1bdea5237d488dbef47d224c00293d93fa478fc16949e58"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/s390x/fedora-coreos-37.20230303.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "c7fc7e273c83dfbdd49e3279796129c54b5592ca9813b14aa2a34c119bcbe51c",
-                                "uncompressed-sha256": "ebac87cbdd577ba151089de443a09062f6d871e3de7e8442d9f3e11f07293dd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "2eb15c052018497f955570baafd6b9cd8171292d46ef70fbe426e5b730cdd6d5",
+                                "uncompressed-sha256": "30f0c682efb48ab2537b783d2bb77e54cbe0d1232f9229813af51fe068ad3df0"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "3864da30d55f87e1bbe9c760d5bb4fb88aca10283544347fcb41f6865e4a3c65",
-                                "uncompressed-sha256": "2c35a672fb837e5dd45fcc771bb0f2b311c905e9f9727aed7d90da837ccf5238"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "3760b3087e7530cad20af6cb58a197ac2d906339bfaaa645d2d316d13ce70cad",
+                                "uncompressed-sha256": "645c38515f8902a80f6d4bfa3432c4bf215e3a6731fc9464660032ef3c83ca1d"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "45c65240d3d7490c7676dcc8dbc15643fa3ef42d59a183907366232c7ec42366",
-                                "uncompressed-sha256": "93fb9ad5b5989328ab41bbc563438a1d2c141e5b50deb82e7dbbc50271477068"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "7a60c5e7c314165a7e48d25a8ab76147e54192e2bd225b9b9f31ad67ec851d35",
+                                "uncompressed-sha256": "baa80658b28e658f2918972e76197048128df33607b7cd4145680396c7fcd61e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "1a0c51492694cdd682c49a97a14f1ba39d4666f65112258aeaa60fc9d40dc30e",
-                                "uncompressed-sha256": "811de4673d9e058fbc8e96fa56f302a6fefe9eeba9a0eb42f5dd3b7e4f81d952"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "4a9c45b65cb0eec4b040f5846d1a1ccfa0bf98bd25e13214faca14e0299d7a48",
+                                "uncompressed-sha256": "edc89bb6b1009ef18799354ff2caff697439320289371fe585dac17c0ada17fe"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "c8f40c6a43dcfdd15e34af10935433a2379bde743960cbd2cbb1f84ec5628bff",
-                                "uncompressed-sha256": "a97bbded8995359081ace027c8cb7a7c5477c8bdcce2af8922bf094a25b22997"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "45c9021d5388759d4f69730bdf5dad823e0a528d28f9245ae1e42fea2a900030",
+                                "uncompressed-sha256": "3148b5a540987cb8b1780a2d0444c2d68ed7bd14fc0ec628c73cd5fdb85a0171"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "aeacc38ac75940f97d4d0dde438ad089ba4eca7d97cf7d3e91283a7d6c192b19",
-                                "uncompressed-sha256": "7fa18dc26de956fc74fb29aa59a255c636c9dbfc1b963946a507957421bba5f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "47b43a8c0340967afe1a00fa856da6c97c146428ab3b3dec081eff121b7bf2b4",
+                                "uncompressed-sha256": "e0c7749908965f5e8d23844ff42dd0b1385c6e13db83e1972bf481883c420415"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "f91ccda218830ce95fa078a64e61bf0a0c7d949b34d2ef15160166001837d995",
-                                "uncompressed-sha256": "550d9062e2ba47f6e3eb397f88af98d89971baff0ea7010870690d1d511f7c13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "1ef193c14d3fdfe991fa987f82cbf0afd52387838d6f2d1ab51f3ae98900fd6a",
+                                "uncompressed-sha256": "6ac91428ee15b8bd129f99c866888ba54a235c1e59b183b88207c9a605f84937"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "df9c807960ba869fa65ebf7e961b0db0de12191f627d63f7c994240a0de3dc89",
-                                "uncompressed-sha256": "4e17cb5dd539604882e6481382c2a9b18f70eee3c94b2c679ee523a2bf82d7cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "5cb41f78ba411ae0fae7b3bbc92beb56e6d3db762cdb0e02a7a5aa62b9eae03c",
+                                "uncompressed-sha256": "f90ad8d9a144405da676ad9b360f2c387032327ff74f6ae79893b8f41a27afb4"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "43c0f55fcbaea5821c3157892454ada333fa8ca21fe0cce4b68ffdcd663a48f7",
-                                "uncompressed-sha256": "eebda37dc7309fe1960a459076ad8b26955cc6f03b3296ef0300d19c52aeff2c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "36695f476d61ec7fd5d183b1a75e9dfbfafef83138060120b2fb7340bfa69c62",
+                                "uncompressed-sha256": "7b65e0b8b9797898c00d6c27fb23efd4618913682e0ac43a731e56ab39d95198"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "f2cd36fddf31f26e6a6f71b044db2b5ddff8b1a3c07e1c88c35b70c37cb16f2e",
-                                "uncompressed-sha256": "3b40a2aa4c6b5d126571aafcb6b4beba30fb3afd75e4ae58d38711fd01f34739"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "f957cece82c80fbdf83a64a52b38013e9fc458aca7623c189583baabb776502f",
+                                "uncompressed-sha256": "94ccce0de16345332111e4e3a6eeb5da7057872675af13df8b8b083d08cd5cff"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-live.x86_64.iso.sig",
-                                "sha256": "274fa212bbb5f59998227797e9ae7ba7176b3d6c1ef0f71d1984bc3c3d3e4858"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-live.x86_64.iso.sig",
+                                "sha256": "0442eb0fef688cc06318b296922fec19c5abfceb08928ac68c9c3ebf4801e21b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-live-kernel-x86_64.sig",
-                                "sha256": "862d7ccbcbb26f36e53772a7022bbc3921d5db8edb47fe6df94065d20cf73830"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-live-kernel-x86_64.sig",
+                                "sha256": "cc47f1102fc229a1624f425b9c064937b07a6a7e39a6a5ab8fd37f49358e1fb0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "e7f88613439bd3b66107d829be6fd24d3abfc0a7d6107ede3c0735e4c4bbc651"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "0ee44ac9ef4938686bbd5d6bf108ac481e9a46c9760a0dd0a3e7edb1b22cdce0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "e80f1b6bcf66a0643f038c98874cb92ad33e9bd0f90cd8f01e91a4773b06ff02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "c3e21706b4bd858b35ee479c9ad85a911a37c2b442aafdd57caaad76f6e59751"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "b2faaf27426f0ccad3234a3cf5284f1c4e9cfd5817b7919e6c7151fd9458c3ab",
-                                "uncompressed-sha256": "923a22395b7632a73199358f215eda7660fc88299ad862b3a53eee3895e12544"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "36f3f4c68287ecf33f7653de6346a9d2ccf397d4fe37aaa1ae6d64eea75f23e8",
+                                "uncompressed-sha256": "9a3bdb3773c05b03b87072fecb6b6645f28384e5d5cbf00624c58f82aa594745"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "da41e9c1f202a890e347bfe082f18fbb5754e90533c5fff23aa1e8fffb584d88"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "ba7fce876854722ed010704434f2842c41b623197b9069166bc36c0a8b43d6ad"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "377ff5eb2112ca5f2eee7a438e8bba1bb92a236bb0fd69f92b5c7f986cbfb0ae",
-                                "uncompressed-sha256": "0215fa466e4f2bd03a3584a70788d1a83a5e182171ebf817c1aceefbd33a7705"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "0bc5d4061b607adb18ca5afeb6ae1c434d3a06a5ca65a395fcf04b9cd084769d",
+                                "uncompressed-sha256": "bc3429ccf56c3d45c2e90b8922076c40488dac94f0dbb646164368ff32f83e9b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "6b9ec6b593ce80a76c22e8b7f4876c07430b498207ea0d85a80d820144344cbd",
-                                "uncompressed-sha256": "41b251d18e5894a0f51ae0a472968c9de349c6ee903cfe1803aa4ff8e06c2356"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "cdfea01419fdda1e164662aeaf8c6a7550e7e00bccb5cd63abbd9de18ecf7937",
+                                "uncompressed-sha256": "c817c0f35b10e2d35db50539999402e06f38e8eacac60d12e9ee88cf8c608ac9"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "17929673d3d66dd926bb0582d3b523687bf596546df0c768296ad228d9cfd97f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "395ea80efc6d14d86eeb543fa31463697494ff57c18965360341986216656167"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "219785e31ff0ba2a356e62ace083fe4fe5501407f039fe3d561f59a27e4176eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "ca1dc5aec3f9677ac1aa067a90fa970a32ba54832937774dff987a729aff33cb"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230303.2.0/x86_64/fedora-coreos-37.20230303.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "57cda460fa1b3aac81b41853a0e90be499186c7fed9c1cde08bb99b6ef6a2ef8",
-                                "uncompressed-sha256": "7810699e3a459a4ea3d4901c7b4c99e7e55e7f27e21c6d3091307fd15018f7b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "6055ce50af9883abdde13a7ae1ba8fd6937203b32d259b491b5c5eae0ca2c7b1",
+                                "uncompressed-sha256": "4cee75a95507ef372b20ac194fb074087a62a4f53b0bf7c9f188677c81731e91"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-02097d16a61fbeffd"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-012c92119dc44293e"
                         },
                         "ap-east-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0639b2472d8fd416e"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-09145ced6ba8a726c"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-07fcfa81d770af659"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-00bb82b13ab556bfd"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-09fd255c4e33b8240"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0fd4ab5ccf89ea082"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-09893c739d20336f4"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-07f8b45aba01d30aa"
                         },
                         "ap-south-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0b7696f241e502318"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-01e1b4c3aca904e2d"
                         },
                         "ap-south-2": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-06cb0e42b206ebf8e"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0285c17c90e0d3ada"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-03d0935a3673c21d9"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-098b8d6af8dea8dde"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-09f2f107fa0bd4490"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-05e93346814b5cb76"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-04ae08eab4361dc33"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-03b4a4850188727ab"
                         },
                         "ca-central-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-03116bb56b91710a3"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-01e27fb2fe28f0356"
                         },
                         "eu-central-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0734acb45b4ae8788"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-06c8295be82f729a0"
                         },
                         "eu-central-2": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-050dee80ff06daa87"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0be86961879c46fe9"
                         },
                         "eu-north-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0cf5828fccd755d35"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0d539025e7f33442b"
                         },
                         "eu-south-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0ce70695a772eadb1"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-021b05597f4c611d6"
                         },
                         "eu-south-2": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0e00c41bdb926165c"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0ba7d47746e373948"
                         },
                         "eu-west-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-02e93c3b61c083d0d"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0b0d67ce0995c3758"
                         },
                         "eu-west-2": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-023be26fd05995f64"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-061f63710f2725577"
                         },
                         "eu-west-3": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0b0a3a73c0bb25955"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-04ca1d82c1ec1a75f"
                         },
                         "me-central-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0b67035b631c75179"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0ec5814f59b008f5d"
                         },
                         "me-south-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0c18e254efdb3b7db"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-043350c564dbb5e89"
                         },
                         "sa-east-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-052225389012a9fc7"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-06de3d32ba8868ca1"
                         },
                         "us-east-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-06f72317d3b7692e6"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0d5e3c0a8f262f93a"
                         },
                         "us-east-2": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-05b90f01ad27ca23b"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0ee855552aea7e899"
                         },
                         "us-west-1": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0fe1ac0e44989a2e0"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0feefac5a750ba978"
                         },
                         "us-west-2": {
-                            "release": "37.20230303.2.0",
-                            "image": "ami-0acbbaecc2650f8c4"
+                            "release": "37.20230322.2.0",
+                            "image": "ami-0c2a413c3221042a6"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230303.2.0",
+                    "release": "37.20230322.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-37-20230303-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230322-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-03-07T13:05:06Z"
+    "last-modified": "2023-03-23T02:20:28Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "37.20230205.3.0",
+      "version": "37.20230218.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "37.20230218.3.0",
+      "version": "37.20230303.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1678204800,
+          "start_epoch": 1679630400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-03-07T13:05:07Z"
+    "last-modified": "2023-03-23T02:20:29Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "37.20230218.2.0",
+      "version": "37.20230303.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "37.20230303.2.0",
+      "version": "37.20230322.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1678204800,
+          "start_epoch": 1679630400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).