### PR TITLE
Roll out stable 38.20230414.3.0, testing 38.20230430.2.1, next 38.20230430.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-04-18T10:20:12Z",
+        "last-modified": "2023-05-03T00:27:27Z",
         "generator": "fedora-coreos-stream-generator v0.2.12"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "9e804abb9d2d0cd9c204278b875d6ec31f2fe8623472a042e5748c9edd739bb9",
-                                "uncompressed-sha256": "462b7ebf1f758f94d31281740bef04834e12edf2c6e906a2dc2314f71dda94ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "8102a9ace87ff502bede9b74f24e21ac0d74490283aae38ec73d729983b726a5",
+                                "uncompressed-sha256": "abd82fbefb0f1c7534222ab140cc24f7dcf286c494bfc0da4cdd551934dc5dbc"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "61e3463a5fb246f84b82cfcc6e0eda6010e422516573578e373470b038337028",
-                                "uncompressed-sha256": "3e6816da2b1cd11099de60346a6304f6c9efcfa62be54cfcc8b3f0cfb66aacbb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "ffeddf36f58b51da56e7e0cefdf25ecaf2c7991045a655a977d58f9abd07700f",
+                                "uncompressed-sha256": "97eae912871113e34f8a2e80a179ebb530ebbb32874ceac8cbb21731cd8481b9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "0a22d415e00ea0948092085cee9c879a0e4f63ac82625fe0b36d040560e22cd1",
-                                "uncompressed-sha256": "7a0e6e93fd41b1e76c6fe64b6aeae356fbd44baa43519a65211c42182ae368a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "debccd5bd4e2f9d2c421ecc9bb4af13fb6d9993f4c6179e36a96e4096fe296e8",
+                                "uncompressed-sha256": "36758e7ea4a8341905674990bdae2aa8f6f66ca046aa60501eaf78c914da0425"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-live.aarch64.iso.sig",
-                                "sha256": "55f0cce944b041c0ad66163389c1e7c993cc928288629a25b9f8a06d89b50fe3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-live.aarch64.iso.sig",
+                                "sha256": "1ad6de094780a0245a4a5b5f4249422b6b2f591f8c64c3e768db0f14c13b00e5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-live-kernel-aarch64.sig",
-                                "sha256": "20b16a28dcacf124df13132b4f76e7ca6f793265d393167a9bc6a5c4a0e7ee2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-live-kernel-aarch64.sig",
+                                "sha256": "6b5de67b74372403c01f3eba3181f4a09a6dcbd990beee19afc91fe7d06d7ee0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "c6f8d6f2f4f36928df3b73c04e51f49d3faa99999271952f6bba3dcaf2638d9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "d98eacba22145707d7b566aecdf5bbb366a13ba0b85b6641c709ab10dc2e600c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "39daeebf98a207b8a4d3310e3fb4c9e0352871e4819204581ec8f895d83fa693"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "7ed4daa716a8e321f4544b392d0f8469b67ae84d54129f4a535fd26ba1b4a558"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "77c5ddbea1fe090f6ad3dd0ae9209ef6c2eef51a45d136b203cfc125f8e478f0",
-                                "uncompressed-sha256": "42708cc12813dd11ab6ec2c27f6d1e00c948885e105ad5c5af838dea5b4a0594"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "c9c3ad3c3bab39c5c53bcf544da126a7e918b5f55f79c69f8cc6196dadd47342",
+                                "uncompressed-sha256": "250a7fd9db880008afbb0fb26d66b34d35737dde5db7c35644d6e35bf07aee39"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "43be08594d8a355606436437ec83aae396443631191cd78d8dbf1305183d4cc7",
-                                "uncompressed-sha256": "8e11890d4b5f89e644f40b76eacf1c424e617bba2707ce94abd74c0380623c6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "4c3eacdf71881b9af7df308a331d9236b2d507b2cbddd4bf82f80cc90f7841bf",
+                                "uncompressed-sha256": "9dc5914df16e1dbb9288cb2036a6a0e61cf9d8a9bf7776ec0a68c1e15b366889"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/aarch64/fedora-coreos-38.20230417.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "0db021920bf42c8b2065e50bfa3080dd264b98965ef5b733541819470c54c6b5",
-                                "uncompressed-sha256": "3f0e83dc6cd4e75221e25d55b8ecc7845979ffa1cd92b2121562a12e638bca03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "cd69486e6ea21ea94f7787259b37355faf26b0f0f9106be6babd66276a1935cc",
+                                "uncompressed-sha256": "04eeb496dd168e46edeb0686b747b45089c6f87135b2e3372f2bff1c53b31806"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0945712b358e5ac2e"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0db7e3ba8205b26ab"
                         },
                         "ap-east-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0ed6b2511261821b9"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-042a917e3b5de40b1"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-06d99b89ea4ff1c3c"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0b9a0cc4b4e6e8611"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-02d44b870f24079da"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-01dbfee11ed6254c5"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-04b2bf61ed9f09600"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0e01319d26fca4717"
                         },
                         "ap-south-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-003166e0641d84db4"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0380c3007c1f7afbe"
                         },
                         "ap-south-2": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0f61d8f172b41660e"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0419aa5278e7fa30f"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-08b8445b72e1aa571"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-097f03990e50c8284"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-01a6558bf1b8cd0c7"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-04f405fdef4a1990c"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-04ab5ebab32194bc3"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0dfa3033bfd28ed54"
                         },
                         "ca-central-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-013ba6fa057203bbe"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0f06cd9d36e2b38f4"
                         },
                         "eu-central-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0088d968ddc72c725"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-02e21a5d7c6129ad7"
                         },
                         "eu-central-2": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0c22ebfeb04869100"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0048806abdaf94d22"
                         },
                         "eu-north-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0966d7c14b3250772"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0f83b18a502d85eb7"
                         },
                         "eu-south-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0a559d5b2f25ebcfb"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-08a82c32b42eb9358"
                         },
                         "eu-south-2": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-08351a52294a7ea5c"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-08f59810f99ae56ae"
                         },
                         "eu-west-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-03fd18929ae52f214"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0801dd578299f0f37"
                         },
                         "eu-west-2": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-08f92bb16c50dc87a"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-05174ec297910e375"
                         },
                         "eu-west-3": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0bbe4a248b6d5434f"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-080261d14eddd00ca"
                         },
                         "me-central-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-01c82b532ebc2c0d8"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-02e5a66fcbc085f96"
                         },
                         "me-south-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0cb18e3dfc3af2530"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-021518eed149a1d3e"
                         },
                         "sa-east-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-02bdf24b17f42d8eb"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0d513d2b93e032856"
                         },
                         "us-east-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0b12ac9ff2e3433a1"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-055ca88f90adb6255"
                         },
                         "us-east-2": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-042e1d5d3c05b5d92"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-03797c20ae15dab05"
                         },
                         "us-west-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0713a3e95794b8329"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-01f5acf38212d009a"
                         },
                         "us-west-2": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0d1daee6316c12135"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-05c2ced05652d8408"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "7bbdaac0c00e15e4420474688c4e9b94573886cff2bb726180aad1bf6576949a",
-                                "uncompressed-sha256": "01a120985bf2a732219cd19a49dfc4bc0ec17b4b8eb7eb43082cb80d93c696bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "60f0277cf7b42036e73488ee1f7972973ede0ec62961374117f9df4e29b64453",
+                                "uncompressed-sha256": "3045e165c2ba72689ec3cd7adcdb4851ad73bb8b910ea6126556ae83133e5b78"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "e8eec31f9415aa816ae3e4197ed11a1073f903273c9b5463e0801b2b76a9f0cf",
-                                "uncompressed-sha256": "9362b2e846d65bfb62fdf83f8c1579b7775832d004f13e4f658eea47ad22879d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "484506d87753a058a60e6a1afe64c6e21f3ce511cc10b267c6c43409f94e7732",
+                                "uncompressed-sha256": "d0f10adca981da7bb3d1fa3f350cff9f8d5b53eb6fedb899fd9b7fb02fa3da71"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-live.s390x.iso.sig",
-                                "sha256": "24b46766e2b941075d30eee1bca417e00fa062a703cb6ef0bf264603c968abb0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-live.s390x.iso.sig",
+                                "sha256": "ebd4ea41660f345a3b7325d601c8aa37f027a0c6099aa8758265afd2a335d295"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-live-kernel-s390x.sig",
-                                "sha256": "0d0604e7f08137980bc3c68c0ed0f32edb1b5f5e2a6816535f2273ed81c20591"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-live-kernel-s390x.sig",
+                                "sha256": "ec8c8feea8752b1774859a47506a52f76434ab97a1a87a17cfe70a0d3c107f5e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "fb35315ccf7b4a87fd2170802e9901a91889b28da33b7adc3faeb9157c587d33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "5ce779bbfa0323a884629c454133ff6d3c167a9593a9d90ee8de2140edb5866b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "917cd9384f992277b014cb7fd49ef2ae41b64950854c9a0a8e8a32821d8dc33b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "a5f880e5e0ff61bd7c862e9bcff22da0acfdbaa7592cc910fa8a698a29d58a39"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "4310ea4450a8ee09ed98b225e75d831b4c927de84bc580ce065e91e5c5a9ffed",
-                                "uncompressed-sha256": "978b7ca21b3883033cfe4c8a43d156789e439bc298648915d905fc37d0cfddf9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "f4e2c4aebda40a71d2e316a32858867d779f2d806f61d3a0e9d6e192792bbcc8",
+                                "uncompressed-sha256": "ddd78688e964238ef09a294b51b1e763e6812065b82c5759e349216d28fb8e05"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "e99ea804707c918554909c3741e7846138f5c9254f6ae9de319998a9d7c651db",
-                                "uncompressed-sha256": "256efab18c6bd82355f566bad6abe9e93331e487fd7b22ee537ebc0b4baa1dbf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "1513d2bdc5896e7a196f4951c0dca069f1c0e0cbce72756a906bb892b025e6ec",
+                                "uncompressed-sha256": "3fb294797f59c18c744775c6608e2f1f7e9aac4e9606356651804d8c1669b28d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/s390x/fedora-coreos-38.20230417.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "83d7088e9dc8e07b1c413562b0d276360b88fc90dc0c47b35104727fccd09eef",
-                                "uncompressed-sha256": "8c58d3320f023236c530928154b39e7f1a527b6c5b93445b5e8296ce479c4ff6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "8f7f080f48a127a96874f52452cf7c51a0033f76c15968e5457e61bbeb6a33e2",
+                                "uncompressed-sha256": "4ee2063ce9247b5b92e089b567cb78e3710741ba0cc8872af3357fc8120acc8a"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "87f3837a619d397c7560c6412b789b7d3ba42f0475d8fd56281a782ed49f3216",
-                                "uncompressed-sha256": "371ecf48c64c26eb6d6388004b7e12bf75c322538b4485a3f571d332883cb5b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "b4067d5ed553439969003df3534df79eb32bff782d60475fe678ee1620c0c044",
+                                "uncompressed-sha256": "f2496b8f65e273cfaad9b972802dcc8f2a6df47222e0d07f106571f02c83c329"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "65c566bf60f22d3d059e961407ea69044a4ef4855a7ebcae05e00bf34ed7f3a3",
-                                "uncompressed-sha256": "2b675ad54c272e0278beb5becc96ee7ad73143ee58f9fe998ff54590ddcac995"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "8be2895b67b4df5856a98ca1d7dfeb6d28db250cce2c32b08044db0c4aa1c22b",
+                                "uncompressed-sha256": "40cdcaba139faaca5c2ef176e53418a4ebdac63a4e00776b894cf3fbf8b18b03"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7a294461cbf286529c1497eec5ae534051486d6746a8663079cd9752c1228b4c",
-                                "uncompressed-sha256": "08fd77d733702bd3de7f329aa39eef7ef1d09108ca0dd73103cf1c5cea3b93a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "a75b8ae767e2564eaa521cd8a13b3d25a0f84aff4c94d7b62d0398f59e62a18e",
+                                "uncompressed-sha256": "df63ce7bee72a6e4507bddd2c4dc5f4db22900d28bb6283d39e03b952722cd3a"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "7fa721b0dea9c06ea37e75b6f7077000d8f56465162def76367bbb29b0bcc50e",
-                                "uncompressed-sha256": "b16edf56d3343a5398e0edc2124e3959cdd30cbdb3cb0802d1b1c02aa0c992cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "f962dfd3f7cd6fbe65b6671ccaf8fff89ca498a9fd27e9bdfa0e8e7b84d0968e",
+                                "uncompressed-sha256": "753a72e7a687318754df2ff0847d408d6433eef0245d81240f744f6b1a788708"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "32828bb8d9437d324f0781504480fa21d419a832a9f17293ea947c6fff26c7cc",
-                                "uncompressed-sha256": "a35d565f989a7b8266ba801a6bf1ef1e96f72c4080d8e2d671163f2816c8be99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "b5237d3f5eed96ff5121badbfa53ecd26849071a7fc7bf4285053275cb48c0fa",
+                                "uncompressed-sha256": "69fb7e369622055b14b0ab27fb1ad6ae1713ce547f1e4285eff44a579b13043f"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "f9c3a09919b77f75a7f12671ece35a06c670dcc81c55c3fc84cd34f899ef2bc7",
-                                "uncompressed-sha256": "b2b0d9ab601d2c4cc5d87e9e6062870061e00d379f9686babdd9ae7645198b6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "69db1943bbbf1b9378433b527c371cc9a232950b1425e68138b6d1bb81e78a32",
+                                "uncompressed-sha256": "731189346180038d499ccec76d0735b875989c201555250ba1a25f08c2934a1e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "9e903c134b155a41b984c6d349655ca9324a9eeacf75b64fdfc035ee1070cd7f",
-                                "uncompressed-sha256": "206d99e5bbd9b39ab4a7edd2865f01ce49005cd2707afb0ab197592a0ca014d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "a6888f70922db96191cee22dcca8826624b1a971755da92ccf548f6a949e2456",
+                                "uncompressed-sha256": "9e6410e51c13731dfae3aa4eea6b1a8cfe09a7dab4799f06af33ee4b5aaa128a"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "c4aed6b43881f4a4141e90bba6510708afb0bc735e5a5c46f50976de48ef03bd",
-                                "uncompressed-sha256": "4575e56d314f2f7b6cb690c969021a13471eed6f251ea4b666cc3bc944bae5e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "3cedb5d6e8c213be872896d724986edcecd70a6483843043e803e734e8f301fb",
+                                "uncompressed-sha256": "a78eab0da9189baff94443b5d7a2be9b12c807b8ed3f84b96fb73c3cac922819"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "719107dae5c67fd68b2d676db2d6c46c8355fe503b4f008ac461c8ca07a418b1",
-                                "uncompressed-sha256": "d86dbb24930590aa01befe9983dfcb4459decbe20e954b815fc216c9cd7139ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "000f8c755c3e24ce63dac5c85d97ff0d1a52b682f1addc5e561cfcd2ce27bdb8",
+                                "uncompressed-sha256": "4da7d0c22fc7dd61fdc3bfa3ce67d82b5e617f76694be4d498208188b41cd170"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-live.x86_64.iso.sig",
-                                "sha256": "af683eddfb92b36ea2e53cd00ee36cce40dd04c8e521dbf2b4a98f1d1eaeccb3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-live.x86_64.iso.sig",
+                                "sha256": "670dc898653d511db68010aae9b65d0579ae0c2a69333edf3cc847a545d62aed"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-live-kernel-x86_64.sig",
-                                "sha256": "56b09147c4a23ca52a24217ea59ba306a2b42d3a1c1ec0a5596b063b0691e0a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-live-kernel-x86_64.sig",
+                                "sha256": "6efe0d99d01d35119dfc06d971edbf6d13d783ecbdb48dccc924185177a1bd98"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "dd71493110d39038cb3ec4aeb2aa75a5a4409512ebc257d270e4ea1b1c702939"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "a45b02f35c18b76a17a073ec8cd80d33f475dde57a6d92ab1eb07c2d2c5e153c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "f7c932c0d985359e05b01d1fd4e1826fe214ed1100f83a96a0f27dbecc8fd40a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "bb104f7bc2212c2debebd9d038c4ff206215a93a00349686c3d9bf781e53ae52"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "6ec3e3e20dc56f9e3e8e0f81e1b2d914586b9426fe50a5bce016317b6ef57eac",
-                                "uncompressed-sha256": "a2552a2592aabb277aef7aaec41c85be7e20eb1cc2d898ee0fdb748b402e0830"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "00c6ca8334705db4e55132dc2990333b555e8d671733a2483f4a98d8f23ed921",
+                                "uncompressed-sha256": "d7d4b2eda16d58e226d66713668a9c7ba765cb786f734e3e1564cdb1b698c72f"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "cf57c703563794fd2deff9ef085558390726f6146aa8ea800f167030b8360647"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "3232f14e826161671b6bd1d3abcf6ac1f689fdfb49b0be60e47801f9fb95af74"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "b3474e92aae2722a04c368245bf7c2af8f56050e5e9e4c7bbb8666448acf0a21",
-                                "uncompressed-sha256": "42f2e60c528abcd305fcb6bac8cdee5951cc5fb5bd3bb900249f915229e2f24d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "00c2f82ad74ec15f295b58c1e7af0d89dc6df2454a1da7353b53460d820c3c43",
+                                "uncompressed-sha256": "643d44219e0a865ddce2d48171b078a4b846d017ac51fd09d03f560d284f92fb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "b76666c1bc56b5d5b76388f9662f941dbf499cbf971457982eacfba687cddd19",
-                                "uncompressed-sha256": "98593d31e4bb507740d2856400502054e7adbd7a1be06b52f1ff7a912e8b36bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "5eb950d0a6c7a386367ec6805734d479780c10f11abab7234861a64cd66312de",
+                                "uncompressed-sha256": "c73daab563afbd7af95db9f6aba9f8dd94cecbc93181edccaed8b3276b452e06"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "31f9f52307a2f7efa53b284aebc94a517e35ccbdaec159127fb30cdf05d2f79a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "dff0eaa30aeddb05f59bf72837e2ad6260767ba9c01b285432afa88ad418c0ce"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "b0ff279c0b1c9692527c54dad46930f53a418fd50c8d18556046897bdb619cd7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "564963897f3b759d1f330b0d1aeba789caaf2b8bc7b06cd4e77b7f8fbe7a66c2"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230417.1.0/x86_64/fedora-coreos-38.20230417.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "09d4270d1c9f47892c25dda223ff4e4127d98e8b715213462a51cec061d18ce8",
-                                "uncompressed-sha256": "04f5415162d2d56e8a9d98820d2793b994ea1103bad1e853cdc2c20be19e9d8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "16e7b7eeaad0cb77a713431f1adc49afeadab39fd22d242205fac3b8f307106d",
+                                "uncompressed-sha256": "5d03a655dd1fd396936b0eb2017d1dd45ff3f0ffb5f0d809037751565580909f"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-02e458efac3d0d618"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-077e96a08d04a8067"
                         },
                         "ap-east-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-08522056f0f95d3a8"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-04ea29a1f5ccc3699"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-08ffcdf422f14b811"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-016031e6c1b2be334"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-046d31bafb5a369ac"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-024b1bd30162a75ac"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-05ba41afab5174480"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0436d61e8dc91b34d"
                         },
                         "ap-south-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-095b17dc0c749834b"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0a0d1df24956f1f38"
                         },
                         "ap-south-2": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-08a0ff62270bb4742"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0bb6bd2e378e55eee"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0c4a9cafed3769b1b"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-03993026c4c8362b7"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-052f08433af183188"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0a24c0bcf1cc527fa"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0aa55c714bf3bd266"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-094beda6b0c2cc00c"
                         },
                         "ca-central-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-053f9b14a51feb176"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-070a977541fd9c842"
                         },
                         "eu-central-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0db22b650511a7e84"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0a9e375ef67afdfec"
                         },
                         "eu-central-2": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0464aa9f8604b5cbd"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0f60dd6608d38e75e"
                         },
                         "eu-north-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-043ddddedb0020ffb"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0fc6ec197d21f0b1b"
                         },
                         "eu-south-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0c6fde03ecc53c5a5"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0eefa60896dcb1b4f"
                         },
                         "eu-south-2": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-04a9318c27d4af1d8"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-06657ee6e1ea85dd6"
                         },
                         "eu-west-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0d1603f22a31a0641"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-02f3d0825949b8fc6"
                         },
                         "eu-west-2": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0298e48214be372d0"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0de8dcad1d9d080e9"
                         },
                         "eu-west-3": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0cb2164506270f9d6"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0e2fe10cce7dbc970"
                         },
                         "me-central-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-01a98f2cf7a6bec03"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0daea505f55cd2d7f"
                         },
                         "me-south-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-099b996a8c823c4c7"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0661a9a4105019d20"
                         },
                         "sa-east-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0e279bf95f4bf766d"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-08da4afa34100fcae"
                         },
                         "us-east-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-08f1d00eca726d2c9"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-0e94bb0c322a0e572"
                         },
                         "us-east-2": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-0b2784ccfbe9dc5b5"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-023e371ccfcc54b68"
                         },
                         "us-west-1": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-091c1ea3d031e71cc"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-04f3b14c7d4b0ba77"
                         },
                         "us-west-2": {
-                            "release": "38.20230417.1.0",
-                            "image": "ami-06555186441d41031"
+                            "release": "38.20230430.1.0",
+                            "image": "ami-07b9eb73360e1fa46"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230417.1.0",
+                    "release": "38.20230430.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-38-20230417-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230430-1-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,105 +1,105 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-04-18T10:20:10Z",
+        "last-modified": "2023-05-03T00:27:25Z",
         "generator": "fedora-coreos-stream-generator v0.2.12"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "8d4d1f73dd61de4b0ccf8477cd64c4e0f33ce85fd05cd5b8238f079835d240de",
-                                "uncompressed-sha256": "2f671dcafa702d048c7cac35dfbe23e0aec7e4553539db42310801d39dc82d07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "ddfdc8a0ee3fe3d64c01eb4d3072dab7c8887516884e7fc399ca9404307ab6bc",
+                                "uncompressed-sha256": "9f44489532a2f29dd98d107399bcea1e739f8a84012a5eda12f7156a6943bc6e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "ad548b352db4543583fee430b56d71f6297a2ed23d5b8ffd2140dad3a9944220",
-                                "uncompressed-sha256": "b615c71485fcf25ae29e192ff38e0ea112a807a625b1bbabbe222c38e0820f3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "d83d8e2c4d5ea2c5bcb35b9c8ffa99811a9ab996e2e4f60f6239e19173a7627d",
+                                "uncompressed-sha256": "54b0771588c2d940d45bd29b3576e244fbeab216994f76c1220a8f99d023ae99"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "2bd5ac086185dda663ff5e1b3c31dfb9dd1e4eb56067f3b3ba51277faa99da36",
-                                "uncompressed-sha256": "39ea6796ea48c6b5e09be2ffdded3481d3ed51a5b33d8b6b55f3b89870ff665b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "5699bc9c86c63b36602584c96cba4ed03770d1215e006ef9d6fbc85313add5f2",
+                                "uncompressed-sha256": "7923bc483b94e3aa9091336b061aae0ff6ed3fe8d20ce1fe132b4a249c8764dd"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-live.aarch64.iso.sig",
-                                "sha256": "525ac76fedc8d691f5bb1dce8b86daa09b8e340d91f980a3bbc36ebcaa3d816a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-live.aarch64.iso.sig",
+                                "sha256": "b96932f5c90bcc486feea68a9f82f3137b746caeb68f4f0d590ef7c6e3fb1a48"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-live-kernel-aarch64.sig",
-                                "sha256": "f97554c216f3dc0ba0cfe97d69907b7164deda9444bdd9eceeda13c60e7fc23c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-live-kernel-aarch64.sig",
+                                "sha256": "1b1ffd1be1caf04cb7f77d5e34646a2998ca2cfe7d214a28ef749d40dc86c650"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "998d86299a92a4be89f715aa6c142b3698748e472327bc760aeb7da6d8224690"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "657f839ac17526e4404a1ae909d66a93fb4a4b75f019b0d9350f237ff9c4443f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "2a4d099da6cdb8454c81658cc9c1e23ae6c5b77db3d45b9c48218775b652c323"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "71d637d9cbcbf7f200b94296667d86d154a23743a014e2c78ac899d938a5219c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "c8def1a9c21020520a166f49dda37116cc23d02270b61e5aced5d1118aedf530",
-                                "uncompressed-sha256": "0141b547782fe5241d156102f2c0054296c677650c6e7fdfddb92d73b4417733"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "1565b71b024200d6cc0b9c3f5d5b00607ecea63d90d03711a2cb5dd532e27205",
+                                "uncompressed-sha256": "cbae31702b181c3993fc72394e57c97a25d8e19ca414218ffb87738996a20f7c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "33f3b69598c60bf56abad5fd5e47c8f2342bae7dae6fb74c0832dfea7725fcef",
-                                "uncompressed-sha256": "1b671e3f2d4873ad784223a1a499227f29ba8c201680bc3c17db53317a1d16ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "32b8519d4ed5b94cb6811c20a64e6cdad8f8c3ad051d76995462d94b8d92fe4c",
+                                "uncompressed-sha256": "c10a7bd3f99695a6d24bb8ba1ff0cad7bf7f2c991de3fede671d1b20cc692c8e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/aarch64/fedora-coreos-37.20230401.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "6daee52248abb01ef10c84fe09da6f11bc747f172309459027401eceabd4b5a5",
-                                "uncompressed-sha256": "23096242cbdadabc7e3e864f63812105f7e19c08bdca335cf1ed71ee23b8d810"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "5d1f86a8e240fce7edee3a4fddd4d78fad76ed0f9e84f1a9d6c734ad1750ffa0",
+                                "uncompressed-sha256": "aa755ad03436ac85a83862371911c78d6d91b6255086a2a907ce9abc7987177d"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0693ab953a6bc2c70"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-013a1b0e80d98bff6"
                         },
                         "ap-east-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-09e8d85052fd0d959"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-049b5c3802236aadd"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-050d45445c8c5bc76"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0ea3bf68f67c16eaf"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0189c1ef4b035874c"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0346f556f695944c9"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0c4f62f0afb4d7385"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-080c735b2d540de11"
                         },
                         "ap-south-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0f1afde3c3bc366e9"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0609458ab045da8e1"
                         },
                         "ap-south-2": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-01a125da3409d12f7"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0d9a7d1f73c665a83"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-08bad2ee54fd840b8"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-030d16c599913f6bb"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-04d0d040d833982c9"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-04db910f9641e9604"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-097889eadb1cdaa15"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-06cd82cd6d41f2c62"
                         },
                         "ca-central-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0db29a37c7876a10f"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0913f130b110db33b"
                         },
                         "eu-central-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0162974b05eab5e95"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0ee1f7ac3da995099"
                         },
                         "eu-central-2": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-012d490cf0f3f766b"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0fa5f45199511befd"
                         },
                         "eu-north-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0f108df4c1061f242"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0dfeda4d2d1bcf128"
                         },
                         "eu-south-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0002c5529c6fff5a4"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0394a6244ff001d1f"
                         },
                         "eu-south-2": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-01193762e93f41e66"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0890aec217d9df037"
                         },
                         "eu-west-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-081acdf4f03203bb4"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-06cfc9dad9e1bee9d"
                         },
                         "eu-west-2": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-060a7fad92b320f16"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0e9ce3c8a5f35bc79"
                         },
                         "eu-west-3": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0d1549ef7122fb9a5"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0541188425409a01e"
                         },
                         "me-central-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-04c8ce7eb5bb9677f"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-05cf6272b4d91572d"
                         },
                         "me-south-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0481577595eec3e3e"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-063cd3b797e06749f"
                         },
                         "sa-east-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-037dfb87e2ca478b4"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-02e45adb6bd567086"
                         },
                         "us-east-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-02b9bdff58471dbd5"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-02716a9e60b5ab6d4"
                         },
                         "us-east-2": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-00f116716a4d6d12d"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0d3575c012d2ff2e3"
                         },
                         "us-west-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0afbdd8c2ef83830b"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0c6222e2d66e35d12"
                         },
                         "us-west-2": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-02b7677166da2e465"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0181cd2652d8948e9"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "4a0c7f6c97010b970edb56234ad622d7b7c4d1a73c04ca806c587a050375aa9c",
-                                "uncompressed-sha256": "5a1754aff675397b72049d0a2400f7e165b978a08a82f4a0e3bbcb5a2ae52f74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "e96eb82bea479b66591b13bdea5d2d59641ef87c7ffd28a0a26ea6f4ea89fc13",
+                                "uncompressed-sha256": "e308b0703e15eb6231f1de47cc8cc62bf4983b616fa14900008c1e96e79b72ce"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "765d2f16c121df7c08aed9845249ae7a03fbfdf6aeb3dfa5af1a8bc167a18351",
-                                "uncompressed-sha256": "fad3d0e6f6fd1113eb5f2b94139658ba643815fd0d549e6e7831b278f4f7d5be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "b3282db6ecea7defd280826829f0e02921dd10a5e1e8b7599d7964016ad1f9ac",
+                                "uncompressed-sha256": "ed8ac121ffb00f9373c6a57775af5d1ccc00e44c1cd679a3c61a96494c0682ed"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-live.s390x.iso.sig",
-                                "sha256": "1c551592a6ab783e4d3b159cae12301581686a11eeb5c6befb61587cad04b438"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-live.s390x.iso.sig",
+                                "sha256": "d5414b246fe3c7a2d8b5c310f459ad8eed8fa4a296a747d17302ad0c28be119a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-live-kernel-s390x.sig",
-                                "sha256": "cd760a88d35c79c87f49ce37559b540ed2a1328011abd9b365ef709c773a62cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-live-kernel-s390x.sig",
+                                "sha256": "237cf0e1a77cf15890707b4d32177c7bb26c4531195c63f5a3055a176c160fe8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "21d404ef394587767240f5aa9b2665b7ad7051b1ba940212d8b0c0c1865f933b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "7a61eff04950c06a2a8f04606b6197e0368b26817daca0f3b85fae02659a52ff"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "960b0ad90f2a6577b033429a8f1e2ee91779a89a9731d5b19edb4d52357401ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "0a322b4597d48f6574a5c5b7e3e7cadb1629a6bf479fd92f269a1311acf6466b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "43b8cae86dd7341454a758fe7d07e34adb4262c7f0954018cc17063e060e33e8",
-                                "uncompressed-sha256": "cb19f17194bc4c23921e7ff87773600ed0cc92995af6f6885fb30344bb3e33fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "fa61703ad7c7fea15edadbcb9a66b438f1019c285b7a3887b286b10047b427e5",
+                                "uncompressed-sha256": "de91a4d13c640e292949c12edcfdb5ecbffec5c2bd84819644aba71b85e093e0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "905d07c4a8522823973da813be1794c4f88502cec295024ceeaabbfbcfc470ab",
-                                "uncompressed-sha256": "899ca1ee1bd5929d6373032c321aec5b85089a33b330874c2954fec22ab27421"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "4213b378b2943b02849568f527297a5d91f5ef41c6c8625a7e3f694ea4a5b0af",
+                                "uncompressed-sha256": "de87b8ef8e0974fc7fecc9f145d65337d794223421a007f9a9596309907982bb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/s390x/fedora-coreos-37.20230401.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "9bc0c27b65d6bc07571ab84b0478112ac6cba4a7e03540cabff9230511cf1cf9",
-                                "uncompressed-sha256": "ece50de4fed3c2a62b5beed7378e1c4fc164db86d82d09058cace10ec8797139"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "2c455f15587c985305fd86d1bb0640e823d60760ad5c4cebd0b32bc408a8727c",
+                                "uncompressed-sha256": "d63f676584f1e96d9234261edf19d7407c2a7fa0f21a3085d6192b9a153e972a"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "23e65ccea26a0b3fc40007f8d37a880c9169baed63e37e37359370114572cb52",
-                                "uncompressed-sha256": "6a769b2e1a5aff7c5bce56be5b23b8459e99a2b706499d714b6e6f98026fbb7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8b4ef7e0cf1f5b2f9920ec726192310ead260ffc40c5b17ca9de82e81d059164",
+                                "uncompressed-sha256": "bd43d588f23cbf3f5e74bd2bb0d0e277e138e7068469b33f6755e31b2e303d92"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "fc4a376ad5447c496950941b165a12a7bbcf0207df02f1addee69c4ff91b4bd8",
-                                "uncompressed-sha256": "ea1ef5b0aa1a282fe3dd73d60966e3548b5a24499e8328382ade31cba22da71e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "d7b0651b5aa3dca0113b3c11dd9b825d0f176ff8f5fb466201ba00ac4ed783f1",
+                                "uncompressed-sha256": "2e9f86994e6395e06d1f49328b064feb01d634594925383cbccfec2e89d53319"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "21094ae40c8ded7f6d279e8c0c2b3dfe11c7c5032aac339a394e6519337983db",
-                                "uncompressed-sha256": "4fef2568d8153ab7fa50f0826dfeb4286922c32a1b6756c4c1c65a259c582923"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "81a18a7ae62d4fa3a5aae96e9581ded9ee0214f2726d14e1f3b59d55de317003",
+                                "uncompressed-sha256": "0cb733dd76d09dedbdfa06771de960a7c6ac624aec5524fa7acd2158cfe8b17a"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "bd4debc5e9dd288ca23ca481670384d603ef3b227df9a491cea53a00b7726dec",
-                                "uncompressed-sha256": "797f99846ece7008a473ec1c239eada79f6dd109d2e44e0f4aaa8ce3290f8648"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "e05f8c5b3038c7b490c673b78f93bcbeea4e79054c119a98301029f81a91e20f",
+                                "uncompressed-sha256": "f22da4b4d5c897a12094d438714c8a0d3d5cfc8040079c10ac3ce85eb3143137"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "24dfd9022889b240c17394f327e039008be2d3d3c1fd539ab96f29631ce78b41",
-                                "uncompressed-sha256": "bdb1eb0eb772c5f8890c5dd0551c946e3900f1e53fc376432a8396ac7ead4ca7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "13dea6cb6b01aba0e72b1f7545fec740e5d7b1d60ad0908b444a37c40cc6cfb5",
+                                "uncompressed-sha256": "6680c0bb80434f2ec555330f2d1ef98ee77d7d85b59d625fd3dc93afc81efbe6"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "54309b971b2de480e0792fe8b45cac8c81c3b1e067bb47550f52e91191894797",
-                                "uncompressed-sha256": "92738eeef7eb22c1d4d597abbd4045ae584bc876602b087cf090333badf604dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "4c422c44df94297f48d0b4ea745eec3076350b07fa58d44b03e409f86a960f07",
+                                "uncompressed-sha256": "25e2322f4a59ce5a88cec17e6d78de6c6ebe86be8f089e2b114ff02929fbeaed"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "dbe5289b7c5add6595f0cdb589c5766011dcec80d6e80bd1cf6016cccd67fc46",
-                                "uncompressed-sha256": "b51126417d52612a6685d1a2837279e420f95b498d209067b60c499c8efa1d45"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "187a89a1f50b030796ea5baa193056dd57d516a6ca6b0210967a7b1e38e22319",
+                                "uncompressed-sha256": "a9911fd4f756ec6c5b61501aca7a2fc33b29d2ed53c59a7a5cf9937159a1c673"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a6dee91b557a8e749a277947e23eba05ddace6171b416bca8b597c8223e2c25c",
-                                "uncompressed-sha256": "53a255ef4b0475d2f9d014b7b4cb37599f4204a52c7aa7b829fbb7f3fcbb097b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "991d6c6c9a06ef3fc4a085ee0177bf6b81015b1eddc8a0bbe77f691d9a7eafbd",
+                                "uncompressed-sha256": "fdab589f337d8c3a26a8004009cbc5e36929eca65fa12257e057b568f4677539"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "eba1e3a653246a962c801de41179285ac7ed73573d93f8c1a5597f6d64109cab",
-                                "uncompressed-sha256": "56cd8a9cf6f7ed3e5d6ba1558ac2ecf5a810ea51cbdf0a1b852c5d029ade95d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "be13bfbb8f9a3f9be1ec5999c823a9229cf791f24149c545c69231f5b80d3a61",
+                                "uncompressed-sha256": "b0ad090af84732056926e5bf211738315c382b62a930e244cb723fb51cf6ff77"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-live.x86_64.iso.sig",
-                                "sha256": "4f6f77d3417c11f659a7570e75cc394539bf5afaeacd443b6c72c8aea430dd9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-live.x86_64.iso.sig",
+                                "sha256": "1e8e27b2e6cbd7cc2ff6e59bee9fcd078826c565ef07681b08161497abadfc80"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-live-kernel-x86_64.sig",
-                                "sha256": "d8926be6a5ff4b1f51fd9d31bf41a1046e391d47a6b5c5f9247ca4003203988d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-live-kernel-x86_64.sig",
+                                "sha256": "744218da9e6c1302c9d436070c1094a829ad9b5821cc714a5a2835877e657327"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "2db17962dc8f8bd5718c2577cf53a6fac27efd9b6ba6c9ece39b5c730c9fb6f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "cfa480a352ce82d9de7640b5cba4d9ea4381ec1ade66b812ac248af61d7e54b8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "a6bc2aaaec2e17e401402ee07448d16dcb5376ae7dce3c386333e611a9431a13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "81f009f3b68094d124ea4c06c350e20e7c91fedc2418b65dd63801ba8e0632c4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "b2bc720b9678047a444d83e1eb9507a812f56283d5abb6229105f1677dd23d1b",
-                                "uncompressed-sha256": "95416bbb237e3a99b0c2e81cafb0ab80c1fd67b1b539e5415093f4e39497455a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "5d103d806b14c936958f8b080a850c82294ee537324449219534ee63c017e7ac",
+                                "uncompressed-sha256": "4adb1b3fb893c7bd9a584b105e5e2b9d35d8e86e6637baaf75dadc164fff173a"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "dbe422f2fc4763b582dd81b1b90a225997480e06d84c744dee0ebe137ff7266e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "98625b7d74565da23cea4781f4704d40f4cd7feda059ee95bbd8a4293918cbc3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "eb14a2b6b1b4d4ef43bcc53d17a3fb86946bec3716531c07e127a992cdb39cd8",
-                                "uncompressed-sha256": "6f03a0117fa8371c4e2f511ce24fbd277457083e9fd19bb2be00d1a445b99fbe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "34e8e658e390ffa4837145313943d5174712a8d669b6ed45a00f610e5faee17f",
+                                "uncompressed-sha256": "c092ca53365231608875525cd5ddffd6803c8fa508f923cda8ab719aa02644e5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "042aace9442ecb090a1e5bd8dd448ad1026df81c16d7c72483bece1de61675e8",
-                                "uncompressed-sha256": "19ff2c24f6196456ba80735e3b1653f716ce6e34a3dde333b3c4b9ccad2eba15"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "1c036b1c57517a92f69038169cc4e9a7b327d5704732285d5d632ad9965a0436",
+                                "uncompressed-sha256": "af9c4de553aaaee436f654c2d8e092c8ccdbab44a93e6b125b66f6910a193e97"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "e51aa9a34a8fec4b6e811d4f89c274ce5d00d735ef48f22d801152dd70f661c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "d39f75a66e953e2ccbeeadb16e31be945daa26f2e80a6eaf08086bb1559727df"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "5b037431b28e709ddaf0b4e54dc3f5d23813ee00e4fd1d897a258f82a8b291c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "d19ff41a4c01861d9909edde149937d80a113a97d4855f8b85e815ba2dd10177"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20230401.3.0/x86_64/fedora-coreos-37.20230401.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "bd2e1892212784a2aa75de465b9c444baf779c230dda59e3d96f80c6d67b86e8",
-                                "uncompressed-sha256": "6f8eb98144edf182c4e60a9ca91f7057d28b4550f8f9a63f5ae6d3de560759a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "73d4b4c2e3bf773cdeaad2d3419e26cb717cec6503fa3bf728cc7a3a351c44ba",
+                                "uncompressed-sha256": "5dc9fbcbe99d02c08cc57f5a947c15fe5ccd37e3fbe359f6207acfb4294b2bff"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-060d8b750411f0a1e"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-07c6bab153090361b"
                         },
                         "ap-east-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-09d375e53466b8292"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-02f752a8eab30767d"
                         },
                         "ap-northeast-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0395e17973f58f59c"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-021ce9d57120f278e"
                         },
                         "ap-northeast-2": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0b54c78429b00aa60"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0a928eda7bbc26f61"
                         },
                         "ap-northeast-3": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0addcdbc1eb06e102"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-035af90aadbfb054d"
                         },
                         "ap-south-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-03f12d0c14f170181"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0fc8b71a82d007030"
                         },
                         "ap-south-2": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-02a52c9a4cbade805"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0363fb2d3fa70c34c"
                         },
                         "ap-southeast-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-07cdc497ada46fe5f"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0a4def2e23c71ce28"
                         },
                         "ap-southeast-2": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-08d02ad9bcb28680f"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0dc2c2117b485580a"
                         },
                         "ap-southeast-3": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0d59acc935387ac73"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-01a407528de64c221"
                         },
                         "ca-central-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-09747343c3b330f05"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-025e1413b0d0c7e5b"
                         },
                         "eu-central-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0fc7179e3132b3409"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-097f5ccd7b9deca93"
                         },
                         "eu-central-2": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-08b0b5f98d9c96881"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0526f133afb517818"
                         },
                         "eu-north-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0ae1abb83c8ef02ea"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0db34d5f0725d4fea"
                         },
                         "eu-south-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0e3537df7b9c729fc"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-01b6019592933d09a"
                         },
                         "eu-south-2": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-05e41dfdc6a228bb6"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0237d8f0e4c0fd797"
                         },
                         "eu-west-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-03d68acf0ae6ad65c"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-00b20638909705745"
                         },
                         "eu-west-2": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-07431dbb2c56842f2"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-072940f7ede2725c8"
                         },
                         "eu-west-3": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0b831e891e6aafba0"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-067830ede2dd1ec5b"
                         },
                         "me-central-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0c67e1bfd3ff486c9"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0740b2fa197668a4a"
                         },
                         "me-south-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-06189d10948d5848c"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0e498233240e32f20"
                         },
                         "sa-east-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-0086f21e13ff348bb"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-051f5aebb6368ac00"
                         },
                         "us-east-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-047e335abdee84b97"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-081f29ca9a2a16cec"
                         },
                         "us-east-2": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-044203a306539fe4d"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-04bafa6ec56bb062d"
                         },
                         "us-west-1": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-05df765805a5fec58"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0f0275cd40ef451d6"
                         },
                         "us-west-2": {
-                            "release": "37.20230401.3.0",
-                            "image": "ami-00afdea0ca7e94c24"
+                            "release": "38.20230414.3.0",
+                            "image": "ami-0fd81c7dc02861e05"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "37.20230401.3.0",
+                    "release": "38.20230414.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-37-20230401-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230414-3-0-gcp-x86-64"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-04-21T19:13:55Z",
+        "last-modified": "2023-05-03T00:27:26Z",
         "generator": "fedora-coreos-stream-generator v0.2.12"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/aarch64/fedora-coreos-38.20230414.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/aarch64/fedora-coreos-38.20230414.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "478ba4b363380e3b1ca657f4ca0af06659ce1d3cb25de9ab0fc7af63b9960db7",
-                                "uncompressed-sha256": "dafeecbe8ccb3e67f75c484a5faa97dda0f51dbeb720b6729e40f10ca4ea8d64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "0be4ad2d4ec98bfec5ee86445315b2d83d6b1fc4db1c0aa38c3b5061cf4eadf0",
+                                "uncompressed-sha256": "da01474e8f59c91058443bc91d5c6298152176da853d0edad20604e784855b97"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/aarch64/fedora-coreos-38.20230414.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/aarch64/fedora-coreos-38.20230414.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "e86e7edb0d0a9f98648fc1198717c60c4a54b55a4579c296450ab57c8385d979",
-                                "uncompressed-sha256": "2e7804ff58ab2838669d8b27169feb0b958595152518d8cc589b640eae69fcad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "b1eaae1d52bd5027c847802394a28a99cc7d13cc5c90a78bcbc2fbbc7b304f83",
+                                "uncompressed-sha256": "c953a96daffcdae22b8519dad7a63381068240a7c88ee55740a296dac6ba5725"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/aarch64/fedora-coreos-38.20230414.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/aarch64/fedora-coreos-38.20230414.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "9dfc3c9e3642ae6f5ea5eaf184f8445c4004f8f1448015e7bca7d42a5cb26e8e",
-                                "uncompressed-sha256": "38c7e192bd961f0967d6a86e4ffb81dc4c7e548e65e9fd6f7b0c4f42e79ae23c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "6463e2c7bf1c2f92167a3c3e8b40ee2817901e325f4196d28ba3a1ba3e02e28e",
+                                "uncompressed-sha256": "fdc4770af5149ebebedd8308c199542565c20f6c9ba12fd64fd4f8068b4c13c0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/aarch64/fedora-coreos-38.20230414.2.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/aarch64/fedora-coreos-38.20230414.2.1-live.aarch64.iso.sig",
-                                "sha256": "f55e131d68baf5df9e9a9c00fd92d8900ec50708f3159901deb926edcc985c96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-live.aarch64.iso.sig",
+                                "sha256": "7978f5c9b606805ef26824cfea216801cb80759b454c58bbdcc6ed7340e56bce"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/aarch64/fedora-coreos-38.20230414.2.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/aarch64/fedora-coreos-38.20230414.2.1-live-kernel-aarch64.sig",
-                                "sha256": "1b1ffd1be1caf04cb7f77d5e34646a2998ca2cfe7d214a28ef749d40dc86c650"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-live-kernel-aarch64.sig",
+                                "sha256": "6b5de67b74372403c01f3eba3181f4a09a6dcbd990beee19afc91fe7d06d7ee0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/aarch64/fedora-coreos-38.20230414.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/aarch64/fedora-coreos-38.20230414.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "8683b3769c6b4d724b351913a12b8f380d4cb95e4bf274a7e8acdca537868d24"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "fd73ee693bf10711ccdb74f2319dd3cd561365c98baa71658476a3f940b3c847"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/aarch64/fedora-coreos-38.20230414.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/aarch64/fedora-coreos-38.20230414.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "2f4d24e1eb88f3c74cf586b4953de25974935397d71de72b88cb99f4171adc72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "5a432e4e59e23281c36783aa5089da9ed39cbd50831ad352f49b2926e6e1e215"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/aarch64/fedora-coreos-38.20230414.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/aarch64/fedora-coreos-38.20230414.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "30f95e874dfabc669cf4c5774970a81329a4aee6c9ee243023c920778a94c185",
-                                "uncompressed-sha256": "9814f1bc774e9bff170c759f11083bb5ca8239d6bdcd7b748458f9b4518a4423"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "cb3bdbbc7225d6e1e161b94422b4038be3ce52b57c43dc26e85ac777401b7073",
+                                "uncompressed-sha256": "fe501de047e9b43906e9460153049c07d33e693547a62eb0fbd0dca406e5f307"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/aarch64/fedora-coreos-38.20230414.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/aarch64/fedora-coreos-38.20230414.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "cab8d1054498bc0ade856bc32225386393b7d180f2d52d99bc3b48fad4ce9ccc",
-                                "uncompressed-sha256": "2328e04304ec9f34f1b657fea8d3cc9da3f9c5d3310502a9ee5d29efa606fbe9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "bbf961f218198dafd3035f4b6b4bc5535301dfb3e15626b610bc28e3f8d13117",
+                                "uncompressed-sha256": "a59b8f402ae824160e8922b41b03a01faec921c55a537047725440b5148ebeff"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/aarch64/fedora-coreos-38.20230414.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/aarch64/fedora-coreos-38.20230414.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "845eabf7ae4b4dda308c937cffd2d8e713606d210bd5e82dc5da21b894ede2f8",
-                                "uncompressed-sha256": "18cf6c7de937bd5e51c462beec962a6aba75a92281156e4ad31227287557ffd4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "b84b11a3a2ceee07f6edc79ebc775d5bc418fe5a816deced5ba79bea6c8e972d",
+                                "uncompressed-sha256": "6fddf89e73688be86d20529ea9aa449f38854232f8e53ffbddb2956eb1fd67fa"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0eabb5e38f5520707"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0509bd00df68c04dd"
                         },
                         "ap-east-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0709249975aeb7ea2"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0fe3b22ca10573d5f"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0a20aca1647504d69"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0446bfb31825dbe11"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0506f24b4e5004642"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-068ed7d9d8f19bd47"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0ceb8b2e0cc0822b5"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0da769e4ad9947991"
                         },
                         "ap-south-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-07922ae6023228eb0"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-09be4b89bb1c229fe"
                         },
                         "ap-south-2": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-04f389022ae342cf2"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0ad87d4f988549fb3"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0b4da98963bf339f8"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0346c80877992c053"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-03e23e712ee9600bf"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-012c8ec1657bdae9c"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0f07f5d791d580a5e"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0acd843c769c8bff3"
                         },
                         "ca-central-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0278405e82c23361d"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-048f7a9c364c194a8"
                         },
                         "eu-central-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-08944b70b7175ed31"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-048f240014ef82be6"
                         },
                         "eu-central-2": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0978faf811f2b4fe2"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-015fd1b92eddabe92"
                         },
                         "eu-north-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0ea2153170c928ae4"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0b9f3ac0fa3a565ad"
                         },
                         "eu-south-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0299c82bfa562bb0a"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-016a64dd1dc1e6412"
                         },
                         "eu-south-2": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-020bc9bc91ffbc70a"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0f73d208a1aada960"
                         },
                         "eu-west-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-03a78168d33fc8967"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-07db82d58c3b17f7d"
                         },
                         "eu-west-2": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-033199d8872c0ef84"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0fec2c1f90ccd1c9e"
                         },
                         "eu-west-3": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-00d69a4c28b7a8875"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-005aa56ad102cff86"
                         },
                         "me-central-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-02f02a03158d8496b"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-00cb55fb5a63fbdb9"
                         },
                         "me-south-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0fd3d54df075ef701"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0b6fbc9659591d43f"
                         },
                         "sa-east-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-04d1a33fd77340e05"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0741fde260ca8a2db"
                         },
                         "us-east-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0bc6bd4649fba5584"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-060f3a8eaf519e60e"
                         },
                         "us-east-2": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0c6fba9f83bc11691"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-06b3c01cdb960e917"
                         },
                         "us-west-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-063e9867c31dae431"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-00eb2b3041805b52b"
                         },
                         "us-west-2": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-032194da527aa22c7"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-062c21a7e67d44bfc"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/s390x/fedora-coreos-38.20230414.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/s390x/fedora-coreos-38.20230414.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "8751faadd9824c2aa2fbaf8915d691b9fdda274f2c2c505dc0464b1304d13bf0",
-                                "uncompressed-sha256": "5a7dd7a10f27ef150805ed34a3898fc106aaf61a368a5633dcc3bbf955863c90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "f3e0229a0c6ac8b82bd152f56812108fa4db7c2a31d3d1a96f096e3f80bfddf6",
+                                "uncompressed-sha256": "b601c6a6e2110df0c84f6b3feab037e98e11e49643de1876b72d03bf85e57588"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/s390x/fedora-coreos-38.20230414.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/s390x/fedora-coreos-38.20230414.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "259d38e17b2b033f13a1bc9b29ea847f22c1a667f7969a5d0854fbeeb4c50341",
-                                "uncompressed-sha256": "dee7c357cb9f0383f55aa876347ee9fec985c4e23638e3d6bbc546e44410eaf7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "b6d92a19e03659af2f0e657975720d4969b6e8bffe957d7373b8291251a91007",
+                                "uncompressed-sha256": "49ba59c88670e6abe4a1b41a9e018ac4a87d9f24809d797645d0f0e26b4dd2ea"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/s390x/fedora-coreos-38.20230414.2.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/s390x/fedora-coreos-38.20230414.2.1-live.s390x.iso.sig",
-                                "sha256": "d2296191b4dfcf96ddbf292edf94f7c5a4a2f534f61b05e29d405d8f606b47fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-live.s390x.iso.sig",
+                                "sha256": "72ab17c6dd8b22e28ae343a8d873b49e933fc98f2b2150055b4accf864db6a77"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/s390x/fedora-coreos-38.20230414.2.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/s390x/fedora-coreos-38.20230414.2.1-live-kernel-s390x.sig",
-                                "sha256": "237cf0e1a77cf15890707b4d32177c7bb26c4531195c63f5a3055a176c160fe8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-live-kernel-s390x.sig",
+                                "sha256": "ec8c8feea8752b1774859a47506a52f76434ab97a1a87a17cfe70a0d3c107f5e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/s390x/fedora-coreos-38.20230414.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/s390x/fedora-coreos-38.20230414.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "c3c4fa39f3b4ed374fe5784de79c90b4190f6132a3e838270fd5c9bae710b4f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "435f8965f6f8e21f7e6a2d5a8c160257aaf9843d5abd05cb8a6573f9e159cfe2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/s390x/fedora-coreos-38.20230414.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/s390x/fedora-coreos-38.20230414.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "9256b8cc3e04c18076494ef1137e0a03c77bf8e27bee2207964cb1482ceed8f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "a43caf17fafc26e21a4743082ff6ee2aead0855cca6e30fe311081f15a344cda"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/s390x/fedora-coreos-38.20230414.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/s390x/fedora-coreos-38.20230414.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "f20c9334c4018011e19ddbaa0b0d330d1306d06398844fbdd8be7dad97b28559",
-                                "uncompressed-sha256": "0a2bbc8121ba393e7d4a7c3837c2039145957ff70088d6f1d19baac99cb81057"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "c77d5068562a6d5a37e20584bc58e8b9e29eea83414f5707d11e2f71295b5d3e",
+                                "uncompressed-sha256": "6e2120cdb74be8d82fc09a7a541e48484fc9bc30a59e0631deceff6401e6457e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/s390x/fedora-coreos-38.20230414.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/s390x/fedora-coreos-38.20230414.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "c8b6be7ac81a9fd56d7773db4bcc00e2e42914b13bd54b34f7130b4504063e5c",
-                                "uncompressed-sha256": "f89ca333c665019b92653f6047d4f42b4ca1244baf291fb620f0ff424c747c5c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "83c0f3b9749c807df7ecf87ccbb09e11dcdd38d2114e3a1f81de1ada4036ffc2",
+                                "uncompressed-sha256": "59d102565a8f334d66a5d23a3a06eb431fb079af2c79f67906cc95445873d003"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/s390x/fedora-coreos-38.20230414.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/s390x/fedora-coreos-38.20230414.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "ecf755eb0d6c707d6270d4d7be0440421c860b1c2d66f0c6735cbf33ef24230d",
-                                "uncompressed-sha256": "748c11a0a0b668a3bd71c767cf9cc4774e6cdf4e55e0b5ab9215887cdd703acd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "2af061e5e7774d4c1cd030ee09c80e87d849f533a78a9eebb75cfcb66c4b9ce2",
+                                "uncompressed-sha256": "415b42155127f74b191aa369d85b168c70bc6c0c71d05f58c4c020ff7d6185df"
                             }
                         }
                     }
@@ -308,225 +308,225 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "12774b796bff5279eef8f47c1a4667527cec0b9b55450b79666a55ea24c0379f",
-                                "uncompressed-sha256": "4c6fae245e9277669422cdbff1825c06064221564d5a02a4075f3f4854891d36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "6db5dd0d0a76a3a2c3864d2e9a4e213628f90716c44d171570a0fcc7e97a0b54",
+                                "uncompressed-sha256": "1151bef479ff16b9f9da03e25cec3e4c8ca71e64bd3e383da74ff0cfc52050b9"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "925bf0c73c10433ac51350237f9649bcccb563706b5bf9fda450f3322873138a",
-                                "uncompressed-sha256": "fdc343bb2a911b0c597ae27c8eb0d8da6458a34098b30c181041e19a92f32c8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "06485eb9c44213ac6e8f7476879d1058790a37a906f78a3ae9249d1e30f42f4e",
+                                "uncompressed-sha256": "7dbefb28cb2a1a136f33a0f7780cfb510e1aecfcdf2fb26a4910a859423ec8a1"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "843cfe27819753114f9272cda18f16d13cebe075e72246b90a7bac163cf88040",
-                                "uncompressed-sha256": "052bc72317388e6f3aa997d932c71e5227ca04c9c3adb15978d9af149e25f1f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "54e7ef0be595a6e21d78c8daa43b345b1f5fda00a7b196b23e47f822eddfa071",
+                                "uncompressed-sha256": "a5837c691f5d128355844fafc913e071bd8a643fa3dab3911887cbc5d85f3982"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "5c2e8c2c805078f08537c8f41ceca4fb8a8fb9bd12e8d3156a5cec6104e71d22",
-                                "uncompressed-sha256": "37adc9e8faa704181b39edcde88f6267ce59d7f390cdffe89117f6c8defd56b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "c7e456488e35e3491e0f29f6e2ed63344374f1d69d7f8ab0e6213ad455568633",
+                                "uncompressed-sha256": "dc866679f37b2c4eb3219dd83f7c9a9ff025d16a397ff2919feba0a1da7c695c"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "b35f05e5f2299cbc987545758ffdd68a3e203348a2f36a9621fa36815a75b574",
-                                "uncompressed-sha256": "8f9644b738f8190e4e873a4d7e439fad9fb20550cf4ad02685c1b90034c41179"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "c59775ad4d4637248d62f57207b72c24d052dd861d40f11d34aa542b1d9703fb",
+                                "uncompressed-sha256": "300c4369f760b9668c999752e50d3a3f48b00a8e5e15c85bf3d2bbca1bcb6b4a"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a11fd3b9c5f72bceb7ca64d5435d50d6bac5c78a9167acaa81de7ee898bb508c",
-                                "uncompressed-sha256": "50beaa00fb3f70ba82ff5f628274552bbb5cbfa9fb8c9ca57d6cf31b8e25b3ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "63a78979cb62dbae173c2be93db3a24b7d307b80f1119da243855a50fa346db4",
+                                "uncompressed-sha256": "60cf9b50e154e77c7861adf229299024d21df29360001c5aba3ea018717ff16e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "61dfb59e2ece4735239e160017337ea6e86bb49faccb202092c30628ca29a0a0",
-                                "uncompressed-sha256": "75ccb60ce07e7b0fdbdf6cc9ad7cff19fe0ea83da97c75b7b85f6a9b9cba8040"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "ea18da2cefe82edba2463e976e971e6ffc256a3a2acd16d5e114c89d7a362374",
+                                "uncompressed-sha256": "b0a73880983c2a6d31007a8d18185181a2c409b97754b2a37e38909847eceb86"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a4896457555b98e67d0aea03a90bd09fad839edcda70dd7c6107f8d64d4e8e8b",
-                                "uncompressed-sha256": "7ad6c6fe1364823255dac488c27d72da761944751d3f9aeba3aaa29f1d3f93fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "e5bd9136ac455f12f290856c5619e615ec71a4765430a4eb24a1f502268967e7",
+                                "uncompressed-sha256": "be94694a6fb950b79b0d031023dfda02282f152eaa8837027e495ec3faa35304"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "49d242a1b9e356ee20a28674e7d24ea966ea39ddd45d13ed2f9078fd359c3595",
-                                "uncompressed-sha256": "00cc29c0d8aebbeecbe1269f3c863850f49835c447c34bc8499bdee0589c7e6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "4fc31a3727be8991eaee2b900f5ad0337079febf7a94fe61ec23a014f7ad13fc",
+                                "uncompressed-sha256": "b8cec7c4e03dbb502da429c18852ddc3ad34964645fa81663720dc303bcf5842"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-live.x86_64.iso.sig",
-                                "sha256": "b035409a1cdfceb197259a322ca6ee07b5e4e4cc58bc594e6a51779f5449b2e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-live.x86_64.iso.sig",
+                                "sha256": "bb57c65b7f1b7cce0946e97cd9518c9ec19c5bbcd18519bbb7544326c6742f87"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-live-kernel-x86_64.sig",
-                                "sha256": "744218da9e6c1302c9d436070c1094a829ad9b5821cc714a5a2835877e657327"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-live-kernel-x86_64.sig",
+                                "sha256": "6efe0d99d01d35119dfc06d971edbf6d13d783ecbdb48dccc924185177a1bd98"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "a1d8628a14557a20ae10f2199bbbf2ee0b864e2cbe6331b82d1506e854b9ee60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "660724b7af6a4b64164af7f517b7d047c8c7e3edec65e31216fda2e376112185"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "4677810f1a6ab116ed2833d888b8daf747ca47c934f2e0701175294027e1ded3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "8f92509d224b4ec6f87178cae50f4ff34eb79d4b419b1be8c6fc65beb7ddc9e7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "360f6403ac86786b2556d43dc596c37b937098efc678fac17c1e3454c766722c",
-                                "uncompressed-sha256": "be4fc03cac0df0c5c5d296129bba42ada132029d8296c05901bfa07641fcc075"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "1a8fa0a246b9372ba63907eb423b4d3aafbf9d26c5a0e1ba73f294d7ef1e33f9",
+                                "uncompressed-sha256": "7fe8791090ca87abaa15061f6daeb47dce034b852caefc3be728cb022eac435d"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "33659eef8b7854ded8fdf1325bd33027f13eda5944563b6bc1f45fb5d4deaf5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "950eafaacaa6bcdda34fbd2fa3bad81e50e3021074a1858de278af19b57443bd"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "cd73efcec0e38850a5c02fde28ad972fd3a8ece88bd0f79c76bd35e0f5eb9013",
-                                "uncompressed-sha256": "23b87d8c33465c01a817d447c909eec881d4b54f8833519a661cc80faa232265"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "7d54e5de0e9e853b8ab4143c0321efc867fdbf06b6fbb020da0705240818f8d1",
+                                "uncompressed-sha256": "3f0bd77c68465cc6095bd16e5a2ad8e61164d5e07f69fde4c350e12cd1e81905"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "60c06a67539ed99473778a8254306a024bb208589d4ecd30fdc5071a1d5f3c20",
-                                "uncompressed-sha256": "b5199027e671917eb91edc4efbca0d82b893f0db30ad65f0ea56cb963bca1880"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "07fc40961c2c9b068acd00bfd132c462045a1006acbff8d15a7442bf290745c9",
+                                "uncompressed-sha256": "ab2c61a32a4970d93cc138eed6ca97802057121a42aece23f2a77fbdb6e9deac"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "ecaa77123ce5e6ee8e701cc49d3083a05fe6a39273314b3114c5fb3159cc50d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "798ff93d1513e3be1c0a00fdc4150e83a812111077c2a1a61713c9b4e67c3c95"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "d23ae7d9b62b5e62a6e9b1e9060fb1a6992a4f5b6b6b8cbe4d7d4696892d101b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "1bdea65801f789b78bb1e01864e16b8cb6ca20551f43a01572975b86322c7b8b"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230414.2.1/x86_64/fedora-coreos-38.20230414.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "116b8c7a7c20c9096eb0a7b2d730703e1d526f03bf3150f23a49f82fd21df97e",
-                                "uncompressed-sha256": "84c4e1d49dca3088787c9a6a0d0615a266fed3076eb9de5083112e1ec6de3757"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "3c371ed1ec59fbcb2820f3097a12cc5de7d05458201038b87e55963e6ad506bc",
+                                "uncompressed-sha256": "6edb11fcb57effb036a454221db402b9348da9610364b88fb33eefa177f219c3"
                             }
                         }
                     }
@@ -536,116 +536,116 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-042c579f60ee47756"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0c04d080ec103b682"
                         },
                         "ap-east-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-01b71a651bc776f53"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0cba5e207c689c102"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0931715767d40f0c5"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-091d6e75987cead42"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0bfdd06e8269f50ba"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0126c9b92b4e7dccc"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-064b4373cf3ce5370"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0964f2b70cb9dc2fd"
                         },
                         "ap-south-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-03d557ade913335c1"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-00d263c7e3c2d9d5f"
                         },
                         "ap-south-2": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0d743f61efa416445"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0536c410229d0252a"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0112412c00556e8c2"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0eeadd56412728803"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-016ee949fbe572048"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0a0f659f3b65c97cd"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0fc3350c654954776"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0770268b27ff43544"
                         },
                         "ca-central-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0c106feea44b4a0c4"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-077ac2bf074e6b9e6"
                         },
                         "eu-central-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0d7d59743feb3c07d"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-092867aa07860c4a3"
                         },
                         "eu-central-2": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0976fbe6b05b709c8"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0a055a14fc16784c4"
                         },
                         "eu-north-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-03f767e648e08e9fc"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-02a47f0a0790abf06"
                         },
                         "eu-south-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-01de8b0ce3debdd94"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-021ad22793933b5ec"
                         },
                         "eu-south-2": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0899d5d7cb13fd691"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-01d0a927237c5db21"
                         },
                         "eu-west-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-01c9c5ab0f0e9747c"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0a30436fcd451d9bb"
                         },
                         "eu-west-2": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0af354afbb9cc1817"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0484e32c7d79d2c00"
                         },
                         "eu-west-3": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-04cffce1c57f17ce3"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-06f30f79aa8e2e921"
                         },
                         "me-central-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0118ba8c14aef820a"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0260370c88b71ab14"
                         },
                         "me-south-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0db0ff4c37ed67bcc"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-08f7e3be38b7d6281"
                         },
                         "sa-east-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-053a620d386247384"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-01131170fcd044e0e"
                         },
                         "us-east-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0a2e2424bc36a64b4"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0a0af013cb20b8aae"
                         },
                         "us-east-2": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-07a4f80a6aad2a9d2"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0e552e542520dba14"
                         },
                         "us-west-1": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-0c70f74fcf647aa69"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0ea8cdcd48ebca78c"
                         },
                         "us-west-2": {
-                            "release": "38.20230414.2.1",
-                            "image": "ami-049ddc8d12a3e3e5a"
+                            "release": "38.20230430.2.1",
+                            "image": "ami-0f4e9e5b012a2db1a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230414.2.1",
+                    "release": "38.20230430.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-38-20230414-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230430-2-1-gcp-x86-64"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-04-18T10:20:13Z"
+    "last-modified": "2023-05-03T00:27:28Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "38.20230414.1.0",
+      "version": "38.20230417.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "38.20230417.1.0",
+      "version": "38.20230430.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1681830000,
+          "start_epoch": 1683122400,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-04-18T10:20:11Z"
+    "last-modified": "2023-05-03T00:27:26Z"
   },
   "releases": [
     {
@@ -73,9 +73,6 @@
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1441"
-        },
-        "rollout": {
-          "start_percentage": 1.0
         }
       }
     },
@@ -83,8 +80,16 @@
       "version": "37.20230401.3.0",
       "metadata": {
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "38.20230414.3.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1681830000,
+          "start_epoch": 1683122400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-04-21T19:13:56Z"
+    "last-modified": "2023-05-03T00:27:27Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "37.20230401.2.0",
+      "version": "38.20230414.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "38.20230414.2.1",
+      "version": "38.20230430.2.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1682344800,
+          "start_epoch": 1683122400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).