### PR TITLE
Roll out stable 37.20230401.3.0, testing 38.20230414.2.0, next 38.20230417.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-04-14T16:01:41Z",
+        "last-modified": "2023-04-18T10:20:12Z",
         "generator": "fedora-coreos-stream-generator v0.2.12"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/aarch64/fedora-coreos-38.20230414.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/aarch64/fedora-coreos-38.20230414.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "243e3c6e7c0f926ab36b684473b41679c7ab1f9a6588cc02b2753f77b741af00",
-                                "uncompressed-sha256": "baf465bc9e330ccc8fee9a07dc56a1884aea53193db90862a4e1983362ebc81c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "9e804abb9d2d0cd9c204278b875d6ec31f2fe8623472a042e5748c9edd739bb9",
+                                "uncompressed-sha256": "462b7ebf1f758f94d31281740bef04834e12edf2c6e906a2dc2314f71dda94ca"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/aarch64/fedora-coreos-38.20230414.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/aarch64/fedora-coreos-38.20230414.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "bcd8b8470b4d8dfe9e21741657c5237a323852326b9a18af0f71205da3771c24",
-                                "uncompressed-sha256": "5fdafefa0b8cfb5b35628d3e57403685c1688b85edf94b6d34347f7c62ab0ec2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "61e3463a5fb246f84b82cfcc6e0eda6010e422516573578e373470b038337028",
+                                "uncompressed-sha256": "3e6816da2b1cd11099de60346a6304f6c9efcfa62be54cfcc8b3f0cfb66aacbb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/aarch64/fedora-coreos-38.20230414.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/aarch64/fedora-coreos-38.20230414.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "7e8777f13da92ba689ee93c5161dcc085c80e41050c5c0bbda23139ee80426be",
-                                "uncompressed-sha256": "bc0a9f3a08edea97069e472c0403895557acf020630223ff3d51b9cc714e979a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "0a22d415e00ea0948092085cee9c879a0e4f63ac82625fe0b36d040560e22cd1",
+                                "uncompressed-sha256": "7a0e6e93fd41b1e76c6fe64b6aeae356fbd44baa43519a65211c42182ae368a7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/aarch64/fedora-coreos-38.20230414.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/aarch64/fedora-coreos-38.20230414.1.0-live.aarch64.iso.sig",
-                                "sha256": "dd4d97bca7d9f6cbfafca5e6e6deffab1a8cb5375ad5638cafe99ebd64ae29fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-live.aarch64.iso.sig",
+                                "sha256": "55f0cce944b041c0ad66163389c1e7c993cc928288629a25b9f8a06d89b50fe3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/aarch64/fedora-coreos-38.20230414.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/aarch64/fedora-coreos-38.20230414.1.0-live-kernel-aarch64.sig",
-                                "sha256": "1b1ffd1be1caf04cb7f77d5e34646a2998ca2cfe7d214a28ef749d40dc86c650"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-live-kernel-aarch64.sig",
+                                "sha256": "20b16a28dcacf124df13132b4f76e7ca6f793265d393167a9bc6a5c4a0e7ee2f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/aarch64/fedora-coreos-38.20230414.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/aarch64/fedora-coreos-38.20230414.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "a50e32ab8d078ba6967370681b233d0fcb3cd501d3e73ce2e308cf9d564b795c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "c6f8d6f2f4f36928df3b73c04e51f49d3faa99999271952f6bba3dcaf2638d9f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/aarch64/fedora-coreos-38.20230414.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/aarch64/fedora-coreos-38.20230414.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "91e2964ded82184d76882b88077b513a97b792d05a2b852a8ee68cbdf0c968b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "39daeebf98a207b8a4d3310e3fb4c9e0352871e4819204581ec8f895d83fa693"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/aarch64/fedora-coreos-38.20230414.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/aarch64/fedora-coreos-38.20230414.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "c4f7b6c5dc255e3bead259c76ed8edc5c1bb7ffc6cdcfa7ebe7372dd3a002bca",
-                                "uncompressed-sha256": "d8ef32f4ad2f8f27ee5277e60ed0f2d230960033ba47ec937b5c729434465095"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "77c5ddbea1fe090f6ad3dd0ae9209ef6c2eef51a45d136b203cfc125f8e478f0",
+                                "uncompressed-sha256": "42708cc12813dd11ab6ec2c27f6d1e00c948885e105ad5c5af838dea5b4a0594"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/aarch64/fedora-coreos-38.20230414.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/aarch64/fedora-coreos-38.20230414.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "599009f6f18ae0aa213d57c5c433af843c6ede607150dcc0967a1e35c14b8c2a",
-                                "uncompressed-sha256": "8e81155ceaced41a70a972253a5f42f342219336641433ff13bb84379fec6b90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "43be08594d8a355606436437ec83aae396443631191cd78d8dbf1305183d4cc7",
+                                "uncompressed-sha256": "8e11890d4b5f89e644f40b76eacf1c424e617bba2707ce94abd74c0380623c6f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/aarch64/fedora-coreos-38.20230414.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/aarch64/fedora-coreos-38.20230414.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "5a1cfe556d32669c44b1c79142ade5c30b708373922074a010d227a1fcbb2880",
-                                "uncompressed-sha256": "8ef46314db3f9528e2d9af18527beb3f831dfdc1a8a892298a01f8dee239c6b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "0db021920bf42c8b2065e50bfa3080dd264b98965ef5b733541819470c54c6b5",
+                                "uncompressed-sha256": "3f0e83dc6cd4e75221e25d55b8ecc7845979ffa1cd92b2121562a12e638bca03"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-07032686005ebf29f"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0945712b358e5ac2e"
                         },
                         "ap-east-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-040ddc04e960cae16"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0ed6b2511261821b9"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-03c313692b3490823"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-06d99b89ea4ff1c3c"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-05dce6e684f4e55c5"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-02d44b870f24079da"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-02d14de54ab753396"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-04b2bf61ed9f09600"
                         },
                         "ap-south-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0a50bd7cdeaf83316"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-003166e0641d84db4"
                         },
                         "ap-south-2": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-038bfcf09e86ed5d6"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0f61d8f172b41660e"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0b4fb90503fd1494b"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-08b8445b72e1aa571"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-06e3b4725eb94ee56"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-01a6558bf1b8cd0c7"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-006bcd5890db58005"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-04ab5ebab32194bc3"
                         },
                         "ca-central-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0e6b4f6b1f40f6a51"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-013ba6fa057203bbe"
                         },
                         "eu-central-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0db292cd66e1ed367"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0088d968ddc72c725"
                         },
                         "eu-central-2": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-092e0b556e4d1f142"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0c22ebfeb04869100"
                         },
                         "eu-north-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0fc343c644bf81c5e"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0966d7c14b3250772"
                         },
                         "eu-south-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0ebb755ba716a9861"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0a559d5b2f25ebcfb"
                         },
                         "eu-south-2": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0f318d7cbfac31965"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-08351a52294a7ea5c"
                         },
                         "eu-west-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-05af86d6e68bb839a"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-03fd18929ae52f214"
                         },
                         "eu-west-2": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0b79c83d0f88da40a"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-08f92bb16c50dc87a"
                         },
                         "eu-west-3": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0cc30322c783e5fd7"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0bbe4a248b6d5434f"
                         },
                         "me-central-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0c15de671f4d67775"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-01c82b532ebc2c0d8"
                         },
                         "me-south-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0bd54bc3c68a9cf0a"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0cb18e3dfc3af2530"
                         },
                         "sa-east-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0aecee3073c0a12be"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-02bdf24b17f42d8eb"
                         },
                         "us-east-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0aa6f17945b7ec786"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0b12ac9ff2e3433a1"
                         },
                         "us-east-2": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0c131dd43f280f59f"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-042e1d5d3c05b5d92"
                         },
                         "us-west-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0ffc8ffbc43916e96"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0713a3e95794b8329"
                         },
                         "us-west-2": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-06781e63646b761d2"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0d1daee6316c12135"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/s390x/fedora-coreos-38.20230414.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/s390x/fedora-coreos-38.20230414.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "59e6feeec1612f161e852f8928aede05695bb46b7bd7ac90df2b5511b4247a46",
-                                "uncompressed-sha256": "81e2388cd49adba1edf7ba6784b65fcef0366b751802ae6ff4f8ca7abbdbe118"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "7bbdaac0c00e15e4420474688c4e9b94573886cff2bb726180aad1bf6576949a",
+                                "uncompressed-sha256": "01a120985bf2a732219cd19a49dfc4bc0ec17b4b8eb7eb43082cb80d93c696bc"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/s390x/fedora-coreos-38.20230414.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/s390x/fedora-coreos-38.20230414.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "04f55cf7fcc738b4f0812ce623ac04a8339eea9aa4eae70500250d87cf7eeabe",
-                                "uncompressed-sha256": "6e5d3cf599cded3b88386f7bd93deb27dca3dbb127635ffbc4b297510c004bcc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "e8eec31f9415aa816ae3e4197ed11a1073f903273c9b5463e0801b2b76a9f0cf",
+                                "uncompressed-sha256": "9362b2e846d65bfb62fdf83f8c1579b7775832d004f13e4f658eea47ad22879d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/s390x/fedora-coreos-38.20230414.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/s390x/fedora-coreos-38.20230414.1.0-live.s390x.iso.sig",
-                                "sha256": "886c39b006f919dbf4900ba28f702d8c0ad5cf4c9a49adf7a457f4b9edc262dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-live.s390x.iso.sig",
+                                "sha256": "24b46766e2b941075d30eee1bca417e00fa062a703cb6ef0bf264603c968abb0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/s390x/fedora-coreos-38.20230414.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/s390x/fedora-coreos-38.20230414.1.0-live-kernel-s390x.sig",
-                                "sha256": "237cf0e1a77cf15890707b4d32177c7bb26c4531195c63f5a3055a176c160fe8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-live-kernel-s390x.sig",
+                                "sha256": "0d0604e7f08137980bc3c68c0ed0f32edb1b5f5e2a6816535f2273ed81c20591"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/s390x/fedora-coreos-38.20230414.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/s390x/fedora-coreos-38.20230414.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "ebd0d9c2e329d07d45d5add6f0675a4eb0a8ba5bdbdd94b7d352939b21fe290f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "fb35315ccf7b4a87fd2170802e9901a91889b28da33b7adc3faeb9157c587d33"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/s390x/fedora-coreos-38.20230414.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/s390x/fedora-coreos-38.20230414.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "64ec02f64b594d310457dcaf6cc7cfefc8a4e94482ca12432cd65e765f155235"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "917cd9384f992277b014cb7fd49ef2ae41b64950854c9a0a8e8a32821d8dc33b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/s390x/fedora-coreos-38.20230414.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/s390x/fedora-coreos-38.20230414.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "0b175e69d16c98ffb3e735b318ef49a58f46332715409584a3e43a14e3956891",
-                                "uncompressed-sha256": "92e61fa7726ff315ef4222b72c63c01772c5aef1f87cb7726bcaff3fef925425"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "4310ea4450a8ee09ed98b225e75d831b4c927de84bc580ce065e91e5c5a9ffed",
+                                "uncompressed-sha256": "978b7ca21b3883033cfe4c8a43d156789e439bc298648915d905fc37d0cfddf9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/s390x/fedora-coreos-38.20230414.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/s390x/fedora-coreos-38.20230414.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "83a5b2d9f7f4e0c1e195f282e749289ee5416166bcadf925c396923954c7d66d",
-                                "uncompressed-sha256": "c423e10af020ed7df6616e4bca900a3fb9d44a0ba72f466df87c88bb1a08548e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "e99ea804707c918554909c3741e7846138f5c9254f6ae9de319998a9d7c651db",
+                                "uncompressed-sha256": "256efab18c6bd82355f566bad6abe9e93331e487fd7b22ee537ebc0b4baa1dbf"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/s390x/fedora-coreos-38.20230414.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/s390x/fedora-coreos-38.20230414.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "497ed2375a99456cd0738f54b69b20b5e1f57669a277f304eb63f834452061f1",
-                                "uncompressed-sha256": "9f0e01abf9471dbdaa1a513bdcf4b377fd074a47e554885fa7e7ebe817d25c28"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "83d7088e9dc8e07b1c413562b0d276360b88fc90dc0c47b35104727fccd09eef",
+                                "uncompressed-sha256": "8c58d3320f023236c530928154b39e7f1a527b6c5b93445b5e8296ce479c4ff6"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "dd2d24bcf59db994fb01c74001d2973cf8a1e62aa7dda626fc4caa8bef95dd55",
-                                "uncompressed-sha256": "4e0809464655a19e136a2f0c5c927bc84e0106a2803e7f7b9eb5b938a89537bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "87f3837a619d397c7560c6412b789b7d3ba42f0475d8fd56281a782ed49f3216",
+                                "uncompressed-sha256": "371ecf48c64c26eb6d6388004b7e12bf75c322538b4485a3f571d332883cb5b5"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "ab4879e40e4a050aa27c3ce08c24968c291b0f80a86a4c109fc8b0caeee98082",
-                                "uncompressed-sha256": "955749ba13bbb85f0ac8cf5e66e8607642ea4dc15b9ac70e60ffdbab0adcc4be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "65c566bf60f22d3d059e961407ea69044a4ef4855a7ebcae05e00bf34ed7f3a3",
+                                "uncompressed-sha256": "2b675ad54c272e0278beb5becc96ee7ad73143ee58f9fe998ff54590ddcac995"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "e897cf72f7a216cbfd70c838c2da5987b647033c3325f42f9a16c8ffbd8c9a4e",
-                                "uncompressed-sha256": "aeee76a61201b465c73463fd074b132eaa651cd1af606dfc2a14e5e99ea50ec2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "7a294461cbf286529c1497eec5ae534051486d6746a8663079cd9752c1228b4c",
+                                "uncompressed-sha256": "08fd77d733702bd3de7f329aa39eef7ef1d09108ca0dd73103cf1c5cea3b93a5"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "6aee7ea0375250b0fb24178667d062cb28a3e27ef187622736fa8d77e08a545e",
-                                "uncompressed-sha256": "5b27facc2bb5c908b9bd67f413b7cd50a2e6202da34616d9b0b47394804c2466"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "7fa721b0dea9c06ea37e75b6f7077000d8f56465162def76367bbb29b0bcc50e",
+                                "uncompressed-sha256": "b16edf56d3343a5398e0edc2124e3959cdd30cbdb3cb0802d1b1c02aa0c992cc"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "37e79248f3428e05435a8e10d5f3d10c11213ae339836ac5fd6b113b7fe8c00c",
-                                "uncompressed-sha256": "4fc477ccc77c34513901072ed422f51ca6883978c48d85ef281b506a855afaca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "32828bb8d9437d324f0781504480fa21d419a832a9f17293ea947c6fff26c7cc",
+                                "uncompressed-sha256": "a35d565f989a7b8266ba801a6bf1ef1e96f72c4080d8e2d671163f2816c8be99"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a89f6430ffa984a799f77f84941e703aec5b774707446c4cb44034e8970df380",
-                                "uncompressed-sha256": "a89a46ff82026fc34599db782bee8d2ac0536153963d4c12e0de107ccdb1a8f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "f9c3a09919b77f75a7f12671ece35a06c670dcc81c55c3fc84cd34f899ef2bc7",
+                                "uncompressed-sha256": "b2b0d9ab601d2c4cc5d87e9e6062870061e00d379f9686babdd9ae7645198b6f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "937176af971439004a8098e2cf37aff26cdfc09e750969baf1cfb994d713b4f7",
-                                "uncompressed-sha256": "cc64ce37cf496ccded897751cd5562c2b3fc04cf1e6b68cdcfcd185f67b20ff4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "9e903c134b155a41b984c6d349655ca9324a9eeacf75b64fdfc035ee1070cd7f",
+                                "uncompressed-sha256": "206d99e5bbd9b39ab4a7edd2865f01ce49005cd2707afb0ab197592a0ca014d1"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a23e1950cb3d533016af7cce8c6aa2a4984dae7c7a88dac2ed76a8c8ca916517",
-                                "uncompressed-sha256": "c5c188a79bd9f82b859e70e51d33356125612c4f86556aa2e78570ee3feb6333"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "c4aed6b43881f4a4141e90bba6510708afb0bc735e5a5c46f50976de48ef03bd",
+                                "uncompressed-sha256": "4575e56d314f2f7b6cb690c969021a13471eed6f251ea4b666cc3bc944bae5e3"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "c68c5d915a446d2e8714614cfb2e5e7aafd98f672e1a4ce2743c6ff3f961bd7d",
-                                "uncompressed-sha256": "c8b8babdd5c0c21c27834f6e23e159eaa962d7efd101528065b39c8f253a88d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "719107dae5c67fd68b2d676db2d6c46c8355fe503b4f008ac461c8ca07a418b1",
+                                "uncompressed-sha256": "d86dbb24930590aa01befe9983dfcb4459decbe20e954b815fc216c9cd7139ec"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-live.x86_64.iso.sig",
-                                "sha256": "ad3e7955d3d96595c9f1b45457a153b0cad12d4570b554373a9aa96e9ae94ba8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-live.x86_64.iso.sig",
+                                "sha256": "af683eddfb92b36ea2e53cd00ee36cce40dd04c8e521dbf2b4a98f1d1eaeccb3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-live-kernel-x86_64.sig",
-                                "sha256": "744218da9e6c1302c9d436070c1094a829ad9b5821cc714a5a2835877e657327"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-live-kernel-x86_64.sig",
+                                "sha256": "56b09147c4a23ca52a24217ea59ba306a2b42d3a1c1ec0a5596b063b0691e0a2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "c0963dc5ccad92e8e088d66d0dbcac565994b0d4b644e1f430fb3518605c3712"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "dd71493110d39038cb3ec4aeb2aa75a5a4409512ebc257d270e4ea1b1c702939"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "ecab2f879e42047a98254478f0abf68eecbb778805ff360d92d3401d472dec66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "f7c932c0d985359e05b01d1fd4e1826fe214ed1100f83a96a0f27dbecc8fd40a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "0d8cd5707ed6868a8f6ac1ea1505cd1dc0136fdfb3b77da1e96ad87c2ae57ef7",
-                                "uncompressed-sha256": "cbffce196e2ad317e494a15e5627cdc44e99f52cb4ee6491c51d6dcb1d45b6d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "6ec3e3e20dc56f9e3e8e0f81e1b2d914586b9426fe50a5bce016317b6ef57eac",
+                                "uncompressed-sha256": "a2552a2592aabb277aef7aaec41c85be7e20eb1cc2d898ee0fdb748b402e0830"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "fb96e58b94dd8db21912d09ef13a0775ddf3d1c5f6bcb8792c86a191dedf284c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "cf57c703563794fd2deff9ef085558390726f6146aa8ea800f167030b8360647"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "dbabaed1c441c7352aeaa1bd888a97b91170266df9de887e24719e30387924f1",
-                                "uncompressed-sha256": "20f3a1b390317c28c449c8235c338a007daa1c1e37d7a600bade0fe688e273b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "b3474e92aae2722a04c368245bf7c2af8f56050e5e9e4c7bbb8666448acf0a21",
+                                "uncompressed-sha256": "42f2e60c528abcd305fcb6bac8cdee5951cc5fb5bd3bb900249f915229e2f24d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "2d44cdcd328b0a27bb3baa5170af1248e54df1c90a5a0de53eff3aedae1c9106",
-                                "uncompressed-sha256": "ce9e2faed422218275022b1bcea0316a61d4de650016f24ba94394f379b2aa36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "b76666c1bc56b5d5b76388f9662f941dbf499cbf971457982eacfba687cddd19",
+                                "uncompressed-sha256": "98593d31e4bb507740d2856400502054e7adbd7a1be06b52f1ff7a912e8b36bb"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "b4cba3c84a1fd32f97d43a48e729f4b5ace9c1b28bf3f947a973a3d60e4dd1d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "31f9f52307a2f7efa53b284aebc94a517e35ccbdaec159127fb30cdf05d2f79a"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "e418e770fb8ba45d2e1a2f9145269961017609cab4511c64f87d873f00d70e8d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "b0ff279c0b1c9692527c54dad46930f53a418fd50c8d18556046897bdb619cd7"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230414.1.0/x86_64/fedora-coreos-38.20230414.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "af81bcbb47a605e34cdcece801480e282751c61566bfcdef0a6fee7fc9a24fd3",
-                                "uncompressed-sha256": "6b90010bb68b0ba12c19f50795f577ed9319e3e9dae5616089563b21d4af10ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "09d4270d1c9f47892c25dda223ff4e4127d98e8b715213462a51cec061d18ce8",
+                                "uncompressed-sha256": "04f5415162d2d56e8a9d98820d2793b994ea1103bad1e853cdc2c20be19e9d8f"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0aa69f70764aec926"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-02e458efac3d0d618"
                         },
                         "ap-east-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0c5bb059d19ec8798"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-08522056f0f95d3a8"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0810897ffadd92549"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-08ffcdf422f14b811"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0c998e1e5f01860eb"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-046d31bafb5a369ac"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-053a424f971c969d8"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-05ba41afab5174480"
                         },
                         "ap-south-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0a9660008904d0f5e"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-095b17dc0c749834b"
                         },
                         "ap-south-2": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0c3739437c2e729cd"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-08a0ff62270bb4742"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-090e741f6893570b4"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0c4a9cafed3769b1b"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0604e0288ca4112ea"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-052f08433af183188"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-060ab4ae8e74512a6"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0aa55c714bf3bd266"
                         },
                         "ca-central-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0cb2daa4cd0e54afd"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-053f9b14a51feb176"
                         },
                         "eu-central-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0148bb31aee360769"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0db22b650511a7e84"
                         },
                         "eu-central-2": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-04e4e647f13a3defa"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0464aa9f8604b5cbd"
                         },
                         "eu-north-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0ee5f7530602c8e24"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-043ddddedb0020ffb"
                         },
                         "eu-south-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-05f5a0aad0cc90918"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0c6fde03ecc53c5a5"
                         },
                         "eu-south-2": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0e7568b44ac665cf0"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-04a9318c27d4af1d8"
                         },
                         "eu-west-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-01b8d102891ad773c"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0d1603f22a31a0641"
                         },
                         "eu-west-2": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-08c4a717163754e31"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0298e48214be372d0"
                         },
                         "eu-west-3": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0aea552891bcedd8f"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0cb2164506270f9d6"
                         },
                         "me-central-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0614ae923dbd7e80c"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-01a98f2cf7a6bec03"
                         },
                         "me-south-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-01949162df7974cf8"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-099b996a8c823c4c7"
                         },
                         "sa-east-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-02bad3362d0d71c95"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0e279bf95f4bf766d"
                         },
                         "us-east-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0443bfba51a1131b7"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-08f1d00eca726d2c9"
                         },
                         "us-east-2": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0e36f309cd3cdb849"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-0b2784ccfbe9dc5b5"
                         },
                         "us-west-1": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-03c850ef1189a3d8f"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-091c1ea3d031e71cc"
                         },
                         "us-west-2": {
-                            "release": "38.20230414.1.0",
-                            "image": "ami-0e7a2efa4546fead9"
+                            "release": "38.20230417.1.0",
+                            "image": "ami-06555186441d41031"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230414.1.0",
+                    "release": "38.20230417.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-38-20230414-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230417-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,105 +1,105 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-04-04T19:25:13Z",
+        "last-modified": "2023-04-18T10:20:10Z",
         "generator": "fedora-coreos-stream-generator v0.2.12"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "1ad571ba42e047f6a994b5d07630996f462872db9b5c932ac4f1d314b42e97cc",
-                                "uncompressed-sha256": "10d9ce23e20100bc2ff127c012031d7e816a1e6992055b525c00f2fc99193276"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "8d4d1f73dd61de4b0ccf8477cd64c4e0f33ce85fd05cd5b8238f079835d240de",
+                                "uncompressed-sha256": "2f671dcafa702d048c7cac35dfbe23e0aec7e4553539db42310801d39dc82d07"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "95b0bfac5ea77000a1345ec25b9d256f048839fe5e9cb9f9038d0393d5dc01c3",
-                                "uncompressed-sha256": "6ccf5a34d243da70430a45ee4578d899e829e87c8bbca28649cfd11cdcde42e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "ad548b352db4543583fee430b56d71f6297a2ed23d5b8ffd2140dad3a9944220",
+                                "uncompressed-sha256": "b615c71485fcf25ae29e192ff38e0ea112a807a625b1bbabbe222c38e0820f3a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "83d8ec0f0b109062f03721bc5d48036421497a4aa650339f6f8d62080ebd56ea",
-                                "uncompressed-sha256": "33bd334359388969972374d88086d959dad105710c572f8537fc5da912b2479e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "2bd5ac086185dda663ff5e1b3c31dfb9dd1e4eb56067f3b3ba51277faa99da36",
+                                "uncompressed-sha256": "39ea6796ea48c6b5e09be2ffdded3481d3ed51a5b33d8b6b55f3b89870ff665b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-live.aarch64.iso.sig",
-                                "sha256": "97dd830dbc67eccf23b0fe7cf15a062fded39f5388d496a83caf44ecb128bd35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-live.aarch64.iso.sig",
+                                "sha256": "525ac76fedc8d691f5bb1dce8b86daa09b8e340d91f980a3bbc36ebcaa3d816a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-live-kernel-aarch64.sig",
-                                "sha256": "a99228f65715b0bfe75ef83db32739ba54ec4b6d0103760de915c2b0f4928fa9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-live-kernel-aarch64.sig",
+                                "sha256": "f97554c216f3dc0ba0cfe97d69907b7164deda9444bdd9eceeda13c60e7fc23c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "e5ccda9c0658dfb0332c3e031548ef991fd4c721271bda4d19ebf17a8c84923e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "998d86299a92a4be89f715aa6c142b3698748e472327bc760aeb7da6d8224690"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "ebebf198165dea14f4b5466ad82cc78babb9fe9e21c168a8ae079caa34b0b880"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "2a4d099da6cdb8454c81658cc9c1e23ae6c5b77db3d45b9c48218775b652c323"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "8119056f3ffd6bfb146461bb8dd9157c9810e31139d70290a57947709ceb7f9f",
-                                "uncompressed-sha256": "6f272d3c8c34603498efcecda4acfa69c19b56e0aa154f5ab1ce5ff24d07a5fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "c8def1a9c21020520a166f49dda37116cc23d02270b61e5aced5d1118aedf530",
+                                "uncompressed-sha256": "0141b547782fe5241d156102f2c0054296c677650c6e7fdfddb92d73b4417733"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "8fb949a146100e5ff4ddd0212b7402f7da0f2d53e6135239b023ff1024a02bbf",
-                                "uncompressed-sha256": "f65dac5dee5b5a28c50ec2e5d9e1a9a57905ec9ee2b941f17c1dd4c03d32d3ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "33f3b69598c60bf56abad5fd5e47c8f2342bae7dae6fb74c0832dfea7725fcef",
+                                "uncompressed-sha256": "1b671e3f2d4873ad784223a1a499227f29ba8c201680bc3c17db53317a1d16ef"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/aarch64/fedora-coreos-37.20230322.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "b894e6135d59aa550625dd034544d50addda2f49c7612caae9b3d90de34ded90",
-                                "uncompressed-sha256": "05024224a8b2d35c3e1bd9e71032d10f9f2ad106eb9dccca2436a0289f100555"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "6daee52248abb01ef10c84fe09da6f11bc747f172309459027401eceabd4b5a5",
+                                "uncompressed-sha256": "23096242cbdadabc7e3e864f63812105f7e19c08bdca335cf1ed71ee23b8d810"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-02506bfdfa9a2400f"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0693ab953a6bc2c70"
                         },
                         "ap-east-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-07442eb46ed01728a"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-09e8d85052fd0d959"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-06549d6426a949e25"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-050d45445c8c5bc76"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0509dfd4dbc6afb5a"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0189c1ef4b035874c"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0f88586b4fa749488"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0c4f62f0afb4d7385"
                         },
                         "ap-south-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-064ca61e51701a565"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0f1afde3c3bc366e9"
                         },
                         "ap-south-2": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-018a22b894549848d"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-01a125da3409d12f7"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-035bc0d9b91998992"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-08bad2ee54fd840b8"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0a7bdaa8bdc0f616f"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-04d0d040d833982c9"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0f469d9e9434782c8"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-097889eadb1cdaa15"
                         },
                         "ca-central-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0e1ce4c9317bb39cb"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0db29a37c7876a10f"
                         },
                         "eu-central-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0ad7456d4deec7695"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0162974b05eab5e95"
                         },
                         "eu-central-2": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0ddb3b4394995c03c"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-012d490cf0f3f766b"
                         },
                         "eu-north-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-08366b4769147fc42"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0f108df4c1061f242"
                         },
                         "eu-south-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-02e7562869c6b1f46"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0002c5529c6fff5a4"
                         },
                         "eu-south-2": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0241a82c64b527d5d"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-01193762e93f41e66"
                         },
                         "eu-west-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0085833c542a124e9"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-081acdf4f03203bb4"
                         },
                         "eu-west-2": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0c54f33e78a0f294f"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-060a7fad92b320f16"
                         },
                         "eu-west-3": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0784a1fc3dca7fbbc"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0d1549ef7122fb9a5"
                         },
                         "me-central-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0df8e0c048c71adf9"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-04c8ce7eb5bb9677f"
                         },
                         "me-south-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0716e071b996ec08f"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0481577595eec3e3e"
                         },
                         "sa-east-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0b2d1b849bdf68e46"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-037dfb87e2ca478b4"
                         },
                         "us-east-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0ba09a18d6c9d4064"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-02b9bdff58471dbd5"
                         },
                         "us-east-2": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-009cd786b8978a81e"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-00f116716a4d6d12d"
                         },
                         "us-west-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0e619c137b7418116"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0afbdd8c2ef83830b"
                         },
                         "us-west-2": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0b57d3fe3014a8997"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-02b7677166da2e465"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "07c89cbc5d53e2d469ef8e43c793107bcbd23e978deac9fffbdb6c71dab3977b",
-                                "uncompressed-sha256": "c918d10b09858f43bff1054af1830f015bf7f0a9c41a9898d77c189af2e1f30e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "4a0c7f6c97010b970edb56234ad622d7b7c4d1a73c04ca806c587a050375aa9c",
+                                "uncompressed-sha256": "5a1754aff675397b72049d0a2400f7e165b978a08a82f4a0e3bbcb5a2ae52f74"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "3fc5fdc29179852e1dbb69e835c736d11a7fba01336614da881e0bfaae74d1ed",
-                                "uncompressed-sha256": "920bf26ee5c15fd7687d58433a143e4ed6fc23e995e47ce9c97e3cb477e11661"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "765d2f16c121df7c08aed9845249ae7a03fbfdf6aeb3dfa5af1a8bc167a18351",
+                                "uncompressed-sha256": "fad3d0e6f6fd1113eb5f2b94139658ba643815fd0d549e6e7831b278f4f7d5be"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-live.s390x.iso.sig",
-                                "sha256": "629e508cb4add82459a4c6d7bcd25ccdcb6dad66f62302d63f3f43992bb8416b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-live.s390x.iso.sig",
+                                "sha256": "1c551592a6ab783e4d3b159cae12301581686a11eeb5c6befb61587cad04b438"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-live-kernel-s390x.sig",
-                                "sha256": "47dcd65d330d40d0cd6e7e9f95c64088e2c3a8f394a77b13cfb109198b93e4f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-live-kernel-s390x.sig",
+                                "sha256": "cd760a88d35c79c87f49ce37559b540ed2a1328011abd9b365ef709c773a62cd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "e5b618737fb1a24b80ddec6364bca7d446b922a808b13f8d1f5a8a653766a3a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "21d404ef394587767240f5aa9b2665b7ad7051b1ba940212d8b0c0c1865f933b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "790dc577c393762589e93b3c22a396be16112986892b9c0c0c98243ae8533eac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "960b0ad90f2a6577b033429a8f1e2ee91779a89a9731d5b19edb4d52357401ec"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "34ca2406c62a8bdd75bbf40c9013e9b7a8f6a2cac77b4a2e2565030625af6f18",
-                                "uncompressed-sha256": "1b7b2a6e0f3993cba5ff0930757b6ab0d7f6d289d9843b4f2e2284c4afd51d81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "43b8cae86dd7341454a758fe7d07e34adb4262c7f0954018cc17063e060e33e8",
+                                "uncompressed-sha256": "cb19f17194bc4c23921e7ff87773600ed0cc92995af6f6885fb30344bb3e33fb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "b572218fb989efc096604992633a255292957d09498db3d2d4c6895a1d91951b",
-                                "uncompressed-sha256": "51c544a7bf7b431cd66e57e52f18cac95c096cac2642bde6bc8ea8c3cc35f195"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "905d07c4a8522823973da813be1794c4f88502cec295024ceeaabbfbcfc470ab",
+                                "uncompressed-sha256": "899ca1ee1bd5929d6373032c321aec5b85089a33b330874c2954fec22ab27421"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/s390x/fedora-coreos-37.20230322.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "4ad8c436d913a67c0b0cfc2a35322a953682e5d8d8215af613c66ca5f3339830",
-                                "uncompressed-sha256": "86b673c768736cc329a3924d08ac4afb5a5af325ab90b8caaa054c8c2a5705ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "9bc0c27b65d6bc07571ab84b0478112ac6cba4a7e03540cabff9230511cf1cf9",
+                                "uncompressed-sha256": "ece50de4fed3c2a62b5beed7378e1c4fc164db86d82d09058cace10ec8797139"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "b0182b551019fe6846aeefe5c1874313137be4d501eec5d2f2f853c38d080447",
-                                "uncompressed-sha256": "7463eeb361dbabc439ed0281eb57872dccc7a4b836082d26a8ced9e3ac8a4fc5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "23e65ccea26a0b3fc40007f8d37a880c9169baed63e37e37359370114572cb52",
+                                "uncompressed-sha256": "6a769b2e1a5aff7c5bce56be5b23b8459e99a2b706499d714b6e6f98026fbb7b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "590fe93f59d7395147699e35e9252bfad22ea7cdaf92a963ab4374e8d8226702",
-                                "uncompressed-sha256": "701d44e68378931030c7f175fda0a1c02c0a095b86c4eb80a6d2207624a8f97d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "fc4a376ad5447c496950941b165a12a7bbcf0207df02f1addee69c4ff91b4bd8",
+                                "uncompressed-sha256": "ea1ef5b0aa1a282fe3dd73d60966e3548b5a24499e8328382ade31cba22da71e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "9048b4c2cea93521ecfa891bdc6e9b9eed734c7b284d0a1149a34593d040cf4c",
-                                "uncompressed-sha256": "064eb7bce8b9800ae204dfd8b382f6d1e153321cccb998d3d6a3b43f27759bb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "21094ae40c8ded7f6d279e8c0c2b3dfe11c7c5032aac339a394e6519337983db",
+                                "uncompressed-sha256": "4fef2568d8153ab7fa50f0826dfeb4286922c32a1b6756c4c1c65a259c582923"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "fda2cab2359eb3b2cf322280dc8e333636fff86deb3dd335eb4a8b24082fd4c2",
-                                "uncompressed-sha256": "654d76f096ef0daa57cac8470aaa382ca47fa47294a7d120fa2418be0cf85753"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "bd4debc5e9dd288ca23ca481670384d603ef3b227df9a491cea53a00b7726dec",
+                                "uncompressed-sha256": "797f99846ece7008a473ec1c239eada79f6dd109d2e44e0f4aaa8ce3290f8648"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "3390976e081cc0390690156ab56f4dd986bd5af5ef835c6ef7cd5071e5bd3287",
-                                "uncompressed-sha256": "5f41c213944c4867971171857e7743f7a7b2d2a4784446d728682fa70b068489"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "24dfd9022889b240c17394f327e039008be2d3d3c1fd539ab96f29631ce78b41",
+                                "uncompressed-sha256": "bdb1eb0eb772c5f8890c5dd0551c946e3900f1e53fc376432a8396ac7ead4ca7"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "d26210bc67858df6d58b36e959b3feed60a75da0556231a0168628dd7fb4b517",
-                                "uncompressed-sha256": "9b0720d2f4831f86d3d2207aef1f1c976e148af618081cdcdc914391ffc0b1b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "54309b971b2de480e0792fe8b45cac8c81c3b1e067bb47550f52e91191894797",
+                                "uncompressed-sha256": "92738eeef7eb22c1d4d597abbd4045ae584bc876602b087cf090333badf604dd"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "5c2d604ef1942d782c7d4525ab94ea366d69dc2bae849a4ff959f3c504b4f434",
-                                "uncompressed-sha256": "5f4672f4d5952537f2f466b5c752bf91c221cb6d4e79ef9ba567806787b111ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "dbe5289b7c5add6595f0cdb589c5766011dcec80d6e80bd1cf6016cccd67fc46",
+                                "uncompressed-sha256": "b51126417d52612a6685d1a2837279e420f95b498d209067b60c499c8efa1d45"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "e4189c8541784b1e911ca41f02a8a88c307eeecdce6313f00ce47290867649af",
-                                "uncompressed-sha256": "c0c9328d4b03bb37f4cb71ad7f4abf206bea9aecd021713341c2638c7e728b0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "a6dee91b557a8e749a277947e23eba05ddace6171b416bca8b597c8223e2c25c",
+                                "uncompressed-sha256": "53a255ef4b0475d2f9d014b7b4cb37599f4204a52c7aa7b829fbb7f3fcbb097b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "950b001f7e40b4c160e187a95fa1e1cb43194a56cd197094a090f2e0d9a6d865",
-                                "uncompressed-sha256": "81bf778fbdc6306b4aa326e483e2a027fa4927149a28945c8e3ca5420a5db9b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "eba1e3a653246a962c801de41179285ac7ed73573d93f8c1a5597f6d64109cab",
+                                "uncompressed-sha256": "56cd8a9cf6f7ed3e5d6ba1558ac2ecf5a810ea51cbdf0a1b852c5d029ade95d1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-live.x86_64.iso.sig",
-                                "sha256": "3a4e0f97c58afb74accb89b444c62b3089568fea16e4a475fc63b753009655cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-live.x86_64.iso.sig",
+                                "sha256": "4f6f77d3417c11f659a7570e75cc394539bf5afaeacd443b6c72c8aea430dd9a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-live-kernel-x86_64.sig",
-                                "sha256": "cc47f1102fc229a1624f425b9c064937b07a6a7e39a6a5ab8fd37f49358e1fb0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-live-kernel-x86_64.sig",
+                                "sha256": "d8926be6a5ff4b1f51fd9d31bf41a1046e391d47a6b5c5f9247ca4003203988d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "7695649f67f23acbaf812d978c8f8fd4ed8f07bf8b8b490f6c4d661c93a9c4e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "2db17962dc8f8bd5718c2577cf53a6fac27efd9b6ba6c9ece39b5c730c9fb6f4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "1c8558bf6558e8c65bbc01b4176b2e4f99c683908db2ab64668b6e8c0a0d6190"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "a6bc2aaaec2e17e401402ee07448d16dcb5376ae7dce3c386333e611a9431a13"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "e636118e646aca08afd408737df63023a30793ce8f7096c87b76daefcbdea285",
-                                "uncompressed-sha256": "1906271ab1d3056531c5f30b5003e719d95ce8e7600dba790f19c0efdce91005"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "b2bc720b9678047a444d83e1eb9507a812f56283d5abb6229105f1677dd23d1b",
+                                "uncompressed-sha256": "95416bbb237e3a99b0c2e81cafb0ab80c1fd67b1b539e5415093f4e39497455a"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "edaad00e42f8267f25a04406c957e29e3cdf36b0c3763e36d55bc660ab650732"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "dbe422f2fc4763b582dd81b1b90a225997480e06d84c744dee0ebe137ff7266e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "fb6bdf6164c60408ef0a58ed7e51f2d7201958ae91b5b8be46e9822b4b1d9eab",
-                                "uncompressed-sha256": "e8722fe98c5f649f716310510f558fa4f6976b38aaf8d042956ef9f9d274de3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "eb14a2b6b1b4d4ef43bcc53d17a3fb86946bec3716531c07e127a992cdb39cd8",
+                                "uncompressed-sha256": "6f03a0117fa8371c4e2f511ce24fbd277457083e9fd19bb2be00d1a445b99fbe"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "dce72abb5093f06311485e758f1d1b598efbc670a7ae75a6a083868e0f3a1fd5",
-                                "uncompressed-sha256": "427e74bcf76e399e65f04830ba82980cb360a4fe58b3cf0581412b6919dd4cb1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "042aace9442ecb090a1e5bd8dd448ad1026df81c16d7c72483bece1de61675e8",
+                                "uncompressed-sha256": "19ff2c24f6196456ba80735e3b1653f716ce6e34a3dde333b3c4b9ccad2eba15"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "a3b504b7e8ba12cba59c127e54b752ba4d0fc231a4ba14737093a4599df81e68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "e51aa9a34a8fec4b6e811d4f89c274ce5d00d735ef48f22d801152dd70f661c2"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "11b6e92264f0dc9a837018cdaf1d550e38a94b55e9458fed4851bbfcddbc8f7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "5b037431b28e709ddaf0b4e54dc3f5d23813ee00e4fd1d897a258f82a8b291c0"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230322.3.0/x86_64/fedora-coreos-37.20230322.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "af0392dd5ddba49761d7e98154602345cc88555db86cbcc2e1472b628d76f229",
-                                "uncompressed-sha256": "9a47bfd6943a03266d0cfcaffaff6d8300a4789f687d8b306e4ba5ece611ba5c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "bd2e1892212784a2aa75de465b9c444baf779c230dda59e3d96f80c6d67b86e8",
+                                "uncompressed-sha256": "6f8eb98144edf182c4e60a9ca91f7057d28b4550f8f9a63f5ae6d3de560759a1"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0fe38343b4a5f9823"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-060d8b750411f0a1e"
                         },
                         "ap-east-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0553739b516d54772"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-09d375e53466b8292"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-00b60a49c0dfc5cce"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0395e17973f58f59c"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0ab5936dbb122ae94"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0b54c78429b00aa60"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-093ef11d288efa2b5"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0addcdbc1eb06e102"
                         },
                         "ap-south-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0c40bea510379f0a1"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-03f12d0c14f170181"
                         },
                         "ap-south-2": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0461fc3e2d4904974"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-02a52c9a4cbade805"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-096380fa619c8589e"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-07cdc497ada46fe5f"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0b0277ded96475e2b"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-08d02ad9bcb28680f"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0009d3ba566c4f4e8"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0d59acc935387ac73"
                         },
                         "ca-central-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-01d5380eda95675d5"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-09747343c3b330f05"
                         },
                         "eu-central-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0c0485ff0aa3faf46"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0fc7179e3132b3409"
                         },
                         "eu-central-2": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-097a609ac37371002"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-08b0b5f98d9c96881"
                         },
                         "eu-north-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-01229105e804fb14e"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0ae1abb83c8ef02ea"
                         },
                         "eu-south-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0d790ad6dc590e22e"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0e3537df7b9c729fc"
                         },
                         "eu-south-2": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-08240e4806cab529c"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-05e41dfdc6a228bb6"
                         },
                         "eu-west-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0a85721f6fc871ddb"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-03d68acf0ae6ad65c"
                         },
                         "eu-west-2": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-041b4f245d21eca9a"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-07431dbb2c56842f2"
                         },
                         "eu-west-3": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-003970580d6031f0a"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0b831e891e6aafba0"
                         },
                         "me-central-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-084717230e2bda7cd"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0c67e1bfd3ff486c9"
                         },
                         "me-south-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-015fb8707abf35d37"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-06189d10948d5848c"
                         },
                         "sa-east-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-08f90707dee104bcd"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-0086f21e13ff348bb"
                         },
                         "us-east-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0d041be9630f7b147"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-047e335abdee84b97"
                         },
                         "us-east-2": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0496fafa1e5e7c7e6"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-044203a306539fe4d"
                         },
                         "us-west-1": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-0180bed0c68421780"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-05df765805a5fec58"
                         },
                         "us-west-2": {
-                            "release": "37.20230322.3.0",
-                            "image": "ami-00b761330e0b30e10"
+                            "release": "37.20230401.3.0",
+                            "image": "ami-00afdea0ca7e94c24"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230322.3.0",
+                    "release": "37.20230401.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-37-20230322-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-37-20230401-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-04-04T19:25:16Z",
+        "last-modified": "2023-04-18T10:20:11Z",
         "generator": "fedora-coreos-stream-generator v0.2.12"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "60784cbbed5564dc356828f4dd79c4cdc87eff4fe01c0f58ed72c765c47d3909",
-                                "uncompressed-sha256": "8da09a585a207ecb612596da7b2bb841777b24af7b0855a6d83345032091ba32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/aarch64/fedora-coreos-38.20230414.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/aarch64/fedora-coreos-38.20230414.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "ba1c6c9d39996f922dbe8fb9518db4166bc841563dc87c78353744776a837c69",
+                                "uncompressed-sha256": "82e1d4e572e08851d71baea62b6c5f86715186eeecf332a19c930e542bb8c92b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "3e40a70723eeab36beaaefe9a9e0cf6b0cea5fdb06ade867b8bf68ec19986a82",
-                                "uncompressed-sha256": "9b2db33163acd4417e5eb60c58db7ba3d1a72da7df075f31d6f7a3d2225dc37c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/aarch64/fedora-coreos-38.20230414.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/aarch64/fedora-coreos-38.20230414.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "19e31666929c21fa723dec39b65fbfeadd9af597454e5ec0c6d98126e51f6661",
+                                "uncompressed-sha256": "62cbd832de3cbf19689f810ce340730b9abfe3b0d6307c41e0620116ebd1ed4b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "105b9472da0e06ba0daf9cc82fca4de2d8327e6c142e4b7c2c40d4b0e381f188",
-                                "uncompressed-sha256": "7c0af4833aa36aa6c127feca33b0616fc715d0c162a1e5769e9a0666dfcd1f3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/aarch64/fedora-coreos-38.20230414.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/aarch64/fedora-coreos-38.20230414.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "505fa083a1ab38999094ffa21aa882205783275d22f79d297b5bb9c36cd9a61b",
+                                "uncompressed-sha256": "8b5b41f4fc3a60a7e64d453628c247cdcadd7dfd1e9a3c385a6709e241c359ba"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-live.aarch64.iso.sig",
-                                "sha256": "89d4040b373fb119bd8e805924195fb8b16f9f80a9e843e4a34eb061cc766689"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/aarch64/fedora-coreos-38.20230414.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/aarch64/fedora-coreos-38.20230414.2.0-live.aarch64.iso.sig",
+                                "sha256": "9bf4ad868c8fc78e428db1c1f2815a06a8cffa63d8fb19a0f71753087f146d6b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-live-kernel-aarch64.sig",
-                                "sha256": "f97554c216f3dc0ba0cfe97d69907b7164deda9444bdd9eceeda13c60e7fc23c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/aarch64/fedora-coreos-38.20230414.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/aarch64/fedora-coreos-38.20230414.2.0-live-kernel-aarch64.sig",
+                                "sha256": "1b1ffd1be1caf04cb7f77d5e34646a2998ca2cfe7d214a28ef749d40dc86c650"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "3de308a9fe40fa046712e310d0885ff264c797a1481c16982e3407b2e2551c54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/aarch64/fedora-coreos-38.20230414.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/aarch64/fedora-coreos-38.20230414.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "e3df95360c41c71a739d6d29294c7f8b4f22413d330d9cdde6a4636e1ff2e17e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "c7c38c6bdc3fe32ef6bb787600f0854d677a0646fad6efec498310f3c0a79b41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/aarch64/fedora-coreos-38.20230414.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/aarch64/fedora-coreos-38.20230414.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "67e6fd7c0135000ea62a2c6cce2c29c8d25cacf2f746af7c96b4d85fd3577328"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "ae4f89a2f3f1f6e63b8be3dd91fd04c51130381665433e4d426f18be8ce16308",
-                                "uncompressed-sha256": "7108869ecaaaeaefbca94b853373704cbf0200648bee56348cd8f50b581fbad7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/aarch64/fedora-coreos-38.20230414.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/aarch64/fedora-coreos-38.20230414.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "3749a66be3bff772217712363e9f9b25042038e2473298e0067ba154aacf9f42",
+                                "uncompressed-sha256": "7c296dfa2d857dcfe0700acdf9fce2f359eb9ff5b200ba8b42091b33f4856f8e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "b9d9de99d88facafc2223bc0bb6ab2cb356bc0e6b5a8edd48d095f5934c33252",
-                                "uncompressed-sha256": "debe17bac2c6208713cc0474395c2ce90f567dba98389d249f86535853d356a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/aarch64/fedora-coreos-38.20230414.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/aarch64/fedora-coreos-38.20230414.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "e4803db99dcc04f06c972fec010f3675eeb203f761761502524aa5b94030b5fc",
+                                "uncompressed-sha256": "556109782e30fd15a902f2eaac916d87dbec0838bc303835d2be7661c4b94131"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/aarch64/fedora-coreos-37.20230401.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "1a9b64c77543cff711e5883958744e716f1ad903baa6268799cf9a9e710be995",
-                                "uncompressed-sha256": "4d6344a439495752a5b74252629e00c1a5b8409d88f44cf17bf45afbcf54214c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/aarch64/fedora-coreos-38.20230414.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/aarch64/fedora-coreos-38.20230414.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "d4965137098cd6d32639cf34bb95e14b42f00aeb3a94a2c9b5b869b46b788136",
+                                "uncompressed-sha256": "80b62b2487f055dfc773e17d394423f9e645cbd5c4a1bc437fb180f09f1628a2"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-02e22881526df2a3f"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0be0418d01298e932"
                         },
                         "ap-east-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-03c08cc87c1711e59"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-09e8bb653921da086"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-02e3c32c6e3053dcb"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0db7a441fef69c7d9"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0aef46eefe50f36af"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0174a232c02a1ba24"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-02c11b9e62c23a6ff"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-03ff24cc384e11dba"
                         },
                         "ap-south-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-07209072ced99deb0"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-070993b224ef090e7"
                         },
                         "ap-south-2": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0dc0a6784b6a8c75d"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-06c5bb1f6e867d442"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-013af8dab7be4fb90"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-089b9a736d7d63e61"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-09a816d568abcf616"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-07dcb787759c73bd2"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-003421443c550169c"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0b388f9d02b7738fe"
                         },
                         "ca-central-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0fa827447700abf48"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0a5d6356dc2e86c8a"
                         },
                         "eu-central-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-05b8af5c79d668088"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0fa21ad53e82aead4"
                         },
                         "eu-central-2": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0caff07a6e8384cdf"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-08db0e2cdab698295"
                         },
                         "eu-north-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0790a1afe2de01cd8"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0082b061620970200"
                         },
                         "eu-south-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0324a833c3c63f428"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0c730aaf732660273"
                         },
                         "eu-south-2": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0c5dbc97007506aa9"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0af96b425440a7ae5"
                         },
                         "eu-west-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-071957a542e4bfeb2"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-01470b4f35e94681f"
                         },
                         "eu-west-2": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0103ad7d7811e8944"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-09f27578d7518afcf"
                         },
                         "eu-west-3": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-044388a3869765b55"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-004fed6c3732405ec"
                         },
                         "me-central-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0fb18887d69e2476b"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-026a08fa1d83b64c1"
                         },
                         "me-south-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-02082d227f095c496"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-00acb88f185892552"
                         },
                         "sa-east-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0329b84142a50c322"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-020b541b4792405f4"
                         },
                         "us-east-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0deefd756a9bf9097"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-08f3ffcf776697d54"
                         },
                         "us-east-2": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-04a48ede172e50c5f"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-07bcb1589e304b256"
                         },
                         "us-west-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-05b66df31c864c8d7"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0051798775dfba04b"
                         },
                         "us-west-2": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-082e4ed3e8140ad33"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0abaf1ccfdeff9611"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "e701dd7bd2cba41710727d0dea9a836b24ec3566837fbff1ffc35660a1583eaf",
-                                "uncompressed-sha256": "01683f4a2010d96d6aa218f7297ffd27353737eef2a296b69b0573efc9dabcb9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/s390x/fedora-coreos-38.20230414.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/s390x/fedora-coreos-38.20230414.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "8e239a03afe8934fc8c70405126ba772bcb58c998d850677f1aa88f77e962d87",
+                                "uncompressed-sha256": "7624b586160b758d4bfcee906d0fd35de9276acae53cd3c50c35ce864cbfff7c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "95d063560e84d6b610eabebca8b80e19399bfaeb71773a1997d32f836ccef406",
-                                "uncompressed-sha256": "eedc900a553b364f35ab25847f6570b344328535245e6441716500602c727bf4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/s390x/fedora-coreos-38.20230414.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/s390x/fedora-coreos-38.20230414.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "40178d0cdafc10e7252f453b97a600f7a465e78fd9a67214c21fa4d8ff0ef085",
+                                "uncompressed-sha256": "c441e6aca8a072ac8959373fcbe591fc79e3543804254bca5164f8ddda551396"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-live.s390x.iso.sig",
-                                "sha256": "0548a5a1578893d63b39501c9969787592c64969e308d0b76129bd2c73f65585"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/s390x/fedora-coreos-38.20230414.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/s390x/fedora-coreos-38.20230414.2.0-live.s390x.iso.sig",
+                                "sha256": "a49b73cf0837745734c1f111eed88760bc46ac264f57d54d54909bb70b747ddd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-live-kernel-s390x.sig",
-                                "sha256": "cd760a88d35c79c87f49ce37559b540ed2a1328011abd9b365ef709c773a62cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/s390x/fedora-coreos-38.20230414.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/s390x/fedora-coreos-38.20230414.2.0-live-kernel-s390x.sig",
+                                "sha256": "237cf0e1a77cf15890707b4d32177c7bb26c4531195c63f5a3055a176c160fe8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "1ace9107f5c8a5b2306dd9e96b9ead44afb349c2ae48c21065ce5901da232317"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/s390x/fedora-coreos-38.20230414.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/s390x/fedora-coreos-38.20230414.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "1c23cacd7406490daeea57dff7443b7b338228887588dafacb495acc2e270c70"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "5dd17bec6f5bfd62efe8e9eebcf1f898f599fdc74d0f65f59ccd2a2a607582f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/s390x/fedora-coreos-38.20230414.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/s390x/fedora-coreos-38.20230414.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "03167541f134d5a150b583c71ef5b05f64d42b280c896ddc73f4eff54e948352"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "a4c814664999339869193b45cd603815d41ff8742b596947d24eedca08de3541",
-                                "uncompressed-sha256": "304aa7debc21d8f1f16c18c509d36fce86dd44bccf61b613f0c23b85315ee07a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/s390x/fedora-coreos-38.20230414.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/s390x/fedora-coreos-38.20230414.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "e9e3702d216aa927bcbcebbc9d2904712e703cbd6c60da2d17f7475724c388cf",
+                                "uncompressed-sha256": "8085f7b1c5eed16e752dcc3e2702570cb808ecc922ad6b617f2dc968239422c5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "ed7c98752ab0424854ba7c12be7a5870798ddb02e1fba473ecbee4a72eb56bdb",
-                                "uncompressed-sha256": "0f142b04dd0930346362892a0478215f6c92ae92a42debb276505cfb2c5ae6dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/s390x/fedora-coreos-38.20230414.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/s390x/fedora-coreos-38.20230414.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "6f76485bcca0aa25c9063a13f5073ea27a0f8a9afd912366624ce84c15feee77",
+                                "uncompressed-sha256": "ed90ab647101e86831fb591b1b40eceb911837da1bcd2efedb22209773113f6f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/s390x/fedora-coreos-37.20230401.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "98ad0f9985d854343017b757ded1174999d2ecc1f2acdf28500d953d5765d467",
-                                "uncompressed-sha256": "be7aed560dea9a717419ce54d9f62fa46573a968830273a4b10692bcf7c4c629"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/s390x/fedora-coreos-38.20230414.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/s390x/fedora-coreos-38.20230414.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "9960be59824cd6b0554eacc0938c2f693f6a8fd3f7b9de6db1732db086f1db0c",
+                                "uncompressed-sha256": "3a8c4c2c128eb56f32fe7a2289ede2410b17390f76325fca40f309b4492cb770"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "91fecdb85b788e871e3cd3e86de1d435ff1b9992e4be1e4d235f6d638ca71f7f",
-                                "uncompressed-sha256": "600ad7d30e5f1d824054b4af7b1449da6be9bb0975e41c325fc2bf4463e00dd5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "6a544334d4973be8c35cc553a6c00649dd5d8014832dff1e870079d11ac533d8",
+                                "uncompressed-sha256": "91a615767faac2576dfafc6d33d075c7406458cc1c2bcd7e7f48c228157fa7e2"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "04ba0a89872dc0696a76a481984d48ad04d4af27e9c3df03de465ec79de25df6",
-                                "uncompressed-sha256": "025f0989156e1bb25c96d60129d541535199a262313a9030baf0a612e4611371"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "8b461b16e0c33ac7f77ed7baf5fcda14d001c35bf1056a5e58f6f4fb9800d497",
+                                "uncompressed-sha256": "a667a79563bff4d847bba585acfc0964f3e5a8715055ab192314d2d2726d4766"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "6c3fe95a72678f05e962ead4592ba07fa2b75ba1b467c751f00e36f54d5c9c4b",
-                                "uncompressed-sha256": "efd6e1ee9cb152a1fd6421f2a91f2fa16cd6d836f60091f4527d6fb91cee4832"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "93faff031199719b8e2b253a23c7245055d564983464dbdcac9b1cb29aabaa71",
+                                "uncompressed-sha256": "556522c8077f22e00c9bdeacc5c5a5e3bb327e8925f82f71944299a959ef8092"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "54a20936062655b92f44367c2deb635967813250ac89e874ff9acf8ae87d58fc",
-                                "uncompressed-sha256": "9efe09fee1153805e7d20ff4a297fc2a7cfa20605fdf0546ee6193dba18e4680"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "2f88968a2eb9b2fec80f51c3dbc59aeaf8a18a739c56623090d01280e4f8ce79",
+                                "uncompressed-sha256": "0e443c0a53876506181af20afd604ef87263a9aa17291e6a3635be61bacf86e8"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "d76570a45c2a5eb7f7c590c0136b9cd0e47062f95a6dbdcc377d79c520a5a0d8",
-                                "uncompressed-sha256": "a026b8d6c25e02ee0fded3dc55000e492bfd25031e4254b861d50eab3ef4a7bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "bf68789dbbb6bba70e8c8a622314b7f68a2bc5e25491d85556fa265a620b1a09",
+                                "uncompressed-sha256": "111b98311f0b1814db10aaa2b855d81686ff1d2d4eb82e40ff266da922b44e4a"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "8c0f242b80ba39a16f73436bb8e001fae0f11a814a929d4f71934697e00350b1",
-                                "uncompressed-sha256": "a2e96a3e39550bf063c17505d279ae1c62081abfca31012ba57920d5dfe24007"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "17fc1ea2dde2be0a567e96d6887a650ccf849df6243585248771fe28e8e5e898",
+                                "uncompressed-sha256": "822fd5135e797791c1a2d1b4386d234e179d17a36ed77271d0a8f11b85fcb6ca"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "bc388aa7e959de4605fa5f5668a099aaf5eaa624c1f70837eb2491e2d381f93f",
-                                "uncompressed-sha256": "7e7c151294db030c4daad1a658802ada6652305f724195a2f0f2e290826ce191"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "ea5e0947d8dfaf69c242933a8e558a079384b588636edb4bbf17092bb0076f81",
+                                "uncompressed-sha256": "922f730a9486a56d0f8620201ee66bc23e32649373bffecc317657ebbb24bf37"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "346b809cdc963ab2c36eb4be38b6f90582492d4a5b59d8bb5e6cb25cf98c446a",
-                                "uncompressed-sha256": "0efe04da8a51bf198ed5938fdbea0799d5934c75a68a52e1f33e2a542f34caff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "02d2151a4291e099965a51a9ed787bb0780a7e95d0dc2cf51e3ba478428e834f",
+                                "uncompressed-sha256": "c2384f0638fb9d4a994ad2ef24bf371dee3a07001ae14002d79619c54a61aa7b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "1da39a9674e5e55566f17bdd9682b678b55f24f1ea67f721bcaa340f2f1955f7",
-                                "uncompressed-sha256": "c09c81a53b1528736b6c3bf08ac1f0dbc1b62fbd83af5fad990b5ce7ceee50c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "6b2463abf6e29faed557a6e11063addd60c4a09453d04098486e6acef59a0e8b",
+                                "uncompressed-sha256": "ce0f67440791267dc14e25a091e55c56ad50eb68143e7a44cf7757693841f1bc"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-live.x86_64.iso.sig",
-                                "sha256": "40dff5fd69ded0df888383992e3e2b007563a70a4265be23b2810113310400f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-live.x86_64.iso.sig",
+                                "sha256": "4d3d94a8a817dfc4feb3828fdbcf648ceb908ea9cfd0572a81d0db562ab58902"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-live-kernel-x86_64.sig",
-                                "sha256": "d8926be6a5ff4b1f51fd9d31bf41a1046e391d47a6b5c5f9247ca4003203988d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-live-kernel-x86_64.sig",
+                                "sha256": "744218da9e6c1302c9d436070c1094a829ad9b5821cc714a5a2835877e657327"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "681781ca46dbe927460472fb5c2b0314ed5a58184d895a0a51bbfd554f0acf83"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "52adc5db8840d3d15c3b0a422a2c4d33851c899bc5eea2debe67bb6ec97e3e1d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "4fbc043d7b4c5189986cbf1779d065f88dcc72b549bf933672034f0e97b3ec2a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "b6092484d7306cb1a56c7e787778d57f6a8675cd7f825f9f306d9fa51c150843"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "3289322554a945f3e3b278b8d7412a115df925f9fad12a8dd9a32ea3ac349f36",
-                                "uncompressed-sha256": "e3becf00883ca70b228e32ab24ea53a88ef1e083b4ecc4d7491796f9c7777f70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "a071f90001c5b2be553f8bee7e9888df07df3f803b94c344617013269acfbc07",
+                                "uncompressed-sha256": "7613b8d98b78d86baaa601f6307da007cc5359e56a3a92560f1aaf4fc3297ae1"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "f1e76b1952b54016b3631315121d4f9aa4aaed7f5dc96751f81533efc254b6db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "c2c6d23fddac29a0aa09bb0af4cf2faa25c444a084fb18925f6477815faa3185"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "28a22dcfffbb2b148f383bc5dcecad9c6999086d0928559afe043f09818a8770",
-                                "uncompressed-sha256": "51fc4d32965c27c0b61653382652b8b631ed354e3c6f54b7f2e60e0ce9d56a25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "870fac120462183ba2f3744a5d54f96d09014c2dde405838f4e83d85316115be",
+                                "uncompressed-sha256": "c0775c4f94184e7033880a831e82db437df7d1a493e600ea8aed15bf484df5a8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "32a74f3f1089110981fbd86be43f2abbb96458790e41b7f0d3d8dc9199dae709",
-                                "uncompressed-sha256": "159482dea9ff23f85aa275c621ac55cd80e327399dd341b50820c8a2611923a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "6b1f53c3f5ccc7d07d37c8909e56e85f7634b851c4d47e2231f46c53f95ae72c",
+                                "uncompressed-sha256": "dd67e7be633db720ed967199aacd4afb77de8ff1be209a58a00b0ac0f847e1db"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "cae53cb7b234d9f945161ce0c74c9877b4b59bba19eced011de7331b16685b56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "faa6ac3cecc839a0558495524f56ecc8ed2df5a50ef4ce6492ad3ca5125056a2"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "bc67900d62c6bd83311d6e9574c1b484e29242165426fa307f1b50679f63de01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "ded5291b1a7d08a6620028c3f5ff3db40a6716afd58952a65d61a8b5d7594782"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/37.20230401.2.0/x86_64/fedora-coreos-37.20230401.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "eb899e98db8461625c6ed9299221bfd430997559be1e6bdb2bfd4e29420eb1c7",
-                                "uncompressed-sha256": "deeee249a0f6bc16dd72ed24aca460474691317114d90a0320799e70c6b07bc8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.0/x86_64/fedora-coreos-38.20230414.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "ba25b2fd3b11d9707189f973abc71fa9781ea9a33e643b30f01b2a4316d47845",
+                                "uncompressed-sha256": "5fe9a97478519094a8cae5e7efddfdbf79e34c9bb8e4f59342d91960ddef86be"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-02f780212d89e4176"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-049eb18afc6e32fe4"
                         },
                         "ap-east-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-027adc4cc93764ab3"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-09e8111c0c7e467b7"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-09afed197039b0c58"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-05ccb329ec7dd8e17"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-00ad913c64da3a8ef"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0198a5a6836d34574"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0f1c5727e952a29dc"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-05d102768d4e62dbf"
                         },
                         "ap-south-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0e47e8be1cc0e896e"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-08bace74ef87c1b92"
                         },
                         "ap-south-2": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-055fa102391d1e637"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0a5636c667373e42c"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0d37374e97e7cc575"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-00fb62fa1a365ac5f"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-013d7b198c0e86289"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-075930507c942d4ce"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-007193d52b4a5c324"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0995025119fb8aa65"
                         },
                         "ca-central-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0477fd0bef10f5db7"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-021dc5601181bdf3a"
                         },
                         "eu-central-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0a6e3b99d8f11d7e7"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0d110b772e4ec22b8"
                         },
                         "eu-central-2": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0f0c837a806117f67"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-04009f1f366a5fcec"
                         },
                         "eu-north-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0a307fe4550c1b396"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0823bebf7573d0137"
                         },
                         "eu-south-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-00d3bbf9cc05bf37e"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-02e90214f2e42b8e4"
                         },
                         "eu-south-2": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0f55b8398eeaa6a3c"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0cdb7701457a20e41"
                         },
                         "eu-west-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0b5999cd5d2af7211"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0c17ed4cdc4264f80"
                         },
                         "eu-west-2": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-05ccd73a1e4583558"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0e08ee4d974d2520c"
                         },
                         "eu-west-3": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-020ea21daa6724de3"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0849d8b9562dc25d0"
                         },
                         "me-central-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0c3345d6d0c032f0d"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-068b07171f946dc1f"
                         },
                         "me-south-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-03a0161e2bd5ea8e8"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0494f57c7a7273268"
                         },
                         "sa-east-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-072bd1ebcc46aaaab"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-08834ef3e86e3dada"
                         },
                         "us-east-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-037fb6fad27f873ad"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-072e4ebdf44807fb4"
                         },
                         "us-east-2": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-02c9c719285c63de2"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-0e462e35f9846cf12"
                         },
                         "us-west-1": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-06fc3dce6b53eb655"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-04e0b262e1ca3d961"
                         },
                         "us-west-2": {
-                            "release": "37.20230401.2.0",
-                            "image": "ami-0e44b7fe37676f80c"
+                            "release": "38.20230414.2.0",
+                            "image": "ami-03b91e47f8faaaebe"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230401.2.0",
+                    "release": "38.20230414.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-37-20230401-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230414-2-0-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-04-14T16:01:41Z"
+    "last-modified": "2023-04-18T10:20:13Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "38.20230408.1.1",
+      "version": "38.20230414.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "38.20230414.1.0",
+      "version": "38.20230417.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1681489800,
+          "duration_minutes": 2880,
+          "start_epoch": 1681830000,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-04-04T19:25:15Z"
+    "last-modified": "2023-04-18T10:20:11Z"
   },
   "releases": [
     {
@@ -69,22 +69,22 @@
       }
     },
     {
-      "version": "37.20230303.3.0",
-      "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        }
-      }
-    },
-    {
       "version": "37.20230322.3.0",
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1441"
         },
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "37.20230401.3.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1680703200,
+          "start_epoch": 1681830000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-04-04T19:25:17Z"
+    "last-modified": "2023-04-18T10:20:12Z"
   },
   "releases": [
     {
@@ -89,9 +89,6 @@
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1441"
-        },
-        "rollout": {
-          "start_percentage": 1.0
         }
       }
     },
@@ -99,8 +96,16 @@
       "version": "37.20230401.2.0",
       "metadata": {
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "38.20230414.2.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1680703200,
+          "start_epoch": 1681830000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @cverna via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).