### PR TITLE
Roll out stable 38.20230514.3.0, testing 38.20230527.2.0, next 38.20230527.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-05-16T15:54:53Z",
-        "generator": "fedora-coreos-stream-generator v0.2.12"
+        "last-modified": "2023-05-31T18:52:48Z",
+        "generator": "fedora-coreos-stream-generator v0.2.12-3-gd40c776"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "5358bfa32cdbcd0ca7d0631aa03b08f8ab9cb94062c53ccb28c0ab08c2897e03",
-                                "uncompressed-sha256": "ce2a2de9161a243dc733f5fd243124a0ef73a04fd8a595e0eaa61905162f56d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "cde760e766d38b9cd401a8c2853bbb7a959adce18d7ad7e926c2ef69cc9236db",
+                                "uncompressed-sha256": "47645ee05c2fc031899f39b877120a383ebdb8897c899be86a256c85397f638b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "a2dca08ae120d75ffe64794da8b005ecd4678a92598a6ca6214dd8444caae476",
-                                "uncompressed-sha256": "db2c06837cd0f273da870f32487b9c7b25f899a665ff524a4506a624529e73fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "ee47c8b416907f5990204780eee99efddf919bc76e0f67e7a00d273685451c61",
+                                "uncompressed-sha256": "e5bff3ecc825a88ec97a29d4a13280a9fc31ce4d3b5eed6380f4a8ecb2c536f5"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "bd13235c9877faf7465560ecc38b779aa8aa48340c2aec6fa2f9ad87bcc14350",
-                                "uncompressed-sha256": "29257ac81ecb9509d2b63061868617ad5ef5042e11a6ef5f41b03d75d97900f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "4d456e6c4d9f9286fc38664b8d3f0f13d052d3e13d75e7f09903c296c4894ba1",
+                                "uncompressed-sha256": "308e8628c76b9e2cc2155fb3746ba7ce9ae262331e92721e1710efff10167969"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-live.aarch64.iso.sig",
-                                "sha256": "095c219ff824eaf8c27e5859d267f92d0ce877dc3901febea68e47e8e9b38d47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-live.aarch64.iso.sig",
+                                "sha256": "3fe57b5685997c3d495cd7053228276c0a5d56621214d37eafa9f6b574c6ca4f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-live-kernel-aarch64.sig",
                                 "sha256": "3220992101cc232cb4531063ab6a0e99b704f389d76cd65eee23c0c8fb02d3a0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "435faa89689b2692f4b4bf97a01ea0e3616b3eaf260c16c89324478895e2388a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "991d92fece7535d281eea8699b93d21d11c5104c004c875bf4cbe0a06b93f11d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "688513128abed267941e88755010da305eeaa6bf8d09c35b39002897f462a533"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "3cc72fddcb8b0232f0eea0df5aeeb2c16c9d9f3814ddb88f37c74d2d070bf353"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "ab2b8fde01db7e416731218e4c285417d801efd4c135a9d2b37c8def00cbba60",
-                                "uncompressed-sha256": "7a44da4014a42b238aaaa7fe186d58b3b0290ed4a92862731127f0fd9e630f7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "9c4d8160b8fa38ce1b3d460265a42a30ccbd9188d0b4cab8c875f358ce5aa5c3",
+                                "uncompressed-sha256": "6a0ffc5da7fdb1fd24fac7e67f2de245436aa745c9647f2c28ad6b04a5ab40f6"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "5046b1547457f5f37a7308bb5da0011615ab403ab685b3247a9c32f4932a89a7",
-                                "uncompressed-sha256": "99c0e22d94d7bbb6f2632dcaee1e2ba9cfd3b185f6a4373d8142247b6dfdb8d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "99682e304979cf85d13b5c0e8106c0178a4f062a6cffe844a9169565f0a09bb9",
+                                "uncompressed-sha256": "f44bb9ad3c9d8913d75ac4f7734ec94da9d6b72b7d7d039932f83b6366e6b8fb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/aarch64/fedora-coreos-38.20230514.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "c4669a674450dc67653f93538c57d0526e334a819cf28632114a47d12ba2d14b",
-                                "uncompressed-sha256": "b1d0e93518740be3934eb64ca08c20126ee5d20b8dde53e5b76d6f16d331982f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "5e3b9bf22d001f7b94b11ec10d0ead757f13012cbcca57e7f1c0d45fce275467",
+                                "uncompressed-sha256": "cfa7dfae62ebad68acbb55e1a1404a8513a274fa641925ea930e8e926428de47"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0d2fe9c417d9bb149"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-03ccb527b6c9d024c"
                         },
                         "ap-east-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-00f7922a9854eb7bf"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0f49d0a547b8e782b"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-05558bc689b780cba"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0cb1ee73859691134"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-096d1cdb51925e81e"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-045491a933c1f06f9"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0f85863618a3e2308"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0749717e091e09f40"
                         },
                         "ap-south-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-08798b61fc2f0ea3e"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-033556953537bdd43"
                         },
                         "ap-south-2": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0c0d1eba3605c28b8"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0cf4a1376552c2b70"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-09b068ea0cc1e1159"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0b49fc20f85a26409"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-098916b7f73a5f9dd"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0e13830b2f55d7f83"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0e908ecab197f260c"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-01c7ca17f46f0257a"
                         },
                         "ca-central-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-03846bcf15befce44"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0f996ddd45edb71fe"
                         },
                         "eu-central-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-003afc70d5c57af53"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0624ad6581bb743dd"
                         },
                         "eu-central-2": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0bfdffeba0c47dca1"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-024ed1c408bac9344"
                         },
                         "eu-north-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-03c97f35215a36c33"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0e96fd0db14e57769"
                         },
                         "eu-south-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0ef73e64cc7e5268c"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-023c8db196329b843"
                         },
                         "eu-south-2": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0a45b3885a363f66e"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0c23fe64fae467c9d"
                         },
                         "eu-west-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-027a0f0339752d4ed"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0f508360a921a5ef1"
                         },
                         "eu-west-2": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0f0df95acd4e6a958"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-003cb85e5c68783e8"
                         },
                         "eu-west-3": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-00a91c55ed0570aca"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0df98374b2647a52d"
                         },
                         "me-central-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0d0b2c5eeb37ba194"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-02222b85d101e434f"
                         },
                         "me-south-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0a60dc888399c087d"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-06e63d77e83ba83ca"
                         },
                         "sa-east-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0c99189328bbe3042"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0760806476c066b79"
                         },
                         "us-east-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0cf228bbe359e9989"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0f4d9c5620c476e3c"
                         },
                         "us-east-2": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-064f1f20715e65d6d"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0a382de98b70f420e"
                         },
                         "us-west-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0e5738e981e19f4be"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0624801ff6c422056"
                         },
                         "us-west-2": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0ff2827c57a05ff69"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0176872a2cc7d5c13"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "7734ccd34896327335a31c5d7aa831a29039edf4219695920b5a1d21f387666b",
-                                "uncompressed-sha256": "68d678e55db22d71e7a8cb3d292114cc488c5d709974e0fb6d8dfb09e9738645"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "beb4aac983dc1c76a2be1d5775338601060ed6bbc0e5f02c730419ab01a4f72c",
+                                "uncompressed-sha256": "5fa810098797decad2b402b23b3567d0fb29ed0b998fb7e94ef15e9bb3ed9209"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "a822a5a558663c44f0ef746ee2656f43457c73bc8af80e01ea1b40eb2da96e22",
-                                "uncompressed-sha256": "df64edd1c3e54853073ec20f202b8f6c83b607e86a544725ce6d1283d4e1b8a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "3b8c43cb66165e1a75cf683168044fa63250f97d7e15cc301a513aece22bd6d5",
+                                "uncompressed-sha256": "598130776bce1e2d82f41e77b4ab2c30fe426fbd763d6d4903f5501e8d960faa"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-live.s390x.iso.sig",
-                                "sha256": "624c26e9e129cf7e85e9dccf956bc30a2404f688552ac8c801a158ec64cc5cc4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-live.s390x.iso.sig",
+                                "sha256": "7286a9cc862c5e26b09d1b69a97f735d1c812a89c0fea381f6892b46db51027c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-live-kernel-s390x.sig",
                                 "sha256": "f364e3ec3e2945dcbc12d89bb45baf1cea8efae09bb22e79e4e989936dec6da0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "90662372216c2a35013a575eb7e06722b03bdbc128b56f5132bff978b7508aff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "b717fda439fed4b05ba66c884469b6486e844e99017fde321b18b14e160f5431"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "4fde6236d4a1a7eb99f551f1837d952a5ea605fdeb9099064d2b2adc565995a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "ff4387931e4d5537aa14d2e73e544dc4591ce4dfff58c74f78b3195a145a1fc2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "311d24ebb88bd712272d0234bf5e1297c9ff4dfc364be117d1dd4a1054c17b4a",
-                                "uncompressed-sha256": "b3f3c55039364673f854942fd6b6480fe835c9b02eec62c07b6c259657121457"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "03152ba9dd24c040efbb593d5bbceadaeba63a44634102e82c77d37b89fcfaad",
+                                "uncompressed-sha256": "2c938cdf60c5c5a9dbe3b4d95f3f6495180290d1c6ba4063743bc755bb42a31c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "c9e3b14b27824e0cf8fd6fbc3c80e1c8c407b02d61a2ac8753abe4ca91a11a09",
-                                "uncompressed-sha256": "303438d66d21af77a6f57d93b02c64bbd01c4c7ee7a07254da4b7f2465704ba9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "8e972190ee56330b3404e8702f7cd7604617ec83ce40b20369e926efde8e0250",
+                                "uncompressed-sha256": "d7b9525ffc4d85ca68319c5961d78d1430e49c4cdfde07a55be8a0e6921c80a7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/s390x/fedora-coreos-38.20230514.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "15a91c559dad6c6a9210fb0d84eaec86e234461649d29585ed76e84858f437be",
-                                "uncompressed-sha256": "02a06d1eba206bc08091acc5763290e5ea8e80ef0b121bbe087a49dc7d74ce55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "792cbdf55f9b7556be8ce30dfcfa2845f22d86cc2d8430fb22db7cbf4e98cd15",
+                                "uncompressed-sha256": "fb0f2e59afbddc0258f5802f3a01c2fdbeb1773b94f17072a80cf6421d2450c8"
                             }
                         }
                     }
@@ -308,237 +308,237 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "fbb45b2f36550dcae56d68cafc207a8188f7d08dbc7e9bd9fb4348fa2d30b937",
-                                "uncompressed-sha256": "213243097384853d2f372366fd84053098545061301abe5ccf2cb7cb6d5007df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "84f0bd77b58f0606e6627f1035404444ec52786ace61fb4734d67885ef6cefe9",
+                                "uncompressed-sha256": "dc41d050b5a68ae477101e70ca7d6bf81e9bda1989f38ccaff9e4d80a0d6cd3f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "c903e5f88c8584a201cc832034ce5a97e9a6f149902e4a5878a8c96b7527e916",
-                                "uncompressed-sha256": "5371a9b77174effa2cf57dbcdef62acc36725e8e1261b44613c8a1f3b7afa5fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "f12f92afb0a41e8187210d729372eee617f75a6ebfb622ba57b351d64afe59a3",
+                                "uncompressed-sha256": "fcebf93cb8962b73b000dc03f05714f55306d43c74b3103f0882eaee06767501"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "1ed2db4e261d9e24f6fd5cf1d5c0d5e66d38a6acdf9f272327ba1e84316877d1",
-                                "uncompressed-sha256": "7b71c26fba6dca52ef9719ea6d318bd85de1b79f669a7e65e037fd48cead2612"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "463476852e39448c8cd5176771e551e48cb6a39f2fab9924019d25a2a4b46f13",
+                                "uncompressed-sha256": "607d572b5afa9708fc6aba29222de826af5e4d8898ad677bd1bdc9e5403224a3"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "3c816385a431b4ef22032c6c3ded8ba70bdf811a90121e7c130d43734e625a90",
-                                "uncompressed-sha256": "77cc0bb6b8626508cf4049608de0cdf50299260b15f12f172e60329577889822"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "5d46693ae9d4822910779b61182bf0ab3999a97a0337b73325cd1d9e2c3c911f",
+                                "uncompressed-sha256": "39c47bb4c01b5919d30b8db026346b5a21a406733c334741150308d178c2f4b9"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "ea8507910584d97384240d877342533b878274ebad6811a7a3394a0b9dd8085f",
-                                "uncompressed-sha256": "32e5efb8256f350f0ddc36f2302dadc8ae2d1684a2ff1fd0e80e2d5559eaf518"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "d935627cdc3cd0049f60cad043b89861fb4890a9693f9d97af8b5922a6221eb6",
+                                "uncompressed-sha256": "46f1567bf48294afeab1d5e9dfbe8d05b7d7e5fe4fcd04e0258793895283fb0c"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a4db987371d5302a5fec38d0a2d67653458a3b3d4a51a6b903a887b8080435b6",
-                                "uncompressed-sha256": "8cc6eda3cc4e87672da4032c2022c6d052e97cf548b57fb2343844eee2ff43aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e31db2de21058bc6aeab495ff3cf3e21502595d0974fd3d4ecd01a7ae326d1ca",
+                                "uncompressed-sha256": "490fffdc4fcb503e4904abfd10c798196f5e74a5753eb6d6eca827baa35d112c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "37251245a63ac4ea10b1226e972a34477f8fb72a971b44a9e42040c46718608e",
-                                "uncompressed-sha256": "39f936f32c3e4401bea0b0052d2a84605f4cafb44a02592e7f1e609c2484927b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "2b46d8206c07cd11ed1d06f8e8c2266e7b191fda75dc909cb873f7fb752a1b0e",
+                                "uncompressed-sha256": "6576d316ca7e649d321cf297981ce28845dbcb35c7f858b404a5d159af8cb942"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a68ba7497713c6689e9ba18db0a4011271d20ebe5e1f8c394e4e619dc96dcc95",
-                                "uncompressed-sha256": "1ae872a99b5c223db0d58c7ed2956f52f1cfc0bc1c54fda1c8083c83848a5795"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "472d9a5dd9de102b3d9d01b65d678d298886204b9c9b095148b7e7a1278a2b76",
+                                "uncompressed-sha256": "cb79f19fad0a77453e4b00f6d443e9ce53e306e5b96399ce4c334aea8c181c7a"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "bcad1707de1d7e0061c1537a10c9ac8a59dd648ecd5c49470baaec96bc35238d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "5cddbc6ce8d52c534cb0720af59b8be2807118f7ed26df933405439fd8daa36b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "6864a772240ed67d4208a2a5aa1b3f776c33af0ff1bf512b982f4dfbba3c76ec",
-                                "uncompressed-sha256": "0035e0686729a615aa7f5d3c274225f21a61ccdfb77decddd1602774b08f75fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "a4b85c746a1faa8c71980b56aeb1fe75a11b53671ee34a4099d8d888236e0f38",
+                                "uncompressed-sha256": "38e6cf2db13164826eacf8b99ca1178dbe222b31f0471159cff1554996dc298d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-live.x86_64.iso.sig",
-                                "sha256": "b98f900abb14fb690b4e953960afbae8e4c861926d3e228b8005264b508cb845"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-live.x86_64.iso.sig",
+                                "sha256": "f89198c7782c39882a22ea65303e66e4d87168c54dc61b26e92a0209559aea0b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-live-kernel-x86_64.sig",
                                 "sha256": "1caa067a5593e432c61db22864d09519219f7d926280e50817bd33fd609ce2eb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "e6e016fe2eb9381a93b2c24601de1399b31a160944b5d7895392700544785119"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "b2c6cbe3fd622c92a64fe03ce4af398da2037701bf892d204e14ed6842d5d4a6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "0af9041e3f381bdb321df0b39260817441e1ceb83c40069f18043df4cae3fe3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "b307631f700b68e2257fcde708a7733467d4ce6594b93e968ce7d8d14e1675ca"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "39bc365d9ebf4707dfbd13e3df1fa2fadf5b41aa9f8d803729a43fbbc142fe51",
-                                "uncompressed-sha256": "46cfe714c43353b0c344b247eba1abe4496779397332ca1eb57df2b0e4f3d8cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "3cb76c5feaffbfb0187d1a98db95f3113c079127300851dbf6dd079bda83d6a5",
+                                "uncompressed-sha256": "f5e75f5b0331c4bc508143cdb3439cea884e3090a8e2cdf719afb45fca67f68a"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "8d76851d90577f504b1a9cdd92fbbc9f4c40356edc5ec6e223d81916b15c7402"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "47de795a14366c77cb47f7dacfb748e63d5b22f6230c6fe45d9457a9e1036d5c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "53593f2ba9699bdd18434e7c435ca41a46e9a6864974b69cc0a4b6c60a715fec",
-                                "uncompressed-sha256": "ff384e4583c6ae0d4e5043be973bcfc6be0d6d2b5d64241387130125e53b28f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "d6f598eb03d5a22fb6500dd5f22d0f03dc3a172f7e0e069c58b02df27e7c7c10",
+                                "uncompressed-sha256": "b92a1414b08bf520d12b0473ecd832dbdc99927d201a8ae5b84709c940f2dfe8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "22ee731c8620d669224203612de7f8ae80b11b543fb55bcebe6d8b9834686515",
-                                "uncompressed-sha256": "a367a3c0164edec1fd33b61066e7fc6b873abbc7d9c22873e3ba0b889bfdb620"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "8338080f6869d0e566a91182b755ab01863e1bcc912d492ec861d78058248edd",
+                                "uncompressed-sha256": "b3b3db0e0acd4513a21dd779e3ddab1aaca1afc9e595eabbc661e014f23a0f58"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "4fdb1380d695e79481828a9d40dd78987d0398f44c43d976891f8ebebb9803b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "8a5f740f8771d7734ed53deeb22a5248435db2c3404df8d6dd78af3b3d700466"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "fb9b8e3737c690566f1a852d5a09fd3e1ba985842569c0391c961c66ca33a6b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "bb1dc5924f172b240cfd33a34af5141dea681ed63eef77ccfcc810ae826e379b"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230514.1.0/x86_64/fedora-coreos-38.20230514.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "d790aba50e9aa30da5796b4d2a5ad18930791ad696de8e1a53291640bed74c76",
-                                "uncompressed-sha256": "478c8df0dfb9163b1f658df2c976514ecdd5bb02c24b3c4aa63718cc36b06395"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "1c4e85bbcf6b723f83610db3503bddb4fa832e4a576620d2dbe286440d8b9a42",
+                                "uncompressed-sha256": "d80fe6aebc80b6dc7125b73dd0f2ac39ae4d3b59de67ea78576473f80295077e"
                             }
                         }
                     }
@@ -548,121 +548,121 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0af94c4a0e58b7994"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0cd8c11bb6a342132"
                         },
                         "ap-east-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-096b770f302babdfe"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-00db7d06472476f26"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0ade55108ccb6db63"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-07679d8ab3d187c0b"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0dfd02a2293d23c5b"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0f1ee435056dc80f6"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-091f22e984b42b90a"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0cba67d17a2fcdd84"
                         },
                         "ap-south-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-00597d157e786b265"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-04b834ddc1d722c7a"
                         },
                         "ap-south-2": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0610b10819c95f156"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0960152487b99a766"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-08741582ed3a20eb3"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-02ec9bb7c4ec28290"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0c257eb75e9ea53a8"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0d93f34cf20c0c3a6"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-046681aba1faa22c2"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0fda19fdffde7cdb2"
                         },
                         "ca-central-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0c7c6b33ad487063c"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0f7e944163a412df8"
                         },
                         "eu-central-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0cbaf40da41f5667b"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0f3e2a393ef263403"
                         },
                         "eu-central-2": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-014c135c11cb9a2bd"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-03ff8d9f8516b7544"
                         },
                         "eu-north-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0134efc90759a9e65"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-085f993c7c79622b0"
                         },
                         "eu-south-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0bf0dacb3ce3deed0"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-01af7420e9a557e39"
                         },
                         "eu-south-2": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0f526f9b2dc6a9b7a"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-04aa9b20a211af4f4"
                         },
                         "eu-west-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0eb4e265d9bd71164"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-07bc0d9603295a1a3"
                         },
                         "eu-west-2": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0de2491b98ce6f3c5"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-06c5b1bf10d980590"
                         },
                         "eu-west-3": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-035e27901f740aa66"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0cd3562f778216b08"
                         },
                         "me-central-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-03aab5ae63e2bb725"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-084a7ace2939cf8d3"
                         },
                         "me-south-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-085ddf4546d70d447"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0fa72b381bc7ed043"
                         },
                         "sa-east-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0d2d1e959d293f310"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-06b77cc4f080dc59a"
                         },
                         "us-east-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0642677111e4b2434"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-05f5f3cc554895598"
                         },
                         "us-east-2": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-026224203b03b4f6a"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-03ae04c49cf7c16d5"
                         },
                         "us-west-1": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-0a33f5dc3a951b1a5"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0a9f9896fc1cf7dfa"
                         },
                         "us-west-2": {
-                            "release": "38.20230514.1.0",
-                            "image": "ami-019eba97a082fe43c"
+                            "release": "38.20230527.1.1",
+                            "image": "ami-0870f8c97b74a04ca"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-38-20230514-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230527-1-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230514.1.0",
+                    "release": "38.20230527.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b4cef246ab214c2a7d650213c7fc093e1e4cf6acef3abe9549c2b757f1b24e93"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e7b62ad1ebe6df765f28415f99afa782278644c9e329f0bd49e3dc7e68ff4c8d"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,105 +1,105 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-05-16T15:54:50Z",
-        "generator": "fedora-coreos-stream-generator v0.2.12"
+        "last-modified": "2023-05-31T18:52:44Z",
+        "generator": "fedora-coreos-stream-generator v0.2.12-3-gd40c776"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "ca3077412649f778a10d61660e784ffd15839fe5d162bbfadf48bd1bb6c6c3e7",
-                                "uncompressed-sha256": "257d03e603919f6105033ce0998a3db4feb0d1dbe2d61edd27a9ba4e4d3608b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "3ed2a7ef9297a008ace2a993c291bde00f6147b1a748226e71b71d687d397c26",
+                                "uncompressed-sha256": "92ae2f332b576082abf1684548c6bb526d89e88838d8db920341970c48e20e93"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "ee7cd71de4306c7f6114fa7e16ced413e7b81ecdfa71d0965448854a40c90417",
-                                "uncompressed-sha256": "7b44bc729f3d17de36d9ec40682b0fcc75dea35a82674e0381b04aa9d7fa0cb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "04854bd6dbac7c18777a9abd41c25e77e1fc02e936bbdd6bc3b5365866e00358",
+                                "uncompressed-sha256": "bba5a0f7e85217c03d53bc4fcf736cbb2e469a59420deaf48fd9c4a044f25014"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "d4f34b4141f56309cbc0df0823ae0b824b665b414f4e2e6d9569603b14225d7e",
-                                "uncompressed-sha256": "c4aea8befd47c5337de63510086249017c88b311ec6f946174348cba6658f1b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "57ba29e2a3061493459748b79aef060b4afdf45f20cc5ee358cafae63a09a6df",
+                                "uncompressed-sha256": "f15af69ed221fc7cfd2f88d0f172f2da70c2838a6a5e22aa65879a0e1919c28b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-live.aarch64.iso.sig",
-                                "sha256": "1b1986cf6a8885666477c815fe13d65d271d6b3bda3c66281c65bdb1e67c2af4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-live.aarch64.iso.sig",
+                                "sha256": "c863ae564a8bee8b6cefaf5569a56206b5028c0e22291bc5b49dd044852fe563"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-live-kernel-aarch64.sig",
-                                "sha256": "6b5de67b74372403c01f3eba3181f4a09a6dcbd990beee19afc91fe7d06d7ee0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-live-kernel-aarch64.sig",
+                                "sha256": "3220992101cc232cb4531063ab6a0e99b704f389d76cd65eee23c0c8fb02d3a0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "f60534e2093e196aaa2205503a5ddfad0a2d5d5b783a32099212c0d900b18199"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "56fcd31b1dd1405292989eaac2076b8829af2ad390b121c1eece564e6b887dd2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "1bde677114c3887fdc782c29dc7ea526dacef803d8d92d7ce28f64d3a5289ff2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "5fa752faf845f88cd0018d44c4116688341ab56d969f3ef4fa398a2e94978ab3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "f32f5a88506759b3aa77db7994c75c01bddd26ad833f31c4c4368e738855dcf4",
-                                "uncompressed-sha256": "c60b46069150b33f309b7ec5828bd16072cf16dd90c794016030665bf0cf981b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "f33b632fe68b7df9a47d39afd3d172d9e3d432b91c7e5a348c4df6f5261b76e7",
+                                "uncompressed-sha256": "04be12889fd9acc7499975072f76fa976cdaf36725275db5f61d41e0d47ba62f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "87a46a818509f6dfc2614250e18e00a245d27af556467c5bbe2e4b3035025f31",
-                                "uncompressed-sha256": "cf0a943af83abec10c86c973c4be5f92ac3c816fadbb8c0145a0c6a5d6200a22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "11cea1199d7233125c7e33f42fd2cd6e65b2aa8f87d7f50642193d03d8bfb822",
+                                "uncompressed-sha256": "b5d0bb2145917b727e7cce7c186c29d5dd99ac21d629bf5baaee0b4eb0554760"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/aarch64/fedora-coreos-38.20230430.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "eda7c52cbc2e982ab7fe37643a07f92f1611f2d90fd1920f34c1efd499648b06",
-                                "uncompressed-sha256": "671d419b7324af4e6c7701102d85f40fbe214bd0c5cbb032913e10c76906b861"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "9eada4a8b301e8db6f4e19d8bb22ae4f289a5ff8d0e4674a399cf62a0ad43ced",
+                                "uncompressed-sha256": "333e03567aa6b8f3af5a45009fc14434ff0d686c9fa22679dae12c152b120246"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-09a7e13359485871c"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-059bdbc0560c02fbe"
                         },
                         "ap-east-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0ccc2c4cb18de7041"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-029449553daa44611"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-04ba2074279e775ef"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0e54b39858e0a6bf7"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0f1155709f0a2056d"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0115b8e36ede73127"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0b2ab7bbd3b1793e9"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0f85cc7b6449033f8"
                         },
                         "ap-south-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0fdb89d8330609ccd"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0963dbda260e7dab5"
                         },
                         "ap-south-2": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-017f60c59f4ddd9ac"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-09417cbb0654dd06e"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0dd6585683ec00a3c"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0e7ac1ec150c1f2ef"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-09f00ec0fe0fe8e6a"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-01157b35360b43f24"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-023cf088a1674daab"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0b16570dd4efd1213"
                         },
                         "ca-central-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-017f050c1e9c95a40"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-06402829ee92e1bcd"
                         },
                         "eu-central-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0d4ec06da56ed5932"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0902c1b597bcc58e2"
                         },
                         "eu-central-2": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-06e5ac46f4ccb6320"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-08063b3820c0b227a"
                         },
                         "eu-north-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0bcce737a4785db91"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-002a7deb3b0ca195f"
                         },
                         "eu-south-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0d558bd3f882471d7"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-039be789042383e36"
                         },
                         "eu-south-2": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0be7e04a54478cebb"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0e131f4050ddf4a6e"
                         },
                         "eu-west-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-08c618075accfee80"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0bf8f61edc7bde703"
                         },
                         "eu-west-2": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0f3dbff6a39fa7e4d"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-029fd536153edd69a"
                         },
                         "eu-west-3": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-090b6b1f2fb0e49a6"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0275058a8a5043410"
                         },
                         "me-central-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0513b8ea91ccb8390"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0c830c0dbb94ae3d5"
                         },
                         "me-south-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-07a6494238fd2ae61"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-024cfa496438a095a"
                         },
                         "sa-east-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-043548f5bdc4aee52"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-066e8e04a04bfb64e"
                         },
                         "us-east-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-06586483e8bc3b022"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-07aded6c65aaf9c00"
                         },
                         "us-east-2": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-02acb4c69e4be09eb"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-014d108bc6b7c7d87"
                         },
                         "us-west-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-087788c56157ee19a"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-034d3563e4b2a95d7"
                         },
                         "us-west-2": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-07a7625b43119f64e"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-00d1431a6b9945e80"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "e4866ddca041a8bc0b5eac8ae9e642d5a8a4fe26d33258adcbdb85cd15d58f87",
-                                "uncompressed-sha256": "d0d1d07fd7dd04880ea498be9f1cdaf45b2d55797fb19eae537d93022c19d48b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "a49e5cba317e81144d8b0c9b1915b5ea47cb242f54beb8f6215ce5314aebf87c",
+                                "uncompressed-sha256": "d4211ac1de16e047a254c7a902b811a97f011b777fe0e70226c747a96f4a8469"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "ec4a3d5754b6448651e15ac759b15ab2cf19c493a65e42454fc2941c330db0ed",
-                                "uncompressed-sha256": "0ed0329f6f6c323bf7fd2775cabdf60ddd9eae0848bc45cfaaeb89c2753cfec1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "66269a2ae64b85b6b69a47c3d5d85a1c9959818c0d645c6ff8ffd14aa3b3c895",
+                                "uncompressed-sha256": "ff0e391597b780610627aa6f4022d2019c253b07551f08b412acc6ae737fe3df"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-live.s390x.iso.sig",
-                                "sha256": "cd2e27c0a6789e6aafc6b08642334a152c672f04edf7f4569fceb8139eef4711"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-live.s390x.iso.sig",
+                                "sha256": "4ecf13f615f986eca5143740000b30b8a0cb8d84ce754c5d060bbbf74a1350b9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-live-kernel-s390x.sig",
-                                "sha256": "ec8c8feea8752b1774859a47506a52f76434ab97a1a87a17cfe70a0d3c107f5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-live-kernel-s390x.sig",
+                                "sha256": "f364e3ec3e2945dcbc12d89bb45baf1cea8efae09bb22e79e4e989936dec6da0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "82e2c7004a93fbc6c9901138bf3e2403a67309e80ba690a4eec49471a38388b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "5f0585c5b976acddcebebaad9d9a4e9ad80e3a579cdc21e32082060cf617c702"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "a8213f6b9574b0f04b7194046209c4926fd32126cae200d3a94297e0c662fbe4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "253a35a7203b695865802812e7c68746fbc00c8c58373c28cc1f644aad9293ce"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "9e55c7be56244b20d770e1b7f8ea7845b7be02fdd4841b367f79a365fccf63db",
-                                "uncompressed-sha256": "55d7713a93922ee150d09e0fcdc06446e1d7ddf4272cbb86c1905fbeb51eab7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "af85f0b5794c7e3351418c2e6637b8af21fc6f9bbfc44ddc99d0b4ccee26596f",
+                                "uncompressed-sha256": "e2b882378fd4c9aa8be7364468a985dbcefead332cf47a4324725864dfc9fa81"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "f28cafdcca2122ca0d5bfa67112f8b41f7414804662e376c912493cd99761b19",
-                                "uncompressed-sha256": "8c49be02dd5d6423518a8dca9bc5742f9aaed237c95fa09ec4e32207c7909a8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "b4e38ae11632ff591fd4f9fb2a57643a6f4aceda1e39c315a4b077d3cf2b1f77",
+                                "uncompressed-sha256": "8a87a71c241caf49dd899516556245c8fbec414a2b7ad640c735737ee44e7eaa"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/s390x/fedora-coreos-38.20230430.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "e5c6e72731b6dabdd72d2df4804ce191a94d5fb9d69e123c95ef037466252d06",
-                                "uncompressed-sha256": "b606ceaff8333fd1e8e4737d39067813c009c0e928945d824e13a70cd726604a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "949e77844d226ef13b4587ae05d5b255a97ad1fe555187cbc265e89532a6fa51",
+                                "uncompressed-sha256": "50e5ba9d44d2a7e8f4859d0672956e81d87350e3889fa42f6d3307059ae88759"
                             }
                         }
                     }
@@ -308,237 +308,237 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "cb827c8ad87e296cf515848231f86b9117479588d64fe8da59bd817ad7c05c0e",
-                                "uncompressed-sha256": "b1717d7cbcc93746a76426fbd6d9bc45ac559cf1a873c670f072705594a4a5c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "ac31f14defc39c391e5f06d9bd526689c3514f511d0bb15813165d8d7f8c26c4",
+                                "uncompressed-sha256": "b16a7d48546f5e23bbcc749b002f8852f7460e9e4b4d9c845135a770966e2537"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "c4678dbd1acf9d5e541d96bea90c2de3cc94579734866d2577c749bd39df2c04",
-                                "uncompressed-sha256": "2058503b048970726f3aae58013a916bf24a7e69524d27e4191856404b387102"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "91bb24522f58fa1ed1482d1a4fe2ea04b9e0235006afa0a5c1e9043611c6bb96",
+                                "uncompressed-sha256": "b7f804c2435eb6309b32fc0f70ef483995b1158b4444956ff83f56833b1d2579"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "82049f1607032638210241608435f17b5dbbdd0f25a14e24a42996128a122c58",
-                                "uncompressed-sha256": "a22c88a43bb17184bb96fe8db45f4b8a382e0da1450d6d1ba66f6fa631bc4ae1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "b3b0f94fff809d1786a6daadf27c4189f64c996e445e812862ac1e11127fef8d",
+                                "uncompressed-sha256": "3b949e7b83acbaf774a5914f6092878fa4c8fedf41aaf688909b250a5407b9f0"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "17125777b76296d66df745d5c893d0d4f5551f5714b31fcaa60c6c88d5132803",
-                                "uncompressed-sha256": "37dbc2cb9306e03f987534bdd178d923ac985fed09feff83705fab8a6d84104f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "78b379ca5b2da3b74ea634078d53ec3f5f278af95522a683d7e936217908ad0a",
+                                "uncompressed-sha256": "c63af56ee16464acd6557dd05e9b619ebd3869c885c9b40dd5d4b4d958f6e817"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "a8a85d52a7c69811b8a8c3780e0f0eb9ff22aa196c83cbd807029f6d70837dcb",
-                                "uncompressed-sha256": "ab1d852157dfe061ff7c9282fa8096009de28bb0f57879dea22949db5e98b6e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "9a8d098bc38da32b41a10ea66cce6d1f94cac25e38f10b865923396b52cf64bf",
+                                "uncompressed-sha256": "debc9319c086f15e9571d9e85e037bbe8b0ab9dbec98c3ec1f515ee348b3a251"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "28dcace39ef1b1026136bd34206addd75b3c95a17207a34ce737ecaaf11ab5ef",
-                                "uncompressed-sha256": "f9c6ebae18ef74e519846cdea75458a306a50f7cf07c7ac1f84b955954cd0036"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "a466de146d100847e3802d6da98960743f1f1549cdb64230820538365a197117",
+                                "uncompressed-sha256": "bee6e2fa21c32354adb5d303305914bca0350b7565320ccb657f1121e838a671"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "9cdc76c45034af42b87d487def143e9f1a693c028b05250b138708fd6d688bca",
-                                "uncompressed-sha256": "4bab65034eb828123323564845711e600738fc48ceda23eac08427f9aade80a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "51462c8bd9f2ea3417880ee20d667460aca404f1b3b5c28eca560bce088adc07",
+                                "uncompressed-sha256": "4f911a342689a6d3405c67a482013fc643f18395db2dee189e8695423460acd0"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "517502462410a114aad9f8e0a2e4f71b41aa03dc7299727c192023e14a381287",
-                                "uncompressed-sha256": "1e472a7898b97196cf76eb42cd783c7d3a5d5fd21677677c778db35ef5b35104"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "5c52da2532836fa4a11ffcd55e437d9fa9c36b62edec5e49f9f7b905c981f892",
+                                "uncompressed-sha256": "3a444ccfe2ef2fe5eae2138d5af8a2ec8788021b21bc59ec0930a8232424fbd0"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "4aa6baf07a789ce13566fbf6922ac8f3a1af0ba8560d4c4d892273493b3627be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "c5bc0e2e5dcaf06cdf7cddcfa9c11395adddbb310adeb7e5ec28ed66bf3aaccf"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "937082858811b24c5b8ccccd06afc32186585d9e1e00114d25cb347e1684bf99",
-                                "uncompressed-sha256": "a386a9b3a9bda3b93dacc70b49d12ac8d1051041c3febdd6be75f2237005ff88"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "72f874694e94f11f45a3cc450cf412ffbc27106865872bb972576f67464c360b",
+                                "uncompressed-sha256": "4fa6cb6cda63e6bf443cd19ad480689e9d9fc8733ccede9b0e670302339252b0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-live.x86_64.iso.sig",
-                                "sha256": "8403e5a29f99f8493909e3b268cc4a89819e4fe2fe144464b57648ce108f6c36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-live.x86_64.iso.sig",
+                                "sha256": "70cac41c33979bbc9b371b1acfb2f05a8ec77d359e0b484b739b6ac86d3406f7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-live-kernel-x86_64.sig",
-                                "sha256": "6efe0d99d01d35119dfc06d971edbf6d13d783ecbdb48dccc924185177a1bd98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-live-kernel-x86_64.sig",
+                                "sha256": "1caa067a5593e432c61db22864d09519219f7d926280e50817bd33fd609ce2eb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "2305ef19f5badcbd0c3c96ea96a76aed637fa3890028cb67c1ee41a076b3c2db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "b16e1f72e0a3ca5bc59e9ea4d6f10f3ff361fe888c56b309fbbc8eac010f41f5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "b648c09b93a934ae357c83780298d433b13e774dea0b6c65e70306c6d42dffbb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "07a9baf95e9bae4c091db0d420ccb1104c91ced091c2f71363fdb5c87a9d1b99"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "96402582f93f31c606541f314431ad5593aa365e5e230ac86d1bbd098fb885df",
-                                "uncompressed-sha256": "bd72ec14c5eb5d4863d4e6a88b4743ed09b8d0447e23c54f0f71d3672f056fb6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "2447bb309ba399483bafeebb1b509ba23a6d865088fcfdec0816904e811f9f98",
+                                "uncompressed-sha256": "dcf522524b478611259393d5c9dc4f180c35dc5811c6a4b8e08632325f907ec5"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "c58cb8d62a2bda8e8e562e098cb5f057cf41a92acb4dcebdacf36683f13fda40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "dd47470967f310b3f370c33a074483ba3d46b0a7e6e98e12dabce949f154c335"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "95521b5e0d82d8c0a63aef37564d62b1da04c7bf7239d995eb51b9a1c06c1f26",
-                                "uncompressed-sha256": "06cf651b4028f42510fc83784aebf595dc24611f663027e89d24d40aa4e46d26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "4ceb2e1c86181d02722646f5ca3362852cca2825f195646fc5e83af3dd3a8342",
+                                "uncompressed-sha256": "1558783e5fc3faafae47e58fbe11b611fd020aaabf9fc34890c4e6e7b05f36d0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "85a15c20b92702b01da8a05a5df010d35d45d6622cde5e4619a8d447e34d2758",
-                                "uncompressed-sha256": "d3df1277d0436292acf64dec6845c4c070f4eb7684f0a0fc0e896d0e76aa07e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "d5a0ff08fa31c6128ce77aa9ec888c68520da2740d55d17cb5a2ad722aa89857",
+                                "uncompressed-sha256": "12458901d0e66d01ad2239d7ff0bcb2af32bfbdb747a5c1f40dffac6336f7e7a"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "2ac49489393b00e17e7eb2d1c9b794af3a86d383947e4b05b47af0b31e598831"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "310a2e17e8dc513e931df9fbdc3dd5ae361ab09b927d40a10b5b46b35a4a68ba"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "0e104c9e3567828b01a30b0a7486d60c07455389ddd364c85cbe9141d0500286"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "bdf82329f793e1bfcacba1ac02fac55272437b1bacc26c1363795a10d0eb2b1c"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230430.3.1/x86_64/fedora-coreos-38.20230430.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "46ddf2460a91b9fda83f0fd34f464c7f9ebd58c1a0c244d387ba262fe10d8531",
-                                "uncompressed-sha256": "775ca364e31311444fd1bfb2a90ecfa7bd857a971a1a1eb8051e586e70fe9b70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "8e99faaa23b2d310b7e954d5812f25c3ac572b8111d11c8fb9ab4c12ddbc572f",
+                                "uncompressed-sha256": "b1d9f454a08788fd6f24846feaaaa5a0c0d8c2d4b321306b07001c0293491a5e"
                             }
                         }
                     }
@@ -548,121 +548,121 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-095aded899c6c0584"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-024af2479f15f50bb"
                         },
                         "ap-east-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-007160b941b5b6475"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-02801ec91fd412d47"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0e5b30e196864304d"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0251515bbc4aa2c1a"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-04e0d297e32bdb99c"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0a618bf825108eef0"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-09ee958f3220d8cc2"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-06bf33e960a9bcb2d"
                         },
                         "ap-south-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-077b0f0fec6dc6b46"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0a351593d6f68f2ac"
                         },
                         "ap-south-2": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-04e9f7c6badad0704"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-01b2bf2f612a925ae"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0dd45b3fb9093477a"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0ffa52a55088c8f58"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0814ada785535c45e"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-056d5af6fd2d64dd3"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-01ea27f344680b81c"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-09a3c9ead405983be"
                         },
                         "ca-central-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-013ced20eb9ca2d0a"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0f160a93120d3ec65"
                         },
                         "eu-central-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0df3bdf0f770da88f"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-016a79745fc97446a"
                         },
                         "eu-central-2": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0a0b4912efbb65ff7"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0d520ea9e61b1f715"
                         },
                         "eu-north-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-00da87287f5eb857b"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-08b4e31db859f2a35"
                         },
                         "eu-south-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-031163fe0061a8828"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0a47a4a1f88bd94ef"
                         },
                         "eu-south-2": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0b0b6ae3c9cf2fe1d"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-06e1d73df658d9f38"
                         },
                         "eu-west-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0ba268730cb1eb0cb"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0f9c6bddf8b8adde7"
                         },
                         "eu-west-2": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0ef7a0eb7718fda33"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-068b595f0f83eef43"
                         },
                         "eu-west-3": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0efc3829379c3feb6"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-01b3217c9b5d60790"
                         },
                         "me-central-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-041ba76429025f3f7"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0d72a2c16d732638a"
                         },
                         "me-south-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0f4133653f7a9c49f"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0a961427609cf7339"
                         },
                         "sa-east-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0a5b64eddc5498691"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-056764656bd9ed7af"
                         },
                         "us-east-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-03fb7e4f2eb89ecd5"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0f6f48394ee0124eb"
                         },
                         "us-east-2": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-07cfba37bb23cec67"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-0a7cabdd2ae611882"
                         },
                         "us-west-1": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-06dd752813344580a"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-078aedec233f6d9f6"
                         },
                         "us-west-2": {
-                            "release": "38.20230430.3.1",
-                            "image": "ami-0a6b825692925769d"
+                            "release": "38.20230514.3.0",
+                            "image": "ami-053378fc6ecc003e4"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-38-20230430-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230514-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230430.3.1",
+                    "release": "38.20230514.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9d138ef0a3f086cbde6b784db2e3ab165d06001d499f32a6d005c1c24cd5a002"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:8bd5f282df05fa9c999a9f41a9374bfbc70cd86850c139c4941649f842cb4354"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-05-16T15:54:51Z",
-        "generator": "fedora-coreos-stream-generator v0.2.12"
+        "last-modified": "2023-05-31T18:52:46Z",
+        "generator": "fedora-coreos-stream-generator v0.2.12-3-gd40c776"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "de310be90430ea261dd6e07ab1be6bc36d2c314bcf026f050a077d742ddef5f3",
-                                "uncompressed-sha256": "01cd0106d34765cf8ee01b8fae73a2d77277a3d06365f25e6d6c2ab18bfe8b35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "44cf859a5b9e9c0a233c4927f1ae7cd19271b8d09d1b439e090929bf735ba895",
+                                "uncompressed-sha256": "e5b0df4d6d294533f327053c97909927cfe447a54cac6ba32ead5b2c82fe31e9"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "d2dbdb94d7efe0e8d8f3ab7b19d299e078793124afc3502fef95e20292ffcb9b",
-                                "uncompressed-sha256": "88ed5389c5ee09acd1c983ec8891790deef8a9fe9ae45b8d29ed2aa6769b3686"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "7e659437736975f0ea8c71653b0298d61e8f3ebecc416419d2dd3bd06188cfdd",
+                                "uncompressed-sha256": "4720ee4102e768439a68e4066ac7515b0847a54d235e0a23a2b0343aabf5ab8b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "f64cbf99cf992aaaebf088a23b04c76f9007168b8a4080f46e3212bd62459877",
-                                "uncompressed-sha256": "2db42b7546c9ba8cf0401550b5d10743eb88588be914f580fc8bd27823052114"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "4c16bc8cf52f5e91cea5255d486fd61e79e53a7da92780327575e79e03b32653",
+                                "uncompressed-sha256": "41187c0b2e067022247a57bf8da5a3f22226eea38a2ee39501f4238e49951c99"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-live.aarch64.iso.sig",
-                                "sha256": "96dcdbd20a406dabd54f5bfe3384880b520c07dda2908e25aaf1cb79e7283d08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-live.aarch64.iso.sig",
+                                "sha256": "670e8e933c638f6884f7e0f9ca7e3d677a42f479f8102ed66da4ca759de2284f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-live-kernel-aarch64.sig",
                                 "sha256": "3220992101cc232cb4531063ab6a0e99b704f389d76cd65eee23c0c8fb02d3a0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "49cdb7f4a0ebd0422958d472f56ce2bf9dc24926e6e43ce23f5b027b96e24718"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "fdfe605c980ca15c30a1a547593ce4a45a5ad10e3e67a8aad1461cd0341dcc56"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "c072546d2ead2c7b7f62af357bcd742b6a4a0dc66dfce7c84295a3ee79d6607f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "bbc17fb18e04295ed9f9bf9f476a81c73f6ca6f5b48921dfd5579fe64af1998a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "0da758bc9f028c13162fd4a6544c40c9726767942fc6d06f22a6d90b36563c76",
-                                "uncompressed-sha256": "b99f491faccc541d0e3e5825050a8c79118f9f48a3456f97363c59373fbd2c6a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "69db829dee9753f855a51857b5be5875017e1e39712aff5b63a1ff55941cc55d",
+                                "uncompressed-sha256": "a0ec2fe51efc80ec4d7362fd39f796202e96023b2748b9e5f7efe4475b4c233c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "2bc5044b2b247503194a21f220161042b0abdcab6f3cc33cd5762f31bcbd8c43",
-                                "uncompressed-sha256": "bec90db4e05caa3edf83294d7f29eec7686e2abb55ca8683984f357a66e4783e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "8d774992547d567d2e74a419ba717f10f5c4671f36ab62b4cfb09d0e0ec980d7",
+                                "uncompressed-sha256": "7be2fa7bbff45e1f8007f5bd501f2f0353cd1bd45fd5cf8aa6db3c3cf3d9170a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/aarch64/fedora-coreos-38.20230514.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "f5b7445e105e5f8a792ee002d5c90cc5675ae36a4a2afbcff31fde063c8a2747",
-                                "uncompressed-sha256": "2bdfc64daa195a59b9766ab2a9a8312b942c2b84552d98385fcd0c63c1ba83db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "3dbd0f68e23138d529e1a3c9b8c4f4d5a2ad09e52751e89fc3464c08ae909326",
+                                "uncompressed-sha256": "c74b503252f31a9cd2db3d1b6325389cb08f9ee336473b868a088c57936c3e30"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0bfa9cf0de1f5ad9c"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-09ef483d679451ad5"
                         },
                         "ap-east-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0a31dbd564ce54916"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-08d3d4f6ed1b2fa75"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0d98aa268e91bf284"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-06f847a484b599a16"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0a877c37ad2b48c3b"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0d79be11bece47e38"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-045cc8f3d975c8b41"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0ede1a9e499c0ba7b"
                         },
                         "ap-south-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-050115920dea3402b"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-076db453d40eff6c4"
                         },
                         "ap-south-2": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0ef41832c5b1757c7"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-081241ae5bcfbdeb9"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0326ada5423c76c94"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0f2d20640391e474a"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0ba5f12b3d90a10d6"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-00a3c0149e40e0aad"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0de97d8b8b85d1e70"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0d60dd6affbc90930"
                         },
                         "ca-central-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-091d6e4f9f84382b6"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0849e30ecea7f6b64"
                         },
                         "eu-central-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0005acd07e56bd6ea"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0e09c4da81b011372"
                         },
                         "eu-central-2": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-055c5eb06a2b677ec"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0cc89e8e0075ac268"
                         },
                         "eu-north-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0db80e3173a6d7732"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0f3a6af48945f0811"
                         },
                         "eu-south-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0c65a749c4e311378"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-06f364698fbf9bb1c"
                         },
                         "eu-south-2": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0e9aeb4f8b9600f76"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-05d71b77fe99c8404"
                         },
                         "eu-west-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-02f4ba1e48da14562"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-099e332cf519e8104"
                         },
                         "eu-west-2": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0d50a74e14253bfa3"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-027b90acfa4b0b0cb"
                         },
                         "eu-west-3": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0c4ca790b2ae429d5"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-06167e0279c307b02"
                         },
                         "me-central-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-007804512c123392f"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0e5fe316bbf515669"
                         },
                         "me-south-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-08add98d71aa12031"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-011fdb05c83f3f71b"
                         },
                         "sa-east-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-008adf0c1db9435e8"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-03c3f44a86e0a015a"
                         },
                         "us-east-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0916de94944a968d0"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-08fc0fe1876ec492a"
                         },
                         "us-east-2": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-041b9ad42ebdb01ab"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-06b0d71629cb010ca"
                         },
                         "us-west-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-09a4c70f406e4e679"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0a85afdab2fb851a7"
                         },
                         "us-west-2": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0d9305b144bf7520f"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0f28a6cd26ff69996"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "4b40daeb98c4b473a6acfdea405dbe5cd4dce908b049436b9ae4a6ef46319498",
-                                "uncompressed-sha256": "709906c5557ade480be8b961f0399cea02d6500edc2f12ef7298593c56b61e42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "aa6df63e63ebb8b0ab113dff911f486a6c4904cb66ea7d305a0794f3cec8a9c2",
+                                "uncompressed-sha256": "95ee4d42eb397f966919b980e0aa2b7740c756240ac5777161d6d5fcc2407ea5"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "12ab7938f066f07507056d4a0c5e426fb3989ff0ae24eab90ce73e997e72e360",
-                                "uncompressed-sha256": "bb58708ae3d24af93dc397bcb3b319ff713dcac4217975e8503c3b3b4448ab65"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "3ef870cad27ee72f249dd691b5c72727d1505531425048dbbf4a8c0449ae7758",
+                                "uncompressed-sha256": "730ca6f551e255cbff0f01fde6f8e22147a3bc29ba9176a3f1d91a11ded17819"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-live.s390x.iso.sig",
-                                "sha256": "6daad7ce213168367bfd78d565d7dde00e4c15ac4e5c44576e730e763059ff2b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-live.s390x.iso.sig",
+                                "sha256": "a72f6a9cdabf6ba6d1b755f42143ca98e9fbfef7151bde48e7ea64d845a7050c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-live-kernel-s390x.sig",
                                 "sha256": "f364e3ec3e2945dcbc12d89bb45baf1cea8efae09bb22e79e4e989936dec6da0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "12149e7f0458380f40db39c505e968a33726d9ea9989620c94ca3a81c8a67536"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "d64e73fdb248046104c9cdf005a54842692a6bf00a4136532fc994c9e2573103"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "fe10bd868383ad52e7d5985f4b228863f0ef4cfedd7adf232fbf35c9b6b54fba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "083272d344c7102a7be0d304abf14ebcbe083443378f30ae6bf1623efb04056b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "8b576a4fb2e25f904cfe457aa86fed4a8e53dc74d0ba1a6b3e0945091724fe21",
-                                "uncompressed-sha256": "669e076ead2c5e6ce12e99c90e5ef9d30cac8cd00018ec82d11b76ca2405d59a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "1105c4a283a677a8a7050412026568b3c0ef5a36a18127bc73816347724d3094",
+                                "uncompressed-sha256": "d99fd9d4d0ab4ad61d01eca65fe598e3a99b2829361148b1621bf7e7dc8b7d9b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "95c50d31579bddf1fb611e62d8404ee07acd30557789c70a83f592d0409f19ff",
-                                "uncompressed-sha256": "095b0e81b717780d5c3dcd9893e77eeca82267f40b2d1ee46cb6fc573be2f401"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "2274bf2debb94f90e564286227fb0e2ae3b71c92ae442805cb6e2234f1ab5070",
+                                "uncompressed-sha256": "ed5aa433ae253f9a3810b1c92e42ef0d3cf853aef158fdfabdc3fa6d5c3036b7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/s390x/fedora-coreos-38.20230514.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "717ecf8f60f28c2c901c4631d68db069344e51035dc9cb66840555550ce04ebf",
-                                "uncompressed-sha256": "2efef098d42f6228d96c8ab736c318b62f9e3e4ee040151a891729bd64320dcf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "46eea1f0064d14527dc3e2c145f6b9a8e3f8254807e92abf93a0bf384adc3b0d",
+                                "uncompressed-sha256": "1fc9f3a1103b449f5cc46aba84b975e3501c156af9597ce55fb7e030d6b99531"
                             }
                         }
                     }
@@ -308,237 +308,237 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "f908c60411c24c1cf59da4b900815db183f3611be0a5da594c1b1ac1b803bc2d",
-                                "uncompressed-sha256": "13389f4257fba2cb1e2880ffaef859d5896a7ee654d37b9a18938ec7ae7051b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "abf5f858527a9df9517f65cc80acb3dfde6c8fd0dc5fc82d1c5234fd244747ff",
+                                "uncompressed-sha256": "e7c25ba975da65db4d017b9094824637fbf58f8f9636836f0db6f47c98f9de54"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "815ba9de078c633530c9e3636787417ff364ef570b27192d60dafbbf5119dbb4",
-                                "uncompressed-sha256": "26dc0fb94dedaf46c402a93871cb94d7b7e6a33ef2ae948780170a992a837704"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "0553a4b8cd92b08111182a990d75cd0b1b9d1bb1ee926aa5d9702a779cd8c5aa",
+                                "uncompressed-sha256": "28378a08558b7f02ecc31e95074be3a1fa6be10808027e1f2a23c7210873d7bb"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "b97d3a67068234fb1ed4e5b4fc457c13e0073893eaa7c0851b8fd76c3483c297",
-                                "uncompressed-sha256": "64429d305dd3595247581aa3b41f7d111838d1fdb7167e12411ae0fe9e3498ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "968f8017560aa616d40c259a504b06f8d432ffd25fe858a3501778d62d9fd1b3",
+                                "uncompressed-sha256": "435b9038938f214acf0bf7b56078660f559080fbf4d0c6db7ef830abd9a2fdba"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "cd5843be8637fb242e8cf4e260990f2c784ba23de525a232aedf8993d25f68c3",
-                                "uncompressed-sha256": "5c78e022ddd96299811047b275c9d294b5da8d4b39371bc0136838d2cc618707"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "693b6d33a79e39bc878eb21c7764bce045fd74514c05029b4a88e32dfd2226a9",
+                                "uncompressed-sha256": "be39a01d67f854d2c788266afec8f1a2e59045f1a921fccfc3480fc1316e2832"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c7638f6f7926f9c47eb04bf91472de83d3ba284e375dd6f5d0d3ee04334eadcb",
-                                "uncompressed-sha256": "d88930eefdc37fce0e427121134abe1aa7b10f41cb125b3d10bc4a7ea0846b82"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "212c1e80d959f936186fd6cf2a23cfc029ca6ffafde203b3f87b283ed280c97e",
+                                "uncompressed-sha256": "0160482530413473b1b2dc6d6571bdd7cd1d6e29e5ad4b3e9aea5b06c0743872"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "ebc9514eb12ae39fffb8e0af7bd50f283a5d3288f7a3428506d891dfea6d7070",
-                                "uncompressed-sha256": "e876b8f6c32b8704239fe36535fbded18001ffe7d93d01dd722374883405a058"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "105f6996bc0a3ff69b441bf6e414d565c352150a8c48ff423f8667e5761c470d",
+                                "uncompressed-sha256": "dce0019f1379109bb79488611dcc1ac07e629bebf127210aaf995d3796cb0f38"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "9731bc25fd775258717a8972f8cf36dddf4b20b8b4082a304de6123d481531ce",
-                                "uncompressed-sha256": "ab175e0d549d903437048b6b514c94b641e819c6cb27a85eeb1de815d597fa84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "fb991a63c282519f45232bc461eaff67bb10dd5532f2fda8383d0597cb70d4b8",
+                                "uncompressed-sha256": "4ad9b0cca42b461fc5397f06cdeaca8c6370c1950acbfa54140bc998db453536"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "dde3b59e129723c990f60d9f10091f9c4d56d7b3ff142c3b0527a0677fae099b",
-                                "uncompressed-sha256": "44726a761df456ba5106a27a7004b250224e0b564b47077e40d0ca542a2da746"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "c469c6781f007be73a1969099dda0fe67675710e0b3b1f4ba5a362fe3acba8cf",
+                                "uncompressed-sha256": "1e0849541651ac980be2b07f0c9ecb8efa80173bc3cb122679950117e5a928fb"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "08506e08c63759743cf2b43a6bb6704398818bd0ddf9727478b23ff5b41fe2b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "ce16b20497ecc210f9ed4b2facef44ae0b157f561aa663b4df03cdbf4dc536dd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "79c7cde5ddbd98ffd7ec65bf9d6586d24d93f5455a6879fc5ffce87b3920189e",
-                                "uncompressed-sha256": "561e7fe3d41e7b93bcdccb7af7a18f1599833017b7539b8f03cd614700649a2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "1312ae92d66073e1dff2030224f12f49dc8c4e1dbb51b45f33c06b493dceeae3",
+                                "uncompressed-sha256": "9e3bb9a9bd6755edef78c243566ba2ab8a2f37492ecc9f767d548d922f6ac8d5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-live.x86_64.iso.sig",
-                                "sha256": "82115fabc431b91d1157518f7a69d67b67a571a75f138494ce221bf0f705a213"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-live.x86_64.iso.sig",
+                                "sha256": "8e25a6dcddd3c8ebe9e56497602c1969f9ff71f0180b254afdca5e3e0daeb758"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-live-kernel-x86_64.sig",
                                 "sha256": "1caa067a5593e432c61db22864d09519219f7d926280e50817bd33fd609ce2eb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "90ecdca9fc2b698671a8b79fe686d11977a4aae7478e3a570f2741d95c234079"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "e2903ac671c377cc0dd069b6cb70b8c84140db9cacd86f4eca77584abbfe729c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "044b8fe4c2693c04fcff4e8828ef460fa366267ef22c00a92fcab11c8898d91a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "eb9b87e17ed963e019bc0aa7af69a17ddfbc3bf309873fa878f5ef14bfc9b18d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "2a0fb133d822d3855a484f98ceae56dcc9d385e2c2147106d8d421268219c5c5",
-                                "uncompressed-sha256": "9d12b2c871a8fbb139051cde8dbbaf9eaa20db64585ff4a9d23671bf7e093af5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "f4145ff353d49d5cbd528763baab05c813b082b005eff2f43766fa5f27900df9",
+                                "uncompressed-sha256": "57a08eece86f05239cfa24646a7cd2637cca946e8878e2ae2aacf68fdb3da273"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "5e7e6fabb3a6adb570c558297ec4816edc0983114ac99fbc93692264ac48b7c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "1870db419ae64869da1cc2efd6f4cc487b20aa2ba20d0e31d4c6571e3563e916"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "539551a03895ec6e50a9d76b1d3da379ca5e9a095c4ba0df88cdab2515199947",
-                                "uncompressed-sha256": "027a95b171b343d162cd862882900e02554d95b1f0401393d18df11938b25901"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "cec24904f797a55b8ec6d7ca0b5f5fd4bb6e3845400ffad6fed2a3619f32466d",
+                                "uncompressed-sha256": "661c36d24614033a914f203d1171eb22a24aa8a946b1cd74a4dfde2a59a785c5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "64155655729cbe2ba137120f7ca0f5d16e62b160cb5e107be86fdb60074cb262",
-                                "uncompressed-sha256": "a09c6dfa0360df7a42748ba9633d0b8c02196345c1f0c59d2bee126701de02e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "01c2b97e8f8a3e6edadcfb024dfd3993152429f39c737eb86aab6e72030ed0a2",
+                                "uncompressed-sha256": "c9f5030f8a2e8d4e856696e7efce6a91126ef0a0173c5512d6267328729e5dc9"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "ac8c3237093308a49808354615737e29fc4ac84b215772a846bb964b7a6ad4ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "496d5092682def040e7204d8d8cdc730abd72ce8d80312eb6112bf528f8fcffe"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "39b574bf183aa59e738aeb3bf7579f2407f6758b42649d0bcfa5b71ded09851b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "10b22273bec7d36cd0b68ff73ab62c0c054997e82b23272475d7f709bd76a7f1"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230514.2.0/x86_64/fedora-coreos-38.20230514.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "71af70233389bce18d6f0d3a381fc8051caeabde32711c4b7547f67988ecb95d",
-                                "uncompressed-sha256": "7edb07da82d788b2611da9da8308673f60508b2f61f0206fc8b03a6c1ad2f818"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "e67a04ebe423bd355ff18c5e0711ddb72b3ae2567d9b20be70e616167ebab1f5",
+                                "uncompressed-sha256": "59a9de94bf6c16ef1558676b8cb51183e124afa095fbb8bfc2b0bc978da1c0fe"
                             }
                         }
                     }
@@ -548,121 +548,121 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0bddc8534f6d189f8"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-008943ea01cf78492"
                         },
                         "ap-east-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0e5e160c87bea88a7"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0e87b5b74dbd48b26"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-098fffde2db1fc6b5"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-03a5fb9ff8f72e589"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-04426043bd0b52ae2"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-04121deb15fbbbf31"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-09406f36f3a7d1f57"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0df4026f7ffc4633e"
                         },
                         "ap-south-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-01f846e64c79d475f"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0d181a978ee68bf14"
                         },
                         "ap-south-2": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-053fafad2096d88c4"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0b91d941a499cdcfd"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-01963c9c8258ba251"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-08f40b50e7850a7c8"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-096884c513a2bd62b"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0ad393c6337628e55"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-06077cd9ccf56f363"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0c2c6562f862de28b"
                         },
                         "ca-central-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-094ddb7a499965669"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-08f3fe3ae2a24f060"
                         },
                         "eu-central-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-09abdecbd17e89252"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0ea13f9eba1f175fd"
                         },
                         "eu-central-2": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-08955ac0f119f2409"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0e1d89258ecb3831a"
                         },
                         "eu-north-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0519781c282493219"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0d368a5f66e39a6c6"
                         },
                         "eu-south-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-084e2c57cc6976963"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0fef050d3e4db1ee9"
                         },
                         "eu-south-2": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-004dd227fe82c49ba"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-01f11a116d5a81c20"
                         },
                         "eu-west-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-005072e541fe26e85"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-05f11eccc31e071ab"
                         },
                         "eu-west-2": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-08f2f88ce6b6e2afd"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-09f4655cb4418cf55"
                         },
                         "eu-west-3": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-09e9dae30ad881475"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-01d18499aff3122d0"
                         },
                         "me-central-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0e010bd6cd2144b5d"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-05ecb2147a31285af"
                         },
                         "me-south-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0bef7e8933b2f3dce"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-054810c99bb0ae72d"
                         },
                         "sa-east-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-005fd2ad9c308031b"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-088eeaf90d3d4dda8"
                         },
                         "us-east-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0fac2c20a4dedaaac"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-025a766db24f32047"
                         },
                         "us-east-2": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-07c8c8119fcf2bbbc"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-00479421f394bfc6d"
                         },
                         "us-west-1": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-06a3e2d18e0f87aca"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0fc975fb7a0cb1678"
                         },
                         "us-west-2": {
-                            "release": "38.20230514.2.0",
-                            "image": "ami-0141fa04ef410958d"
+                            "release": "38.20230527.2.0",
+                            "image": "ami-0e77264d0a94324b7"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-38-20230514-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230527-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230514.2.0",
+                    "release": "38.20230527.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0ed47f05f22bc55fc3b1cbde2e9a0203962db95edd895c83c03bbcf3a5cea482"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a5d944c4c642f13184c646edc220c81d3293f7c5dfc96e30689bbd94e32e267e"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-05-16T15:54:54Z"
+    "last-modified": "2023-05-31T18:52:49Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "38.20230430.1.0",
+      "version": "38.20230514.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "38.20230514.1.0",
+      "version": "38.20230527.1.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1684252800,
+          "start_epoch": 1685628000,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-05-16T15:54:51Z"
+    "last-modified": "2023-05-31T18:52:45Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "38.20230414.3.0",
+      "version": "38.20230430.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "38.20230430.3.1",
+      "version": "38.20230514.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1684252800,
+          "start_epoch": 1685628000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-05-16T15:54:52Z"
+    "last-modified": "2023-05-31T18:52:47Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "38.20230430.2.1",
+      "version": "38.20230514.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "38.20230514.2.0",
+      "version": "38.20230527.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1684252800,
+          "start_epoch": 1685628000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @c4rt0 via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).