### PR TITLE
updates/testing: pause F38 rollout

### DIFF
--- a/updates/testing.json
+++ b/updates/testing.json
@@ -99,16 +99,6 @@
           "start_percentage": 1.0
         }
       }
-    },
-    {
-      "version": "38.20230414.2.0",
-      "metadata": {
-        "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1681830000,
-          "start_percentage": 0.0
-        }
-      }
     }
   ]
 }


### PR DESCRIPTION
We have some reports of updates not working behind a proxy in F38+ (maybe related to https://bugzilla.redhat.com/show_bug.cgi?id=2185433)

Pause the rollout while we investigate.