### PR TITLE
updates: make 37.20230322.2.0 a barrier release

### DIFF
--- a/updates/testing.json
+++ b/updates/testing.json
@@ -95,6 +95,9 @@
     {
       "version": "37.20230322.2.0",
       "metadata": {
+        "barrier": {
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1441"
+        },
         "rollout": {
           "duration_minutes": 2160,
           "start_epoch": 1679580000,


### PR DESCRIPTION
We need upgrading nodes to flow through 37.20230322.2.0 so they'll run the bootupctl update systemd service to update the bootloader to ensure they can boot the 6.2 kernels on aarch64.