### PR TITLE
Roll out stable 37.20230322.3.0, testing 37.20230401.2.0, next 38.20230402.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-03-23T13:38:24Z",
-        "generator": "fedora-coreos-stream-generator v0.2.11"
+        "last-modified": "2023-04-04T19:25:18Z",
+        "generator": "fedora-coreos-stream-generator v0.2.12"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/aarch64/fedora-coreos-38.20230322.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/aarch64/fedora-coreos-38.20230322.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "9d14fae04b72ce38c48a0c3d39787f5b60efb62225083e0194b1c4de4eb8d284",
-                                "uncompressed-sha256": "b9559fb3b8a32f155a9e13aa75bfcf51dbf4220bd4c791add479e008e078f003"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/aarch64/fedora-coreos-38.20230402.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/aarch64/fedora-coreos-38.20230402.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "b10a95623a4866d4820c90b301f39398c19fa761d6779baa607a5b55e8a6b7c8",
+                                "uncompressed-sha256": "856c4934b867d3925467e8174c8420680ecede670eda3926285cd6fca9db138c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/aarch64/fedora-coreos-38.20230322.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/aarch64/fedora-coreos-38.20230322.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "b846f1b8167d90cffffe715bf3995e71e1a0dfa90a6a7de958f09fbda4527cfb",
-                                "uncompressed-sha256": "846a2b141da288adc162ae3eff9562bdabc65711020a6004aee7cab382cbfb41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/aarch64/fedora-coreos-38.20230402.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/aarch64/fedora-coreos-38.20230402.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "9de0ccefd2b36bbbd35c0dc495e01f604ada68c925cbf082d1b48b5ffd07b8e4",
+                                "uncompressed-sha256": "e06c6a926dfaeb3f38da0e18a5c168e40582b0089cd309783d94431d8277b01b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/aarch64/fedora-coreos-38.20230322.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/aarch64/fedora-coreos-38.20230322.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "7c1e7613014c22e91998fcc6d21c01974044bd77c344ae2a06194ce40a049547",
-                                "uncompressed-sha256": "b7a45cc095326c90ae2ff44ebda0622c571b5b4b495d9c140efad1070b6934c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/aarch64/fedora-coreos-38.20230402.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/aarch64/fedora-coreos-38.20230402.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "d24c43fe0372a0f026459b1f71c84f939aec93aca32ca22024a677a29fe96404",
+                                "uncompressed-sha256": "7fd09b27c44bbe08c6cae9c830c47f3514009c2cac45089de3aa37ff5d5b63d3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/aarch64/fedora-coreos-38.20230322.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/aarch64/fedora-coreos-38.20230322.1.0-live.aarch64.iso.sig",
-                                "sha256": "5fb26aeae3bde1bf4ff92e7e5c6db9b0913316e3b8d7e831ea77809286e995d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/aarch64/fedora-coreos-38.20230402.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/aarch64/fedora-coreos-38.20230402.1.0-live.aarch64.iso.sig",
+                                "sha256": "d5f0f79640685ed991db80b62f9022eae55d57901dbf862174cbcf2ce99b667c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/aarch64/fedora-coreos-38.20230322.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/aarch64/fedora-coreos-38.20230322.1.0-live-kernel-aarch64.sig",
-                                "sha256": "d622f87fb7f20dec663fbbd26ca85f7f6bf78b18094d452a221217f622c1ac9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/aarch64/fedora-coreos-38.20230402.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/aarch64/fedora-coreos-38.20230402.1.0-live-kernel-aarch64.sig",
+                                "sha256": "bd1b55a2d320a571ddbe4e86cffae80558f849bf0b3d0ff21ad4e3899cb32211"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/aarch64/fedora-coreos-38.20230322.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/aarch64/fedora-coreos-38.20230322.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "32ffadcf77564b9f25aa0f5c2baf0089530c2fc8ef0627ab4fd3bcfa72c3cd3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/aarch64/fedora-coreos-38.20230402.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/aarch64/fedora-coreos-38.20230402.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "754cf2da91947dfe4ec56f527786acd7421a1d34b6ef61b81f4b624e48499f36"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/aarch64/fedora-coreos-38.20230322.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/aarch64/fedora-coreos-38.20230322.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "5df3a2c667cddf59da128dd2e6bea43f474c78dc7d358a340d4be6cc27789a7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/aarch64/fedora-coreos-38.20230402.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/aarch64/fedora-coreos-38.20230402.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "cacca014ad7772231395b2aca00c474589e0289f8047c519a009a5d565cf671d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/aarch64/fedora-coreos-38.20230322.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/aarch64/fedora-coreos-38.20230322.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "ddcef3486862c25695c3a255bd98319678ef7b9b8ef57563917965932bf82d9c",
-                                "uncompressed-sha256": "ee0d8d2f0554391fc296f3264e6d12da1113e4f58aefb73438fd78996662e289"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/aarch64/fedora-coreos-38.20230402.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/aarch64/fedora-coreos-38.20230402.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "09ade618702187046ed991e022ff95f37d47f42d5aed70c6b38ec49f1b83a72e",
+                                "uncompressed-sha256": "5bcc837492c795dd56300ed3cde6e92d4eb21ecda57ce3f88362c59086b12e5c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/aarch64/fedora-coreos-38.20230322.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/aarch64/fedora-coreos-38.20230322.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "6b6d0921dcdfe66b976b0b13d5149d1026ab40c550b060b13ee9358936dac7f5",
-                                "uncompressed-sha256": "48ea9b02d95515769cb959a254a1ead9a80ece4c8492a9daa9fbf01e4e166295"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/aarch64/fedora-coreos-38.20230402.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/aarch64/fedora-coreos-38.20230402.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "d954fd92ca47e7698aaf402259fda9afca694aa6e606330fdc9fa711e1f7c6bc",
+                                "uncompressed-sha256": "596998a7bd9cc1a77ad38495472b3fbccb42960cb62f1e1ec3c4bb11fed516f8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/aarch64/fedora-coreos-38.20230322.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/aarch64/fedora-coreos-38.20230322.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "ada164b6dd9808086bd5e60db452bf25e84d0fc9617e66abe3fc94e79a161415",
-                                "uncompressed-sha256": "10569628d0d47cd131f0fa90fa3c7ab8fbdae279a0360d77358b2319692e86b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/aarch64/fedora-coreos-38.20230402.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/aarch64/fedora-coreos-38.20230402.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "be12ef6d335512dedf6a932281b32bf135a5e5f5c256fbb52fda5bf2fbd7b1cc",
+                                "uncompressed-sha256": "f2f3ac709fadd5c552b3011a6624ef4e3d0b14ac69c4b6c935d698a706a68ac6"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0098957030d13c7a5"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0282d5af251001f5f"
                         },
                         "ap-east-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0fdd5c51573ddc381"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-09439ce7d1ca1618a"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-01c68b35b9dc2a618"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-016eca1a3dc7b9d60"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0f2724b53a38f163a"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-001fe768abf389c68"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0f17fa77641f5d647"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0a8f466956c19bd9f"
                         },
                         "ap-south-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-07991d638948b547f"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0a4cb2e3a85b95c00"
                         },
                         "ap-south-2": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-061579133d24f1521"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-06df6cb2fd7e8e56f"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0c1124b9d8661ab80"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-040c13380c28ebbd3"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0cffe935d605ee541"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0a9a397f2694dd79b"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0e220bc5d42b87032"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-04a63af0685af6fa0"
                         },
                         "ca-central-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-07e2c622c3f7a2b58"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-098351048586adbf6"
                         },
                         "eu-central-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0c6aeaaac25ef1f72"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0cec0408089c96ad7"
                         },
                         "eu-central-2": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-03ccd9f6ddb6472fe"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0101dd1c4e70db507"
                         },
                         "eu-north-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0dcac6edd88077aa6"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0f5a94e3d08452ed2"
                         },
                         "eu-south-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-084d2ca15f4a77b1a"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0f7a856f0b3d88619"
                         },
                         "eu-south-2": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-04295228afa590928"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0ca78523670bef57e"
                         },
                         "eu-west-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-007df23ae3cfda3ef"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0310d7cfc0a1473f2"
                         },
                         "eu-west-2": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-007a7572964f5fa0a"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-064d54ca2cbe4a62c"
                         },
                         "eu-west-3": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0b817d8dd7a227ee1"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0610c8846cccf218c"
                         },
                         "me-central-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-01855e19236210aa9"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-06079b2685ee3d783"
                         },
                         "me-south-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0c718beb348ad19c8"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-00f8f391254a32374"
                         },
                         "sa-east-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-09c9b5a29d36b2380"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-07a3dc26795737dc4"
                         },
                         "us-east-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0fd6fe6dfea8ca49b"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0582a6da1aee41481"
                         },
                         "us-east-2": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-090f2c47f4a1e2a21"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0b67c50130b4fe3cf"
                         },
                         "us-west-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0adfbf5db3ed95e70"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0d9816d5d00f91ae4"
                         },
                         "us-west-2": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-053c209a1d515abc7"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0589ad358542d9f62"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/s390x/fedora-coreos-38.20230322.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/s390x/fedora-coreos-38.20230322.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "88cf2fb0f7000ec8609314ab6256e3fab73cf5850a1e0138da2e76378e8fb647",
-                                "uncompressed-sha256": "7a7f6d2c7dda98bfb8b00f6abea1347c4a1921e68ed7afe44bcbbb1ad2aab33f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/s390x/fedora-coreos-38.20230402.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/s390x/fedora-coreos-38.20230402.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "54b4dcf971575b3ba7acc2eb102ee38d592ec527d3411a1e80d4b210d3478e94",
+                                "uncompressed-sha256": "f40fa8a4b46bf521943061002f8d152f7b8f0f76998fff0968c0e147b5dfb63e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/s390x/fedora-coreos-38.20230322.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/s390x/fedora-coreos-38.20230322.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "a993db6ece7b1c50974a34fe066ae6564288ecb287b9f1a5622453acfb070ba4",
-                                "uncompressed-sha256": "050016bf3264cd675da80b2c9d2e3968f2d230ccc565ea7928f8302491789e88"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/s390x/fedora-coreos-38.20230402.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/s390x/fedora-coreos-38.20230402.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "3befd638b91e49bf08d7b2c8c2b0bf2f23abab725c75b5363b21872e59a52f66",
+                                "uncompressed-sha256": "ecc6e1a80a54f98f81991c36bd1905ce9a0b6615c3e841baee7f8c4ae4784fc5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/s390x/fedora-coreos-38.20230322.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/s390x/fedora-coreos-38.20230322.1.0-live.s390x.iso.sig",
-                                "sha256": "88ff77a9567079a67078fc52fa4989b1a5e71efac1a5faa2a411aebccddc0bce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/s390x/fedora-coreos-38.20230402.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/s390x/fedora-coreos-38.20230402.1.0-live.s390x.iso.sig",
+                                "sha256": "4777a89107925d4ff33ec15ab2276ff1f8b809ab8f0c93f248f1c7f8ed30979e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/s390x/fedora-coreos-38.20230322.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/s390x/fedora-coreos-38.20230322.1.0-live-kernel-s390x.sig",
-                                "sha256": "900f2ef9e1ce7c44996b95056dde97edc045ecb27e2a74a0f7481f5648ecf3cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/s390x/fedora-coreos-38.20230402.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/s390x/fedora-coreos-38.20230402.1.0-live-kernel-s390x.sig",
+                                "sha256": "65272204237a8a5ac8d636627761f7693f77f1cbaaff328de0d215356c6f30fc"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/s390x/fedora-coreos-38.20230322.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/s390x/fedora-coreos-38.20230322.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "656133bcb6575fd3786de4c667cafe56bd9adfe041796a8dd1aab0e348103978"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/s390x/fedora-coreos-38.20230402.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/s390x/fedora-coreos-38.20230402.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "6af44eb96d5828e0d059c90b794ce84543bac8679b0becbed12abf4f3faacba2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/s390x/fedora-coreos-38.20230322.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/s390x/fedora-coreos-38.20230322.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "a183e9e2a4121e2ebf614d53ad06d2dac733933d31e4e81a4448a40190a60c90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/s390x/fedora-coreos-38.20230402.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/s390x/fedora-coreos-38.20230402.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "13069f71dcff6837b4e2d0e4398014493cc90be72b97892dd8b50a27ee11aa5c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/s390x/fedora-coreos-38.20230322.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/s390x/fedora-coreos-38.20230322.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "cf84073bab8398464d6d368cd1be2c293e5433422b34c18bcdb9f7631936b44b",
-                                "uncompressed-sha256": "4a3181b7f23a8b3969b340296c51743203207d2dd6270767bf3ac75777a5cb00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/s390x/fedora-coreos-38.20230402.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/s390x/fedora-coreos-38.20230402.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "9b45f53802efd5b0c1574d9209cf8edc1aecf489552f0938ba5d2cddf3867d58",
+                                "uncompressed-sha256": "b02463523b331b2cde6e963ae05971f7c4e0322371082496437482c28e2b4263"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/s390x/fedora-coreos-38.20230322.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/s390x/fedora-coreos-38.20230322.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "4f7a46f2ddc25343dc95f7c6b7cd4d5bfa26c471387c91931c7888c83a52e547",
-                                "uncompressed-sha256": "cfc9ab46901e308f6b76a5b3a5613049ec01111d558678dab66092a30da7d69b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/s390x/fedora-coreos-38.20230402.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/s390x/fedora-coreos-38.20230402.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "0693348097c120a45da37c8f36743d806dc3eda402696fcb17b68dcb967215dc",
+                                "uncompressed-sha256": "cead68583e457e19598a16cf38595eb7122f15bc65e97bfa515688c080cd0a89"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/s390x/fedora-coreos-38.20230322.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/s390x/fedora-coreos-38.20230322.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "95c1140750bcfa03d4df03e44fda8162244916ea02c3795e3e2a579afbdbfda7",
-                                "uncompressed-sha256": "9ea8ffd014b3fa366d66bf9f2232ca9dd29c11585e61459787e068476c6ae05e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/s390x/fedora-coreos-38.20230402.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/s390x/fedora-coreos-38.20230402.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "d73a1979664b6067f2656aad4625d27689a3e41b8f1d958942169792542a4f91",
+                                "uncompressed-sha256": "260acfb8cdcaae92dcf93fcc9ef5eb7e30157ca371e16fb971f63c035e455e9b"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "bdbd614c6887a24a39d450c3ccbea185687bb8e7a54ad7c560980b6de9e19ac9",
-                                "uncompressed-sha256": "a804f56d45d1b061dc57fa64da7fa139ffbc10d8cfee37886e21fe8ac4bf3ba9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "a7afc64f7dd6616a0a95aa5a630b40caef609070622b17cf57eb88c08b7b6a57",
+                                "uncompressed-sha256": "28361f84c2d1576915ca789689491ead793f8353221637db87757b2d6024d0c9"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "17d2f2ad1e1694ef47f9f9455500d37b24012a6fec08691d763199948003fac1",
-                                "uncompressed-sha256": "3ee63ba2b84f86936848f3d553ac5ff001ca4952da299881ea37260c9fde0d50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "c491f1c40a63e6fceec63eadf94023757a8f20349568d08ab6319b69270e3490",
+                                "uncompressed-sha256": "322bb2e3e27aebb21f114b0d9ab4dedf91d91dad6c017459979cbc2ef35ff523"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "ab2f4cc067d4c110e1afb2349fe43b88be3f43000a36696a9c614b09424e8a90",
-                                "uncompressed-sha256": "31d65846db7e7ed33ecc6ef3eedd1caca0b6ebbd21167cea0cf5a2ed976ae5af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "452bdf1c2c08b0c64577ebec66bd07a0a856ffb36cf8c483feab4291dd3b6b43",
+                                "uncompressed-sha256": "9de4e9fab849ce92e5c1b9671e6373f92097363cc9f60570b89d1b16a804ba85"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "6f3bf487eadda2ae3da67de130e27aceb645987e664420a05aa604fcfef82d90",
-                                "uncompressed-sha256": "d725555b565328be15e1e30ecedb5aa764f99f539837f7df1340ab768572160e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "35f6dfab028a97413cdba6d1e993e53547a3ccf5f2e82185fdcc7aaa0a5b242c",
+                                "uncompressed-sha256": "1524b559bd01a332b4a937b11ad48f7f1b4efd5bd8cb888b257a1c05ad805ee1"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "4919d82b9b1481945984fef840630e2b3b65cc4ed0101f8b861f1d99e17f050c",
-                                "uncompressed-sha256": "45abff5b426d5b87e2b48278120dd7b5e9eca4c658c7e8343dd0beacda32d07d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "ef8a6419a87aa2ee7b4be3f46ea144d240ddac3743506b7270dbf0ffbeae7f01",
+                                "uncompressed-sha256": "3eb8c2f78dd031069d7b9a6e32228b17a915e7e79fe6ee80135c3350bbed5ab8"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "4bb089d98c31cafb30a13fce0a1c426e1842d03c9fcd1af18d7a0372bc9d9aab",
-                                "uncompressed-sha256": "abdbd87d8bff02a3cd79712431dbefa2a67e753dc4ef2a9106c9278398f4f72d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "f2fca9592e6405ba0dd51aa6b2e199a892b46343da0584ded3e1a5b4ca94991d",
+                                "uncompressed-sha256": "c9018fc310371f1e93e715b6b0fb86a02b1d22abc942b25cae7e1406f34dd7f9"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "9801c5f7859ea0ac39316dba35f7a57134f3f4d2cd685bbf3fcd1dfee362abc7",
-                                "uncompressed-sha256": "a1e41b495b5fc7df36bdecadc59f200728d622a7e416a48320ae8d6f7ddb7f50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "e4fbda1bcfd8da5e717934ae84a32a86ed1f3878b283627f225e897ae48bda71",
+                                "uncompressed-sha256": "94916d6b9774e879f4c2a3c1a85dcefc27eb6c9946bc7d08e0c89ada197fd033"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "10ecaa19ee34707dc697e4d59fcb1b7b4c6c01880d45f25fe158f7198ff753aa",
-                                "uncompressed-sha256": "005fa8510ac17d991ee7df8fc634821f2222a8334ed46f86c4a20308723196b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "85b4e400cfb448f4a98efa5284710680b3a7c82f1bec22c8a6ced7a5ff00c210",
+                                "uncompressed-sha256": "3ad7aa5c6c0f6c53175af44b85f3ecb46a9d18e70477da01903d2b81622701a6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "e44c9dc49cbec997555a8dd15c243acc4a128a175562e88931607867414a25c2",
-                                "uncompressed-sha256": "0804b3881a5abd3f7346a78f1c0a4dc456c86b6036fed442c1eb00a3ce6d0821"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "6486bf9641891dcd2d28d8f0a4f91e64e607c6d28eaabab78b0cca3525a5878b",
+                                "uncompressed-sha256": "a4bea1b6bc6b56677af5f4d68aac6684a327660e1c139377d1050897fbe912c1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-live.x86_64.iso.sig",
-                                "sha256": "8efe184e3961ac7e78c89bcaa071e5fd7d980b9d7ce60e03c76cd5d5747a354b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-live.x86_64.iso.sig",
+                                "sha256": "e578fc098356435d1953d4acc05c9d09ec8545c0da26bae44f1c23e82801d259"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-live-kernel-x86_64.sig",
-                                "sha256": "a191a230c094af09da1b29f15026f9cdccf36634805846d6c309432a9eaed5b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-live-kernel-x86_64.sig",
+                                "sha256": "85b31989c8e3bba00df7fb7cad496af9e1abc6581a116b381e8b0ba0e8143a6d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "b0eae0509bbf1d91749d7085d0a1a2556b250b5265fe76c874067564379441e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "4c903e4b51a691ad73bb6feeb24585552280fe117df10b2ea4ea2ae87f93b345"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "f29dc278375bc40c76043e44e1516e6ea429676a14ade33947e2957c233b0edd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "c45e2387fab03caf4dcd33a5b6a792cd3288589ec019c777665de77451ef6597"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "26d68ee26516f71af61df51a56d3dc1267c0030167bd901fedcfe3def123f3ef",
-                                "uncompressed-sha256": "2c8ab090a180cd3757696d085063f81dbc98da85b428de1f99aaca4ed0d7783a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "187d3e024a1114223830df2c30b9402476f08b4ff06be33d7450f1167cd7d002",
+                                "uncompressed-sha256": "50dde23d31394da43db9a8afd941e19e82c877901092d2e89613b6334b1d1908"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "9b898204696fb3ee365659dd493730fe1cc01262479d292b71b7eadb6ed2f69e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "fbf24ffea5f25675d25b03120d69a87a2fa802d401f5a851b4c9dc733ee9f298"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "fe9544ecd43a4e186cf332f3d823befdfdfa8b7971bd363de664dce9d96498cb",
-                                "uncompressed-sha256": "ba783e45d3403f3dcf3c81301600bc1aef89da7ad60f53a22d75078ab5566c6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "cfdd7fd516cf1a5c6587ece289bf4e2ec8183bac54750a0212e02142bc0eaa64",
+                                "uncompressed-sha256": "02bfca933181dae2885cb08e2eba10b50bc6f75ad25be571d7bc5583385776a9"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "add75a55a03f518bcd81d193367d82125743bee591968ea913c900396f95dc03",
-                                "uncompressed-sha256": "bcef7d1bb7c4899f9f23eb7b113f690ecc28dcc49628d008e2f1881f59df2c38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "fa0628b55edd6d5f7d4046c95d6923271b93cdf2ec8003aaec3c64d43c5546e0",
+                                "uncompressed-sha256": "10474a34297ab9f1f793d9eca1050fb5e2ab6eea62742b7bdda7570e48ef46ee"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "b2a1a9ed1d5b4378c3fa81a9678ae34bdb3ee25e0e24768239ef680bdbefad80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "6af313d8bbe9188b8a0e9d5ba794912659ec164a2d830005e212ee64cda00bd6"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "2a1cd56e1738ac00a282675e49736108abfa9274bebb2a693142fa4a7b8e44d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "410ad2b3cb281ed3884c9971135113eaf2115a519496af4b920ea2d8b8587e59"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230322.1.0/x86_64/fedora-coreos-38.20230322.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "39bc3804fb408487c64285cfb2b364616e8eccccc2eea37a8625a5606395bd1e",
-                                "uncompressed-sha256": "79cee375ed7a2315bf13755b7021136b20d60733f56f4dfa531632e638c618b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230402.1.0/x86_64/fedora-coreos-38.20230402.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "20622753b82bed0e8f0df93c553989de033265fb11cb9b07220967eae72689fe",
+                                "uncompressed-sha256": "e803ed678c286e80e57619febc62fe5dc17f36f5448d8ca75c83c884fd477ed1"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-07c90634c66ca5284"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-04badf012cfd055e2"
                         },
                         "ap-east-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-021b39393fa39e267"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-09263f43a3dd071ae"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0184a13b4783abad0"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-01f1d751876fe7477"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-046ed517aead6ea2d"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0ccbabcf5ad5e3564"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-057a04c5c7ce5fd2e"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0074ec36a94c7e4b9"
                         },
                         "ap-south-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0ed2bad2cffa300f4"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0dfbc105ad93e337a"
                         },
                         "ap-south-2": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-07fa1797efed61860"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-077c60086d1484a9b"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0c5947af5b288bebc"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0532b0318a43eb2bb"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0d7d06f5de0651282"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0746b8df256e4039e"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-060a2e6944d33f69c"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-01e26e20b42c9755b"
                         },
                         "ca-central-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-085e6e5f7f13451fc"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0f67b23f40e8822d6"
                         },
                         "eu-central-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-05f241e408cd7eccb"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0109bcaa7224517a9"
                         },
                         "eu-central-2": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0a7badc3044ac998a"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0ddb97cba3da14dca"
                         },
                         "eu-north-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-02687e309d91a1151"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0809766021d2f8ae6"
                         },
                         "eu-south-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-02d1e0480a2bf42bc"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0ac5d9c111adab319"
                         },
                         "eu-south-2": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-05e9b47c5fbf29e06"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0575e7d83b64ff101"
                         },
                         "eu-west-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0b82a1679fbeaf642"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-01b668cfd370cbac9"
                         },
                         "eu-west-2": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-08d61d949a4dbf97f"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0465f99a74e756bf2"
                         },
                         "eu-west-3": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0cb3854840056970d"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0a32e139502dc3619"
                         },
                         "me-central-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0486e95d6908dce79"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-09abdd1cea316e596"
                         },
                         "me-south-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-09e1a8e6321779973"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0d5428a73cea0c863"
                         },
                         "sa-east-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-0653079671d80fc41"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0ed10f0621c8a4d7e"
                         },
                         "us-east-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-092712f0022454924"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0ba2ea878ecff1b73"
                         },
                         "us-east-2": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-09f6b73e3e432a2a4"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0ce8034fb08c24251"
                         },
                         "us-west-1": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-01cc12c5770eb0d6a"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0d73fd4658616b1fb"
                         },
                         "us-west-2": {
-                            "release": "38.20230322.1.0",
-                            "image": "ami-06242318585d8314d"
+                            "release": "38.20230402.1.0",
+                            "image": "ami-0a5d6508a6b47a536"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230322.1.0",
+                    "release": "38.20230402.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-38-20230322-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230402-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,105 +1,105 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-03-23T13:38:21Z",
-        "generator": "fedora-coreos-stream-generator v0.2.11"
+        "last-modified": "2023-04-04T19:25:13Z",
+        "generator": "fedora-coreos-stream-generator v0.2.12"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "e6620ebadf40bde110e528a52593288c52bcc49bdc0e10150d6823034c73d2ce",
-                                "uncompressed-sha256": "d72bc9c6eacab2605f388b1263947c9bb0a50b9de7b31b0e668ed2bb3671ccaa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "1ad571ba42e047f6a994b5d07630996f462872db9b5c932ac4f1d314b42e97cc",
+                                "uncompressed-sha256": "10d9ce23e20100bc2ff127c012031d7e816a1e6992055b525c00f2fc99193276"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "51c89157fabd91fbe6055e4eb86c0452d3cfe3fc086d199dde8d3d2a62707217",
-                                "uncompressed-sha256": "201080ec10b85a638e1916218535d4d2df9757c04daf0469c1e5b79063e19199"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "95b0bfac5ea77000a1345ec25b9d256f048839fe5e9cb9f9038d0393d5dc01c3",
+                                "uncompressed-sha256": "6ccf5a34d243da70430a45ee4578d899e829e87c8bbca28649cfd11cdcde42e3"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "c20d95cbf54cc57125ffc2959608ae147dc5495cc31b0816f3c300284e420d28",
-                                "uncompressed-sha256": "ba23068f809164401fa3d86b440477ed60757a938102ac6b61ea594556af46ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "83d8ec0f0b109062f03721bc5d48036421497a4aa650339f6f8d62080ebd56ea",
+                                "uncompressed-sha256": "33bd334359388969972374d88086d959dad105710c572f8537fc5da912b2479e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-live.aarch64.iso.sig",
-                                "sha256": "bee9ce2dd8434b7ccfce7886700f12cd6cc37802406c9684b174af2cc47d34ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-live.aarch64.iso.sig",
+                                "sha256": "97dd830dbc67eccf23b0fe7cf15a062fded39f5388d496a83caf44ecb128bd35"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-live-kernel-aarch64.sig",
-                                "sha256": "c5f240c9e7d6299de97568c2829add78adbf97a7ed8b46183d432e51da3e3e53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-live-kernel-aarch64.sig",
+                                "sha256": "a99228f65715b0bfe75ef83db32739ba54ec4b6d0103760de915c2b0f4928fa9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "d41706f87b0cdd3921c09c685ca9ee89ab1280284f0a1762beaf32ce4bb4d8fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "e5ccda9c0658dfb0332c3e031548ef991fd4c721271bda4d19ebf17a8c84923e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "2c618b439528d952c940cdf4ad9477fbab7bdd27ee8d0ecddcc4613a66d113a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "ebebf198165dea14f4b5466ad82cc78babb9fe9e21c168a8ae079caa34b0b880"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "25208e0c06176a10ca52d33c1795f516e996e53a2c0202740a3765db863e53e1",
-                                "uncompressed-sha256": "9ed8d99dd547fc87807d3197ca509b8e1f46bbbc46a67a480bb41a723697dbdb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "8119056f3ffd6bfb146461bb8dd9157c9810e31139d70290a57947709ceb7f9f",
+                                "uncompressed-sha256": "6f272d3c8c34603498efcecda4acfa69c19b56e0aa154f5ab1ce5ff24d07a5fa"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "ceb9fe6b1b82c56f1e7495e954360b1772dc19676b251fe671380ec86d8c1a07",
-                                "uncompressed-sha256": "1836a0565d5d14738cbd9faf6a13a5337ea5673c243339ce6680b37afc67868b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "8fb949a146100e5ff4ddd0212b7402f7da0f2d53e6135239b023ff1024a02bbf",
+                                "uncompressed-sha256": "f65dac5dee5b5a28c50ec2e5d9e1a9a57905ec9ee2b941f17c1dd4c03d32d3ef"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/aarch64/fedora-coreos-37.20230303.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "602c1a2f1915f1646048855ec8c49721ac3de72b25eb0ded2290b7e3ddc07ec7",
-                                "uncompressed-sha256": "7e45dc3bc990ef51240fcc57d042459155438ae9ad6bf177cb118b7466deb8ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "b894e6135d59aa550625dd034544d50addda2f49c7612caae9b3d90de34ded90",
+                                "uncompressed-sha256": "05024224a8b2d35c3e1bd9e71032d10f9f2ad106eb9dccca2436a0289f100555"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-023d601f5e5444b75"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-02506bfdfa9a2400f"
                         },
                         "ap-east-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0aee54ae4f48db3d5"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-07442eb46ed01728a"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0ba7ac76cd5da531b"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-06549d6426a949e25"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0bc671b6866be6b08"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0509dfd4dbc6afb5a"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-00b79e636aff16d65"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0f88586b4fa749488"
                         },
                         "ap-south-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0009ff92079059c6b"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-064ca61e51701a565"
                         },
                         "ap-south-2": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0c882e3e9bb31f74b"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-018a22b894549848d"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0c926247963527349"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-035bc0d9b91998992"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0ffe548b0fffa3e8c"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0a7bdaa8bdc0f616f"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0df57e33549da196b"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0f469d9e9434782c8"
                         },
                         "ca-central-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0d3b83afad1736cfb"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0e1ce4c9317bb39cb"
                         },
                         "eu-central-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-020e13e32a997ab8d"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0ad7456d4deec7695"
                         },
                         "eu-central-2": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0ea9cbd32dc36f975"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0ddb3b4394995c03c"
                         },
                         "eu-north-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-096a6fc85d362e7c5"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-08366b4769147fc42"
                         },
                         "eu-south-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-02a229e56ee04289d"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-02e7562869c6b1f46"
                         },
                         "eu-south-2": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-02d50780473aa11fc"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0241a82c64b527d5d"
                         },
                         "eu-west-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-087fcfc57b54c7216"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0085833c542a124e9"
                         },
                         "eu-west-2": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0e7648a0d321101de"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0c54f33e78a0f294f"
                         },
                         "eu-west-3": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0597c8a637e26a015"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0784a1fc3dca7fbbc"
                         },
                         "me-central-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0f7e1c4790e8b71fa"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0df8e0c048c71adf9"
                         },
                         "me-south-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0ae47caaf54968d8a"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0716e071b996ec08f"
                         },
                         "sa-east-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-061b9d4cc5e713670"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0b2d1b849bdf68e46"
                         },
                         "us-east-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0a75935f93bd371af"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0ba09a18d6c9d4064"
                         },
                         "us-east-2": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0128f699a4448ab4e"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-009cd786b8978a81e"
                         },
                         "us-west-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-086db802b89b47bb1"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0e619c137b7418116"
                         },
                         "us-west-2": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-069ce7754d7f30062"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0b57d3fe3014a8997"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "ba94ea54be9cb7181e9813741e545d40744c04d91c9222929a05ce92805618f3",
-                                "uncompressed-sha256": "8949e781bd1fdfd7d810fd803f02aeb216d0ed8d964e173731d0a6cc41fcca76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "07c89cbc5d53e2d469ef8e43c793107bcbd23e978deac9fffbdb6c71dab3977b",
+                                "uncompressed-sha256": "c918d10b09858f43bff1054af1830f015bf7f0a9c41a9898d77c189af2e1f30e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "798c5234a607765ca9d402fb3664ef2801549b103a184c17a903fbdaf681f49b",
-                                "uncompressed-sha256": "451470111e2a0327b9ca21f2b046895de11051eabeb3a77044c9a69c183ff8a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "3fc5fdc29179852e1dbb69e835c736d11a7fba01336614da881e0bfaae74d1ed",
+                                "uncompressed-sha256": "920bf26ee5c15fd7687d58433a143e4ed6fc23e995e47ce9c97e3cb477e11661"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-live.s390x.iso.sig",
-                                "sha256": "63b55fc4e99f63ad02abf5fe7f42812c68e97ee3848a1efdcffeb7417a93149c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-live.s390x.iso.sig",
+                                "sha256": "629e508cb4add82459a4c6d7bcd25ccdcb6dad66f62302d63f3f43992bb8416b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-live-kernel-s390x.sig",
-                                "sha256": "c4efcc3b3ee50d31221a98b349fb6a723f1db725156d95adcfa45877c31948d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-live-kernel-s390x.sig",
+                                "sha256": "47dcd65d330d40d0cd6e7e9f95c64088e2c3a8f394a77b13cfb109198b93e4f4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "ac021fc606092481643fd782566374e07fadb376c8e214ec284e29223493a1a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "e5b618737fb1a24b80ddec6364bca7d446b922a808b13f8d1f5a8a653766a3a9"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "c9b0f34724b65e768f987f0b6ddd82ffc3b9b16930682b74c8d1a2daa5589d65"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "790dc577c393762589e93b3c22a396be16112986892b9c0c0c98243ae8533eac"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "d335714fed753b32ee037d92cdcbce63bb5a7e8e7490ea871c501582402823d4",
-                                "uncompressed-sha256": "f9c93fcf916546b625fecde34748d9c5e1dabb479fb7636f8958b818a03e067e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "34ca2406c62a8bdd75bbf40c9013e9b7a8f6a2cac77b4a2e2565030625af6f18",
+                                "uncompressed-sha256": "1b7b2a6e0f3993cba5ff0930757b6ab0d7f6d289d9843b4f2e2284c4afd51d81"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "c4c2c92f809368250b8cb829f5532d7319f65ebba409e18d9391b43fb5c0e5e2",
-                                "uncompressed-sha256": "d4c3d2468c565f0cdcddc98ff8ed61f98293f57100d5621147f6ac8cd3c0136e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "b572218fb989efc096604992633a255292957d09498db3d2d4c6895a1d91951b",
+                                "uncompressed-sha256": "51c544a7bf7b431cd66e57e52f18cac95c096cac2642bde6bc8ea8c3cc35f195"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/s390x/fedora-coreos-37.20230303.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "46f5f38563c13b347de1b061c7039443e063f746fd02df4a2847b8809de7d8d1",
-                                "uncompressed-sha256": "99070de0a9b53bbf1ab6100a995d522f58880a0d5e2273dc3582c3d45af56834"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "4ad8c436d913a67c0b0cfc2a35322a953682e5d8d8215af613c66ca5f3339830",
+                                "uncompressed-sha256": "86b673c768736cc329a3924d08ac4afb5a5af325ab90b8caaa054c8c2a5705ba"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "3c028debfcddac1c960f253cab408441e0943ecac29e1f8037684816484649ca",
-                                "uncompressed-sha256": "5202c3b93e24ae664c06d8a05659a2be26dcc2755b9f0937fc97586a05bda5be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "b0182b551019fe6846aeefe5c1874313137be4d501eec5d2f2f853c38d080447",
+                                "uncompressed-sha256": "7463eeb361dbabc439ed0281eb57872dccc7a4b836082d26a8ced9e3ac8a4fc5"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "2759c3a86a7e952313c8736b1b3aa1e809ecbc39398f7608e7e1fbfd5308379e",
-                                "uncompressed-sha256": "f85e356ec91e395f8c22e5b56ee1cb603a778931bf91a5e01cd89fdd03e21dd1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "590fe93f59d7395147699e35e9252bfad22ea7cdaf92a963ab4374e8d8226702",
+                                "uncompressed-sha256": "701d44e68378931030c7f175fda0a1c02c0a095b86c4eb80a6d2207624a8f97d"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "e5ee6f627b0e92d9d6167e0f586fc7ed5739efc0beebec7b78e8875b89d56911",
-                                "uncompressed-sha256": "5627abee7a80886cc03cfe53d6f96f54427aa4b5108058096549fcad734c3adb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "9048b4c2cea93521ecfa891bdc6e9b9eed734c7b284d0a1149a34593d040cf4c",
+                                "uncompressed-sha256": "064eb7bce8b9800ae204dfd8b382f6d1e153321cccb998d3d6a3b43f27759bb4"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "04593723eca9d158f1ed65d1ecf520c4d3dc00feb5a862117d4b6c687474367e",
-                                "uncompressed-sha256": "1546ee48d145bee895ed1c316661e2dbafa6f2aae4403ffea07492005a42314d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "fda2cab2359eb3b2cf322280dc8e333636fff86deb3dd335eb4a8b24082fd4c2",
+                                "uncompressed-sha256": "654d76f096ef0daa57cac8470aaa382ca47fa47294a7d120fa2418be0cf85753"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "aa6ecc8d5bed353dd7c915794558b6838e64d6abd788f138417b0688e03231fe",
-                                "uncompressed-sha256": "ab5886f5418db2bae33ad418607969124d93236103dc70eab8cb951378e56c14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "3390976e081cc0390690156ab56f4dd986bd5af5ef835c6ef7cd5071e5bd3287",
+                                "uncompressed-sha256": "5f41c213944c4867971171857e7743f7a7b2d2a4784446d728682fa70b068489"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "ed8c20129ef97c6cd627c24cbe7288856704f50ce823f455f65048c82bc0f328",
-                                "uncompressed-sha256": "147cbe547315ddda19145d9d449f44a97a651225b35400c3c00809d05a7fb104"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "d26210bc67858df6d58b36e959b3feed60a75da0556231a0168628dd7fb4b517",
+                                "uncompressed-sha256": "9b0720d2f4831f86d3d2207aef1f1c976e148af618081cdcdc914391ffc0b1b2"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "41c78c085081debca22e794dc9c2623a2e5f371d2c7e7182ddab51d6de747735",
-                                "uncompressed-sha256": "b23b3d2ce72fb2c8571ab5372c672878e1aa27c23a24e1303b87fccab62e8781"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "5c2d604ef1942d782c7d4525ab94ea366d69dc2bae849a4ff959f3c504b4f434",
+                                "uncompressed-sha256": "5f4672f4d5952537f2f466b5c752bf91c221cb6d4e79ef9ba567806787b111ff"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "7f9bf72928ada04884e4c09e14c958e0c1657d6c07837afbcb060646ca3b72d5",
-                                "uncompressed-sha256": "285d1323f036847f214f5797ee7a6e1138e1e477719ccc90e48ca6ebf8146b3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "e4189c8541784b1e911ca41f02a8a88c307eeecdce6313f00ce47290867649af",
+                                "uncompressed-sha256": "c0c9328d4b03bb37f4cb71ad7f4abf206bea9aecd021713341c2638c7e728b0a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "aee85c3ab6e0ca100e727d07384cb4775cbfadb1333c46518564ee65ca320446",
-                                "uncompressed-sha256": "835054b71529f144f18f7605673c10aa5d1ed1734e96839fdea4c7239aa0d290"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "950b001f7e40b4c160e187a95fa1e1cb43194a56cd197094a090f2e0d9a6d865",
+                                "uncompressed-sha256": "81bf778fbdc6306b4aa326e483e2a027fa4927149a28945c8e3ca5420a5db9b0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-live.x86_64.iso.sig",
-                                "sha256": "955f20f4287a910bc9f9eaaf87d75f7595a41ca7a42487701c38298097587200"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-live.x86_64.iso.sig",
+                                "sha256": "3a4e0f97c58afb74accb89b444c62b3089568fea16e4a475fc63b753009655cb"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-live-kernel-x86_64.sig",
-                                "sha256": "862d7ccbcbb26f36e53772a7022bbc3921d5db8edb47fe6df94065d20cf73830"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-live-kernel-x86_64.sig",
+                                "sha256": "cc47f1102fc229a1624f425b9c064937b07a6a7e39a6a5ab8fd37f49358e1fb0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "4c1e74e78bf87aac43aca5016012bc1a11fe6518d6b63ac844bf1a0d59ea4a75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "7695649f67f23acbaf812d978c8f8fd4ed8f07bf8b8b490f6c4d661c93a9c4e9"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "ee5e9d4f7fd4c16f479144cf98a7ffce25b257f05e3871d031fa4f6e4c55a892"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "1c8558bf6558e8c65bbc01b4176b2e4f99c683908db2ab64668b6e8c0a0d6190"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "30bd2a734663b04b0b8ce2ceb0a5fe81fb8ad801dc75e661345184ba19b2e15a",
-                                "uncompressed-sha256": "94bc39f7797830d5867223b186aed7ccda77c8371dfef380b674c6fec8a5c85f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "e636118e646aca08afd408737df63023a30793ce8f7096c87b76daefcbdea285",
+                                "uncompressed-sha256": "1906271ab1d3056531c5f30b5003e719d95ce8e7600dba790f19c0efdce91005"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "d8b75c22fd31fe4f57202dd2a4264d50abd3cee13c3264a6b6db775172f2c757"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "edaad00e42f8267f25a04406c957e29e3cdf36b0c3763e36d55bc660ab650732"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e1d79baff5e4e45a50e05011ff3d8ab745b96466416f37c1105f9a480cd7b269",
-                                "uncompressed-sha256": "461aec429f5fbe07c7efdbdde4fdb1d417ffb81f5868af08926baea97edb556d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "fb6bdf6164c60408ef0a58ed7e51f2d7201958ae91b5b8be46e9822b4b1d9eab",
+                                "uncompressed-sha256": "e8722fe98c5f649f716310510f558fa4f6976b38aaf8d042956ef9f9d274de3a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "98bf7b4707439ac8a0cc35ced01f5fab450ccbe5be56d8ae1a7b630d1c3ab0ae",
-                                "uncompressed-sha256": "e27090d4465c0e33e656cb35c251b508fc079c4a86fa74e631a64762eef90cbd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "dce72abb5093f06311485e758f1d1b598efbc670a7ae75a6a083868e0f3a1fd5",
+                                "uncompressed-sha256": "427e74bcf76e399e65f04830ba82980cb360a4fe58b3cf0581412b6919dd4cb1"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "fc7786e40245a8802f9dcb5f7c8f2b597ca513cb890407b8b360999843ea4805"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "a3b504b7e8ba12cba59c127e54b752ba4d0fc231a4ba14737093a4599df81e68"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "04308d63170ecc33dc4a76d20056eb7f2fe33f8e27e92650302b541e73a68cbb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "11b6e92264f0dc9a837018cdaf1d550e38a94b55e9458fed4851bbfcddbc8f7a"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230303.3.0/x86_64/fedora-coreos-37.20230303.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "768235f02024a32d84b2f6f3c170696520e41c4b198dbf1b97e3b5cea8fc52b0",
-                                "uncompressed-sha256": "d1b24cb37a4a5f8a3e3eaf6287e44f318187300747c17f77b218654436204c94"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "af0392dd5ddba49761d7e98154602345cc88555db86cbcc2e1472b628d76f229",
+                                "uncompressed-sha256": "9a47bfd6943a03266d0cfcaffaff6d8300a4789f687d8b306e4ba5ece611ba5c"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-02e2635158daadee8"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0fe38343b4a5f9823"
                         },
                         "ap-east-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-00b4c955ac5c85314"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0553739b516d54772"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0deb1576298bba708"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-00b60a49c0dfc5cce"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0f2d70db33108cdd5"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0ab5936dbb122ae94"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-05725adfe7bd9878b"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-093ef11d288efa2b5"
                         },
                         "ap-south-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0cbb65419bd2739f2"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0c40bea510379f0a1"
                         },
                         "ap-south-2": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-027aed14203ed15d4"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0461fc3e2d4904974"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-07b3cd735e05dc2c9"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-096380fa619c8589e"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0b1c1736f1241c5ab"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0b0277ded96475e2b"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0db744020bec7ac88"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0009d3ba566c4f4e8"
                         },
                         "ca-central-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-084aafc893a27acc5"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-01d5380eda95675d5"
                         },
                         "eu-central-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-05426870cdf857352"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0c0485ff0aa3faf46"
                         },
                         "eu-central-2": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-045d8869c56080fa1"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-097a609ac37371002"
                         },
                         "eu-north-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0166a82ade2f560f2"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-01229105e804fb14e"
                         },
                         "eu-south-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-09e3fd56e9b3e691f"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0d790ad6dc590e22e"
                         },
                         "eu-south-2": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0fb840bb50c533945"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-08240e4806cab529c"
                         },
                         "eu-west-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-079508508f25b4921"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0a85721f6fc871ddb"
                         },
                         "eu-west-2": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0940afd01dda29df6"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-041b4f245d21eca9a"
                         },
                         "eu-west-3": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-01edfbfe6d458399b"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-003970580d6031f0a"
                         },
                         "me-central-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-044976b27f21d87aa"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-084717230e2bda7cd"
                         },
                         "me-south-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-07f8d7f8ad72dec35"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-015fb8707abf35d37"
                         },
                         "sa-east-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-037eb53919858639c"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-08f90707dee104bcd"
                         },
                         "us-east-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0c0bc857a43b6d158"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0d041be9630f7b147"
                         },
                         "us-east-2": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0ed17ac79c5602c98"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0496fafa1e5e7c7e6"
                         },
                         "us-west-1": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0a89df44e67c12c29"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-0180bed0c68421780"
                         },
                         "us-west-2": {
-                            "release": "37.20230303.3.0",
-                            "image": "ami-0b9f8b8320dc825d6"
+                            "release": "37.20230322.3.0",
+                            "image": "ami-00b761330e0b30e10"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230303.3.0",
+                    "release": "37.20230322.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-37-20230303-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230322-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-03-23T13:38:23Z",
-        "generator": "fedora-coreos-stream-generator v0.2.11"
+        "last-modified": "2023-04-04T19:25:16Z",
+        "generator": "fedora-coreos-stream-generator v0.2.12"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "05035eee0cea2c3b2f67d95db15aa6a5158a684fe3f7362781a0606e830b2b7b",
-                                "uncompressed-sha256": "ec98472ead34daea8bf2e4542081734d099c7995f82b63911b561d3faa729750"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "60784cbbed5564dc356828f4dd79c4cdc87eff4fe01c0f58ed72c765c47d3909",
+                                "uncompressed-sha256": "8da09a585a207ecb612596da7b2bb841777b24af7b0855a6d83345032091ba32"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "7f081a4aa8d8c45e0b657f317bf672641aeac867a6cc697844a9a66011f4a6ff",
-                                "uncompressed-sha256": "19dd7a56381b2b308809ec9e43f861aa3fc1d7e6e102ee97627248b4cfc9773b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "3e40a70723eeab36beaaefe9a9e0cf6b0cea5fdb06ade867b8bf68ec19986a82",
+                                "uncompressed-sha256": "9b2db33163acd4417e5eb60c58db7ba3d1a72da7df075f31d6f7a3d2225dc37c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "0f16e15bdd2518da0f39953337fe7177dc531ba196b78f64c3b0fe2e78870921",
-                                "uncompressed-sha256": "2691a22a00605612659c9ae38dcd1d4f619680f8a06f53316493ff01a849bd0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "105b9472da0e06ba0daf9cc82fca4de2d8327e6c142e4b7c2c40d4b0e381f188",
+                                "uncompressed-sha256": "7c0af4833aa36aa6c127feca33b0616fc715d0c162a1e5769e9a0666dfcd1f3b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-live.aarch64.iso.sig",
-                                "sha256": "7046960daf7012ba2cc075f47e4cfc05567e77cb678e11fd09de64f0780ac963"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-live.aarch64.iso.sig",
+                                "sha256": "89d4040b373fb119bd8e805924195fb8b16f9f80a9e843e4a34eb061cc766689"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-live-kernel-aarch64.sig",
-                                "sha256": "a99228f65715b0bfe75ef83db32739ba54ec4b6d0103760de915c2b0f4928fa9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-live-kernel-aarch64.sig",
+                                "sha256": "f97554c216f3dc0ba0cfe97d69907b7164deda9444bdd9eceeda13c60e7fc23c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "7dea8edd437e47dec84658a8e6c04da8c915f7e41278a7ee45d8f184f070c506"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "3de308a9fe40fa046712e310d0885ff264c797a1481c16982e3407b2e2551c54"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "a0f77734ccc15fad7e10178906e4cc9086d00b88129da2c227ed63b8acfd65d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "c7c38c6bdc3fe32ef6bb787600f0854d677a0646fad6efec498310f3c0a79b41"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "a2f896d928f2a13f0709a0eea7a7ad32da3c8c9c3a35e27b66d998b338704d48",
-                                "uncompressed-sha256": "6672665860d568de1536339aa3624e63d0411b6453cfab6d2a0f6319327c85e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "ae4f89a2f3f1f6e63b8be3dd91fd04c51130381665433e4d426f18be8ce16308",
+                                "uncompressed-sha256": "7108869ecaaaeaefbca94b853373704cbf0200648bee56348cd8f50b581fbad7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "d2c557cc5a1189dbf6ac3fe7d5144923c5b7d4528b4b227f8c2904dfedd53ea4",
-                                "uncompressed-sha256": "4cb1a1991fc4f43ecfd1e906484989526acccfffa0f409df3ae329aff71be850"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "b9d9de99d88facafc2223bc0bb6ab2cb356bc0e6b5a8edd48d095f5934c33252",
+                                "uncompressed-sha256": "debe17bac2c6208713cc0474395c2ce90f567dba98389d249f86535853d356a6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/aarch64/fedora-coreos-37.20230322.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "a1885681b3125db0a7aff36bfeb01b65a8a42268fe096080d69af21c43d0d363",
-                                "uncompressed-sha256": "a037a7fd8668d008af1c9152cd759e60c7e79dcde01bf5b9367aa09ef3f7253a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "1a9b64c77543cff711e5883958744e716f1ad903baa6268799cf9a9e710be995",
+                                "uncompressed-sha256": "4d6344a439495752a5b74252629e00c1a5b8409d88f44cf17bf45afbcf54214c"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-098abb681d88fec82"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-02e22881526df2a3f"
                         },
                         "ap-east-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-03881796e67997f1b"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-03c08cc87c1711e59"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-038dd52d074a98734"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-02e3c32c6e3053dcb"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-082d1372fbb540604"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0aef46eefe50f36af"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-098bbdce9596f3d81"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-02c11b9e62c23a6ff"
                         },
                         "ap-south-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0a8c8370efb8e714d"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-07209072ced99deb0"
                         },
                         "ap-south-2": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0b3f31cd747766a06"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0dc0a6784b6a8c75d"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-060ee00af96b6fe27"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-013af8dab7be4fb90"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0b9dc4e2e5130b680"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-09a816d568abcf616"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0cd18f22c607eaa89"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-003421443c550169c"
                         },
                         "ca-central-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0761e90970d4b052e"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0fa827447700abf48"
                         },
                         "eu-central-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0e7b9ae29e9f1cdaf"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-05b8af5c79d668088"
                         },
                         "eu-central-2": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-08f428c8a20668959"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0caff07a6e8384cdf"
                         },
                         "eu-north-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-03fbd0adbcea414f4"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0790a1afe2de01cd8"
                         },
                         "eu-south-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-036f9913b2c094953"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0324a833c3c63f428"
                         },
                         "eu-south-2": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0fc84af08a42de8ce"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0c5dbc97007506aa9"
                         },
                         "eu-west-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0f7caceced3df152f"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-071957a542e4bfeb2"
                         },
                         "eu-west-2": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-09fc7fb27797dcec5"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0103ad7d7811e8944"
                         },
                         "eu-west-3": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0c0aaf59c6cf53d87"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-044388a3869765b55"
                         },
                         "me-central-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0c49e3d663d9cfa3e"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0fb18887d69e2476b"
                         },
                         "me-south-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-02bd500b6ce507470"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-02082d227f095c496"
                         },
                         "sa-east-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-017a8529eb012d2d8"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0329b84142a50c322"
                         },
                         "us-east-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-097d6e0dc7c80b45b"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0deefd756a9bf9097"
                         },
                         "us-east-2": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0cc6945769585aa55"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-04a48ede172e50c5f"
                         },
                         "us-west-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0064b63fb25645d4f"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-05b66df31c864c8d7"
                         },
                         "us-west-2": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0db5fcd611330582f"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-082e4ed3e8140ad33"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "b785a669f0daf7c1aa32a980d5013c18d74101673a83ae7215e184ecaf3b2781",
-                                "uncompressed-sha256": "ecd107c275809c52d31a5938a528bc659f9e7ddfb9c9a66ba13dbea8f1d438c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "e701dd7bd2cba41710727d0dea9a836b24ec3566837fbff1ffc35660a1583eaf",
+                                "uncompressed-sha256": "01683f4a2010d96d6aa218f7297ffd27353737eef2a296b69b0573efc9dabcb9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "993c6160b008bc67afd1db93d42c2fd4f091ba171488681490bbb61e537237d3",
-                                "uncompressed-sha256": "246bc1bac009b4abf2e0ac33b246687c86c9f04bb54ac463eeeeee951ac4079d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "95d063560e84d6b610eabebca8b80e19399bfaeb71773a1997d32f836ccef406",
+                                "uncompressed-sha256": "eedc900a553b364f35ab25847f6570b344328535245e6441716500602c727bf4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-live.s390x.iso.sig",
-                                "sha256": "1a846058bfc76f377a36caa5b6affa33ff413d3658ed109ea1475388928b8676"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-live.s390x.iso.sig",
+                                "sha256": "0548a5a1578893d63b39501c9969787592c64969e308d0b76129bd2c73f65585"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-live-kernel-s390x.sig",
-                                "sha256": "47dcd65d330d40d0cd6e7e9f95c64088e2c3a8f394a77b13cfb109198b93e4f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-live-kernel-s390x.sig",
+                                "sha256": "cd760a88d35c79c87f49ce37559b540ed2a1328011abd9b365ef709c773a62cd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "002b9447ae9c0f2077f0d677173fee437528f207f637df5b9ee36292a2d45324"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "1ace9107f5c8a5b2306dd9e96b9ead44afb349c2ae48c21065ce5901da232317"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "5058f7a96ee91d255fc45c50041753fbbbd1fad122a54982a41087c5de8caf50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "5dd17bec6f5bfd62efe8e9eebcf1f898f599fdc74d0f65f59ccd2a2a607582f0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "bbc061669dc61f5596cf15890f9dea5ad30b0340cec286be7ebf892a6d3dacb4",
-                                "uncompressed-sha256": "e844a504476768655c7b21deff568041d3d0e982deae82b955d8b7100ef789c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "a4c814664999339869193b45cd603815d41ff8742b596947d24eedca08de3541",
+                                "uncompressed-sha256": "304aa7debc21d8f1f16c18c509d36fce86dd44bccf61b613f0c23b85315ee07a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "fa96a18644de322d6f28d5ef2c22a9a4a2ebe223c0758012928cb0702bbe9127",
-                                "uncompressed-sha256": "268e7b02944b6cfba1bdea5237d488dbef47d224c00293d93fa478fc16949e58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "ed7c98752ab0424854ba7c12be7a5870798ddb02e1fba473ecbee4a72eb56bdb",
+                                "uncompressed-sha256": "0f142b04dd0930346362892a0478215f6c92ae92a42debb276505cfb2c5ae6dc"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/s390x/fedora-coreos-37.20230322.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "2eb15c052018497f955570baafd6b9cd8171292d46ef70fbe426e5b730cdd6d5",
-                                "uncompressed-sha256": "30f0c682efb48ab2537b783d2bb77e54cbe0d1232f9229813af51fe068ad3df0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "98ad0f9985d854343017b757ded1174999d2ecc1f2acdf28500d953d5765d467",
+                                "uncompressed-sha256": "be7aed560dea9a717419ce54d9f62fa46573a968830273a4b10692bcf7c4c629"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "3760b3087e7530cad20af6cb58a197ac2d906339bfaaa645d2d316d13ce70cad",
-                                "uncompressed-sha256": "645c38515f8902a80f6d4bfa3432c4bf215e3a6731fc9464660032ef3c83ca1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "91fecdb85b788e871e3cd3e86de1d435ff1b9992e4be1e4d235f6d638ca71f7f",
+                                "uncompressed-sha256": "600ad7d30e5f1d824054b4af7b1449da6be9bb0975e41c325fc2bf4463e00dd5"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "7a60c5e7c314165a7e48d25a8ab76147e54192e2bd225b9b9f31ad67ec851d35",
-                                "uncompressed-sha256": "baa80658b28e658f2918972e76197048128df33607b7cd4145680396c7fcd61e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "04ba0a89872dc0696a76a481984d48ad04d4af27e9c3df03de465ec79de25df6",
+                                "uncompressed-sha256": "025f0989156e1bb25c96d60129d541535199a262313a9030baf0a612e4611371"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "4a9c45b65cb0eec4b040f5846d1a1ccfa0bf98bd25e13214faca14e0299d7a48",
-                                "uncompressed-sha256": "edc89bb6b1009ef18799354ff2caff697439320289371fe585dac17c0ada17fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "6c3fe95a72678f05e962ead4592ba07fa2b75ba1b467c751f00e36f54d5c9c4b",
+                                "uncompressed-sha256": "efd6e1ee9cb152a1fd6421f2a91f2fa16cd6d836f60091f4527d6fb91cee4832"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "45c9021d5388759d4f69730bdf5dad823e0a528d28f9245ae1e42fea2a900030",
-                                "uncompressed-sha256": "3148b5a540987cb8b1780a2d0444c2d68ed7bd14fc0ec628c73cd5fdb85a0171"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "54a20936062655b92f44367c2deb635967813250ac89e874ff9acf8ae87d58fc",
+                                "uncompressed-sha256": "9efe09fee1153805e7d20ff4a297fc2a7cfa20605fdf0546ee6193dba18e4680"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "47b43a8c0340967afe1a00fa856da6c97c146428ab3b3dec081eff121b7bf2b4",
-                                "uncompressed-sha256": "e0c7749908965f5e8d23844ff42dd0b1385c6e13db83e1972bf481883c420415"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "d76570a45c2a5eb7f7c590c0136b9cd0e47062f95a6dbdcc377d79c520a5a0d8",
+                                "uncompressed-sha256": "a026b8d6c25e02ee0fded3dc55000e492bfd25031e4254b861d50eab3ef4a7bb"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "1ef193c14d3fdfe991fa987f82cbf0afd52387838d6f2d1ab51f3ae98900fd6a",
-                                "uncompressed-sha256": "6ac91428ee15b8bd129f99c866888ba54a235c1e59b183b88207c9a605f84937"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "8c0f242b80ba39a16f73436bb8e001fae0f11a814a929d4f71934697e00350b1",
+                                "uncompressed-sha256": "a2e96a3e39550bf063c17505d279ae1c62081abfca31012ba57920d5dfe24007"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "5cb41f78ba411ae0fae7b3bbc92beb56e6d3db762cdb0e02a7a5aa62b9eae03c",
-                                "uncompressed-sha256": "f90ad8d9a144405da676ad9b360f2c387032327ff74f6ae79893b8f41a27afb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "bc388aa7e959de4605fa5f5668a099aaf5eaa624c1f70837eb2491e2d381f93f",
+                                "uncompressed-sha256": "7e7c151294db030c4daad1a658802ada6652305f724195a2f0f2e290826ce191"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "36695f476d61ec7fd5d183b1a75e9dfbfafef83138060120b2fb7340bfa69c62",
-                                "uncompressed-sha256": "7b65e0b8b9797898c00d6c27fb23efd4618913682e0ac43a731e56ab39d95198"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "346b809cdc963ab2c36eb4be38b6f90582492d4a5b59d8bb5e6cb25cf98c446a",
+                                "uncompressed-sha256": "0efe04da8a51bf198ed5938fdbea0799d5934c75a68a52e1f33e2a542f34caff"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "f957cece82c80fbdf83a64a52b38013e9fc458aca7623c189583baabb776502f",
-                                "uncompressed-sha256": "94ccce0de16345332111e4e3a6eeb5da7057872675af13df8b8b083d08cd5cff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "1da39a9674e5e55566f17bdd9682b678b55f24f1ea67f721bcaa340f2f1955f7",
+                                "uncompressed-sha256": "c09c81a53b1528736b6c3bf08ac1f0dbc1b62fbd83af5fad990b5ce7ceee50c8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-live.x86_64.iso.sig",
-                                "sha256": "0442eb0fef688cc06318b296922fec19c5abfceb08928ac68c9c3ebf4801e21b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-live.x86_64.iso.sig",
+                                "sha256": "40dff5fd69ded0df888383992e3e2b007563a70a4265be23b2810113310400f0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-live-kernel-x86_64.sig",
-                                "sha256": "cc47f1102fc229a1624f425b9c064937b07a6a7e39a6a5ab8fd37f49358e1fb0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-live-kernel-x86_64.sig",
+                                "sha256": "d8926be6a5ff4b1f51fd9d31bf41a1046e391d47a6b5c5f9247ca4003203988d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "0ee44ac9ef4938686bbd5d6bf108ac481e9a46c9760a0dd0a3e7edb1b22cdce0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "681781ca46dbe927460472fb5c2b0314ed5a58184d895a0a51bbfd554f0acf83"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "c3e21706b4bd858b35ee479c9ad85a911a37c2b442aafdd57caaad76f6e59751"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "4fbc043d7b4c5189986cbf1779d065f88dcc72b549bf933672034f0e97b3ec2a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "36f3f4c68287ecf33f7653de6346a9d2ccf397d4fe37aaa1ae6d64eea75f23e8",
-                                "uncompressed-sha256": "9a3bdb3773c05b03b87072fecb6b6645f28384e5d5cbf00624c58f82aa594745"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "3289322554a945f3e3b278b8d7412a115df925f9fad12a8dd9a32ea3ac349f36",
+                                "uncompressed-sha256": "e3becf00883ca70b228e32ab24ea53a88ef1e083b4ecc4d7491796f9c7777f70"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "ba7fce876854722ed010704434f2842c41b623197b9069166bc36c0a8b43d6ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "f1e76b1952b54016b3631315121d4f9aa4aaed7f5dc96751f81533efc254b6db"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "0bc5d4061b607adb18ca5afeb6ae1c434d3a06a5ca65a395fcf04b9cd084769d",
-                                "uncompressed-sha256": "bc3429ccf56c3d45c2e90b8922076c40488dac94f0dbb646164368ff32f83e9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "28a22dcfffbb2b148f383bc5dcecad9c6999086d0928559afe043f09818a8770",
+                                "uncompressed-sha256": "51fc4d32965c27c0b61653382652b8b631ed354e3c6f54b7f2e60e0ce9d56a25"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "cdfea01419fdda1e164662aeaf8c6a7550e7e00bccb5cd63abbd9de18ecf7937",
-                                "uncompressed-sha256": "c817c0f35b10e2d35db50539999402e06f38e8eacac60d12e9ee88cf8c608ac9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "32a74f3f1089110981fbd86be43f2abbb96458790e41b7f0d3d8dc9199dae709",
+                                "uncompressed-sha256": "159482dea9ff23f85aa275c621ac55cd80e327399dd341b50820c8a2611923a0"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "395ea80efc6d14d86eeb543fa31463697494ff57c18965360341986216656167"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "cae53cb7b234d9f945161ce0c74c9877b4b59bba19eced011de7331b16685b56"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "ca1dc5aec3f9677ac1aa067a90fa970a32ba54832937774dff987a729aff33cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "bc67900d62c6bd83311d6e9574c1b484e29242165426fa307f1b50679f63de01"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230322.2.0/x86_64/fedora-coreos-37.20230322.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "6055ce50af9883abdde13a7ae1ba8fd6937203b32d259b491b5c5eae0ca2c7b1",
-                                "uncompressed-sha256": "4cee75a95507ef372b20ac194fb074087a62a4f53b0bf7c9f188677c81731e91"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "eb899e98db8461625c6ed9299221bfd430997559be1e6bdb2bfd4e29420eb1c7",
+                                "uncompressed-sha256": "deeee249a0f6bc16dd72ed24aca460474691317114d90a0320799e70c6b07bc8"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-012c92119dc44293e"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-02f780212d89e4176"
                         },
                         "ap-east-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-09145ced6ba8a726c"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-027adc4cc93764ab3"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-00bb82b13ab556bfd"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-09afed197039b0c58"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0fd4ab5ccf89ea082"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-00ad913c64da3a8ef"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-07f8b45aba01d30aa"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0f1c5727e952a29dc"
                         },
                         "ap-south-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-01e1b4c3aca904e2d"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0e47e8be1cc0e896e"
                         },
                         "ap-south-2": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0285c17c90e0d3ada"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-055fa102391d1e637"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-098b8d6af8dea8dde"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0d37374e97e7cc575"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-05e93346814b5cb76"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-013d7b198c0e86289"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-03b4a4850188727ab"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-007193d52b4a5c324"
                         },
                         "ca-central-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-01e27fb2fe28f0356"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0477fd0bef10f5db7"
                         },
                         "eu-central-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-06c8295be82f729a0"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0a6e3b99d8f11d7e7"
                         },
                         "eu-central-2": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0be86961879c46fe9"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0f0c837a806117f67"
                         },
                         "eu-north-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0d539025e7f33442b"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0a307fe4550c1b396"
                         },
                         "eu-south-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-021b05597f4c611d6"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-00d3bbf9cc05bf37e"
                         },
                         "eu-south-2": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0ba7d47746e373948"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0f55b8398eeaa6a3c"
                         },
                         "eu-west-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0b0d67ce0995c3758"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0b5999cd5d2af7211"
                         },
                         "eu-west-2": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-061f63710f2725577"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-05ccd73a1e4583558"
                         },
                         "eu-west-3": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-04ca1d82c1ec1a75f"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-020ea21daa6724de3"
                         },
                         "me-central-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0ec5814f59b008f5d"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0c3345d6d0c032f0d"
                         },
                         "me-south-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-043350c564dbb5e89"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-03a0161e2bd5ea8e8"
                         },
                         "sa-east-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-06de3d32ba8868ca1"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-072bd1ebcc46aaaab"
                         },
                         "us-east-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0d5e3c0a8f262f93a"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-037fb6fad27f873ad"
                         },
                         "us-east-2": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0ee855552aea7e899"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-02c9c719285c63de2"
                         },
                         "us-west-1": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0feefac5a750ba978"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-06fc3dce6b53eb655"
                         },
                         "us-west-2": {
-                            "release": "37.20230322.2.0",
-                            "image": "ami-0c2a413c3221042a6"
+                            "release": "37.20230401.2.0",
+                            "image": "ami-0e44b7fe37676f80c"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230322.2.0",
+                    "release": "37.20230401.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-37-20230322-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230401-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-03-23T13:38:25Z"
+    "last-modified": "2023-04-04T19:25:19Z"
   },
   "releases": [
     {
@@ -81,9 +81,6 @@
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1441"
-        },
-        "rollout": {
-          "start_percentage": 1.0
         }
       }
     },
@@ -91,8 +88,16 @@
       "version": "38.20230322.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2160,
-          "start_epoch": 1679580000,
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "38.20230402.1.0",
+      "metadata": {
+        "rollout": {
+          "duration_minutes": 2880,
+          "start_epoch": 1680703200,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-03-23T13:38:22Z"
+    "last-modified": "2023-04-04T19:25:15Z"
   },
   "releases": [
     {
@@ -69,7 +69,7 @@
       }
     },
     {
-      "version": "37.20230218.3.0",
+      "version": "37.20230303.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -77,11 +77,11 @@
       }
     },
     {
-      "version": "37.20230303.3.0",
+      "version": "37.20230322.3.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1679580000,
+          "duration_minutes": 2880,
+          "start_epoch": 1680703200,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-03-23T13:38:23Z"
+    "last-modified": "2023-04-04T19:25:17Z"
   },
   "releases": [
     {
@@ -85,22 +85,22 @@
       }
     },
     {
-      "version": "37.20230303.2.0",
-      "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        }
-      }
-    },
-    {
       "version": "37.20230322.2.0",
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1441"
         },
         "rollout": {
-          "duration_minutes": 2160,
-          "start_epoch": 1679580000,
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "37.20230401.2.0",
+      "metadata": {
+        "rollout": {
+          "duration_minutes": 2880,
+          "start_epoch": 1680703200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).