### PR TITLE
Roll out stable 38.20230430.3.1, testing 38.20230514.2.0, next 38.20230514.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-05-03T00:27:27Z",
+        "last-modified": "2023-05-16T15:54:53Z",
         "generator": "fedora-coreos-stream-generator v0.2.12"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "8102a9ace87ff502bede9b74f24e21ac0d74490283aae38ec73d729983b726a5",
-                                "uncompressed-sha256": "abd82fbefb0f1c7534222ab140cc24f7dcf286c494bfc0da4cdd551934dc5dbc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "5358bfa32cdbcd0ca7d0631aa03b08f8ab9cb94062c53ccb28c0ab08c2897e03",
+                                "uncompressed-sha256": "ce2a2de9161a243dc733f5fd243124a0ef73a04fd8a595e0eaa61905162f56d3"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "ffeddf36f58b51da56e7e0cefdf25ecaf2c7991045a655a977d58f9abd07700f",
-                                "uncompressed-sha256": "97eae912871113e34f8a2e80a179ebb530ebbb32874ceac8cbb21731cd8481b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "a2dca08ae120d75ffe64794da8b005ecd4678a92598a6ca6214dd8444caae476",
+                                "uncompressed-sha256": "db2c06837cd0f273da870f32487b9c7b25f899a665ff524a4506a624529e73fb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "debccd5bd4e2f9d2c421ecc9bb4af13fb6d9993f4c6179e36a96e4096fe296e8",
-                                "uncompressed-sha256": "36758e7ea4a8341905674990bdae2aa8f6f66ca046aa60501eaf78c914da0425"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "bd13235c9877faf7465560ecc38b779aa8aa48340c2aec6fa2f9ad87bcc14350",
+                                "uncompressed-sha256": "29257ac81ecb9509d2b63061868617ad5ef5042e11a6ef5f41b03d75d97900f4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-live.aarch64.iso.sig",
-                                "sha256": "1ad6de094780a0245a4a5b5f4249422b6b2f591f8c64c3e768db0f14c13b00e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-live.aarch64.iso.sig",
+                                "sha256": "095c219ff824eaf8c27e5859d267f92d0ce877dc3901febea68e47e8e9b38d47"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-live-kernel-aarch64.sig",
-                                "sha256": "6b5de67b74372403c01f3eba3181f4a09a6dcbd990beee19afc91fe7d06d7ee0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-live-kernel-aarch64.sig",
+                                "sha256": "3220992101cc232cb4531063ab6a0e99b704f389d76cd65eee23c0c8fb02d3a0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "d98eacba22145707d7b566aecdf5bbb366a13ba0b85b6641c709ab10dc2e600c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "435faa89689b2692f4b4bf97a01ea0e3616b3eaf260c16c89324478895e2388a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "7ed4daa716a8e321f4544b392d0f8469b67ae84d54129f4a535fd26ba1b4a558"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "688513128abed267941e88755010da305eeaa6bf8d09c35b39002897f462a533"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "c9c3ad3c3bab39c5c53bcf544da126a7e918b5f55f79c69f8cc6196dadd47342",
-                                "uncompressed-sha256": "250a7fd9db880008afbb0fb26d66b34d35737dde5db7c35644d6e35bf07aee39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "ab2b8fde01db7e416731218e4c285417d801efd4c135a9d2b37c8def00cbba60",
+                                "uncompressed-sha256": "7a44da4014a42b238aaaa7fe186d58b3b0290ed4a92862731127f0fd9e630f7b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "4c3eacdf71881b9af7df308a331d9236b2d507b2cbddd4bf82f80cc90f7841bf",
-                                "uncompressed-sha256": "9dc5914df16e1dbb9288cb2036a6a0e61cf9d8a9bf7776ec0a68c1e15b366889"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "5046b1547457f5f37a7308bb5da0011615ab403ab685b3247a9c32f4932a89a7",
+                                "uncompressed-sha256": "99c0e22d94d7bbb6f2632dcaee1e2ba9cfd3b185f6a4373d8142247b6dfdb8d1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/aarch64/fedora-coreos-38.20230430.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "cd69486e6ea21ea94f7787259b37355faf26b0f0f9106be6babd66276a1935cc",
-                                "uncompressed-sha256": "04eeb496dd168e46edeb0686b747b45089c6f87135b2e3372f2bff1c53b31806"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "c4669a674450dc67653f93538c57d0526e334a819cf28632114a47d12ba2d14b",
+                                "uncompressed-sha256": "b1d0e93518740be3934eb64ca08c20126ee5d20b8dde53e5b76d6f16d331982f"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0db7e3ba8205b26ab"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0d2fe9c417d9bb149"
                         },
                         "ap-east-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-042a917e3b5de40b1"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-00f7922a9854eb7bf"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0b9a0cc4b4e6e8611"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-05558bc689b780cba"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-01dbfee11ed6254c5"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-096d1cdb51925e81e"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0e01319d26fca4717"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0f85863618a3e2308"
                         },
                         "ap-south-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0380c3007c1f7afbe"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-08798b61fc2f0ea3e"
                         },
                         "ap-south-2": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0419aa5278e7fa30f"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0c0d1eba3605c28b8"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-097f03990e50c8284"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-09b068ea0cc1e1159"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-04f405fdef4a1990c"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-098916b7f73a5f9dd"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0dfa3033bfd28ed54"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0e908ecab197f260c"
                         },
                         "ca-central-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0f06cd9d36e2b38f4"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-03846bcf15befce44"
                         },
                         "eu-central-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-02e21a5d7c6129ad7"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-003afc70d5c57af53"
                         },
                         "eu-central-2": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0048806abdaf94d22"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0bfdffeba0c47dca1"
                         },
                         "eu-north-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0f83b18a502d85eb7"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-03c97f35215a36c33"
                         },
                         "eu-south-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-08a82c32b42eb9358"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0ef73e64cc7e5268c"
                         },
                         "eu-south-2": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-08f59810f99ae56ae"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0a45b3885a363f66e"
                         },
                         "eu-west-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0801dd578299f0f37"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-027a0f0339752d4ed"
                         },
                         "eu-west-2": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-05174ec297910e375"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0f0df95acd4e6a958"
                         },
                         "eu-west-3": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-080261d14eddd00ca"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-00a91c55ed0570aca"
                         },
                         "me-central-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-02e5a66fcbc085f96"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0d0b2c5eeb37ba194"
                         },
                         "me-south-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-021518eed149a1d3e"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0a60dc888399c087d"
                         },
                         "sa-east-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0d513d2b93e032856"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0c99189328bbe3042"
                         },
                         "us-east-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-055ca88f90adb6255"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0cf228bbe359e9989"
                         },
                         "us-east-2": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-03797c20ae15dab05"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-064f1f20715e65d6d"
                         },
                         "us-west-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-01f5acf38212d009a"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0e5738e981e19f4be"
                         },
                         "us-west-2": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-05c2ced05652d8408"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0ff2827c57a05ff69"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "60f0277cf7b42036e73488ee1f7972973ede0ec62961374117f9df4e29b64453",
-                                "uncompressed-sha256": "3045e165c2ba72689ec3cd7adcdb4851ad73bb8b910ea6126556ae83133e5b78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "7734ccd34896327335a31c5d7aa831a29039edf4219695920b5a1d21f387666b",
+                                "uncompressed-sha256": "68d678e55db22d71e7a8cb3d292114cc488c5d709974e0fb6d8dfb09e9738645"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "484506d87753a058a60e6a1afe64c6e21f3ce511cc10b267c6c43409f94e7732",
-                                "uncompressed-sha256": "d0f10adca981da7bb3d1fa3f350cff9f8d5b53eb6fedb899fd9b7fb02fa3da71"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "a822a5a558663c44f0ef746ee2656f43457c73bc8af80e01ea1b40eb2da96e22",
+                                "uncompressed-sha256": "df64edd1c3e54853073ec20f202b8f6c83b607e86a544725ce6d1283d4e1b8a2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-live.s390x.iso.sig",
-                                "sha256": "ebd4ea41660f345a3b7325d601c8aa37f027a0c6099aa8758265afd2a335d295"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-live.s390x.iso.sig",
+                                "sha256": "624c26e9e129cf7e85e9dccf956bc30a2404f688552ac8c801a158ec64cc5cc4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-live-kernel-s390x.sig",
-                                "sha256": "ec8c8feea8752b1774859a47506a52f76434ab97a1a87a17cfe70a0d3c107f5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-live-kernel-s390x.sig",
+                                "sha256": "f364e3ec3e2945dcbc12d89bb45baf1cea8efae09bb22e79e4e989936dec6da0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "5ce779bbfa0323a884629c454133ff6d3c167a9593a9d90ee8de2140edb5866b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "90662372216c2a35013a575eb7e06722b03bdbc128b56f5132bff978b7508aff"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "a5f880e5e0ff61bd7c862e9bcff22da0acfdbaa7592cc910fa8a698a29d58a39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "4fde6236d4a1a7eb99f551f1837d952a5ea605fdeb9099064d2b2adc565995a7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "f4e2c4aebda40a71d2e316a32858867d779f2d806f61d3a0e9d6e192792bbcc8",
-                                "uncompressed-sha256": "ddd78688e964238ef09a294b51b1e763e6812065b82c5759e349216d28fb8e05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "311d24ebb88bd712272d0234bf5e1297c9ff4dfc364be117d1dd4a1054c17b4a",
+                                "uncompressed-sha256": "b3f3c55039364673f854942fd6b6480fe835c9b02eec62c07b6c259657121457"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "1513d2bdc5896e7a196f4951c0dca069f1c0e0cbce72756a906bb892b025e6ec",
-                                "uncompressed-sha256": "3fb294797f59c18c744775c6608e2f1f7e9aac4e9606356651804d8c1669b28d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "c9e3b14b27824e0cf8fd6fbc3c80e1c8c407b02d61a2ac8753abe4ca91a11a09",
+                                "uncompressed-sha256": "303438d66d21af77a6f57d93b02c64bbd01c4c7ee7a07254da4b7f2465704ba9"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/s390x/fedora-coreos-38.20230430.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "8f7f080f48a127a96874f52452cf7c51a0033f76c15968e5457e61bbeb6a33e2",
-                                "uncompressed-sha256": "4ee2063ce9247b5b92e089b567cb78e3710741ba0cc8872af3357fc8120acc8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "15a91c559dad6c6a9210fb0d84eaec86e234461649d29585ed76e84858f437be",
+                                "uncompressed-sha256": "02a06d1eba206bc08091acc5763290e5ea8e80ef0b121bbe087a49dc7d74ce55"
                             }
                         }
                     }
@@ -308,225 +308,237 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "b4067d5ed553439969003df3534df79eb32bff782d60475fe678ee1620c0c044",
-                                "uncompressed-sha256": "f2496b8f65e273cfaad9b972802dcc8f2a6df47222e0d07f106571f02c83c329"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "fbb45b2f36550dcae56d68cafc207a8188f7d08dbc7e9bd9fb4348fa2d30b937",
+                                "uncompressed-sha256": "213243097384853d2f372366fd84053098545061301abe5ccf2cb7cb6d5007df"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "8be2895b67b4df5856a98ca1d7dfeb6d28db250cce2c32b08044db0c4aa1c22b",
-                                "uncompressed-sha256": "40cdcaba139faaca5c2ef176e53418a4ebdac63a4e00776b894cf3fbf8b18b03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "c903e5f88c8584a201cc832034ce5a97e9a6f149902e4a5878a8c96b7527e916",
+                                "uncompressed-sha256": "5371a9b77174effa2cf57dbcdef62acc36725e8e1261b44613c8a1f3b7afa5fd"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "a75b8ae767e2564eaa521cd8a13b3d25a0f84aff4c94d7b62d0398f59e62a18e",
-                                "uncompressed-sha256": "df63ce7bee72a6e4507bddd2c4dc5f4db22900d28bb6283d39e03b952722cd3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "1ed2db4e261d9e24f6fd5cf1d5c0d5e66d38a6acdf9f272327ba1e84316877d1",
+                                "uncompressed-sha256": "7b71c26fba6dca52ef9719ea6d318bd85de1b79f669a7e65e037fd48cead2612"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "f962dfd3f7cd6fbe65b6671ccaf8fff89ca498a9fd27e9bdfa0e8e7b84d0968e",
-                                "uncompressed-sha256": "753a72e7a687318754df2ff0847d408d6433eef0245d81240f744f6b1a788708"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "3c816385a431b4ef22032c6c3ded8ba70bdf811a90121e7c130d43734e625a90",
+                                "uncompressed-sha256": "77cc0bb6b8626508cf4049608de0cdf50299260b15f12f172e60329577889822"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "b5237d3f5eed96ff5121badbfa53ecd26849071a7fc7bf4285053275cb48c0fa",
-                                "uncompressed-sha256": "69fb7e369622055b14b0ab27fb1ad6ae1713ce547f1e4285eff44a579b13043f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "ea8507910584d97384240d877342533b878274ebad6811a7a3394a0b9dd8085f",
+                                "uncompressed-sha256": "32e5efb8256f350f0ddc36f2302dadc8ae2d1684a2ff1fd0e80e2d5559eaf518"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "69db1943bbbf1b9378433b527c371cc9a232950b1425e68138b6d1bb81e78a32",
-                                "uncompressed-sha256": "731189346180038d499ccec76d0735b875989c201555250ba1a25f08c2934a1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "a4db987371d5302a5fec38d0a2d67653458a3b3d4a51a6b903a887b8080435b6",
+                                "uncompressed-sha256": "8cc6eda3cc4e87672da4032c2022c6d052e97cf548b57fb2343844eee2ff43aa"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "a6888f70922db96191cee22dcca8826624b1a971755da92ccf548f6a949e2456",
-                                "uncompressed-sha256": "9e6410e51c13731dfae3aa4eea6b1a8cfe09a7dab4799f06af33ee4b5aaa128a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "37251245a63ac4ea10b1226e972a34477f8fb72a971b44a9e42040c46718608e",
+                                "uncompressed-sha256": "39f936f32c3e4401bea0b0052d2a84605f4cafb44a02592e7f1e609c2484927b"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "3cedb5d6e8c213be872896d724986edcecd70a6483843043e803e734e8f301fb",
-                                "uncompressed-sha256": "a78eab0da9189baff94443b5d7a2be9b12c807b8ed3f84b96fb73c3cac922819"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "a68ba7497713c6689e9ba18db0a4011271d20ebe5e1f8c394e4e619dc96dcc95",
+                                "uncompressed-sha256": "1ae872a99b5c223db0d58c7ed2956f52f1cfc0bc1c54fda1c8083c83848a5795"
+                            }
+                        }
+                    }
+                },
+                "kubevirt": {
+                    "release": "38.20230514.1.0",
+                    "formats": {
+                        "ociarchive": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "bcad1707de1d7e0061c1537a10c9ac8a59dd648ecd5c49470baaec96bc35238d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "000f8c755c3e24ce63dac5c85d97ff0d1a52b682f1addc5e561cfcd2ce27bdb8",
-                                "uncompressed-sha256": "4da7d0c22fc7dd61fdc3bfa3ce67d82b5e617f76694be4d498208188b41cd170"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "6864a772240ed67d4208a2a5aa1b3f776c33af0ff1bf512b982f4dfbba3c76ec",
+                                "uncompressed-sha256": "0035e0686729a615aa7f5d3c274225f21a61ccdfb77decddd1602774b08f75fc"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-live.x86_64.iso.sig",
-                                "sha256": "670dc898653d511db68010aae9b65d0579ae0c2a69333edf3cc847a545d62aed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-live.x86_64.iso.sig",
+                                "sha256": "b98f900abb14fb690b4e953960afbae8e4c861926d3e228b8005264b508cb845"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-live-kernel-x86_64.sig",
-                                "sha256": "6efe0d99d01d35119dfc06d971edbf6d13d783ecbdb48dccc924185177a1bd98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-live-kernel-x86_64.sig",
+                                "sha256": "1caa067a5593e432c61db22864d09519219f7d926280e50817bd33fd609ce2eb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "a45b02f35c18b76a17a073ec8cd80d33f475dde57a6d92ab1eb07c2d2c5e153c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "e6e016fe2eb9381a93b2c24601de1399b31a160944b5d7895392700544785119"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "bb104f7bc2212c2debebd9d038c4ff206215a93a00349686c3d9bf781e53ae52"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "0af9041e3f381bdb321df0b39260817441e1ceb83c40069f18043df4cae3fe3f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "00c6ca8334705db4e55132dc2990333b555e8d671733a2483f4a98d8f23ed921",
-                                "uncompressed-sha256": "d7d4b2eda16d58e226d66713668a9c7ba765cb786f734e3e1564cdb1b698c72f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "39bc365d9ebf4707dfbd13e3df1fa2fadf5b41aa9f8d803729a43fbbc142fe51",
+                                "uncompressed-sha256": "46cfe714c43353b0c344b247eba1abe4496779397332ca1eb57df2b0e4f3d8cf"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "3232f14e826161671b6bd1d3abcf6ac1f689fdfb49b0be60e47801f9fb95af74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "8d76851d90577f504b1a9cdd92fbbc9f4c40356edc5ec6e223d81916b15c7402"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "00c2f82ad74ec15f295b58c1e7af0d89dc6df2454a1da7353b53460d820c3c43",
-                                "uncompressed-sha256": "643d44219e0a865ddce2d48171b078a4b846d017ac51fd09d03f560d284f92fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "53593f2ba9699bdd18434e7c435ca41a46e9a6864974b69cc0a4b6c60a715fec",
+                                "uncompressed-sha256": "ff384e4583c6ae0d4e5043be973bcfc6be0d6d2b5d64241387130125e53b28f0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "5eb950d0a6c7a386367ec6805734d479780c10f11abab7234861a64cd66312de",
-                                "uncompressed-sha256": "c73daab563afbd7af95db9f6aba9f8dd94cecbc93181edccaed8b3276b452e06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "22ee731c8620d669224203612de7f8ae80b11b543fb55bcebe6d8b9834686515",
+                                "uncompressed-sha256": "a367a3c0164edec1fd33b61066e7fc6b873abbc7d9c22873e3ba0b889bfdb620"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "dff0eaa30aeddb05f59bf72837e2ad6260767ba9c01b285432afa88ad418c0ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "4fdb1380d695e79481828a9d40dd78987d0398f44c43d976891f8ebebb9803b4"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "564963897f3b759d1f330b0d1aeba789caaf2b8bc7b06cd4e77b7f8fbe7a66c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "fb9b8e3737c690566f1a852d5a09fd3e1ba985842569c0391c961c66ca33a6b5"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230430.1.0/x86_64/fedora-coreos-38.20230430.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "16e7b7eeaad0cb77a713431f1adc49afeadab39fd22d242205fac3b8f307106d",
-                                "uncompressed-sha256": "5d03a655dd1fd396936b0eb2017d1dd45ff3f0ffb5f0d809037751565580909f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "d790aba50e9aa30da5796b4d2a5ad18930791ad696de8e1a53291640bed74c76",
+                                "uncompressed-sha256": "478c8df0dfb9163b1f658df2c976514ecdd5bb02c24b3c4aa63718cc36b06395"
                             }
                         }
                     }
@@ -536,116 +548,121 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-077e96a08d04a8067"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0af94c4a0e58b7994"
                         },
                         "ap-east-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-04ea29a1f5ccc3699"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-096b770f302babdfe"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-016031e6c1b2be334"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0ade55108ccb6db63"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-024b1bd30162a75ac"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0dfd02a2293d23c5b"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0436d61e8dc91b34d"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-091f22e984b42b90a"
                         },
                         "ap-south-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0a0d1df24956f1f38"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-00597d157e786b265"
                         },
                         "ap-south-2": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0bb6bd2e378e55eee"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0610b10819c95f156"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-03993026c4c8362b7"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-08741582ed3a20eb3"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0a24c0bcf1cc527fa"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0c257eb75e9ea53a8"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-094beda6b0c2cc00c"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-046681aba1faa22c2"
                         },
                         "ca-central-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-070a977541fd9c842"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0c7c6b33ad487063c"
                         },
                         "eu-central-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0a9e375ef67afdfec"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0cbaf40da41f5667b"
                         },
                         "eu-central-2": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0f60dd6608d38e75e"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-014c135c11cb9a2bd"
                         },
                         "eu-north-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0fc6ec197d21f0b1b"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0134efc90759a9e65"
                         },
                         "eu-south-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0eefa60896dcb1b4f"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0bf0dacb3ce3deed0"
                         },
                         "eu-south-2": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-06657ee6e1ea85dd6"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0f526f9b2dc6a9b7a"
                         },
                         "eu-west-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-02f3d0825949b8fc6"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0eb4e265d9bd71164"
                         },
                         "eu-west-2": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0de8dcad1d9d080e9"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0de2491b98ce6f3c5"
                         },
                         "eu-west-3": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0e2fe10cce7dbc970"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-035e27901f740aa66"
                         },
                         "me-central-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0daea505f55cd2d7f"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-03aab5ae63e2bb725"
                         },
                         "me-south-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0661a9a4105019d20"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-085ddf4546d70d447"
                         },
                         "sa-east-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-08da4afa34100fcae"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0d2d1e959d293f310"
                         },
                         "us-east-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-0e94bb0c322a0e572"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0642677111e4b2434"
                         },
                         "us-east-2": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-023e371ccfcc54b68"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-026224203b03b4f6a"
                         },
                         "us-west-1": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-04f3b14c7d4b0ba77"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-0a33f5dc3a951b1a5"
                         },
                         "us-west-2": {
-                            "release": "38.20230430.1.0",
-                            "image": "ami-07b9eb73360e1fa46"
+                            "release": "38.20230514.1.0",
+                            "image": "ami-019eba97a082fe43c"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230430.1.0",
+                    "release": "38.20230514.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-38-20230430-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230514-1-0-gcp-x86-64"
+                },
+                "kubevirt": {
+                    "release": "38.20230514.1.0",
+                    "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b4cef246ab214c2a7d650213c7fc093e1e4cf6acef3abe9549c2b757f1b24e93"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,105 +1,105 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-05-03T00:27:25Z",
+        "last-modified": "2023-05-16T15:54:50Z",
         "generator": "fedora-coreos-stream-generator v0.2.12"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "ddfdc8a0ee3fe3d64c01eb4d3072dab7c8887516884e7fc399ca9404307ab6bc",
-                                "uncompressed-sha256": "9f44489532a2f29dd98d107399bcea1e739f8a84012a5eda12f7156a6943bc6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "ca3077412649f778a10d61660e784ffd15839fe5d162bbfadf48bd1bb6c6c3e7",
+                                "uncompressed-sha256": "257d03e603919f6105033ce0998a3db4feb0d1dbe2d61edd27a9ba4e4d3608b2"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "d83d8e2c4d5ea2c5bcb35b9c8ffa99811a9ab996e2e4f60f6239e19173a7627d",
-                                "uncompressed-sha256": "54b0771588c2d940d45bd29b3576e244fbeab216994f76c1220a8f99d023ae99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "ee7cd71de4306c7f6114fa7e16ced413e7b81ecdfa71d0965448854a40c90417",
+                                "uncompressed-sha256": "7b44bc729f3d17de36d9ec40682b0fcc75dea35a82674e0381b04aa9d7fa0cb4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "5699bc9c86c63b36602584c96cba4ed03770d1215e006ef9d6fbc85313add5f2",
-                                "uncompressed-sha256": "7923bc483b94e3aa9091336b061aae0ff6ed3fe8d20ce1fe132b4a249c8764dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "d4f34b4141f56309cbc0df0823ae0b824b665b414f4e2e6d9569603b14225d7e",
+                                "uncompressed-sha256": "c4aea8befd47c5337de63510086249017c88b311ec6f946174348cba6658f1b4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-live.aarch64.iso.sig",
-                                "sha256": "b96932f5c90bcc486feea68a9f82f3137b746caeb68f4f0d590ef7c6e3fb1a48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-live.aarch64.iso.sig",
+                                "sha256": "1b1986cf6a8885666477c815fe13d65d271d6b3bda3c66281c65bdb1e67c2af4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-live-kernel-aarch64.sig",
-                                "sha256": "1b1ffd1be1caf04cb7f77d5e34646a2998ca2cfe7d214a28ef749d40dc86c650"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-live-kernel-aarch64.sig",
+                                "sha256": "6b5de67b74372403c01f3eba3181f4a09a6dcbd990beee19afc91fe7d06d7ee0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "657f839ac17526e4404a1ae909d66a93fb4a4b75f019b0d9350f237ff9c4443f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "f60534e2093e196aaa2205503a5ddfad0a2d5d5b783a32099212c0d900b18199"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "71d637d9cbcbf7f200b94296667d86d154a23743a014e2c78ac899d938a5219c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "1bde677114c3887fdc782c29dc7ea526dacef803d8d92d7ce28f64d3a5289ff2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "1565b71b024200d6cc0b9c3f5d5b00607ecea63d90d03711a2cb5dd532e27205",
-                                "uncompressed-sha256": "cbae31702b181c3993fc72394e57c97a25d8e19ca414218ffb87738996a20f7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "f32f5a88506759b3aa77db7994c75c01bddd26ad833f31c4c4368e738855dcf4",
+                                "uncompressed-sha256": "c60b46069150b33f309b7ec5828bd16072cf16dd90c794016030665bf0cf981b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "32b8519d4ed5b94cb6811c20a64e6cdad8f8c3ad051d76995462d94b8d92fe4c",
-                                "uncompressed-sha256": "c10a7bd3f99695a6d24bb8ba1ff0cad7bf7f2c991de3fede671d1b20cc692c8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "87a46a818509f6dfc2614250e18e00a245d27af556467c5bbe2e4b3035025f31",
+                                "uncompressed-sha256": "cf0a943af83abec10c86c973c4be5f92ac3c816fadbb8c0145a0c6a5d6200a22"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/aarch64/fedora-coreos-38.20230414.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "5d1f86a8e240fce7edee3a4fddd4d78fad76ed0f9e84f1a9d6c734ad1750ffa0",
-                                "uncompressed-sha256": "aa755ad03436ac85a83862371911c78d6d91b6255086a2a907ce9abc7987177d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "eda7c52cbc2e982ab7fe37643a07f92f1611f2d90fd1920f34c1efd499648b06",
+                                "uncompressed-sha256": "671d419b7324af4e6c7701102d85f40fbe214bd0c5cbb032913e10c76906b861"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-013a1b0e80d98bff6"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-09a7e13359485871c"
                         },
                         "ap-east-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-049b5c3802236aadd"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0ccc2c4cb18de7041"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0ea3bf68f67c16eaf"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-04ba2074279e775ef"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0346f556f695944c9"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0f1155709f0a2056d"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-080c735b2d540de11"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0b2ab7bbd3b1793e9"
                         },
                         "ap-south-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0609458ab045da8e1"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0fdb89d8330609ccd"
                         },
                         "ap-south-2": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0d9a7d1f73c665a83"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-017f60c59f4ddd9ac"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-030d16c599913f6bb"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0dd6585683ec00a3c"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-04db910f9641e9604"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-09f00ec0fe0fe8e6a"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-06cd82cd6d41f2c62"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-023cf088a1674daab"
                         },
                         "ca-central-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0913f130b110db33b"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-017f050c1e9c95a40"
                         },
                         "eu-central-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0ee1f7ac3da995099"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0d4ec06da56ed5932"
                         },
                         "eu-central-2": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0fa5f45199511befd"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-06e5ac46f4ccb6320"
                         },
                         "eu-north-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0dfeda4d2d1bcf128"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0bcce737a4785db91"
                         },
                         "eu-south-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0394a6244ff001d1f"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0d558bd3f882471d7"
                         },
                         "eu-south-2": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0890aec217d9df037"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0be7e04a54478cebb"
                         },
                         "eu-west-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-06cfc9dad9e1bee9d"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-08c618075accfee80"
                         },
                         "eu-west-2": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0e9ce3c8a5f35bc79"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0f3dbff6a39fa7e4d"
                         },
                         "eu-west-3": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0541188425409a01e"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-090b6b1f2fb0e49a6"
                         },
                         "me-central-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-05cf6272b4d91572d"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0513b8ea91ccb8390"
                         },
                         "me-south-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-063cd3b797e06749f"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-07a6494238fd2ae61"
                         },
                         "sa-east-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-02e45adb6bd567086"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-043548f5bdc4aee52"
                         },
                         "us-east-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-02716a9e60b5ab6d4"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-06586483e8bc3b022"
                         },
                         "us-east-2": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0d3575c012d2ff2e3"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-02acb4c69e4be09eb"
                         },
                         "us-west-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0c6222e2d66e35d12"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-087788c56157ee19a"
                         },
                         "us-west-2": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0181cd2652d8948e9"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-07a7625b43119f64e"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "e96eb82bea479b66591b13bdea5d2d59641ef87c7ffd28a0a26ea6f4ea89fc13",
-                                "uncompressed-sha256": "e308b0703e15eb6231f1de47cc8cc62bf4983b616fa14900008c1e96e79b72ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "e4866ddca041a8bc0b5eac8ae9e642d5a8a4fe26d33258adcbdb85cd15d58f87",
+                                "uncompressed-sha256": "d0d1d07fd7dd04880ea498be9f1cdaf45b2d55797fb19eae537d93022c19d48b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "b3282db6ecea7defd280826829f0e02921dd10a5e1e8b7599d7964016ad1f9ac",
-                                "uncompressed-sha256": "ed8ac121ffb00f9373c6a57775af5d1ccc00e44c1cd679a3c61a96494c0682ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "ec4a3d5754b6448651e15ac759b15ab2cf19c493a65e42454fc2941c330db0ed",
+                                "uncompressed-sha256": "0ed0329f6f6c323bf7fd2775cabdf60ddd9eae0848bc45cfaaeb89c2753cfec1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-live.s390x.iso.sig",
-                                "sha256": "d5414b246fe3c7a2d8b5c310f459ad8eed8fa4a296a747d17302ad0c28be119a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-live.s390x.iso.sig",
+                                "sha256": "cd2e27c0a6789e6aafc6b08642334a152c672f04edf7f4569fceb8139eef4711"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-live-kernel-s390x.sig",
-                                "sha256": "237cf0e1a77cf15890707b4d32177c7bb26c4531195c63f5a3055a176c160fe8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-live-kernel-s390x.sig",
+                                "sha256": "ec8c8feea8752b1774859a47506a52f76434ab97a1a87a17cfe70a0d3c107f5e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "7a61eff04950c06a2a8f04606b6197e0368b26817daca0f3b85fae02659a52ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "82e2c7004a93fbc6c9901138bf3e2403a67309e80ba690a4eec49471a38388b2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "0a322b4597d48f6574a5c5b7e3e7cadb1629a6bf479fd92f269a1311acf6466b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "a8213f6b9574b0f04b7194046209c4926fd32126cae200d3a94297e0c662fbe4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "fa61703ad7c7fea15edadbcb9a66b438f1019c285b7a3887b286b10047b427e5",
-                                "uncompressed-sha256": "de91a4d13c640e292949c12edcfdb5ecbffec5c2bd84819644aba71b85e093e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "9e55c7be56244b20d770e1b7f8ea7845b7be02fdd4841b367f79a365fccf63db",
+                                "uncompressed-sha256": "55d7713a93922ee150d09e0fcdc06446e1d7ddf4272cbb86c1905fbeb51eab7b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "4213b378b2943b02849568f527297a5d91f5ef41c6c8625a7e3f694ea4a5b0af",
-                                "uncompressed-sha256": "de87b8ef8e0974fc7fecc9f145d65337d794223421a007f9a9596309907982bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "f28cafdcca2122ca0d5bfa67112f8b41f7414804662e376c912493cd99761b19",
+                                "uncompressed-sha256": "8c49be02dd5d6423518a8dca9bc5742f9aaed237c95fa09ec4e32207c7909a8f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/s390x/fedora-coreos-38.20230414.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "2c455f15587c985305fd86d1bb0640e823d60760ad5c4cebd0b32bc408a8727c",
-                                "uncompressed-sha256": "d63f676584f1e96d9234261edf19d7407c2a7fa0f21a3085d6192b9a153e972a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "e5c6e72731b6dabdd72d2df4804ce191a94d5fb9d69e123c95ef037466252d06",
+                                "uncompressed-sha256": "b606ceaff8333fd1e8e4737d39067813c009c0e928945d824e13a70cd726604a"
                             }
                         }
                     }
@@ -308,225 +308,237 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "8b4ef7e0cf1f5b2f9920ec726192310ead260ffc40c5b17ca9de82e81d059164",
-                                "uncompressed-sha256": "bd43d588f23cbf3f5e74bd2bb0d0e277e138e7068469b33f6755e31b2e303d92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "cb827c8ad87e296cf515848231f86b9117479588d64fe8da59bd817ad7c05c0e",
+                                "uncompressed-sha256": "b1717d7cbcc93746a76426fbd6d9bc45ac559cf1a873c670f072705594a4a5c1"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "d7b0651b5aa3dca0113b3c11dd9b825d0f176ff8f5fb466201ba00ac4ed783f1",
-                                "uncompressed-sha256": "2e9f86994e6395e06d1f49328b064feb01d634594925383cbccfec2e89d53319"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "c4678dbd1acf9d5e541d96bea90c2de3cc94579734866d2577c749bd39df2c04",
+                                "uncompressed-sha256": "2058503b048970726f3aae58013a916bf24a7e69524d27e4191856404b387102"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "81a18a7ae62d4fa3a5aae96e9581ded9ee0214f2726d14e1f3b59d55de317003",
-                                "uncompressed-sha256": "0cb733dd76d09dedbdfa06771de960a7c6ac624aec5524fa7acd2158cfe8b17a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "82049f1607032638210241608435f17b5dbbdd0f25a14e24a42996128a122c58",
+                                "uncompressed-sha256": "a22c88a43bb17184bb96fe8db45f4b8a382e0da1450d6d1ba66f6fa631bc4ae1"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "e05f8c5b3038c7b490c673b78f93bcbeea4e79054c119a98301029f81a91e20f",
-                                "uncompressed-sha256": "f22da4b4d5c897a12094d438714c8a0d3d5cfc8040079c10ac3ce85eb3143137"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "17125777b76296d66df745d5c893d0d4f5551f5714b31fcaa60c6c88d5132803",
+                                "uncompressed-sha256": "37dbc2cb9306e03f987534bdd178d923ac985fed09feff83705fab8a6d84104f"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "13dea6cb6b01aba0e72b1f7545fec740e5d7b1d60ad0908b444a37c40cc6cfb5",
-                                "uncompressed-sha256": "6680c0bb80434f2ec555330f2d1ef98ee77d7d85b59d625fd3dc93afc81efbe6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "a8a85d52a7c69811b8a8c3780e0f0eb9ff22aa196c83cbd807029f6d70837dcb",
+                                "uncompressed-sha256": "ab1d852157dfe061ff7c9282fa8096009de28bb0f57879dea22949db5e98b6e5"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "4c422c44df94297f48d0b4ea745eec3076350b07fa58d44b03e409f86a960f07",
-                                "uncompressed-sha256": "25e2322f4a59ce5a88cec17e6d78de6c6ebe86be8f089e2b114ff02929fbeaed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "28dcace39ef1b1026136bd34206addd75b3c95a17207a34ce737ecaaf11ab5ef",
+                                "uncompressed-sha256": "f9c6ebae18ef74e519846cdea75458a306a50f7cf07c7ac1f84b955954cd0036"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "187a89a1f50b030796ea5baa193056dd57d516a6ca6b0210967a7b1e38e22319",
-                                "uncompressed-sha256": "a9911fd4f756ec6c5b61501aca7a2fc33b29d2ed53c59a7a5cf9937159a1c673"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "9cdc76c45034af42b87d487def143e9f1a693c028b05250b138708fd6d688bca",
+                                "uncompressed-sha256": "4bab65034eb828123323564845711e600738fc48ceda23eac08427f9aade80a7"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "991d6c6c9a06ef3fc4a085ee0177bf6b81015b1eddc8a0bbe77f691d9a7eafbd",
-                                "uncompressed-sha256": "fdab589f337d8c3a26a8004009cbc5e36929eca65fa12257e057b568f4677539"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "517502462410a114aad9f8e0a2e4f71b41aa03dc7299727c192023e14a381287",
+                                "uncompressed-sha256": "1e472a7898b97196cf76eb42cd783c7d3a5d5fd21677677c778db35ef5b35104"
+                            }
+                        }
+                    }
+                },
+                "kubevirt": {
+                    "release": "38.20230430.3.1",
+                    "formats": {
+                        "ociarchive": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "4aa6baf07a789ce13566fbf6922ac8f3a1af0ba8560d4c4d892273493b3627be"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "be13bfbb8f9a3f9be1ec5999c823a9229cf791f24149c545c69231f5b80d3a61",
-                                "uncompressed-sha256": "b0ad090af84732056926e5bf211738315c382b62a930e244cb723fb51cf6ff77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "937082858811b24c5b8ccccd06afc32186585d9e1e00114d25cb347e1684bf99",
+                                "uncompressed-sha256": "a386a9b3a9bda3b93dacc70b49d12ac8d1051041c3febdd6be75f2237005ff88"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-live.x86_64.iso.sig",
-                                "sha256": "1e8e27b2e6cbd7cc2ff6e59bee9fcd078826c565ef07681b08161497abadfc80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-live.x86_64.iso.sig",
+                                "sha256": "8403e5a29f99f8493909e3b268cc4a89819e4fe2fe144464b57648ce108f6c36"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-live-kernel-x86_64.sig",
-                                "sha256": "744218da9e6c1302c9d436070c1094a829ad9b5821cc714a5a2835877e657327"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-live-kernel-x86_64.sig",
+                                "sha256": "6efe0d99d01d35119dfc06d971edbf6d13d783ecbdb48dccc924185177a1bd98"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "cfa480a352ce82d9de7640b5cba4d9ea4381ec1ade66b812ac248af61d7e54b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "2305ef19f5badcbd0c3c96ea96a76aed637fa3890028cb67c1ee41a076b3c2db"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "81f009f3b68094d124ea4c06c350e20e7c91fedc2418b65dd63801ba8e0632c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "b648c09b93a934ae357c83780298d433b13e774dea0b6c65e70306c6d42dffbb"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "5d103d806b14c936958f8b080a850c82294ee537324449219534ee63c017e7ac",
-                                "uncompressed-sha256": "4adb1b3fb893c7bd9a584b105e5e2b9d35d8e86e6637baaf75dadc164fff173a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "96402582f93f31c606541f314431ad5593aa365e5e230ac86d1bbd098fb885df",
+                                "uncompressed-sha256": "bd72ec14c5eb5d4863d4e6a88b4743ed09b8d0447e23c54f0f71d3672f056fb6"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "98625b7d74565da23cea4781f4704d40f4cd7feda059ee95bbd8a4293918cbc3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "c58cb8d62a2bda8e8e562e098cb5f057cf41a92acb4dcebdacf36683f13fda40"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "34e8e658e390ffa4837145313943d5174712a8d669b6ed45a00f610e5faee17f",
-                                "uncompressed-sha256": "c092ca53365231608875525cd5ddffd6803c8fa508f923cda8ab719aa02644e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "95521b5e0d82d8c0a63aef37564d62b1da04c7bf7239d995eb51b9a1c06c1f26",
+                                "uncompressed-sha256": "06cf651b4028f42510fc83784aebf595dc24611f663027e89d24d40aa4e46d26"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "1c036b1c57517a92f69038169cc4e9a7b327d5704732285d5d632ad9965a0436",
-                                "uncompressed-sha256": "af9c4de553aaaee436f654c2d8e092c8ccdbab44a93e6b125b66f6910a193e97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "85a15c20b92702b01da8a05a5df010d35d45d6622cde5e4619a8d447e34d2758",
+                                "uncompressed-sha256": "d3df1277d0436292acf64dec6845c4c070f4eb7684f0a0fc0e896d0e76aa07e9"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "d39f75a66e953e2ccbeeadb16e31be945daa26f2e80a6eaf08086bb1559727df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "2ac49489393b00e17e7eb2d1c9b794af3a86d383947e4b05b47af0b31e598831"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "d19ff41a4c01861d9909edde149937d80a113a97d4855f8b85e815ba2dd10177"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "0e104c9e3567828b01a30b0a7486d60c07455389ddd364c85cbe9141d0500286"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230414.3.0/x86_64/fedora-coreos-38.20230414.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "73d4b4c2e3bf773cdeaad2d3419e26cb717cec6503fa3bf728cc7a3a351c44ba",
-                                "uncompressed-sha256": "5dc9fbcbe99d02c08cc57f5a947c15fe5ccd37e3fbe359f6207acfb4294b2bff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "46ddf2460a91b9fda83f0fd34f464c7f9ebd58c1a0c244d387ba262fe10d8531",
+                                "uncompressed-sha256": "775ca364e31311444fd1bfb2a90ecfa7bd857a971a1a1eb8051e586e70fe9b70"
                             }
                         }
                     }
@@ -536,116 +548,121 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-07c6bab153090361b"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-095aded899c6c0584"
                         },
                         "ap-east-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-02f752a8eab30767d"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-007160b941b5b6475"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-021ce9d57120f278e"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0e5b30e196864304d"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0a928eda7bbc26f61"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-04e0d297e32bdb99c"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-035af90aadbfb054d"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-09ee958f3220d8cc2"
                         },
                         "ap-south-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0fc8b71a82d007030"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-077b0f0fec6dc6b46"
                         },
                         "ap-south-2": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0363fb2d3fa70c34c"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-04e9f7c6badad0704"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0a4def2e23c71ce28"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0dd45b3fb9093477a"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0dc2c2117b485580a"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0814ada785535c45e"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-01a407528de64c221"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-01ea27f344680b81c"
                         },
                         "ca-central-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-025e1413b0d0c7e5b"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-013ced20eb9ca2d0a"
                         },
                         "eu-central-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-097f5ccd7b9deca93"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0df3bdf0f770da88f"
                         },
                         "eu-central-2": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0526f133afb517818"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0a0b4912efbb65ff7"
                         },
                         "eu-north-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0db34d5f0725d4fea"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-00da87287f5eb857b"
                         },
                         "eu-south-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-01b6019592933d09a"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-031163fe0061a8828"
                         },
                         "eu-south-2": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0237d8f0e4c0fd797"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0b0b6ae3c9cf2fe1d"
                         },
                         "eu-west-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-00b20638909705745"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0ba268730cb1eb0cb"
                         },
                         "eu-west-2": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-072940f7ede2725c8"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0ef7a0eb7718fda33"
                         },
                         "eu-west-3": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-067830ede2dd1ec5b"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0efc3829379c3feb6"
                         },
                         "me-central-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0740b2fa197668a4a"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-041ba76429025f3f7"
                         },
                         "me-south-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0e498233240e32f20"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0f4133653f7a9c49f"
                         },
                         "sa-east-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-051f5aebb6368ac00"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0a5b64eddc5498691"
                         },
                         "us-east-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-081f29ca9a2a16cec"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-03fb7e4f2eb89ecd5"
                         },
                         "us-east-2": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-04bafa6ec56bb062d"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-07cfba37bb23cec67"
                         },
                         "us-west-1": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0f0275cd40ef451d6"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-06dd752813344580a"
                         },
                         "us-west-2": {
-                            "release": "38.20230414.3.0",
-                            "image": "ami-0fd81c7dc02861e05"
+                            "release": "38.20230430.3.1",
+                            "image": "ami-0a6b825692925769d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230414.3.0",
+                    "release": "38.20230430.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-38-20230414-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230430-3-1-gcp-x86-64"
+                },
+                "kubevirt": {
+                    "release": "38.20230430.3.1",
+                    "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9d138ef0a3f086cbde6b784db2e3ab165d06001d499f32a6d005c1c24cd5a002"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-05-03T00:27:26Z",
+        "last-modified": "2023-05-16T15:54:51Z",
         "generator": "fedora-coreos-stream-generator v0.2.12"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "0be4ad2d4ec98bfec5ee86445315b2d83d6b1fc4db1c0aa38c3b5061cf4eadf0",
-                                "uncompressed-sha256": "da01474e8f59c91058443bc91d5c6298152176da853d0edad20604e784855b97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "de310be90430ea261dd6e07ab1be6bc36d2c314bcf026f050a077d742ddef5f3",
+                                "uncompressed-sha256": "01cd0106d34765cf8ee01b8fae73a2d77277a3d06365f25e6d6c2ab18bfe8b35"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "b1eaae1d52bd5027c847802394a28a99cc7d13cc5c90a78bcbc2fbbc7b304f83",
-                                "uncompressed-sha256": "c953a96daffcdae22b8519dad7a63381068240a7c88ee55740a296dac6ba5725"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "d2dbdb94d7efe0e8d8f3ab7b19d299e078793124afc3502fef95e20292ffcb9b",
+                                "uncompressed-sha256": "88ed5389c5ee09acd1c983ec8891790deef8a9fe9ae45b8d29ed2aa6769b3686"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "6463e2c7bf1c2f92167a3c3e8b40ee2817901e325f4196d28ba3a1ba3e02e28e",
-                                "uncompressed-sha256": "fdc4770af5149ebebedd8308c199542565c20f6c9ba12fd64fd4f8068b4c13c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "f64cbf99cf992aaaebf088a23b04c76f9007168b8a4080f46e3212bd62459877",
+                                "uncompressed-sha256": "2db42b7546c9ba8cf0401550b5d10743eb88588be914f580fc8bd27823052114"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-live.aarch64.iso.sig",
-                                "sha256": "7978f5c9b606805ef26824cfea216801cb80759b454c58bbdcc6ed7340e56bce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-live.aarch64.iso.sig",
+                                "sha256": "96dcdbd20a406dabd54f5bfe3384880b520c07dda2908e25aaf1cb79e7283d08"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-live-kernel-aarch64.sig",
-                                "sha256": "6b5de67b74372403c01f3eba3181f4a09a6dcbd990beee19afc91fe7d06d7ee0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-live-kernel-aarch64.sig",
+                                "sha256": "3220992101cc232cb4531063ab6a0e99b704f389d76cd65eee23c0c8fb02d3a0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "fd73ee693bf10711ccdb74f2319dd3cd561365c98baa71658476a3f940b3c847"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "49cdb7f4a0ebd0422958d472f56ce2bf9dc24926e6e43ce23f5b027b96e24718"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "5a432e4e59e23281c36783aa5089da9ed39cbd50831ad352f49b2926e6e1e215"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "c072546d2ead2c7b7f62af357bcd742b6a4a0dc66dfce7c84295a3ee79d6607f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "cb3bdbbc7225d6e1e161b94422b4038be3ce52b57c43dc26e85ac777401b7073",
-                                "uncompressed-sha256": "fe501de047e9b43906e9460153049c07d33e693547a62eb0fbd0dca406e5f307"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "0da758bc9f028c13162fd4a6544c40c9726767942fc6d06f22a6d90b36563c76",
+                                "uncompressed-sha256": "b99f491faccc541d0e3e5825050a8c79118f9f48a3456f97363c59373fbd2c6a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "bbf961f218198dafd3035f4b6b4bc5535301dfb3e15626b610bc28e3f8d13117",
-                                "uncompressed-sha256": "a59b8f402ae824160e8922b41b03a01faec921c55a537047725440b5148ebeff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "2bc5044b2b247503194a21f220161042b0abdcab6f3cc33cd5762f31bcbd8c43",
+                                "uncompressed-sha256": "bec90db4e05caa3edf83294d7f29eec7686e2abb55ca8683984f357a66e4783e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/aarch64/fedora-coreos-38.20230430.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "b84b11a3a2ceee07f6edc79ebc775d5bc418fe5a816deced5ba79bea6c8e972d",
-                                "uncompressed-sha256": "6fddf89e73688be86d20529ea9aa449f38854232f8e53ffbddb2956eb1fd67fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "f5b7445e105e5f8a792ee002d5c90cc5675ae36a4a2afbcff31fde063c8a2747",
+                                "uncompressed-sha256": "2bdfc64daa195a59b9766ab2a9a8312b942c2b84552d98385fcd0c63c1ba83db"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0509bd00df68c04dd"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0bfa9cf0de1f5ad9c"
                         },
                         "ap-east-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0fe3b22ca10573d5f"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0a31dbd564ce54916"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0446bfb31825dbe11"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0d98aa268e91bf284"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-068ed7d9d8f19bd47"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0a877c37ad2b48c3b"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0da769e4ad9947991"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-045cc8f3d975c8b41"
                         },
                         "ap-south-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-09be4b89bb1c229fe"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-050115920dea3402b"
                         },
                         "ap-south-2": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0ad87d4f988549fb3"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0ef41832c5b1757c7"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0346c80877992c053"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0326ada5423c76c94"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-012c8ec1657bdae9c"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0ba5f12b3d90a10d6"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0acd843c769c8bff3"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0de97d8b8b85d1e70"
                         },
                         "ca-central-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-048f7a9c364c194a8"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-091d6e4f9f84382b6"
                         },
                         "eu-central-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-048f240014ef82be6"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0005acd07e56bd6ea"
                         },
                         "eu-central-2": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-015fd1b92eddabe92"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-055c5eb06a2b677ec"
                         },
                         "eu-north-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0b9f3ac0fa3a565ad"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0db80e3173a6d7732"
                         },
                         "eu-south-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-016a64dd1dc1e6412"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0c65a749c4e311378"
                         },
                         "eu-south-2": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0f73d208a1aada960"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0e9aeb4f8b9600f76"
                         },
                         "eu-west-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-07db82d58c3b17f7d"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-02f4ba1e48da14562"
                         },
                         "eu-west-2": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0fec2c1f90ccd1c9e"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0d50a74e14253bfa3"
                         },
                         "eu-west-3": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-005aa56ad102cff86"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0c4ca790b2ae429d5"
                         },
                         "me-central-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-00cb55fb5a63fbdb9"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-007804512c123392f"
                         },
                         "me-south-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0b6fbc9659591d43f"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-08add98d71aa12031"
                         },
                         "sa-east-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0741fde260ca8a2db"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-008adf0c1db9435e8"
                         },
                         "us-east-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-060f3a8eaf519e60e"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0916de94944a968d0"
                         },
                         "us-east-2": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-06b3c01cdb960e917"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-041b9ad42ebdb01ab"
                         },
                         "us-west-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-00eb2b3041805b52b"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-09a4c70f406e4e679"
                         },
                         "us-west-2": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-062c21a7e67d44bfc"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0d9305b144bf7520f"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "f3e0229a0c6ac8b82bd152f56812108fa4db7c2a31d3d1a96f096e3f80bfddf6",
-                                "uncompressed-sha256": "b601c6a6e2110df0c84f6b3feab037e98e11e49643de1876b72d03bf85e57588"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "4b40daeb98c4b473a6acfdea405dbe5cd4dce908b049436b9ae4a6ef46319498",
+                                "uncompressed-sha256": "709906c5557ade480be8b961f0399cea02d6500edc2f12ef7298593c56b61e42"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "b6d92a19e03659af2f0e657975720d4969b6e8bffe957d7373b8291251a91007",
-                                "uncompressed-sha256": "49ba59c88670e6abe4a1b41a9e018ac4a87d9f24809d797645d0f0e26b4dd2ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "12ab7938f066f07507056d4a0c5e426fb3989ff0ae24eab90ce73e997e72e360",
+                                "uncompressed-sha256": "bb58708ae3d24af93dc397bcb3b319ff713dcac4217975e8503c3b3b4448ab65"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-live.s390x.iso.sig",
-                                "sha256": "72ab17c6dd8b22e28ae343a8d873b49e933fc98f2b2150055b4accf864db6a77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-live.s390x.iso.sig",
+                                "sha256": "6daad7ce213168367bfd78d565d7dde00e4c15ac4e5c44576e730e763059ff2b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-live-kernel-s390x.sig",
-                                "sha256": "ec8c8feea8752b1774859a47506a52f76434ab97a1a87a17cfe70a0d3c107f5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-live-kernel-s390x.sig",
+                                "sha256": "f364e3ec3e2945dcbc12d89bb45baf1cea8efae09bb22e79e4e989936dec6da0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "435f8965f6f8e21f7e6a2d5a8c160257aaf9843d5abd05cb8a6573f9e159cfe2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "12149e7f0458380f40db39c505e968a33726d9ea9989620c94ca3a81c8a67536"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "a43caf17fafc26e21a4743082ff6ee2aead0855cca6e30fe311081f15a344cda"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "fe10bd868383ad52e7d5985f4b228863f0ef4cfedd7adf232fbf35c9b6b54fba"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "c77d5068562a6d5a37e20584bc58e8b9e29eea83414f5707d11e2f71295b5d3e",
-                                "uncompressed-sha256": "6e2120cdb74be8d82fc09a7a541e48484fc9bc30a59e0631deceff6401e6457e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "8b576a4fb2e25f904cfe457aa86fed4a8e53dc74d0ba1a6b3e0945091724fe21",
+                                "uncompressed-sha256": "669e076ead2c5e6ce12e99c90e5ef9d30cac8cd00018ec82d11b76ca2405d59a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "83c0f3b9749c807df7ecf87ccbb09e11dcdd38d2114e3a1f81de1ada4036ffc2",
-                                "uncompressed-sha256": "59d102565a8f334d66a5d23a3a06eb431fb079af2c79f67906cc95445873d003"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "95c50d31579bddf1fb611e62d8404ee07acd30557789c70a83f592d0409f19ff",
+                                "uncompressed-sha256": "095b0e81b717780d5c3dcd9893e77eeca82267f40b2d1ee46cb6fc573be2f401"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/s390x/fedora-coreos-38.20230430.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "2af061e5e7774d4c1cd030ee09c80e87d849f533a78a9eebb75cfcb66c4b9ce2",
-                                "uncompressed-sha256": "415b42155127f74b191aa369d85b168c70bc6c0c71d05f58c4c020ff7d6185df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "717ecf8f60f28c2c901c4631d68db069344e51035dc9cb66840555550ce04ebf",
+                                "uncompressed-sha256": "2efef098d42f6228d96c8ab736c318b62f9e3e4ee040151a891729bd64320dcf"
                             }
                         }
                     }
@@ -308,225 +308,237 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "6db5dd0d0a76a3a2c3864d2e9a4e213628f90716c44d171570a0fcc7e97a0b54",
-                                "uncompressed-sha256": "1151bef479ff16b9f9da03e25cec3e4c8ca71e64bd3e383da74ff0cfc52050b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "f908c60411c24c1cf59da4b900815db183f3611be0a5da594c1b1ac1b803bc2d",
+                                "uncompressed-sha256": "13389f4257fba2cb1e2880ffaef859d5896a7ee654d37b9a18938ec7ae7051b6"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "06485eb9c44213ac6e8f7476879d1058790a37a906f78a3ae9249d1e30f42f4e",
-                                "uncompressed-sha256": "7dbefb28cb2a1a136f33a0f7780cfb510e1aecfcdf2fb26a4910a859423ec8a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "815ba9de078c633530c9e3636787417ff364ef570b27192d60dafbbf5119dbb4",
+                                "uncompressed-sha256": "26dc0fb94dedaf46c402a93871cb94d7b7e6a33ef2ae948780170a992a837704"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "54e7ef0be595a6e21d78c8daa43b345b1f5fda00a7b196b23e47f822eddfa071",
-                                "uncompressed-sha256": "a5837c691f5d128355844fafc913e071bd8a643fa3dab3911887cbc5d85f3982"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "b97d3a67068234fb1ed4e5b4fc457c13e0073893eaa7c0851b8fd76c3483c297",
+                                "uncompressed-sha256": "64429d305dd3595247581aa3b41f7d111838d1fdb7167e12411ae0fe9e3498ad"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "c7e456488e35e3491e0f29f6e2ed63344374f1d69d7f8ab0e6213ad455568633",
-                                "uncompressed-sha256": "dc866679f37b2c4eb3219dd83f7c9a9ff025d16a397ff2919feba0a1da7c695c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "cd5843be8637fb242e8cf4e260990f2c784ba23de525a232aedf8993d25f68c3",
+                                "uncompressed-sha256": "5c78e022ddd96299811047b275c9d294b5da8d4b39371bc0136838d2cc618707"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c59775ad4d4637248d62f57207b72c24d052dd861d40f11d34aa542b1d9703fb",
-                                "uncompressed-sha256": "300c4369f760b9668c999752e50d3a3f48b00a8e5e15c85bf3d2bbca1bcb6b4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "c7638f6f7926f9c47eb04bf91472de83d3ba284e375dd6f5d0d3ee04334eadcb",
+                                "uncompressed-sha256": "d88930eefdc37fce0e427121134abe1aa7b10f41cb125b3d10bc4a7ea0846b82"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "63a78979cb62dbae173c2be93db3a24b7d307b80f1119da243855a50fa346db4",
-                                "uncompressed-sha256": "60cf9b50e154e77c7861adf229299024d21df29360001c5aba3ea018717ff16e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "ebc9514eb12ae39fffb8e0af7bd50f283a5d3288f7a3428506d891dfea6d7070",
+                                "uncompressed-sha256": "e876b8f6c32b8704239fe36535fbded18001ffe7d93d01dd722374883405a058"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "ea18da2cefe82edba2463e976e971e6ffc256a3a2acd16d5e114c89d7a362374",
-                                "uncompressed-sha256": "b0a73880983c2a6d31007a8d18185181a2c409b97754b2a37e38909847eceb86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "9731bc25fd775258717a8972f8cf36dddf4b20b8b4082a304de6123d481531ce",
+                                "uncompressed-sha256": "ab175e0d549d903437048b6b514c94b641e819c6cb27a85eeb1de815d597fa84"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "e5bd9136ac455f12f290856c5619e615ec71a4765430a4eb24a1f502268967e7",
-                                "uncompressed-sha256": "be94694a6fb950b79b0d031023dfda02282f152eaa8837027e495ec3faa35304"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "dde3b59e129723c990f60d9f10091f9c4d56d7b3ff142c3b0527a0677fae099b",
+                                "uncompressed-sha256": "44726a761df456ba5106a27a7004b250224e0b564b47077e40d0ca542a2da746"
+                            }
+                        }
+                    }
+                },
+                "kubevirt": {
+                    "release": "38.20230514.2.0",
+                    "formats": {
+                        "ociarchive": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "08506e08c63759743cf2b43a6bb6704398818bd0ddf9727478b23ff5b41fe2b6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "4fc31a3727be8991eaee2b900f5ad0337079febf7a94fe61ec23a014f7ad13fc",
-                                "uncompressed-sha256": "b8cec7c4e03dbb502da429c18852ddc3ad34964645fa81663720dc303bcf5842"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "79c7cde5ddbd98ffd7ec65bf9d6586d24d93f5455a6879fc5ffce87b3920189e",
+                                "uncompressed-sha256": "561e7fe3d41e7b93bcdccb7af7a18f1599833017b7539b8f03cd614700649a2d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-live.x86_64.iso.sig",
-                                "sha256": "bb57c65b7f1b7cce0946e97cd9518c9ec19c5bbcd18519bbb7544326c6742f87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-live.x86_64.iso.sig",
+                                "sha256": "82115fabc431b91d1157518f7a69d67b67a571a75f138494ce221bf0f705a213"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-live-kernel-x86_64.sig",
-                                "sha256": "6efe0d99d01d35119dfc06d971edbf6d13d783ecbdb48dccc924185177a1bd98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-live-kernel-x86_64.sig",
+                                "sha256": "1caa067a5593e432c61db22864d09519219f7d926280e50817bd33fd609ce2eb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "660724b7af6a4b64164af7f517b7d047c8c7e3edec65e31216fda2e376112185"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "90ecdca9fc2b698671a8b79fe686d11977a4aae7478e3a570f2741d95c234079"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "8f92509d224b4ec6f87178cae50f4ff34eb79d4b419b1be8c6fc65beb7ddc9e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "044b8fe4c2693c04fcff4e8828ef460fa366267ef22c00a92fcab11c8898d91a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "1a8fa0a246b9372ba63907eb423b4d3aafbf9d26c5a0e1ba73f294d7ef1e33f9",
-                                "uncompressed-sha256": "7fe8791090ca87abaa15061f6daeb47dce034b852caefc3be728cb022eac435d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "2a0fb133d822d3855a484f98ceae56dcc9d385e2c2147106d8d421268219c5c5",
+                                "uncompressed-sha256": "9d12b2c871a8fbb139051cde8dbbaf9eaa20db64585ff4a9d23671bf7e093af5"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "950eafaacaa6bcdda34fbd2fa3bad81e50e3021074a1858de278af19b57443bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "5e7e6fabb3a6adb570c558297ec4816edc0983114ac99fbc93692264ac48b7c0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "7d54e5de0e9e853b8ab4143c0321efc867fdbf06b6fbb020da0705240818f8d1",
-                                "uncompressed-sha256": "3f0bd77c68465cc6095bd16e5a2ad8e61164d5e07f69fde4c350e12cd1e81905"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "539551a03895ec6e50a9d76b1d3da379ca5e9a095c4ba0df88cdab2515199947",
+                                "uncompressed-sha256": "027a95b171b343d162cd862882900e02554d95b1f0401393d18df11938b25901"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "07fc40961c2c9b068acd00bfd132c462045a1006acbff8d15a7442bf290745c9",
-                                "uncompressed-sha256": "ab2c61a32a4970d93cc138eed6ca97802057121a42aece23f2a77fbdb6e9deac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "64155655729cbe2ba137120f7ca0f5d16e62b160cb5e107be86fdb60074cb262",
+                                "uncompressed-sha256": "a09c6dfa0360df7a42748ba9633d0b8c02196345c1f0c59d2bee126701de02e6"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "798ff93d1513e3be1c0a00fdc4150e83a812111077c2a1a61713c9b4e67c3c95"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "ac8c3237093308a49808354615737e29fc4ac84b215772a846bb964b7a6ad4ea"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "1bdea65801f789b78bb1e01864e16b8cb6ca20551f43a01572975b86322c7b8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "39b574bf183aa59e738aeb3bf7579f2407f6758b42649d0bcfa5b71ded09851b"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230430.2.1/x86_64/fedora-coreos-38.20230430.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "3c371ed1ec59fbcb2820f3097a12cc5de7d05458201038b87e55963e6ad506bc",
-                                "uncompressed-sha256": "6edb11fcb57effb036a454221db402b9348da9610364b88fb33eefa177f219c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "71af70233389bce18d6f0d3a381fc8051caeabde32711c4b7547f67988ecb95d",
+                                "uncompressed-sha256": "7edb07da82d788b2611da9da8308673f60508b2f61f0206fc8b03a6c1ad2f818"
                             }
                         }
                     }
@@ -536,116 +548,121 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0c04d080ec103b682"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0bddc8534f6d189f8"
                         },
                         "ap-east-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0cba5e207c689c102"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0e5e160c87bea88a7"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-091d6e75987cead42"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-098fffde2db1fc6b5"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0126c9b92b4e7dccc"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-04426043bd0b52ae2"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0964f2b70cb9dc2fd"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-09406f36f3a7d1f57"
                         },
                         "ap-south-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-00d263c7e3c2d9d5f"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-01f846e64c79d475f"
                         },
                         "ap-south-2": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0536c410229d0252a"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-053fafad2096d88c4"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0eeadd56412728803"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-01963c9c8258ba251"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0a0f659f3b65c97cd"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-096884c513a2bd62b"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0770268b27ff43544"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-06077cd9ccf56f363"
                         },
                         "ca-central-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-077ac2bf074e6b9e6"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-094ddb7a499965669"
                         },
                         "eu-central-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-092867aa07860c4a3"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-09abdecbd17e89252"
                         },
                         "eu-central-2": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0a055a14fc16784c4"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-08955ac0f119f2409"
                         },
                         "eu-north-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-02a47f0a0790abf06"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0519781c282493219"
                         },
                         "eu-south-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-021ad22793933b5ec"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-084e2c57cc6976963"
                         },
                         "eu-south-2": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-01d0a927237c5db21"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-004dd227fe82c49ba"
                         },
                         "eu-west-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0a30436fcd451d9bb"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-005072e541fe26e85"
                         },
                         "eu-west-2": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0484e32c7d79d2c00"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-08f2f88ce6b6e2afd"
                         },
                         "eu-west-3": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-06f30f79aa8e2e921"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-09e9dae30ad881475"
                         },
                         "me-central-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0260370c88b71ab14"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0e010bd6cd2144b5d"
                         },
                         "me-south-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-08f7e3be38b7d6281"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0bef7e8933b2f3dce"
                         },
                         "sa-east-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-01131170fcd044e0e"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-005fd2ad9c308031b"
                         },
                         "us-east-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0a0af013cb20b8aae"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0fac2c20a4dedaaac"
                         },
                         "us-east-2": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0e552e542520dba14"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-07c8c8119fcf2bbbc"
                         },
                         "us-west-1": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0ea8cdcd48ebca78c"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-06a3e2d18e0f87aca"
                         },
                         "us-west-2": {
-                            "release": "38.20230430.2.1",
-                            "image": "ami-0f4e9e5b012a2db1a"
+                            "release": "38.20230514.2.0",
+                            "image": "ami-0141fa04ef410958d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230430.2.1",
+                    "release": "38.20230514.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-38-20230430-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230514-2-0-gcp-x86-64"
+                },
+                "kubevirt": {
+                    "release": "38.20230514.2.0",
+                    "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0ed47f05f22bc55fc3b1cbde2e9a0203962db95edd895c83c03bbcf3a5cea482"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-05-03T00:27:28Z"
+    "last-modified": "2023-05-16T15:54:54Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "38.20230417.1.0",
+      "version": "38.20230430.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "38.20230430.1.0",
+      "version": "38.20230514.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1683122400,
+          "start_epoch": 1684252800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-05-03T00:27:26Z"
+    "last-modified": "2023-05-16T15:54:51Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "37.20230401.3.0",
+      "version": "38.20230414.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "38.20230414.3.0",
+      "version": "38.20230430.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1683122400,
+          "start_epoch": 1684252800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-05-03T00:27:27Z"
+    "last-modified": "2023-05-16T15:54:52Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "38.20230414.2.1",
+      "version": "38.20230430.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "38.20230430.2.1",
+      "version": "38.20230514.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1683122400,
+          "start_epoch": 1684252800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @c4rt0 via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).